### PR TITLE
Fix 4770 Status field, 1102 UserData parser, coverage test scenario

### DIFF
--- a/src/evidenceforge/evaluation/parsers/windows.py
+++ b/src/evidenceforge/evaluation/parsers/windows.py
@@ -77,7 +77,7 @@ class WindowsEventParser(LogParser):
                     if tid:
                         fields["ExecutionThreadID"] = int(tid)
 
-            # EventData fields
+            # EventData fields (most event types)
             event_data = root.find(f"{{{NS}}}EventData")
             if event_data is not None:
                 for data_el in event_data.findall(f"{{{NS}}}Data"):
@@ -104,6 +104,18 @@ class WindowsEventParser(LogParser):
                                 fields[name] = value
                         else:
                             fields[name] = value
+
+            # UserData fields (1102 LogFileCleared and similar)
+            user_data = root.find(f"{{{NS}}}UserData")
+            if user_data is not None:
+                # UserData contains a wrapper element (e.g., LogFileCleared)
+                # with child elements as fields
+                for wrapper in user_data:
+                    for child in wrapper:
+                        # Strip namespace from tag name
+                        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                        if child.text:
+                            fields[tag] = child.text
 
         except ET.ParseError as e:
             errors.append(f"XML parse error: {e}")

--- a/src/evidenceforge/formats/definitions/windows_event_security.yaml
+++ b/src/evidenceforge/formats/definitions/windows_event_security.yaml
@@ -1236,6 +1236,7 @@ output:
         <Data Name="TicketEncryptionType">{{ TicketEncryptionType }}</Data>
         <Data Name="IpAddress">{{ IpAddress }}</Data>
         <Data Name="IpPort">{{ IpPort | default(0) }}</Data>
+        <Data Name="Status">{{ Status | default('0x0') }}</Data>
         {% elif EventID == 4776 %}
         <Data Name="PackageName">{{ PackageName }}</Data>
         <Data Name="TargetUserName">{{ TargetUserName }}</Data>

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -496,6 +496,7 @@ class WindowsEventEmitter(LogEmitter):
             "TicketEncryptionType": krb.encryption_type,
             "IpAddress": krb.source_ip,
             "IpPort": krb.source_port,
+            "Status": "0x0",
         }
         self.emit_event(event_data)
 


### PR DESCRIPTION
## Summary

Improvement loop (3 iterations) using the coverage-test scenario to find and fix errors/warnings from validate, generate, and eval tools.

- **EventID 4770 (Kerberos TGT renewal)**: Missing required `Status` field — fixed in both the Windows emitter and the Jinja2 XML template
- **EventID 1102 (Log Cleared)**: Windows eval parser only parsed `EventData` XML, missing fields in `UserData/LogFileCleared` structure — added UserData parsing
- **Coverage test scenario**: Generated 40-event APT scenario from COVERAGE-TEST-PROMPT.md exercising all 14 event types and 8 log formats

**Results:** Parsability failures 19 → 0. Acceptance FAIL → PASS. Overall score 88/100.

## Test plan
- [x] 1011 tests passing
- [x] `eforge validate` passes with expected warnings only
- [x] `eforge generate` completes without errors
- [x] `eforge eval` passes all hard acceptance criteria
- [x] Ruff lint + format clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)