### PR TITLE
Complete emitter SecurityEvent migration

### DIFF
--- a/src/evidenceforge/generation/emitters/snort.py
+++ b/src/evidenceforge/generation/emitters/snort.py
@@ -1,9 +1,8 @@
 """Snort/Suricata alert emitter."""
 
-from pathlib import Path
 from typing import Any
 
-from evidenceforge.formats.format_def import FormatDefinition
+from evidenceforge.events.base import SecurityEvent
 from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
 
 
@@ -11,18 +10,54 @@ class SnortEmitter(SensorMultiplexEmitter):
     """Emitter for Snort/Suricata fast alert format.
 
     Per-sensor directory routing: each IDS sensor gets its own alert file.
+
+    Handles SecurityEvents with IdsContext (fan-out from connection events
+    through IDS sensors) and raw dict events from baseline false-positive
+    alert generation.
     """
 
     _log_filename = "snort_alert.log"
     _flat_filename = "snort_alert.log"
-    _supported_types: set[str] = set()
+    _supported_types: set[str] = {"connection"}
+
+    def can_handle(self, event: SecurityEvent) -> bool:
+        """Handle connection events that carry an IdsContext."""
+        return (
+            event.event_type in self._supported_types
+            and event.ids is not None
+        )
+
+    def emit(self, event: SecurityEvent) -> None:
+        """Render IdsContext to Snort fast alert format."""
+        ids = event.ids
+        net = event.network
+
+        event_data = {
+            'timestamp': event.timestamp,
+            'sid': ids.sid,
+            'message': ids.message,
+            'classification': ids.classification,
+            'priority': ids.priority,
+            'protocol': (net.protocol or 'TCP').upper() if net else 'TCP',
+            'src_ip': net.src_ip if net else '',
+            'src_port': net.src_port if net else 0,
+            'dst_ip': net.dst_ip if net else '',
+            'dst_port': net.dst_port if net else 0,
+        }
+        # Get sensor routing from the event's visibility metadata
+        if hasattr(event, '_sensor_hostnames_by_format'):
+            sensor_hosts = event._sensor_hostnames_by_format.get('snort_alert', [])
+            if sensor_hosts:
+                event_data['_sensor_hostnames'] = sensor_hosts
+
+        self._dispatch(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str | None:
         """Render Snort/Suricata alert to fast alert format.
 
-        Returns None if the event lacks required IDS alert fields (sid, message,
-        classification), which means it's a plain connection event that should
-        not generate an IDS alert.
+        Returns None if the event lacks required IDS alert fields (sid, message),
+        which means it's a plain connection event that should not generate an
+        IDS alert. The caller must handle None returns.
         """
         if not event_data.get('sid') and not event_data.get('message'):
             return None

--- a/src/evidenceforge/generation/emitters/web.py
+++ b/src/evidenceforge/generation/emitters/web.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from evidenceforge.events.base import SecurityEvent
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
 
 
@@ -9,10 +10,42 @@ class WebEmitter(HostMultiplexEmitter):
     """Emitter for W3C web server access logs (Apache/Nginx Combined Log Format).
 
     Per-host FQDN directory routing: each web server gets its own access log.
+
+    Handles SecurityEvents with HttpContext (fan-out from connection events
+    to web servers) and raw dict events from baseline web traffic generation.
     """
 
     _log_filename = "web_access.log"
-    _supported_types: set[str] = set()
+    _supported_types: set[str] = {"connection"}
+
+    def can_handle(self, event: SecurityEvent) -> bool:
+        """Handle connection events that carry an HttpContext and target a web server."""
+        return (
+            event.event_type in self._supported_types
+            and event.http is not None
+            and event.host is not None
+        )
+
+    def emit(self, event: SecurityEvent) -> None:
+        """Render HttpContext to Combined Log Format."""
+        http = event.http
+        host = event.host
+        net = event.network
+
+        event_data = {
+            'timestamp': event.timestamp,
+            'client_ip': net.src_ip if net else '',
+            'username': '-',
+            'method': http.method,
+            'path': http.uri,
+            'protocol': f'HTTP/{http.version}',
+            'status_code': http.status_code,
+            'bytes_sent': http.response_body_len,
+            'referer': http.referrer or '-',
+            'user_agent': http.user_agent,
+            '_host_fqdn': host.fqdn or host.hostname,
+        }
+        self._dispatch(event_data)
 
     def _dispatch(self, event_data: dict[str, Any]) -> None:
         """Route web access event to per-host file."""

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -146,8 +146,14 @@ class SensorMultiplexEmitter(LogEmitter):
             self._dispatch(event_data)
 
     def _dispatch(self, event_data: dict[str, Any]) -> None:
-        """Render and route to sensor writers."""
+        """Render and route to sensor writers.
+
+        Skips events where _render_event returns None (e.g., SnortEmitter
+        filters out non-IDS connection events).
+        """
         rendered = self._render_event(event_data)
+        if rendered is None:
+            return
         sensor_hostnames = event_data.pop('_sensor_hostnames', None)
         self.emit_to_sensors(rendered, sensor_hostnames)
 

--- a/src/evidenceforge/generation/emitters/zeek_dhcp.py
+++ b/src/evidenceforge/generation/emitters/zeek_dhcp.py
@@ -8,8 +8,9 @@ from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
 class ZeekDhcpEmitter(SensorMultiplexEmitter):
     """Emitter for Zeek dhcp.log format (NDJSON).
 
-    Generates DHCP transaction logs. Uses dispatch_raw since DHCP has
-    a `uids` array (not single uid) and no standard id.* tuple.
+    Generates DHCP transaction logs. Intentionally dispatch_raw-only:
+    DHCP has a `uids` array (not single uid) and no standard id.* tuple,
+    so it doesn't fit the SecurityEvent canonical model.
     """
 
     _log_filename = "dhcp.json"

--- a/src/evidenceforge/generation/emitters/zeek_packet_filter.py
+++ b/src/evidenceforge/generation/emitters/zeek_packet_filter.py
@@ -8,8 +8,9 @@ from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
 class ZeekPacketFilterEmitter(SensorMultiplexEmitter):
     """Emitter for Zeek packet_filter.log format (NDJSON).
 
-    Generates sensor packet filter state logs.
-    Uses dispatch_raw — emitted once at sensor startup.
+    Generates sensor packet filter state logs. Intentionally
+    dispatch_raw-only: sensor infrastructure events with no
+    SecurityEvent representation.
     """
 
     _log_filename = "packet_filter.json"

--- a/src/evidenceforge/generation/emitters/zeek_reporter.py
+++ b/src/evidenceforge/generation/emitters/zeek_reporter.py
@@ -8,8 +8,9 @@ from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
 class ZeekReporterEmitter(SensorMultiplexEmitter):
     """Emitter for Zeek reporter.log format (NDJSON).
 
-    Generates Zeek sensor diagnostic/warning logs.
-    Uses dispatch_raw — emitted for sensor startup warnings.
+    Generates Zeek sensor diagnostic/warning logs. Intentionally
+    dispatch_raw-only: sensor infrastructure events with no
+    SecurityEvent representation.
     """
 
     _log_filename = "reporter.json"

--- a/src/evidenceforge/generation/emitters/zeek_weird.py
+++ b/src/evidenceforge/generation/emitters/zeek_weird.py
@@ -8,8 +8,9 @@ from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
 class ZeekWeirdEmitter(SensorMultiplexEmitter):
     """Emitter for Zeek weird.log format (NDJSON).
 
-    Generates network anomaly/weird records. Uses dispatch_raw since
-    weird events are probabilistic side-effects, not tied to specific event types.
+    Generates network anomaly/weird records. Intentionally dispatch_raw-only:
+    weird events are probabilistic side-effects of connection processing,
+    not tied to specific SecurityEvent types.
     """
 
     _log_filename = "weird.json"


### PR DESCRIPTION
## Summary

Completes the Phase 7 canonical event model migration for the remaining emitters. After this PR, 16 of 20 emitters handle SecurityEvents via `emit()`, and the remaining 4 are documented as intentionally dispatch_raw-only.

- **WebEmitter**: Add `can_handle()` for connection events with HttpContext, implement `emit()` that extracts fields and routes to per-host access logs.
- **SnortEmitter**: Add `can_handle()` for connection events with IdsContext, implement `emit()` that extracts IDS alert fields from SecurityEvent.
- **SensorMultiplexEmitter._dispatch()**: Guard against `_render_event()` returning None. Previously, SnortEmitter returning None for non-IDS events caused `TypeError: write() argument must be str, not None` on buffer flush.
- **4 Zeek utility emitters** (DHCP, Reporter, PacketFilter, Weird): Documented as intentionally dispatch_raw-only — these emit sensor infrastructure events with no SecurityEvent representation.

### Migration status after this PR

| Status | Count | Emitters |
|--------|-------|----------|
| SecurityEvent dispatch | 16 | Windows, Sysmon, eCAR, Syslog, BashHistory, Zeek (conn, dns, http, ssl, files, x509, ntp, pe, ocsp), Proxy, Web, Snort |
| dispatch_raw only (by design) | 4 | ZeekDhcp, ZeekReporter, ZeekPacketFilter, ZeekWeird |

## Test plan

- [x] Full test suite: 962 passed, 0 failed, 1 skipped
- [x] `eforge generate` on coverage-test scenario completes without crash (previously crashed on snort_alert flush)
- [x] Web access logs generated in per-host directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)