### PR TITLE
Fix P1 tells: privileges, SSH sessions, parent chains, DC offsets

### DIFF
--- a/src/evidenceforge/generation/activity.py
+++ b/src/evidenceforge/generation/activity.py
@@ -782,7 +782,7 @@ class ActivityGenerator:
                 logon_type=logon_type,
                 auth_package=auth_pkg.get('AuthenticationPackageName', 'Negotiate'),
                 source_ip=source_ip,
-                elevated=_get_rng().random() < 0.15,
+                elevated=self._should_elevate(user),
                 logon_process=auth_pkg.get('LogonProcessName', ''),
                 lm_package=auth_pkg.get('LmPackageName', '-'),
                 logon_guid=auth_pkg.get('LogonGuid', '{00000000-0000-0000-0000-000000000000}'),
@@ -1199,6 +1199,79 @@ class ActivityGenerator:
         # eCAR FLOW still via helper (not format-filtered by visibility)
         self._emit_ecar_flow_event(src_ip, dst_ip, dst_port, time, src_ip, src_port=src_port, protocol=proto)
 
+        return uid
+
+    def generate_ssh_session(
+        self,
+        user: User,
+        target_system: System,
+        time: datetime,
+        source_ip: str,
+    ) -> str:
+        """Generate an SSH session as a compound event (Zeek conn + syslog auth + eCAR).
+
+        Builds a single SecurityEvent with Auth+Host+Network contexts and dispatches
+        to all matching emitters. Each emitter renders its format-specific view:
+        - SyslogEmitter: "Accepted password for user from ip port N ssh2"
+        - ZeekEmitter: conn.log record with service=ssh, port 22
+        - EcarEmitter: USER_SESSION/LOGIN event
+
+        Args:
+            user: User initiating the SSH connection
+            target_system: Target Linux system
+            time: Connection timestamp
+            source_ip: Source IP of the SSH client
+
+        Returns:
+            Zeek UID for the connection
+        """
+        from evidenceforge.events.contexts import NetworkContext
+
+        rng = _get_rng()
+        src_port = rng.randint(49152, 65535)
+        duration = rng.uniform(30.0, 3600.0)
+        orig_bytes = rng.randint(2000, 50000)
+        resp_bytes = rng.randint(5000, 200000)
+
+        # Allocate connection in StateManager
+        conn_id = self.state_manager.open_connection(
+            src_ip=source_ip, src_port=src_port,
+            dst_ip=target_system.ip, dst_port=22, protocol='tcp'
+        )
+        uid = self.state_manager.get_zeek_uid(conn_id)
+        self.state_manager.update_connection_bytes(conn_id, orig_bytes, resp_bytes)
+
+        # Emit DNS for SSH target
+        self._emit_dns_lookup(source_ip, target_system.ip, time)
+
+        # Build compound SSH session event
+        event = SecurityEvent(
+            timestamp=time,
+            event_type="ssh_session",
+            host=self._build_host_context(target_system),
+            auth=AuthContext(
+                username=user.username,
+                source_ip=source_ip,
+                source_port=src_port,
+            ),
+            network=NetworkContext(
+                src_ip=source_ip, src_port=src_port,
+                dst_ip=target_system.ip, dst_port=22,
+                protocol='tcp', service='ssh',
+                zeek_uid=uid, conn_id=conn_id,
+                duration=duration,
+                orig_bytes=orig_bytes, resp_bytes=resp_bytes,
+                conn_state='SF', history='ShADadfF',
+                orig_pkts=max(4, orig_bytes // 1460 + 1),
+                resp_pkts=max(4, resp_bytes // 1460 + 1),
+                local_orig=_is_private_ip(source_ip),
+                local_resp=_is_private_ip(target_system.ip),
+                ip_proto=6,
+            ),
+        )
+
+        self.dispatcher.dispatch(event)
+        logger.debug(f"Generated SSH session: {user.username} → {target_system.hostname} (UID: {uid})")
         return uid
 
     def generate_bash_command(
@@ -1895,6 +1968,29 @@ class ActivityGenerator:
         'LOCAL SERVICE': 'S-1-5-19',
         'NETWORK SERVICE': 'S-1-5-20',
     }
+
+    # Personas that represent admin/operator roles (get elevated privileges)
+    _ADMIN_PERSONAS = {'sysadmin', 'security_analyst', 'help_desk'}
+
+    def _should_elevate(self, user: User) -> bool:
+        """Determine if a logon should generate 4672 (Special Privileges).
+
+        Role-based: admins ~80%, machine accounts always, regular users ~5%.
+        """
+        rng = _get_rng()
+        username = user.username
+        # Machine accounts always elevated
+        if username.endswith('$'):
+            return True
+        # System service accounts always elevated
+        if username in ('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE'):
+            return True
+        # Admin personas: ~80% elevated
+        persona = getattr(user, 'persona', None)
+        if persona and str(persona) in self._ADMIN_PERSONAS:
+            return rng.random() < 0.80
+        # Regular users: ~5% (occasional admin task)
+        return rng.random() < 0.05
 
     def _select_auth_package(self, logon_type: int) -> dict[str, str]:
         """Select auth package, LogonProcessName, and LogonGuid based on logon type.

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -17,6 +17,7 @@ class EcarEmitter(LogEmitter):
     _supported_types: set[str] = {
         "logon", "logoff", "failed_logon",
         "process_create", "process_terminate", "system_process_create",
+        "ssh_session",
     }
 
     def can_handle(self, event: SecurityEvent) -> bool:
@@ -32,6 +33,7 @@ class EcarEmitter(LogEmitter):
             "process_create": self._render_process_create,
             "process_terminate": self._render_process_terminate,
             "system_process_create": self._render_process_create,  # Same rendering
+            "ssh_session": self._render_logon,  # SSH session = LOGIN event in EDR
         }.get(event.event_type)
         if renderer is None:
             raise NotImplementedError(

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -12,7 +12,7 @@ from evidenceforge.generation.emitters.base import LogEmitter
 class SyslogEmitter(LogEmitter):
     """Emitter for Linux syslog format."""
 
-    _supported_types: set[str] = {"logon", "logoff", "failed_logon", "system_process_create"}
+    _supported_types: set[str] = {"logon", "logoff", "failed_logon", "system_process_create", "ssh_session"}
 
     def can_handle(self, event: SecurityEvent) -> bool:
         """Syslog emitter handles events on Linux hosts."""
@@ -29,6 +29,7 @@ class SyslogEmitter(LogEmitter):
             "logoff": self._render_logoff,
             "failed_logon": self._render_failed_logon,
             "system_process_create": self._render_system_process,
+            "ssh_session": self._render_ssh_session,
         }.get(event.event_type)
         if renderer is None:
             raise NotImplementedError(
@@ -100,6 +101,25 @@ class SyslogEmitter(LogEmitter):
             'facility': facility,
             'severity': 6,
             'message': f'{app_name}[{proc.pid}]: started: {proc.command_line}',
+        }
+        self.emit_event(event_data)
+
+    def _render_ssh_session(self, event: SecurityEvent) -> None:
+        """Render syslog auth message for SSH session establishment."""
+        rng = random.Random()
+        auth = event.auth
+        net = event.network
+        event_data = {
+            'timestamp': event.timestamp,
+            'hostname': event.host.hostname,
+            'facility': 10,  # authpriv
+            'severity': 6,   # info
+            'app_name': 'sshd',
+            'pid': rng.randint(5000, 60000),
+            'message': (
+                f'Accepted password for {auth.username} from {net.src_ip} '
+                f'port {net.src_port} ssh2'
+            ),
         }
         self.emit_event(event_data)
 

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -98,6 +98,25 @@ class WindowsEventEmitter(LogEmitter):
 
         # 4672 special privileges (when auth.elevated is True)
         if auth.elevated:
+            # Admin/service/machine accounts get full privilege set
+            is_admin = (auth.username.endswith('$')
+                        or auth.username in ('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE')
+                        or auth.logon_type == 5)
+            if is_admin:
+                privs = (
+                    'SeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\t'
+                    'SeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\t'
+                    'SeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\t'
+                    'SeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\t'
+                    'SeDelegateSessionUserImpersonatePrivilege'
+                )
+            else:
+                # Regular user with occasional elevation (e.g., UAC prompt)
+                privs = (
+                    'SeChangeNotifyPrivilege\n\t\t\tSeIncreaseWorkingSetPrivilege\n\t\t\t'
+                    'SeShutdownPrivilege\n\t\t\tSeUndockPrivilege\n\t\t\t'
+                    'SeTimeZonePrivilege'
+                )
             priv_data = {
                 'EventID': 4672,
                 'TimeCreated': event.timestamp,
@@ -110,13 +129,7 @@ class WindowsEventEmitter(LogEmitter):
                 'SubjectUserName': auth.username,
                 'SubjectDomainName': host.netbios_domain,
                 'SubjectLogonId': auth.logon_id,
-                'PrivilegeList': (
-                    'SeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\t'
-                    'SeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\t'
-                    'SeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\t'
-                    'SeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\t'
-                    'SeDelegateSessionUserImpersonatePrivilege'
-                ),
+                'PrivilegeList': privs,
             }
             self.emit_event(priv_data)
 
@@ -476,8 +489,16 @@ class WindowsEventEmitter(LogEmitter):
             # Strip FQDN for counter key (bare hostname)
             counter_key = computer.split(".")[0] if "." in computer else computer
             if counter_key not in self._record_id_counters:
-                # Initialize with deterministic offset from hostname hash
-                self._record_id_counters[counter_key] = (hash(counter_key) % 40000) + 1000
+                # System-role-aware offset: DCs have much higher event volumes
+                # Use deterministic seed (not Python's randomized hash)
+                rng = random.Random(f"erid_{counter_key}")
+                key_lower = counter_key.lower()
+                if 'dc' in key_lower:
+                    self._record_id_counters[counter_key] = rng.randint(5_000_000, 15_000_000)
+                elif any(x in key_lower for x in ('srv', 'server', 'web', 'file', 'db', 'mail', 'exch')):
+                    self._record_id_counters[counter_key] = rng.randint(50_000, 550_000)
+                else:
+                    self._record_id_counters[counter_key] = rng.randint(5_000, 55_000)
             self._record_id_counters[counter_key] += 1
             event["EventRecordID"] = self._record_id_counters[counter_key]
 

--- a/src/evidenceforge/generation/emitters/zeek.py
+++ b/src/evidenceforge/generation/emitters/zeek.py
@@ -17,14 +17,14 @@ class ZeekEmitter(LogEmitter):
     Each connection includes source/dest IPs, ports, protocol, and connection state.
     """
 
-    _supported_types: set[str] = {"connection"}
+    _supported_types: set[str] = {"connection", "ssh_session"}
 
     def can_handle(self, event: SecurityEvent) -> bool:
-        """Zeek conn emitter handles connection events."""
+        """Zeek conn emitter handles connection and session events with network context."""
         return event.event_type in self._supported_types and event.network is not None
 
     def emit(self, event: SecurityEvent) -> None:
-        """Render connection SecurityEvent to Zeek conn.log format."""
+        """Render SecurityEvent to Zeek conn.log format."""
         net = event.network
         event_data = {
             'ts': event.timestamp,

--- a/src/evidenceforge/generation/engine.py
+++ b/src/evidenceforge/generation/engine.py
@@ -983,7 +983,7 @@ class GenerationEngine:
             'logon': ['logon', 'log in', 'login', 'authenticate', 'sign in'],
             'logoff': ['logoff', 'log off', 'logout', 'sign out'],
             'process': ['execute', 'run', 'launch', 'start', 'spawn', 'powershell', 'cmd', 'command'],
-            'connection': ['connect', 'access', 'download', 'upload', 'communicate', 'c2', 'exfiltrate'],
+            'connection': ['connect', 'access', 'download', 'upload', 'communicate', 'c2', 'exfiltrate', 'ssh', 'rdp', 'remote'],
         }
 
         activity_lower = activity.lower()
@@ -1061,7 +1061,12 @@ class GenerationEngine:
                     self._generate_encoded_powershell(hash(f"{time}_{actor.username}"))
                 )
 
-            parent_pid = self.activity_generator._select_parent_pid(system, actor, process_name)
+            # Use previous storyline process as parent (attack chain continuity)
+            last_pid = getattr(self, '_last_storyline_pid', None)
+            if last_pid and self.activity_generator._is_pid_alive(system, last_pid):
+                parent_pid = last_pid
+            else:
+                parent_pid = self.activity_generator._select_parent_pid(system, actor, process_name)
             pid = self.activity_generator.generate_process(
                 user=actor,
                 system=system,
@@ -1073,36 +1078,67 @@ class GenerationEngine:
             )
             self.activity_generator._record_user_process(system, actor, pid, process_name)
 
+            self._last_storyline_pid = pid  # Track for parent chain continuity
             malicious_event['process_name'] = process_name
             malicious_event['command_line'] = command_line
             malicious_event['pid'] = pid
 
         elif event_type == 'connection':
+            # Detect SSH from activity keywords or MITRE technique
+            is_ssh = ('ssh' in activity.lower()
+                      or details.get('technique', '').startswith('T1021.004')
+                      or details.get('dst_port') == 22
+                      or details.get('service') == 'ssh')
+
             # Default C2 IPs: realistic cloud hosting ranges (not RFC 5737)
             _c2_ips = ['159.65.43.201', '134.209.29.115', '167.71.156.88', '64.227.38.102', '108.61.13.174']
-            dst_ip = details.get('dst_ip', random.choice(_c2_ips))
-            dst_port = details.get('dst_port', 443)
-            service = details.get('service', 'https')
+            if is_ssh:
+                # SSH: target is the storyline system, source is from details or actor's workstation
+                dst_ip = system.ip
+                dst_port = 22
+                service = 'ssh'
+            else:
+                dst_ip = details.get('dst_ip', random.choice(_c2_ips))
+                dst_port = details.get('dst_port', 443)
+                service = details.get('service', 'https')
 
             # Validate destination is different from source
-            if dst_ip == system.ip:
+            if dst_ip == system.ip and not is_ssh:
                 logger.warning(
                     f"Skipping storyline connection: dst_ip {dst_ip} matches system IP {system.ip}. "
                     f"Adjusting to external IP."
                 )
                 dst_ip = random.choice(['159.65.43.201', '134.209.29.115', '167.71.156.88'])
 
-            uid = self.activity_generator.generate_connection(
-                src_ip=system.ip,
-                dst_ip=dst_ip,
-                time=time,
-                dst_port=dst_port,
-                service=service,
-                duration=random.uniform(1.0, 30.0),
-                orig_bytes=random.randint(1000, 10000),
-                resp_bytes=random.randint(5000, 50000),
-                emit_dns=True,
-            )
+            # SSH connections use compound ssh_session event (Zeek + syslog + eCAR)
+            if is_ssh:
+                source_ip = details.get('source_ip', system.ip)
+                target = next((s for s in self.scenario.environment.systems if s.ip == dst_ip), system)
+                uid = self.activity_generator.generate_ssh_session(
+                    user=actor, target_system=target, time=time, source_ip=source_ip,
+                )
+            elif dst_port == 22:
+                target = next((s for s in self.scenario.environment.systems if s.ip == dst_ip), None)
+                if target:
+                    uid = self.activity_generator.generate_ssh_session(
+                        user=actor, target_system=target, time=time, source_ip=system.ip,
+                    )
+                else:
+                    uid = self.activity_generator.generate_connection(
+                        src_ip=system.ip, dst_ip=dst_ip, time=time,
+                        dst_port=22, service='ssh', duration=random.uniform(30.0, 1800.0),
+                        orig_bytes=random.randint(2000, 50000), resp_bytes=random.randint(5000, 200000),
+                        emit_dns=True,
+                    )
+            else:
+                uid = self.activity_generator.generate_connection(
+                    src_ip=system.ip, dst_ip=dst_ip, time=time,
+                    dst_port=dst_port, service=service,
+                    duration=random.uniform(1.0, 30.0),
+                    orig_bytes=random.randint(1000, 10000),
+                    resp_bytes=random.randint(5000, 50000),
+                    emit_dns=True,
+                )
 
             malicious_event['dst_ip'] = dst_ip
             malicious_event['dst_port'] = dst_port


### PR DESCRIPTION
## Summary

4 structural fixes for expert panel P1 tells:

1. **Role-based 4672 privileges**: `_should_elevate()` uses account type (machine, service, admin persona). SeDebugPrivilege only for admin/service accounts.
2. **New `ssh_session` canonical event type**: Compound event dispatched to Syslog (auth), Zeek (conn), and eCAR (login). Storyline SSH detected via keywords + MITRE technique.
3. **Storyline parent chain**: `_last_storyline_pid` maintains attack chain continuity across username/context switches (e.g., mimikatz as SYSTEM now parents from net.exe, not explorer).
4. **DC EventRecordID offset**: System-role-aware ranges (DC: 5M-15M, servers: 50K-550K, workstations: 5K-55K).

## Test plan

- [x] 761 tests passing
- [x] SSH "Accepted password" in syslog for storyline lateral movement
- [x] SeDebugPrivilege only for SYSTEM, not regular users
- [x] Mimikatz parent chain follows attack sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)