### PR TITLE
Add NAT support and fix coverage prompt workstation ratios

### DIFF
--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -154,6 +154,9 @@ After reviewing output, you can suggest:
 | bash_history | Bash command history | Linux systems |
 | snort_alert | Snort/Suricata alerts (fast format) | Network IDS via sensors |
 | cisco_asa | Cisco ASA firewall syslog (Built/Teardown/Deny) | Firewall sensors |
+
+When `nat_rules` are configured on the firewall sensor, cisco_asa.log also includes 305011/305012 NAT translation records alongside the normal Built/Teardown connection records.
+
 | web_access | Apache/Nginx combined access logs | Web servers |
 
 See `references/evidence-formats.md` for detailed field documentation, output paths, and known limitations for each format.

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -228,6 +228,9 @@ environment:
           - {src: corporate_lan, dst: any}
           - {src: server_vlan, dst: external, ports: [80, 443, 53]}
           - {src: server_vlan, dst: server_vlan}
+        nat_rules:                # NAT translation rules
+          - {type: dynamic_pat, src: corporate_lan, mapped_ip: "203.0.113.1"}
+          - {type: static, real_ip: "10.10.20.10", mapped_ip: "203.0.113.10"}
 
 personas:                         # Define inline or reference pre-built from personas/
   - name: developer
@@ -285,6 +288,18 @@ output:
   destination: "./output"
   compression: false
 ```
+
+### Firewall NAT Rules
+
+- `nat_rules`: NAT translation rules. Each rule specifies how traffic crossing the firewall boundary gets address-translated.
+  - `type`: `"dynamic_pat"` (many:1 with port translation) or `"static"` (1:1 IP mapping)
+  - `src`: Source segment name(s), IP, or CIDR. Accepts a string or list (e.g., `[workstations, servers]`)
+  - `mapped_ip`: The post-NAT IP address
+  - `real_ip`: (static only) The specific internal IP being mapped
+  - Dynamic PAT: all traffic from matching segments shares one external IP with port translation. Common for outbound user traffic.
+  - Static NAT: bidirectional 1:1 mapping for DMZ servers. Enables inbound connections via public IP.
+  - NAT only applies to permitted connections that cross segment boundaries. Denied connections are not NATted.
+  - ASA logs both real and mapped IPs in Built messages. Outside Zeek sensors see post-NAT IPs; inside sensors see real IPs.
 
 ### OS-Aware Log Routing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,6 +120,8 @@ EvidenceForge models where network sensors are placed and what traffic they can 
 
 When a network connection event is dispatched, the NetworkVisibilityEngine determines which sensors can observe it based on the source/destination IPs and sensor placement. Only sensors with visibility produce log entries for that connection.
 
+**Network Address Translation:** When firewall sensors have `nat_rules`, the dispatcher computes NAT translations for permitted cross-boundary connections. The `NatContext` on `SecurityEvent` carries mapped IPs. The ASA emitter renders both real and mapped addresses (305011/305012 + parenthesized IPs in Built messages). Zeek emitters swap IPs for post-NAT sensors via `_nat_swaps_by_sensor`, so inside sensors see real IPs while outside sensors see translated IPs.
+
 ---
 
 ## Part 2: Internals (For Contributors)

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -232,6 +232,8 @@ Cisco ASA firewall logs for permitted and denied connections. Produced by firewa
 | 302020 | 6 (info) | ICMP | Built inbound/outbound ICMP connection |
 | 302021 | 6 (info) | ICMP | Teardown ICMP connection |
 | 106023 | 4 (warn) | any | Deny by access-group |
+| 305011 | 6 (info) | any | Built dynamic/static NAT translation |
+| 305012 | 6 (info) | any | Teardown dynamic/static NAT translation |
 | 733100 | 4 (warn) | — | Threat detection scanning alert (automatic, rate-based) |
 
 **Example records:**
@@ -244,6 +246,8 @@ Cisco ASA firewall logs for permitted and denied connections. Produced by firewa
 
 **Threat detection (733100):** The ASA emitter automatically tracks per-source-IP deny rates. When both burst rate (default 10 drops/sec over 20s) and average rate (default 5 drops/sec over 60s) are exceeded, a 733100 alert fires. Can re-fire after a 20-second cooldown if rates remain elevated. Configurable via `threat_detection_rate` on the firewall sensor (set to 0 to disable).
 
+**NAT translation (305011/305012):** When `nat_rules` are configured on the firewall sensor, permitted connections that cross the NAT boundary produce 305011 (Built) and 305012 (Teardown) translation records alongside the normal 302013/302014 connection records. Built messages show post-NAT mapped addresses in parentheses. Outside Zeek sensors see post-NAT IPs; inside Zeek sensors see real IPs.
+
 **Baseline deny generation:** When `deny_ratio > 0` on the firewall sensor, the baseline generates denied connection attempts proportional to allowed traffic. Patterns include external scanning (60%), cross-segment blocked (20%), outbound blocked (10%), and ICMP noise (10%).
 
 **Storyline event types:** `port_scan` generates bulk 106023 denies for reconnaissance/scanning. `blocked_c2` generates periodic 106023 denies for blocked malware beaconing. Both produce correlated Zeek conn.log entries on sensors that can see the source-side traffic. Port scans with sufficient rate automatically trigger 733100 threat detection alerts.
@@ -251,7 +255,6 @@ Cisco ASA firewall logs for permitted and denied connections. Produced by firewa
 **Source-only visibility:** Denied connections are only visible to sensors on the source side of the firewall. Sensors on the destination side do not see blocked traffic.
 
 **Known Limitations:**
-- No NAT translation (305011/305012) — mapped addresses equal real addresses
 - Simplified message format — omits IDFW user, internal port numbers, rx_ring metadata
 
 ---

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -149,6 +149,13 @@ Firewall sensors produce Cisco ASA syslog records for permitted and denied conne
       default_action: deny      # deny (default) | permit
       deny_ratio: 5.0           # Deny events per allow event in baseline (default: 5.0)
       threat_detection_rate: 10 # Deny rate (drops/sec) triggering 733100 alerts (0=disabled)
+      nat_rules:
+        - type: dynamic_pat
+          src: [workstations, servers]
+          mapped_ip: 198.51.100.1
+        - type: static
+          real_ip: 172.16.0.5
+          mapped_ip: 203.0.113.5
       policy:                   # Ordered rules — first match wins
         - {src: external, dst: dmz, ports: [80, 443]}
         - {src: workstations, dst: any}
@@ -166,6 +173,14 @@ Firewall sensors produce Cisco ASA syslog records for permitted and denied conne
 **Interfaces**: Map segment names to ASA interface names (e.g., `inside`, `outside`, `dmz`). IPs not in any mapped segment resolve to `"outside"`.
 
 **Threat detection**: The ASA emitter automatically tracks per-source-IP deny rates and fires 733100 alerts when both burst (default 10 drops/sec over 20s) and average (default 5 drops/sec over 60s) thresholds are exceeded. Set `threat_detection_rate: 0` to disable.
+
+**NAT rules**: Define Network Address Translation behavior for the firewall. Each rule in the `nat_rules` list supports:
+- `type`: `dynamic_pat` (many:1 with port translation) or `static` (1:1 IP mapping)
+- `src`: segment name(s), IP, or CIDR. Accepts a string or list.
+- `mapped_ip`: the post-NAT IP address
+- `real_ip`: for static NAT, the specific internal IP being mapped
+
+Dynamic PAT: all traffic from matching segments shares one external IP with port translation. Static NAT: bidirectional 1:1 mapping, enables inbound connections to DMZ servers via public IP. NAT only applies to permitted connections that cross segment boundaries; denied connections are not NATted.
 
 ## Personas
 
@@ -293,8 +308,8 @@ Each event in the `events` list has a `type` field that selects a validated sche
 | `log_cleared` | 1102 | | |
 | `create_remote_thread` | Sysmon 8, eCAR THREAD/REMOTE_CREATE | `target_process` | |
 | `dhcp_lease` | Zeek dhcp.log | | `mac_address`, `requested_ip` |
-| `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `target_count`, `ports`, `protocol`, `scan_rate` |
-| `blocked_c2` | ASA 106023 (periodic denies) | `dst_ip` | `dst_port`, `interval`, `duration`, `jitter` |
+| `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `source_ip`, `target_count`, `ports`, `protocol`, `scan_rate` |
+| `blocked_c2` | ASA 106023 (periodic denies) | `dst_ip` | `source_ip`, `dst_port`, `interval`, `duration`, `jitter` |
 | `raw` | Any single format | `target_format`, `fields` | |
 
 All event types also accept optional `technique` (MITRE ATT&CK ID) and `description` (human-readable detail) fields for GROUND_TRUTH.md enrichment.
@@ -407,7 +422,7 @@ Use `port_scan` for network reconnaissance, host sweeps, lateral scans, or worm-
       technique: "T1046 - Network Service Discovery"
 ```
 
-Fields: `target_ips` (explicit list) or `target_segment` + `target_count` (sample from CIDR). `ports` (default: [22, 80, 443, 445, 3389]). `protocol` (tcp/udp/icmp). `scan_rate` (connections/second, default: 100).
+Fields: `source_ip` (override scan source; default: uses storyline system IP — useful for external attacker scans). `target_ips` (explicit list) or `target_segment` + `target_count` (sample from CIDR). `ports` (default: [22, 80, 443, 445, 3389]). `protocol` (tcp/udp/icmp). `scan_rate` (connections/second, default: 100).
 
 Denied connections are only visible to sensors on the source side of the firewall. The firewall's `drop_mode` controls whether Zeek sees `S0` (silent drop) or `REJ` (RST response).
 

--- a/scenarios/COVERAGE-TEST-PROMPT.md
+++ b/scenarios/COVERAGE-TEST-PROMPT.md
@@ -5,9 +5,9 @@
 
   Duration: 14 hours, starting 2024-03-18T12:00:00Z. Timezone: America/Chicago.
 
-  Systems (mix of Windows and Linux, ~20 total):
-  - 13 Windows workstations (Windows 10/11) across departments: dev, IT, security, finance, data
-  analytics, executive, PM, HR, sales, legal, marketing, front desk
+  Systems (mix of Windows and Linux, ~20+ total):
+  - One Windows workstation (Windows 10/11) per user, distributed across departments: dev, IT,
+  security, finance, data analytics, executive, PM, HR, sales, legal, marketing, front desk
   - 2 Windows servers: DC-01 (domain controller, Server 2022), FILE-SRV-01 (file server, Server 2019)
   - 5 Linux servers: WEB-EXT-01 (Ubuntu, web server in DMZ with roles: [web_server]), PROXY-01 (Ubuntu,
   roles: [forward_proxy]), APP-INT-01 (Ubuntu, internal app server), DB-PROD-01 (CentOS, MySQL),
@@ -37,9 +37,8 @@
       - {src: dmz, dst: server_vlan, ports: [3306]}            # DMZ web → database
 
   Users: 17 users spanning all 15 built-in personas. Realistic diverse names (first.last format). Every
-   user must have a primary_system assigned to one of the workstations (users may share workstations if
-   needed — 17 users across 13 workstations means some sharing). Service accounts: svc_backup,
-   svc_monitor, svc_sqlreader.
+   user must have a dedicated primary_system workstation (1:1 mapping — create one workstation per user).
+   Service accounts: svc_backup, svc_monitor, svc_sqlreader.
 
   Stale accounts (3):
   - jennifer.walsh: last_active 2023-11-15, reason "Transferred to London office"

--- a/scenarios/COVERAGE-TEST-PROMPT.md
+++ b/scenarios/COVERAGE-TEST-PROMPT.md
@@ -28,7 +28,7 @@
     default_action: deny, deny_ratio: 5.0, nat_rules:
       - type: dynamic_pat
         src: [corporate_lan, server_vlan]
-        mapped_ip: 198.51.100.1
+        mapped_ip: 45.33.32.1
     policy:
       - {src: external, dst: dmz, ports: [80, 443]}          # Allow web traffic to DMZ
       - {src: corporate_lan, dst: any}                         # Users can reach anything
@@ -61,9 +61,9 @@
   Attack storyline — APT via web app exploit, full kill chain:
   1. Rogue Device (+0h45m): Attacker plugs rogue laptop into network, obtains IP via DHCP
   (dhcp_lease event with explicit MAC address). Actor: attacker on rogue device.
-  2. Initial Access (+1h): External attacker (203.0.113.45) scans and exploits SQL injection on
+  2. Initial Access (+1h): External attacker (185.70.41.45) scans and exploits SQL injection on
   WEB-EXT-01's EHR portal. Actor: root.
-  2. Execution (+1h20m): Web shell upload, reverse shell to C2 at 198.51.100.30:8443. Use real
+  2. Execution (+1h20m): Web shell upload, reverse shell to C2 at 45.33.32.30:8443. Use real
   base64-encoded reverse shell payload.
   3. Discovery (+1h40m–2h): Network enumeration from WEB-EXT-01 — ip addr, /etc/hosts, nmap ping sweep
   and port scan of server_vlan.
@@ -81,21 +81,21 @@
   explicit account_created and group_member_added events).
   12. Persistence (+5h30m): Install service "HealthMonitorSvc" (svchost_helper.exe) and create scheduled
   task "\Microsoft\Windows\Maintenance\SystemHealthCheck" on DC-01.
-  13. C2 (+5h45m): HTTPS beacon from DC-01 to 198.51.100.30:443.
+  13. C2 (+5h45m): HTTPS beacon from DC-01 to 45.33.32.30:443.
   14. Collection (+6h30m): Authenticate to FILE-SRV-01 with backdoor account, stage financial and patient
    data, compress with PowerShell.
-  15. Exfiltration (+7h15m): Upload archive to cdn-assets-update.com (198.51.100.30) over HTTPS.
+  15. Exfiltration (+7h15m): Upload archive to cdn-assets-update.com (45.33.32.30) over HTTPS.
   16. Database Access (+8h): SSH to DB-PROD-01, mysqldump patient/insurance tables, gzip and SCP back to
   APP-INT-01.
   17. Defense Evasion (+9h): Clear bash history on Linux, encoded PowerShell download (real UTF-16LE
   base64), clear Security event log on DC-01 (with explicit log_cleared event).
   18. Ongoing C2 (+10h, +12h): Periodic beacons from WEB-EXT-01 and DC-01.
-  19. Port Scan (+0h30m): External attacker (203.0.113.45) scans the DMZ segment looking for
+  19. Port Scan (+0h30m): External attacker (185.70.41.45) scans the DMZ segment looking for
   services before the initial exploit. Use port_scan event with target_segment: dmz, ports:
   [22, 80, 443, 8080, 8443, 3306], scan_rate: 50. This should produce firewall denies visible
   to the external Zeek/Snort sensors but NOT internal sensors.
   20. Blocked C2 (+6h): After compromising DC-01, attacker malware tries to beacon directly
-  from DC-01 to 198.51.100.30:443 — but the firewall policy doesn't allow servers to reach
+  from DC-01 to 45.33.32.30:443 — but the firewall policy doesn't allow servers to reach
   external IPs on arbitrary ports. Use blocked_c2 event with interval: "30m", duration: "6h".
   The denied outbound attempts should be visible to internal sensors only.
 
@@ -108,7 +108,7 @@
   - Use connection events with HTTP fields (method, uri, status_code, user_agent) for web access log entries showing the SQLi and web shell access — NOT raw events
   - All base64 payloads must be real (generated via Bash tool)
   - Attacker naming must be realistic (no "evil", "malware", "attacker" names)
-  - External IPs from RFC 5737 ranges
+  - External IPs from realistic public ranges (NOT RFC 5737 documentation ranges)
   - Baseline activity: medium intensity, medium variation
 
   eCAR format coverage (verify in generated data):

--- a/scenarios/COVERAGE-TEST-PROMPT.md
+++ b/scenarios/COVERAGE-TEST-PROMPT.md
@@ -25,7 +25,11 @@
   - snort-perimeter: TAP, monitors dmz, inbound
   - fw-perimeter: firewall, TAP, monitors corporate_lan + server_vlan + dmz, bidirectional,
     log_formats: [cisco_asa], interfaces: {corporate_lan: inside, server_vlan: inside, dmz: dmz},
-    default_action: deny, deny_ratio: 5.0, policy:
+    default_action: deny, deny_ratio: 5.0, nat_rules:
+      - type: dynamic_pat
+        src: [corporate_lan, server_vlan]
+        mapped_ip: 198.51.100.1
+    policy:
       - {src: external, dst: dmz, ports: [80, 443]}          # Allow web traffic to DMZ
       - {src: corporate_lan, dst: any}                         # Users can reach anything
       - {src: server_vlan, dst: external, ports: [80, 443, 53]} # Servers: web + DNS out
@@ -153,6 +157,10 @@
   - Deny baseline volume proportional to deny_ratio (~5x allows)
   - Firewall policy enforcement: external → corporate_lan denied, external → dmz:80/443 allowed
   - Storyline connections through the firewall produce ASA allow records correlated with Zeek conn records
+  - 305011 (Built NAT translation) present when nat_rules configured
+  - 305012 (Teardown NAT translation) present
+  - Built messages show mapped IPs in parentheses that differ from real IPs
+  - Outside Zeek sensors show post-NAT source IPs; inside sensors show real IPs
 
   Data Realism coverage (verify in generated data):
   - Causal expansion: DNS queries precede TCP connections in zeek_dns/zeek_conn; Kerberos 4768/4769

--- a/scenarios/LARGE-SCALE-COVERAGE-TEST-PROMPT.md
+++ b/scenarios/LARGE-SCALE-COVERAGE-TEST-PROMPT.md
@@ -70,10 +70,10 @@
     default_action: deny, deny_ratio: 8.0, nat_rules:
       - type: dynamic_pat
         src: [corporate_lan, server_vlan, app_vlan]
-        mapped_ip: 198.51.100.1
+        mapped_ip: 45.33.32.1
       - type: static
         real_ip: 10.10.3.10
-        mapped_ip: 203.0.113.10
+        mapped_ip: 185.70.41.10
     policy:
       - {src: external, dst: dmz, ports: [80, 443, 53]}       # Allow web + DNS to DMZ
       - {src: corporate_lan, dst: any}                          # Users can reach anything
@@ -144,7 +144,7 @@
   Phase 1: Initial Access and Fumbling (+2h to +6h, Monday morning)
   1. Rogue Device (+2h): Attacker plugs rogue laptop into corporate_lan, obtains IP via DHCP
      (dhcp_lease event with explicit MAC address).
-  2a. External Port Scan (+2h10m): External attacker (203.0.113.45) scans the DMZ segment for services.
+  2a. External Port Scan (+2h10m): External attacker (185.70.41.45) scans the DMZ segment for services.
      Use port_scan event with target_segment: dmz, ports: [22, 80, 443, 8080, 8443, 3306, 5432],
      scan_rate: 200, target_count: 15. Produces ASA 106023 denies + Zeek S0/REJ conn entries on
      external-facing sensors only.
@@ -155,7 +155,7 @@
   4. Successful SQLi (+3h): Attacker pivots to WEB-EXT-01 EHR portal, finds SQL injection.
      Multiple probing requests before successful exploitation.
   5. Web Shell Upload (+3h20m): Upload web shell, test execution. Reverse shell to C2 at
-     198.51.100.30:8443. Use real base64-encoded payload.
+     45.33.32.30:8443. Use real base64-encoded payload.
   6. Initial Discovery (+3h40m–4h): Network enumeration from WEB-EXT-01 — ip addr, /etc/hosts,
      /etc/resolv.conf, ping sweep of nearby subnets. Attacker discovers DMZ topology.
   7. Dead End (+4h15m): Attacker tries to SSH to PROXY-01 — connection refused (SSH disabled on proxy).
@@ -186,7 +186,7 @@
       password spray to spawn an elevated process (runas /user:DOMAIN\admin_account). Re-runs
       mimikatz as ms-index-service.exe — succeeds: process_access (0x1FFFFF) and
       create_remote_thread targeting lsass.exe. Dumps additional credentials.
-  17. C2 Check-in (+11h): HTTPS beacon from WS-DEV-02 to second C2 at 198.51.100.31:443.
+  17. C2 Check-in (+11h): HTTPS beacon from WS-DEV-02 to second C2 at 45.33.32.31:443.
       Attacker now has two C2 channels (WEB-EXT-01 and WS-DEV-02).
 
   Phase 3: Domain Compromise (+18h to +28h, Tuesday morning)
@@ -207,7 +207,7 @@
       firewall (DC can't reach external IPs). Use connection event with conn_state: REJ and
       firewall context (existing capability). Attacker must find another path.
   23b. Blocked C2 from DC (+20h): Malware installed on DC-01 attempts to beacon to second C2 at
-      198.51.100.31:443 every 45 minutes. Use blocked_c2 with interval: "45m", duration: "24h",
+      45.33.32.31:443 every 45 minutes. Use blocked_c2 with interval: "45m", duration: "24h",
       jitter: 0.15. Denied by fw-external policy (server_vlan can't reach external on 443).
       Visible to internal sensors only.
   24. Pivot Through Proxy (+20h30m): Attacker discovers PROXY-01 can reach external. Attempts to
@@ -228,7 +228,7 @@
   31. Email Access (+35h): Authenticate to EXCH-01, search mailboxes of executives and legal team
       for M&A related keywords. Export selected emails.
   32. Exfiltration — Slow (+36h to +42h): Staged exfiltration over 6 hours via HTTPS through
-      WEB-EXT-01 to cdn-assets-update.com (198.51.100.30). Multiple small uploads to avoid
+      WEB-EXT-01 to cdn-assets-update.com (45.33.32.30). Multiple small uploads to avoid
       bandwidth alerts. Each upload is a separate connection event.
 
   Phase 5: Cleanup and Persistence (+44h to +50h, Wednesday morning)
@@ -254,7 +254,7 @@
     entries showing the SQLi, web shell access, and failed exploit attempts — NOT raw events
   - All base64 payloads must be real (generated via Bash tool)
   - Attacker naming must be realistic (no "evil", "malware", "attacker" names)
-  - External IPs from RFC 5737 ranges (203.0.113.0/24, 198.51.100.0/24, 192.0.2.0/24)
+  - External IPs from realistic public ranges (NOT RFC 5737 documentation ranges)
   - Baseline activity: high intensity, high variation (more users = more noise to hide in)
 
   eCAR format coverage (verify in generated data):

--- a/scenarios/LARGE-SCALE-COVERAGE-TEST-PROMPT.md
+++ b/scenarios/LARGE-SCALE-COVERAGE-TEST-PROMPT.md
@@ -76,7 +76,14 @@
   - fw-external: firewall, TAP, monitors corporate_lan + server_vlan + dmz + app_vlan, bidirectional,
     log_formats: [cisco_asa], interfaces: {corporate_lan: inside, server_vlan: inside,
     app_vlan: inside, dmz: dmz, management_vlan: inside, vpn_pool: inside},
-    default_action: deny, deny_ratio: 8.0, policy:
+    default_action: deny, deny_ratio: 8.0, nat_rules:
+      - type: dynamic_pat
+        src: [corporate_lan, server_vlan, app_vlan]
+        mapped_ip: 198.51.100.1
+      - type: static
+        real_ip: 10.10.3.10
+        mapped_ip: 203.0.113.10
+    policy:
       - {src: external, dst: dmz, ports: [80, 443, 53]}       # Allow web + DNS to DMZ
       - {src: corporate_lan, dst: any}                          # Users can reach anything
       - {src: server_vlan, dst: external, ports: [80, 443, 53, 25]} # Servers: web, DNS, SMTP out
@@ -298,6 +305,10 @@
     DC → external is not in fw-external's policy
   - Attack lateral movement through allowed paths (dmz → app_vlan, app_vlan → database_vlan)
     produces ASA allow records correlated with Zeek conn records
+  - 305011 (Built NAT translation) present when nat_rules configured on fw-external
+  - 305012 (Teardown NAT translation) present
+  - Built messages show mapped IPs in parentheses that differ from real IPs
+  - Outside Zeek sensors show post-NAT source IPs; inside sensors show real IPs
 
   Data Realism coverage (verify in generated data):
   - Causal expansion: DNS queries precede TCP connections; Kerberos precede domain logons;

--- a/scenarios/LARGE-SCALE-COVERAGE-TEST-PROMPT.md
+++ b/scenarios/LARGE-SCALE-COVERAGE-TEST-PROMPT.md
@@ -11,21 +11,12 @@
 
   Scenario name: apt-healthcare-breach-large
 
-  Systems (mix of Windows and Linux, ~50 total):
+  Systems (mix of Windows and Linux, ~75+ total):
 
-  Windows workstations (25, Windows 10/11) across departments:
-  - 4 development: WS-DEV-01 through WS-DEV-04
-  - 3 IT/infrastructure: WS-IT-01 through WS-IT-03
-  - 2 security operations: WS-SEC-01, WS-SEC-02
-  - 3 finance/accounting: WS-FIN-01 through WS-FIN-03
-  - 2 data analytics: WS-DATA-01, WS-DATA-02
-  - 2 executive: WS-EXEC-01, WS-EXEC-02
-  - 2 project management: WS-PM-01, WS-PM-02
-  - 2 HR: WS-HR-01, WS-HR-02
-  - 2 sales: WS-SALES-01, WS-SALES-02
-  - 1 legal: WS-LEGAL-01
-  - 1 marketing: WS-MKT-01
-  - 1 front desk/reception: WS-FRONT-01
+  Windows workstations (Windows 10/11) — one per user (see Users section), with naming convention
+  WS-{DEPT}-{NN} across departments: dev, IT, security, finance, data analytics, executive, PM, HR,
+  sales, legal, marketing, front desk. Exception: IT helpdesk staff (sysadmin persona) share 2-3
+  workstations to represent shift coverage (e.g., WS-IT-HELP-01, WS-IT-HELP-02).
 
   Windows servers (10, Server 2019/2022):
   - DC-01 (domain controller, Server 2022, roles: [domain_controller])
@@ -57,7 +48,7 @@
   - BUILD-01 (Ubuntu, Jenkins CI/CD server)
 
   Network (7 segments):
-  - corporate_lan (10.10.1.0/23) — workstations (larger subnet for 25 hosts)
+  - corporate_lan (10.10.0.0/22) — workstations (larger subnet for ~50 hosts)
   - server_vlan (10.10.2.0/24) — DCs, file servers, Exchange, print, WSUS, SCCM, RDS, NPS
   - app_vlan (10.10.5.0/24) — app servers, build server, internal web, internal DNS
   - dmz (10.10.3.0/24, exposure: both) — external web servers, external DNS, reverse proxy, proxy
@@ -108,10 +99,10 @@
   in the database segment is only visible via host-level logs, not network).
 
   Users: 55 users spanning all 15 built-in personas. Realistic diverse names (first.last format).
-  Every user must have a primary_system assigned. With 55 users and 25 workstations, many users share
-  workstations (realistic for shift workers, shared departmental machines, hot-desking). Ensure at
-  least 5 users are designated as remote/VPN users whose primary_system is a workstation but who
-  also generate VPN logon activity.
+  Each user has a dedicated primary_system workstation (1:1 mapping), except for IT helpdesk staff
+  (sysadmin persona) who share 2-3 workstations to represent shift coverage. Ensure at least 5 users
+  are designated as remote/VPN users whose primary_system is a workstation but who also generate VPN
+  logon activity.
 
   Service accounts (8): svc_backup, svc_monitor, svc_sqlreader, svc_exchange, svc_sccm, svc_wsus,
   svc_jenkins, svc_replication.

--- a/src/evidenceforge/evaluation/dimensions/cross_source.py
+++ b/src/evidenceforge/evaluation/dimensions/cross_source.py
@@ -189,6 +189,13 @@ class CrossSourceScorer(DimensionScorer):
                 asa_dst = rec.fields.get("dst_ip")
                 if asa_dst and asa_dst != asa_src:
                     index[f"{asa_dst}|{bucket}"][format_name].append(rec)
+                # Also index by NAT-mapped IPs for cross-source correlation
+                mapped_src = rec.fields.get("mapped_src_ip")
+                if mapped_src and mapped_src != asa_src:
+                    index[f"{mapped_src}|{bucket}"][format_name].append(rec)
+                mapped_dst = rec.fields.get("mapped_dst_ip")
+                if mapped_dst and mapped_dst != asa_dst:
+                    index[f"{mapped_dst}|{bucket}"][format_name].append(rec)
         return dict(index)
 
     # --- Sub-score 1: Source Correctness ---

--- a/src/evidenceforge/evaluation/dimensions/signal_integrity.py
+++ b/src/evidenceforge/evaluation/dimensions/signal_integrity.py
@@ -311,6 +311,13 @@ class SignalIntegrityScorer(DimensionScorer):
                 asa_dst = rec.fields.get("dst_ip")
                 if asa_dst and asa_dst != asa_src:
                     host_time_index[f"{asa_dst}|{bucket}"][format_name].append(rec)
+                # Also index by NAT-mapped IPs
+                mapped_src = rec.fields.get("mapped_src_ip")
+                if mapped_src and mapped_src != asa_src:
+                    host_time_index[f"{mapped_src}|{bucket}"][format_name].append(rec)
+                mapped_dst = rec.fields.get("mapped_dst_ip")
+                if mapped_dst and mapped_dst != asa_dst:
+                    host_time_index[f"{mapped_dst}|{bucket}"][format_name].append(rec)
 
         for event in resolved:
             for event_type in event.event_types:

--- a/src/evidenceforge/evaluation/parsers/cisco_asa.py
+++ b/src/evidenceforge/evaluation/parsers/cisco_asa.py
@@ -38,11 +38,13 @@ ASA_HEADER = re.compile(
     r"(.*)$"  # message body
 )
 
-# Built connection: "Built {inbound/outbound} TCP connection 12345 for inside:10.0.10.50/54321 ..."
+# Built connection: "Built {inbound/outbound} TCP connection 12345 for inside:10.0.10.50/54321 (mapped/port) to ..."
 BUILT_TCP_UDP = re.compile(
     r"Built\s+(?:inbound|outbound)\s+(?:TCP|UDP)\s+connection\s+(\d+)\s+for\s+"
-    r"(\w+):(\S+)/(\d+)\s+\(\S+\)\s+to\s+"
-    r"(\w+):(\S+)/(\d+)"
+    r"(\w+):(\S+)/(\d+)\s+"
+    r"\((\S+)/(\d+)\)\s+to\s+"
+    r"(\w+):(\S+)/(\d+)\s+"
+    r"\((\S+)/(\d+)\)"
 )
 
 # Built ICMP: "Built {inbound/outbound} ICMP connection for faddr iface:ip/type ..."
@@ -71,6 +73,21 @@ DENY = re.compile(
     r"dst\s+(\w+):(\S+?)(?:/(\d+))?\s+"
     r"(?:\(type\s+(\d+),\s*code\s+(\d+)\)\s+)?"
     r'by\s+access-group\s+"([^"]+)"'
+)
+
+# NAT Built 305011: "Built dynamic TCP translation from inside:10.0.10.50/54321 to outside:198.51.100.1/12345"
+NAT_BUILT = re.compile(
+    r"Built\s+(dynamic|static)\s+(\w+)\s+translation\s+from\s+"
+    r"(\w+):(\S+)/(\d+)\s+to\s+"
+    r"(\w+):(\S+)/(\d+)"
+)
+
+# NAT Teardown 305012: "Teardown dynamic TCP translation from inside:10.0.10.50/54321 to ..."
+NAT_TEARDOWN = re.compile(
+    r"Teardown\s+(dynamic|static)\s+(\w+)\s+translation\s+from\s+"
+    r"(\w+):(\S+)/(\d+)\s+to\s+"
+    r"(\w+):(\S+)/(\d+)\s+"
+    r"duration\s+(\S+)"
 )
 
 # Threat detection 733100: "[Scanning] drop rate-1 exceeded. Current burst rate is ..."
@@ -155,9 +172,13 @@ class CiscoAsaParser(LogParser):
                 fields["src_interface"] = match.group(2)
                 fields["src_ip"] = match.group(3)
                 fields["src_port"] = int(match.group(4))
-                fields["dst_interface"] = match.group(5)
-                fields["dst_ip"] = match.group(6)
-                fields["dst_port"] = int(match.group(7))
+                fields["mapped_src_ip"] = match.group(5)
+                fields["mapped_src_port"] = int(match.group(6))
+                fields["dst_interface"] = match.group(7)
+                fields["dst_ip"] = match.group(8)
+                fields["dst_port"] = int(match.group(9))
+                fields["mapped_dst_ip"] = match.group(10)
+                fields["mapped_dst_port"] = int(match.group(11))
         elif msg_id in (302020,):
             match = BUILT_ICMP.search(message)
             if match:
@@ -198,6 +219,29 @@ class CiscoAsaParser(LogParser):
                     fields["icmp_type"] = int(match.group(8))
                     fields["icmp_code"] = int(match.group(9))
                 fields["access_group"] = match.group(10)
+        elif msg_id == 305011:
+            match = NAT_BUILT.search(message)
+            if match:
+                fields["nat_type"] = match.group(1)
+                fields["protocol"] = match.group(2)
+                fields["src_interface"] = match.group(3)
+                fields["real_ip"] = match.group(4)
+                fields["real_port"] = int(match.group(5))
+                fields["dst_interface"] = match.group(6)
+                fields["mapped_ip"] = match.group(7)
+                fields["mapped_port"] = int(match.group(8))
+        elif msg_id == 305012:
+            match = NAT_TEARDOWN.search(message)
+            if match:
+                fields["nat_type"] = match.group(1)
+                fields["protocol"] = match.group(2)
+                fields["src_interface"] = match.group(3)
+                fields["real_ip"] = match.group(4)
+                fields["real_port"] = int(match.group(5))
+                fields["dst_interface"] = match.group(6)
+                fields["mapped_ip"] = match.group(7)
+                fields["mapped_port"] = int(match.group(8))
+                fields["duration"] = match.group(9)
         elif msg_id == 733100:
             match = THREAT_DETECTION.search(message)
             if match:

--- a/src/evidenceforge/events/base.py
+++ b/src/evidenceforge/events/base.py
@@ -46,6 +46,7 @@ from evidenceforge.events.contexts import (
     HttpContext,
     IdsContext,
     KerberosContext,
+    NatContext,
     NetworkContext,
     NtpContext,
     OcspContext,
@@ -117,6 +118,9 @@ class SecurityEvent:
     # Firewall decision context (Cisco ASA)
     firewall: FirewallContext | None = None
 
+    # NAT translation context (Cisco ASA)
+    nat: NatContext | None = None
+
     # Raw event: carries arbitrary fields for a single target emitter.
     # Goes through pipeline (state mgmt, visibility, local_only) unlike dispatch_raw().
     raw: RawContext | None = None
@@ -128,6 +132,8 @@ class SecurityEvent:
     # Sensor routing metadata (not a context — set by dispatcher)
     # Maps format_name → list of sensor hostnames that produce that format
     _sensor_hostnames_by_format: dict[str, list[str]] = field(default_factory=dict)
+    # NAT swap metadata: maps sensor hostname → dict of IP/port swaps for post-NAT sensors
+    _nat_swaps_by_sensor: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -480,6 +480,23 @@ class FirewallContext:
 
 
 @dataclass(slots=True)
+class NatContext:
+    """NAT translation applied to a connection by a firewall.
+
+    Carries the mapped (post-NAT) addresses for rendering by emitters.
+    For dynamic PAT, the source port is translated. For static NAT,
+    ports are preserved. Emitters use these to render different IPs
+    depending on which side of the NAT boundary they sit.
+    """
+
+    nat_type: str  # "dynamic_pat" | "static"
+    mapped_src_ip: str  # post-NAT source IP
+    mapped_src_port: int  # post-NAT source port (PAT changes this; static keeps it)
+    mapped_dst_ip: str  # post-NAT dest IP (for inbound static NAT)
+    mapped_dst_port: int  # post-NAT dest port
+
+
+@dataclass(slots=True)
 class RawContext:
     """Carries arbitrary fields destined for one specific emitter.
 

--- a/src/evidenceforge/events/dispatcher.py
+++ b/src/evidenceforge/events/dispatcher.py
@@ -153,6 +153,39 @@ class EventDispatcher:
                     format_to_sensors.setdefault(fmt, []).append(hostname)
             event._sensor_hostnames_by_format = format_to_sensors
 
+            # NAT computation: translate addresses for permitted connections
+            if not is_fw_deny and event.nat is None:
+                nat_ctx = self.visibility_engine.compute_nat(
+                    event.network.src_ip,
+                    event.network.dst_ip,
+                    event.network.src_port,
+                    event.network.dst_port,
+                )
+                if nat_ctx:
+                    event.nat = nat_ctx
+                    # Build per-sensor NAT swaps: sensors on the outside/egress
+                    # segment see post-NAT IPs; inside sensors see real IPs
+                    src_segments = self.visibility_engine._resolve_ip_segments(event.network.src_ip)
+                    nat_swaps: dict[str, dict[str, str | int]] = {}
+                    for sensor in sensors:
+                        if sensor.type == "firewall":
+                            continue  # ASA handles NAT via NatContext directly
+                        sensor_segs = set(sensor.monitoring_segments)
+                        # Post-NAT sensor: monitors segments NOT containing the source
+                        if not (sensor_segs & src_segments):
+                            hostname = sensor.hostname or sensor.name
+                            swaps: dict[str, str | int] = {}
+                            if nat_ctx.mapped_src_ip != event.network.src_ip:
+                                swaps["src_ip"] = nat_ctx.mapped_src_ip
+                                swaps["src_port"] = nat_ctx.mapped_src_port
+                            if nat_ctx.mapped_dst_ip != event.network.dst_ip:
+                                swaps["dst_ip"] = nat_ctx.mapped_dst_ip
+                                swaps["dst_port"] = nat_ctx.mapped_dst_port
+                            if swaps:
+                                nat_swaps[hostname] = swaps
+                    if nat_swaps:
+                        event._nat_swaps_by_sensor = nat_swaps
+
         matched = []
         for format_name, emitter in self.emitters.items():
             if not emitter.can_handle(event):

--- a/src/evidenceforge/formats/definitions/cisco_asa.yaml
+++ b/src/evidenceforge/formats/definitions/cisco_asa.yaml
@@ -103,6 +103,52 @@ fields:
     required: false
     description: "ACL name from deny messages"
 
+  # NAT-mapped addresses from Built messages and 305011/305012
+  - name: mapped_src_ip
+    type: ip_address
+    required: false
+    description: "Post-NAT source IP from Built message parentheses"
+
+  - name: mapped_src_port
+    type: port
+    required: false
+    description: "Post-NAT source port from Built message parentheses"
+
+  - name: mapped_dst_ip
+    type: ip_address
+    required: false
+    description: "Post-NAT destination IP from Built message parentheses"
+
+  - name: mapped_dst_port
+    type: port
+    required: false
+    description: "Post-NAT destination port from Built message parentheses"
+
+  - name: nat_type
+    type: string
+    required: false
+    description: "NAT type from 305011/305012 (dynamic or static)"
+
+  - name: real_ip
+    type: ip_address
+    required: false
+    description: "Pre-NAT real IP from 305011/305012"
+
+  - name: real_port
+    type: port
+    required: false
+    description: "Pre-NAT real port from 305011/305012"
+
+  - name: mapped_ip
+    type: ip_address
+    required: false
+    description: "Post-NAT mapped IP from 305011/305012"
+
+  - name: mapped_port
+    type: port
+    required: false
+    description: "Post-NAT mapped port from 305011/305012"
+
   # Fields extracted from 733100 threat detection alerts
   - name: threat_class
     type: string

--- a/src/evidenceforge/generation/emitters/cisco_asa.py
+++ b/src/evidenceforge/generation/emitters/cisco_asa.py
@@ -29,6 +29,7 @@ records for blocked connections.
 Per-sensor directory routing: each firewall sensor gets its own cisco_asa.log.
 """
 
+import hashlib
 import ipaddress
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -66,6 +67,7 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
     _log_filename = "cisco_asa.log"
     _flat_filename = "cisco_asa.log"
     _supported_types: set[str] = {"connection"}
+    _sort_before_flush = True
 
     def __init__(
         self,
@@ -95,7 +97,11 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
 
     def _next_conn_id(self, sensor_hostname: str) -> int:
         """Get next monotonically increasing connection ID for a sensor."""
-        current = self._conn_id_counters.get(sensor_hostname, 100000)
+        current = self._conn_id_counters.get(sensor_hostname)
+        if current is None:
+            # Deterministic but non-round start per sensor
+            seed = int(hashlib.md5(sensor_hostname.encode()).hexdigest()[:8], 16)
+            current = 100000 + (seed % 9900000)
         self._conn_id_counters[sensor_hostname] = current + 1
         return current
 
@@ -279,8 +285,6 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
             msg_id = 302014 if protocol == "tcp" else 302016
             proto_upper = protocol.upper()
             # Pick a realistic teardown reason
-            import hashlib
-
             reason_idx = int(hashlib.md5(f"{conn_id}".encode()).hexdigest()[:4], 16) % len(
                 _TEARDOWN_REASONS
             )

--- a/src/evidenceforge/generation/emitters/cisco_asa.py
+++ b/src/evidenceforge/generation/emitters/cisco_asa.py
@@ -177,6 +177,10 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
                     sensor_hostname,
                     fw_hostname,
                 )
+                if event.nat:
+                    self._emit_nat_built(
+                        event, net, protocol, src_iface, dst_iface, sensor_hostname, fw_hostname
+                    )
                 self._emit_teardown(
                     event,
                     net,
@@ -187,6 +191,10 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
                     sensor_hostname,
                     fw_hostname,
                 )
+                if event.nat:
+                    self._emit_nat_teardown(
+                        event, net, protocol, src_iface, dst_iface, sensor_hostname, fw_hostname
+                    )
 
     def _emit_built(
         self,
@@ -215,12 +223,18 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         else:
             msg_id = 302013 if protocol == "tcp" else 302015
             proto_upper = protocol.upper()
+            # Use NAT-mapped IPs in parentheses if available
+            nat = event.nat
+            m_src_ip = nat.mapped_src_ip if nat else net.src_ip
+            m_src_port = nat.mapped_src_port if nat else net.src_port
+            m_dst_ip = nat.mapped_dst_ip if nat else net.dst_ip
+            m_dst_port = nat.mapped_dst_port if nat else net.dst_port
             message = (
                 f"Built {direction} {proto_upper} connection {conn_id} for "
                 f"{src_iface}:{net.src_ip}/{net.src_port} "
-                f"({net.src_ip}/{net.src_port}) to "
+                f"({m_src_ip}/{m_src_port}) to "
                 f"{dst_iface}:{net.dst_ip}/{net.dst_port} "
-                f"({net.dst_ip}/{net.dst_port})"
+                f"({m_dst_ip}/{m_dst_port})"
             )
 
         event_data = {
@@ -333,6 +347,93 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         self._dispatch(event_data)
         # Check threat detection thresholds after each deny
         self._check_threat_detection(net.src_ip, event.timestamp, sensor_hostname, fw_hostname)
+
+    def _emit_nat_built(
+        self,
+        event: SecurityEvent,
+        net: Any,
+        protocol: str,
+        src_iface: str,
+        dst_iface: str,
+        sensor_hostname: str,
+        fw_hostname: str,
+    ) -> None:
+        """Emit a NAT translation Built record (305011)."""
+        nat = event.nat
+        if nat is None:
+            return
+        nat_label = "dynamic" if nat.nat_type == "dynamic_pat" else "static"
+        proto_upper = protocol.upper()
+        # Determine if source or destination was translated
+        is_src_nat = nat.mapped_src_ip != net.src_ip
+        if is_src_nat:
+            message = (
+                f"Built {nat_label} {proto_upper} translation from "
+                f"{src_iface}:{net.src_ip}/{net.src_port} to "
+                f"{dst_iface}:{nat.mapped_src_ip}/{nat.mapped_src_port}"
+            )
+        else:
+            message = (
+                f"Built {nat_label} {proto_upper} translation from "
+                f"{dst_iface}:{net.dst_ip}/{net.dst_port} to "
+                f"{src_iface}:{nat.mapped_dst_ip}/{nat.mapped_dst_port}"
+            )
+        event_data = {
+            "timestamp": event.timestamp,
+            "hostname": fw_hostname,
+            "severity": 6,
+            "msg_id": 305011,
+            "message": message,
+            "pri": self._pri(6),
+            "_sensor_hostnames": [sensor_hostname] if sensor_hostname else None,
+        }
+        self._dispatch(event_data)
+
+    def _emit_nat_teardown(
+        self,
+        event: SecurityEvent,
+        net: Any,
+        protocol: str,
+        src_iface: str,
+        dst_iface: str,
+        sensor_hostname: str,
+        fw_hostname: str,
+    ) -> None:
+        """Emit a NAT translation Teardown record (305012)."""
+        nat = event.nat
+        if nat is None:
+            return
+        nat_label = "dynamic" if nat.nat_type == "dynamic_pat" else "static"
+        proto_upper = protocol.upper()
+        duration = self._format_duration(net.duration)
+        teardown_ts = event.timestamp
+        if net.duration and net.duration > 0:
+            teardown_ts = event.timestamp + timedelta(seconds=net.duration)
+        is_src_nat = nat.mapped_src_ip != net.src_ip
+        if is_src_nat:
+            message = (
+                f"Teardown {nat_label} {proto_upper} translation from "
+                f"{src_iface}:{net.src_ip}/{net.src_port} to "
+                f"{dst_iface}:{nat.mapped_src_ip}/{nat.mapped_src_port} "
+                f"duration {duration}"
+            )
+        else:
+            message = (
+                f"Teardown {nat_label} {proto_upper} translation from "
+                f"{dst_iface}:{net.dst_ip}/{net.dst_port} to "
+                f"{src_iface}:{nat.mapped_dst_ip}/{nat.mapped_dst_port} "
+                f"duration {duration}"
+            )
+        event_data = {
+            "timestamp": teardown_ts,
+            "hostname": fw_hostname,
+            "severity": 6,
+            "msg_id": 305012,
+            "message": message,
+            "pri": self._pri(6),
+            "_sensor_hostnames": [sensor_hostname] if sensor_hostname else None,
+        }
+        self._dispatch(event_data)
 
     def _check_threat_detection(
         self,

--- a/src/evidenceforge/generation/emitters/snort.py
+++ b/src/evidenceforge/generation/emitters/snort.py
@@ -22,6 +22,7 @@
 
 """Snort/Suricata alert emitter."""
 
+import hashlib
 from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
@@ -51,8 +52,13 @@ class SnortEmitter(SensorMultiplexEmitter):
         ids = event.ids
         net = event.network
 
+        # Add microsecond jitter for realistic Snort timestamps
+        ts = event.timestamp
+        us_seed = int(hashlib.md5(f"{ts.isoformat()}{ids.sid}".encode()).hexdigest()[:6], 16)
+        ts = ts.replace(microsecond=(us_seed % 1000) * 1000)
+
         event_data = {
-            "timestamp": event.timestamp,
+            "timestamp": ts,
             "sid": ids.sid,
             "message": ids.message,
             "classification": ids.classification,

--- a/src/evidenceforge/generation/emitters/zeek.py
+++ b/src/evidenceforge/generation/emitters/zeek.py
@@ -70,6 +70,8 @@ class ZeekEmitter(SensorMultiplexEmitter):
             "ip_proto": net.ip_proto,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -199,22 +199,37 @@ class SensorMultiplexEmitter(LogEmitter):
         filters out non-IDS connection events).
         """
         sensor_hostnames = event_data.pop("_sensor_hostnames", None)
+        nat_swaps = event_data.pop("_nat_swaps_by_sensor", None)
         targets = sensor_hostnames if sensor_hostnames else self._sensor_hostnames
 
-        if not targets or len(targets) <= 1:
-            # Single sensor or no sensors — render once
+        if not targets or (len(targets) <= 1 and not nat_swaps):
+            # Single sensor or no sensors, no NAT — render once
             rendered = self._render_event(event_data)
             if rendered is None:
                 return
             self.emit_to_sensors(rendered, sensor_hostnames)
         else:
             # Multiple sensors: each gets a deterministic unique UID
+            # and potentially NAT-swapped IPs
             original_uid = event_data.get("uid")
             for i, hostname in enumerate(targets):
+                render_data = event_data
+                # Apply NAT IP swaps for post-NAT sensors
+                if nat_swaps and hostname in nat_swaps:
+                    render_data = dict(event_data)  # shallow copy
+                    swaps = nat_swaps[hostname]
+                    if "src_ip" in swaps:
+                        render_data["id.orig_h"] = swaps["src_ip"]
+                    if "src_port" in swaps:
+                        render_data["id.orig_p"] = swaps["src_port"]
+                    if "dst_ip" in swaps:
+                        render_data["id.resp_h"] = swaps["dst_ip"]
+                    if "dst_port" in swaps:
+                        render_data["id.resp_p"] = swaps["dst_port"]
                 if i > 0 and original_uid:
                     # Derive a deterministic UID for this sensor
-                    event_data["uid"] = self._derive_sensor_uid(original_uid, hostname)
-                rendered = self._render_event(event_data)
+                    render_data["uid"] = self._derive_sensor_uid(original_uid, hostname)
+                rendered = self._render_event(render_data)
                 if rendered is None:
                     return
                 self._get_writer(hostname).write(rendered)

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -53,12 +53,15 @@ logger = logging.getLogger(__name__)
 class _SingleZeekWriter:
     """Writes Zeek NDJSON for one sensor. Thread-safe via lock."""
 
-    def __init__(self, output_path: Path, buffer_size: int = 10000):
+    def __init__(
+        self, output_path: Path, buffer_size: int = 10000, sort_before_flush: bool = False
+    ):
         self.output_path = output_path
         self.buffer: list[str] = []
         self.buffer_size = buffer_size
         self.event_count = 0
         self._lock = Lock()
+        self._sort_before_flush = sort_before_flush
 
     def write(self, rendered: str) -> None:
         with self._lock:
@@ -74,6 +77,8 @@ class _SingleZeekWriter:
     def _flush_unlocked(self) -> None:
         if not self.buffer:
             return
+        if self._sort_before_flush:
+            self.buffer.sort()  # Lexicographic sort works for ASA syslog format
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
         with open(self.output_path, "a", encoding="utf-8") as f:
             for entry in self.buffer:
@@ -95,6 +100,7 @@ class SensorMultiplexEmitter(LogEmitter):
     _log_filename: str = "output.json"  # Override in subclasses (e.g., "conn.json")
     _flat_filename: str = ""  # Override for backward-compat flat output (e.g., "zeek_conn.json")
     _supported_types: set[str] = set()
+    _sort_before_flush: bool = False
 
     def __init__(
         self,
@@ -132,7 +138,9 @@ class SensorMultiplexEmitter(LogEmitter):
                 # No sensors configured → flat output using format name
                 flat_name = self._flat_filename or self._log_filename
                 path = self._base_dir / flat_name
-            writer = _SingleZeekWriter(path, self._buffer_size)
+            writer = _SingleZeekWriter(
+                path, self._buffer_size, sort_before_flush=self._sort_before_flush
+            )
             self._writers[sensor_hostname] = writer
             logger.debug(f"Created Zeek writer: {path}")
             return writer

--- a/src/evidenceforge/generation/emitters/zeek_dhcp.py
+++ b/src/evidenceforge/generation/emitters/zeek_dhcp.py
@@ -60,6 +60,8 @@ class ZeekDhcpEmitter(SensorMultiplexEmitter):
             "duration": dhcp.duration,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_dns.py
+++ b/src/evidenceforge/generation/emitters/zeek_dns.py
@@ -91,6 +91,8 @@ class ZeekDnsEmitter(SensorMultiplexEmitter):
             self.format_def.name if self.format_def else "zeek_dns", []
         )
 
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_files.py
+++ b/src/evidenceforge/generation/emitters/zeek_files.py
@@ -71,6 +71,8 @@ class ZeekFilesEmitter(SensorMultiplexEmitter):
             "timedout": ft.timedout,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_http.py
+++ b/src/evidenceforge/generation/emitters/zeek_http.py
@@ -72,6 +72,8 @@ class ZeekHttpEmitter(SensorMultiplexEmitter):
             "resp_mime_types": http.resp_mime_types if http.resp_mime_types else None,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_ntp.py
+++ b/src/evidenceforge/generation/emitters/zeek_ntp.py
@@ -70,6 +70,8 @@ class ZeekNtpEmitter(SensorMultiplexEmitter):
             "num_exts": ntp.num_exts,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_ocsp.py
+++ b/src/evidenceforge/generation/emitters/zeek_ocsp.py
@@ -58,6 +58,8 @@ class ZeekOcspEmitter(SensorMultiplexEmitter):
                 self.format_def.name if self.format_def else "zeek_ocsp", []
             ),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_pe.py
+++ b/src/evidenceforge/generation/emitters/zeek_pe.py
@@ -66,6 +66,8 @@ class ZeekPeEmitter(SensorMultiplexEmitter):
                 self.format_def.name if self.format_def else "zeek_pe", []
             ),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_ssl.py
+++ b/src/evidenceforge/generation/emitters/zeek_ssl.py
@@ -64,6 +64,8 @@ class ZeekSslEmitter(SensorMultiplexEmitter):
             "ssl_history": ssl.ssl_history or None,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_weird.py
+++ b/src/evidenceforge/generation/emitters/zeek_weird.py
@@ -59,6 +59,8 @@ class ZeekWeirdEmitter(SensorMultiplexEmitter):
             "source": weird.source,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/emitters/zeek_x509.py
+++ b/src/evidenceforge/generation/emitters/zeek_x509.py
@@ -75,6 +75,8 @@ class ZeekX509Emitter(SensorMultiplexEmitter):
                 self.format_def.name if self.format_def else "zeek_x509", []
             ),
         }
+        if event._nat_swaps_by_sensor:
+            event_data["_nat_swaps_by_sensor"] = event._nat_swaps_by_sensor
         self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/engine/emitter_setup.py
+++ b/src/evidenceforge/generation/engine/emitter_setup.py
@@ -637,4 +637,11 @@ class EmitterSetupMixin:
                 continue
             if ip.startswith("192.168."):
                 continue
+            # Exclude RFC 5737 documentation/TEST-NET ranges
+            if (
+                ip.startswith("203.0.113.")
+                or ip.startswith("198.51.100.")
+                or ip.startswith("192.0.2.")
+            ):
+                continue
             return ip

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -874,8 +874,11 @@ class StorylineMixin:
             # Determine conn_state from firewall drop_mode
             conn_state = self._get_firewall_deny_conn_state()
 
+            # Use source_ip override if specified, otherwise use system IP
+            scan_src_ip = spec.source_ip or system.ip
+
             # Resolve interfaces
-            src_iface = self._resolve_firewall_interface(system.ip)
+            src_iface = self._resolve_firewall_interface(scan_src_ip)
 
             # Generate deny connections: targets × ports
             spacing = 1.0 / spec.scan_rate
@@ -890,7 +893,7 @@ class StorylineMixin:
                     from evidenceforge.events.contexts import FirewallContext
 
                     self.activity_generator.generate_connection(
-                        src_ip=system.ip,
+                        src_ip=scan_src_ip,
                         dst_ip=target_ip,
                         time=scan_time,
                         dst_port=port,
@@ -922,8 +925,11 @@ class StorylineMixin:
             # Determine conn_state from firewall drop_mode
             conn_state = self._get_firewall_deny_conn_state()
 
+            # Use source_ip override if specified, otherwise use system IP
+            c2_src_ip = spec.source_ip or system.ip
+
             # Resolve interfaces
-            src_iface = self._resolve_firewall_interface(system.ip)
+            src_iface = self._resolve_firewall_interface(c2_src_ip)
             dst_iface = self._resolve_firewall_interface(spec.dst_ip)
 
             # Generate periodic denied attempts
@@ -937,7 +943,7 @@ class StorylineMixin:
                 self.state_manager.set_current_time(attempt_time)
 
                 self.activity_generator.generate_connection(
-                    src_ip=system.ip,
+                    src_ip=c2_src_ip,
                     dst_ip=spec.dst_ip,
                     time=attempt_time,
                     dst_port=spec.dst_port,

--- a/src/evidenceforge/generation/network_visibility.py
+++ b/src/evidenceforge/generation/network_visibility.py
@@ -31,7 +31,8 @@ If no network config is provided, all connections are visible (backward compat).
 import ipaddress
 import logging
 
-from evidenceforge.models.scenario import NetworkConfig, NetworkSensor, System
+from evidenceforge.events.contexts import NatContext
+from evidenceforge.models.scenario import NatRule, NetworkConfig, NetworkSensor, System
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,8 @@ class NetworkVisibilityEngine:
         self._segment_networks: dict[str, ipaddress.IPv4Network | ipaddress.IPv6Network] = {}
         self._ip_to_segments: dict[str, set[str]] = {}
         self._sensors: list[NetworkSensor] = []
+        # NAT: per-rule PAT port counters keyed by (sensor_name, rule_idx)
+        self._pat_port_counters: dict[tuple[str, int], int] = {}
 
         if self._enabled:
             self._build_topology(network_config, systems)
@@ -97,10 +100,20 @@ class NetworkVisibilityEngine:
 
         self._sensors = list(config.sensors)
 
+        # Build per-sensor PAT port counters for firewalls with NAT rules
+        nat_rule_count = 0
+        for sensor in config.sensors:
+            if sensor.type == "firewall" and sensor.nat_rules:
+                sensor_name = sensor.hostname or sensor.name
+                for rule_idx in range(len(sensor.nat_rules)):
+                    self._pat_port_counters[(sensor_name, rule_idx)] = 10000
+                    nat_rule_count += 1
+
         logger.info(
             f"Network visibility engine initialized: "
             f"{len(config.segments)} segments, {len(config.sensors)} sensors, "
-            f"{len(self._ip_to_segments)} mapped IPs"
+            f"{len(self._ip_to_segments)} mapped IPs, "
+            f"{nat_rule_count} NAT rules"
         )
 
     def _resolve_ip_segments(self, ip: str) -> set[str]:
@@ -283,3 +296,104 @@ class NetworkVisibilityEngine:
         for sensor in self.get_observing_sensors(src_ip, dst_ip):
             formats.update(sensor.log_formats)
         return expand_formats(formats)
+
+    # ------------------------------------------------------------------
+    # NAT computation
+    # ------------------------------------------------------------------
+
+    def _ip_matches_src(self, ip: str, rule: NatRule) -> bool:
+        """Check if an IP matches any of a NAT rule's src entries."""
+        ip_segments = self._resolve_ip_segments(ip)
+        for src_entry in rule.src:
+            # Check segment name match
+            if src_entry in self._segment_networks and src_entry in ip_segments:
+                return True
+            # Check direct IP match
+            if src_entry == ip:
+                return True
+            # Check CIDR match
+            try:
+                if ipaddress.ip_address(ip) in ipaddress.ip_network(src_entry, strict=False):
+                    return True
+            except ValueError:
+                pass
+        return False
+
+    def compute_nat(
+        self,
+        src_ip: str,
+        dst_ip: str,
+        src_port: int,
+        dst_port: int,
+    ) -> NatContext | None:
+        """Compute NAT translation for a connection.
+
+        Returns NatContext with mapped addresses if a NAT rule matches,
+        or None if no translation applies.
+
+        NAT rules are scoped per-firewall: only rules from firewalls that
+        monitor segments relevant to the connection are considered.
+        Rules are evaluated in order (first match wins). NAT only applies
+        when traffic crosses a segment boundary — same-segment traffic
+        is never NATted.
+        """
+        src_segments = self._resolve_ip_segments(src_ip)
+        dst_segments = self._resolve_ip_segments(dst_ip)
+
+        # Same-segment traffic: no NAT
+        if src_segments and dst_segments and src_segments & dst_segments:
+            return None
+
+        # Iterate firewall sensors with NAT rules, scoped to connection path
+        for sensor in self._sensors:
+            if sensor.type != "firewall" or not sensor.nat_rules:
+                continue
+            sensor_segs = set(sensor.monitoring_segments)
+            # Firewall must monitor a segment relevant to this connection,
+            # OR the dst_ip matches a static NAT mapped_ip on this firewall
+            # (for inbound connections to a public VIP not in any segment)
+            has_static_vip_match = any(
+                r.type == "static" and r.mapped_ip == dst_ip for r in sensor.nat_rules
+            )
+            if not (
+                sensor_segs & src_segments or sensor_segs & dst_segments or has_static_vip_match
+            ):
+                continue
+
+            sensor_name = sensor.hostname or sensor.name
+            for rule_idx, rule in enumerate(sensor.nat_rules):
+                if rule.type == "dynamic_pat":
+                    # Outbound PAT: src matches rule's src segments
+                    if self._ip_matches_src(src_ip, rule) and not dst_segments:
+                        key = (sensor_name, rule_idx)
+                        port = self._pat_port_counters[key]
+                        self._pat_port_counters[key] = port + 1
+                        return NatContext(
+                            nat_type="dynamic_pat",
+                            mapped_src_ip=rule.mapped_ip,
+                            mapped_src_port=port,
+                            mapped_dst_ip=dst_ip,
+                            mapped_dst_port=dst_port,
+                        )
+
+                elif rule.type == "static":
+                    # Outbound static: src_ip is the real_ip
+                    if rule.real_ip and src_ip == rule.real_ip:
+                        return NatContext(
+                            nat_type="static",
+                            mapped_src_ip=rule.mapped_ip,
+                            mapped_src_port=src_port,
+                            mapped_dst_ip=dst_ip,
+                            mapped_dst_port=dst_port,
+                        )
+                    # Inbound static: dst_ip is the mapped_ip (public)
+                    if rule.mapped_ip and dst_ip == rule.mapped_ip and rule.real_ip:
+                        return NatContext(
+                            nat_type="static",
+                            mapped_src_ip=src_ip,
+                            mapped_src_port=src_port,
+                            mapped_dst_ip=rule.real_ip,
+                            mapped_dst_port=dst_port,
+                        )
+
+        return None

--- a/src/evidenceforge/generation/network_visibility.py
+++ b/src/evidenceforge/generation/network_visibility.py
@@ -106,7 +106,10 @@ class NetworkVisibilityEngine:
             if sensor.type == "firewall" and sensor.nat_rules:
                 sensor_name = sensor.hostname or sensor.name
                 for rule_idx in range(len(sensor.nat_rules)):
-                    self._pat_port_counters[(sensor_name, rule_idx)] = 10000
+                    import hashlib as _hl
+
+                    seed = int(_hl.md5(f"{sensor_name}:{rule_idx}".encode()).hexdigest()[:8], 16)
+                    self._pat_port_counters[(sensor_name, rule_idx)] = 1024 + (seed % 50000)
                     nat_rule_count += 1
 
         logger.info(
@@ -367,7 +370,9 @@ class NetworkVisibilityEngine:
                     if self._ip_matches_src(src_ip, rule) and not dst_segments:
                         key = (sensor_name, rule_idx)
                         port = self._pat_port_counters[key]
-                        self._pat_port_counters[key] = port + 1
+                        # Non-sequential gaps (1-3 ports) derived deterministically from current port
+                        gap = 1 + (port % 3)
+                        self._pat_port_counters[key] = port + gap
                         return NatContext(
                             nat_type="dynamic_pat",
                             mapped_src_ip=rule.mapped_ip,

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -415,6 +415,7 @@ class PortScanEventSpec(_EventSpecBase):
     """
 
     type: Literal["port_scan"] = "port_scan"
+    source_ip: str = ""  # Override scan source IP (default: uses storyline system IP)
     target_ips: list[str] = Field(default_factory=list)
     target_segment: str | None = None
     target_count: int = Field(default=50, ge=1, le=5000)
@@ -432,6 +433,7 @@ class BlockedC2EventSpec(_EventSpecBase):
     """
 
     type: Literal["blocked_c2"] = "blocked_c2"
+    source_ip: str = ""  # Override beacon source IP (default: uses storyline system IP)
     dst_ip: str
     dst_port: int = 443
     protocol: str = Field(default="tcp", pattern="^(tcp|udp)$")
@@ -599,6 +601,32 @@ class FirewallRule(BaseModel):
     action: str = Field(default="permit", pattern="^(permit|deny)$")
 
 
+class NatRule(BaseModel):
+    """NAT translation rule for firewall sensors.
+
+    Attributes:
+        type: NAT type -- "dynamic_pat" (many:1 with port translation) or "static" (1:1)
+        src: Source segment name(s), IP, or CIDR. Accepts string or list for multiple segments.
+        mapped_ip: Post-NAT IP address
+        real_ip: For static NAT, the specific internal IP being mapped
+        interface_pair: Optional [inside_iface, outside_iface] for explicit interface binding
+    """
+
+    type: str = Field(..., pattern="^(dynamic_pat|static)$")
+    src: list[str] = Field(default_factory=list)
+    mapped_ip: str
+    real_ip: str = ""
+    interface_pair: list[str] = Field(default_factory=list)
+
+    @field_validator("src", mode="before")
+    @classmethod
+    def normalize_src_to_list(cls, v: str | list[str]) -> list[str]:
+        """Accept a single string or a list; always store as list."""
+        if isinstance(v, str):
+            return [v]
+        return v
+
+
 class NetworkSensor(BaseModel):
     """Network sensor definition.
 
@@ -643,6 +671,7 @@ class NetworkSensor(BaseModel):
             "Set to 0 to disable."
         ),
     )
+    nat_rules: list[NatRule] = Field(default_factory=list)
     description: str = ""
 
 

--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -1325,6 +1325,20 @@ class ScenarioValidator:
                     )
                 )
 
+            # Non-firewall with NAT rules
+            if sensor.type != "firewall" and sensor.nat_rules:
+                self.issues.append(
+                    ValidationIssue(
+                        severity="warning",
+                        field_path=f"{prefix}.nat_rules",
+                        message=(
+                            f"Sensor '{sensor.name}' (type={sensor.type}) has "
+                            f"nat_rules but only firewall-type sensors support NAT"
+                        ),
+                        suggestion="Set type to 'firewall' or remove nat_rules",
+                    )
+                )
+
             # Non-firewall with policy
             if sensor.type != "firewall" and sensor.policy:
                 self.issues.append(
@@ -1387,5 +1401,65 @@ class ScenarioValidator:
                                 f"Use a segment name ({', '.join(sorted(segment_names))}), "
                                 f"'external', 'any', an IP, or CIDR"
                             ),
+                        )
+                    )
+
+            # Validate NAT rules
+            for nat_idx, nat_rule in enumerate(sensor.nat_rules):
+                # Warn if NAT rules on sensor without cisco_asa
+                if "cisco_asa" not in sensor.log_formats:
+                    self.issues.append(
+                        ValidationIssue(
+                            severity="warning",
+                            field_path=f"{prefix}.nat_rules.{nat_idx}",
+                            message=(
+                                f"Sensor '{sensor.name}' has NAT rules but "
+                                f"cisco_asa not in log_formats"
+                            ),
+                            suggestion="Add 'cisco_asa' to log_formats to emit NAT records",
+                        )
+                    )
+                    break  # Only warn once per sensor
+
+                # Validate src segment references
+                for src_entry in nat_rule.src:
+                    if src_entry in segment_names:
+                        continue
+                    try:
+                        ipaddress.ip_address(src_entry)
+                        continue
+                    except ValueError:
+                        pass
+                    try:
+                        ipaddress.ip_network(src_entry, strict=False)
+                        continue
+                    except ValueError:
+                        pass
+                    self.issues.append(
+                        ValidationIssue(
+                            severity="warning",
+                            field_path=f"{prefix}.nat_rules.{nat_idx}.src",
+                            message=(
+                                f"NAT rule src '{src_entry}' references "
+                                f"nonexistent segment or invalid IP/CIDR"
+                            ),
+                            suggestion=(
+                                f"Use a segment name ({', '.join(sorted(segment_names))}), "
+                                f"an IP, or CIDR"
+                            ),
+                        )
+                    )
+
+                # Static NAT: warn if real_ip is missing
+                if nat_rule.type == "static" and not nat_rule.real_ip:
+                    self.issues.append(
+                        ValidationIssue(
+                            severity="warning",
+                            field_path=f"{prefix}.nat_rules.{nat_idx}.real_ip",
+                            message=(
+                                "Static NAT rule missing real_ip — "
+                                "cannot determine which host to translate"
+                            ),
+                            suggestion="Set real_ip to the internal IP of the server",
                         )
                     )

--- a/tests/integration/test_nat_pipeline.py
+++ b/tests/integration/test_nat_pipeline.py
@@ -1,0 +1,347 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for NAT pipeline: scenario -> generation -> output validation.
+
+These tests build minimal scenarios with NAT rules, run connections through the
+full generation pipeline (ActivityGenerator + EventDispatcher + emitters), and
+verify that the output files contain correct NAT translations.
+
+All tests are skipped until Phase 6 NAT implementation is complete.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from evidenceforge.models.scenario import (
+    BaselineActivity,
+    Environment,
+    FirewallRule,
+    NatRule,
+    NetworkConfig,
+    NetworkSegment,
+    NetworkSensor,
+    OutputSpec,
+    Scenario,
+    System,
+    TimeWindow,
+    User,
+)
+
+T0 = datetime(2024, 6, 15, 14, 0, 0, tzinfo=UTC)
+
+
+def _build_nat_scenario(
+    nat_rules: list[NatRule],
+    policy: list[FirewallRule] | None = None,
+    extra_segments: list[NetworkSegment] | None = None,
+    extra_systems: list[System] | None = None,
+) -> Scenario:
+    """Build a minimal scenario with a firewall sensor that has NAT rules.
+
+    Args:
+        nat_rules: NAT rules for the firewall sensor.
+        policy: Firewall policy rules. Defaults to permit internal->any.
+        extra_segments: Additional segments beyond workstations and servers.
+        extra_systems: Additional systems beyond WS-01 and SRV-WEB.
+    """
+    segments = [
+        NetworkSegment(name="workstations", cidr="10.0.10.0/24"),
+        NetworkSegment(name="servers", cidr="10.0.20.0/24"),
+        NetworkSegment(name="dmz", cidr="172.16.0.0/24"),
+    ]
+    if extra_segments:
+        segments.extend(extra_segments)
+
+    systems = [
+        System(hostname="WS-01", ip="10.0.10.50", os="Windows 10", type="workstation"),
+        System(hostname="SRV-WEB", ip="172.16.0.5", os="Linux Ubuntu", type="server"),
+    ]
+    if extra_systems:
+        systems.extend(extra_systems)
+
+    default_policy = policy or [
+        FirewallRule(src="workstations", dst="any", action="permit"),
+        FirewallRule(src="external", dst="dmz", ports=[80, 443], action="permit"),
+    ]
+
+    sensor = NetworkSensor(
+        type="firewall",
+        name="fw01",
+        monitoring_segments=["workstations", "servers", "dmz"],
+        log_formats=["cisco_asa"],
+        interfaces={
+            "workstations": "inside",
+            "servers": "inside",
+            "dmz": "dmz",
+            "_default": "outside",
+        },
+        policy=default_policy,
+        nat_rules=nat_rules,
+    )
+
+    network = NetworkConfig(segments=segments, sensors=[sensor])
+
+    return Scenario(
+        version="1.0",
+        name="nat-integration-test",
+        description="Integration test for NAT pipeline",
+        environment=Environment(
+            description="NAT test environment",
+            users=[
+                User(
+                    username="jsmith",
+                    full_name="John Smith",
+                    email="jsmith@test.com",
+                    primary_system="WS-01",
+                ),
+            ],
+            systems=systems,
+            network=network,
+        ),
+        time_window=TimeWindow(start=T0, duration="1h"),
+        baseline_activity=BaselineActivity(
+            description="Minimal baseline",
+            intensity="low",
+            variation="low",
+        ),
+        output=OutputSpec(
+            logs=[{"format": "cisco_asa"}, {"format": "zeek_conn"}],
+            destination="./output",
+        ),
+    )
+
+
+def _read_asa_lines(output_dir: Path) -> list[str]:
+    """Read all ASA log lines from the output directory."""
+    lines = []
+    for log_file in output_dir.rglob("cisco_asa.log"):
+        lines.extend(line for line in log_file.read_text().strip().split("\n") if line.strip())
+    return lines
+
+
+def _read_zeek_records(output_dir: Path) -> list[dict]:
+    """Read all Zeek conn records from the output directory."""
+    import json
+
+    records = []
+    for log_file in output_dir.rglob("zeek_conn.json"):
+        for line in log_file.read_text().strip().split("\n"):
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+# @pytest.mark.skip(reason="NAT implementation pending")
+class TestOutboundDynamicPat:
+    """Test outbound dynamic PAT: internal host -> internet via shared public IP."""
+
+    def test_outbound_connection_produces_nat_translation(self, tmp_path):
+        """WS-01 connecting outbound should produce 305011/305012 NAT records
+        and the 302013/302014 Built/Teardown should show mapped IPs in parens."""
+        scenario = _build_nat_scenario(
+            nat_rules=[
+                NatRule(
+                    type="dynamic_pat",
+                    src="workstations",
+                    mapped_ip="198.51.100.1",
+                ),
+            ],
+        )
+
+        from evidenceforge.generation.engine import GenerationEngine
+
+        engine = GenerationEngine(scenario, tmp_path)
+        engine.generate()
+
+        asa_lines = _read_asa_lines(tmp_path)
+
+        # Should have 305011 Built translation record
+        nat_built = [line for line in asa_lines if "305011" in line]
+        assert len(nat_built) >= 1, "Expected at least one 305011 NAT Built record"
+        assert "dynamic TCP translation" in nat_built[0] or "dynamic" in nat_built[0].lower()
+        assert "198.51.100.1" in nat_built[0], "Mapped IP should appear in NAT record"
+
+        # Should have 305012 Teardown translation
+        nat_teardown = [line for line in asa_lines if "305012" in line]
+        assert len(nat_teardown) >= 1, "Expected at least one 305012 NAT Teardown record"
+
+        # Built connection records should show mapped IP in parentheses
+        built_conn = [line for line in asa_lines if "302013" in line or "302015" in line]
+        assert len(built_conn) >= 1
+        # The parenthesized source should be the mapped (public) IP
+        assert "198.51.100.1" in built_conn[0], (
+            "Built connection should show mapped IP in parentheses"
+        )
+
+
+# @pytest.mark.skip(reason="NAT implementation pending")
+class TestInboundStaticNat:
+    """Test inbound static NAT: external client -> public IP mapped to DMZ server."""
+
+    def test_inbound_connection_uses_static_nat(self, tmp_path):
+        """External connection to public IP should be translated to DMZ server IP."""
+        scenario = _build_nat_scenario(
+            nat_rules=[
+                NatRule(
+                    type="static",
+                    src="dmz",
+                    real_ip="172.16.0.5",
+                    mapped_ip="203.0.113.5",
+                ),
+            ],
+            policy=[
+                FirewallRule(src="external", dst="dmz", ports=[80, 443], action="permit"),
+                FirewallRule(src="workstations", dst="any", action="permit"),
+            ],
+        )
+
+        from evidenceforge.generation.engine import GenerationEngine
+
+        engine = GenerationEngine(scenario, tmp_path)
+        engine.generate()
+
+        asa_lines = _read_asa_lines(tmp_path)
+
+        # Static NAT should produce 305011 records
+        nat_records = [line for line in asa_lines if "305011" in line]
+        assert len(nat_records) >= 1, "Expected static NAT translation records"
+        assert "static" in nat_records[0].lower()
+
+        # The Built connection should show the real DMZ IP and mapped public IP
+        built_conn = [line for line in asa_lines if "302013" in line]
+        for line in built_conn:
+            if "172.16.0.5" in line:
+                # Inbound connection to DMZ server should show mapped public IP
+                assert "203.0.113.5" in line, (
+                    "Inbound Built should reference both real and mapped IPs"
+                )
+                break
+
+
+# @pytest.mark.skip(reason="NAT implementation pending")
+class TestNoNatRegression:
+    """Test that connections without NAT rules still work correctly."""
+
+    def test_connections_without_nat_produce_identity_parens(self, tmp_path):
+        """When no NAT rules exist, Built records should have matching parens (identity)."""
+        scenario = _build_nat_scenario(nat_rules=[])
+
+        from evidenceforge.generation.engine import GenerationEngine
+
+        engine = GenerationEngine(scenario, tmp_path)
+        engine.generate()
+
+        asa_lines = _read_asa_lines(tmp_path)
+
+        built_conn = [line for line in asa_lines if "302013" in line or "302015" in line]
+        assert len(built_conn) >= 1, "Should produce at least one Built connection"
+
+        # No 305011/305012 NAT records should appear
+        nat_records = [line for line in asa_lines if "305011" in line or "305012" in line]
+        assert len(nat_records) == 0, "No NAT records expected when no NAT rules defined"
+
+
+# @pytest.mark.skip(reason="NAT implementation pending")
+class TestDeniedWithNatRules:
+    """Test that denied connections do NOT produce NAT translation records."""
+
+    def test_denied_connection_has_no_nat_records(self, tmp_path):
+        """Deny records (106023) should not have corresponding NAT translations.
+
+        Note: baseline may still generate permitted connections that produce NAT
+        records. We verify that deny records themselves never produce 305011.
+        """
+        scenario = _build_nat_scenario(
+            nat_rules=[
+                NatRule(
+                    type="dynamic_pat",
+                    src="workstations",
+                    mapped_ip="198.51.100.1",
+                ),
+            ],
+            policy=[
+                # Deny all outbound from workstations (unusual but tests the deny path)
+                FirewallRule(src="workstations", dst="any", action="deny"),
+            ],
+        )
+
+        from evidenceforge.generation.engine import GenerationEngine
+
+        engine = GenerationEngine(scenario, tmp_path)
+        engine.generate()
+
+        asa_lines = _read_asa_lines(tmp_path)
+
+        # Should have deny records from the deny-all policy
+        deny_records = [line for line in asa_lines if "106023" in line]
+        assert len(deny_records) >= 1, "Expected deny records"
+
+        # Deny records should NOT show NAT-mapped IPs in their message body.
+        # The mapped IP 198.51.100.1 should only appear in 305011/305012 and
+        # Built parens, never in a 106023 deny message.
+        for deny_line in deny_records:
+            assert "198.51.100.1" not in deny_line, "Deny records should not contain NAT-mapped IP"
+
+
+# @pytest.mark.skip(reason="NAT implementation pending")
+class TestSameSegmentNoNat:
+    """Test that intra-segment traffic does not get NAT-translated."""
+
+    def test_same_segment_traffic_no_nat(self, tmp_path):
+        """Traffic between two hosts in the same segment should not be NATed."""
+        scenario = _build_nat_scenario(
+            nat_rules=[
+                NatRule(
+                    type="dynamic_pat",
+                    src="workstations",
+                    mapped_ip="198.51.100.1",
+                ),
+            ],
+            extra_systems=[
+                System(
+                    hostname="WS-02",
+                    ip="10.0.10.51",
+                    os="Windows 10",
+                    type="workstation",
+                ),
+            ],
+        )
+
+        from evidenceforge.generation.engine import GenerationEngine
+
+        engine = GenerationEngine(scenario, tmp_path)
+        engine.generate()
+
+        asa_lines = _read_asa_lines(tmp_path)
+
+        # Look for connections between two workstation IPs
+        intra_segment = [
+            line
+            for line in asa_lines
+            if "10.0.10.50" in line and "10.0.10.51" in line and "302013" in line
+        ]
+
+        # If any intra-segment connections exist, they should NOT have NAT translations
+        for line in intra_segment:
+            # The parenthesized IPs should match the real IPs (identity)
+            assert "198.51.100.1" not in line, "Intra-segment traffic should not use NAT mapped IP"

--- a/tests/unit/test_cisco_asa_emitter.py
+++ b/tests/unit/test_cisco_asa_emitter.py
@@ -134,8 +134,8 @@ class TestConnectionIdCounter:
     def test_per_sensor_counters(self, asa_emitter):
         id_fw01 = asa_emitter._next_conn_id("fw01")
         id_fw02 = asa_emitter._next_conn_id("fw02")
-        # Both start from the same base
-        assert id_fw01 == id_fw02
+        # Different sensors get different deterministic starting IDs
+        assert id_fw01 != id_fw02
 
 
 class TestPermitRecords:

--- a/tests/unit/test_cisco_asa_emitter.py
+++ b/tests/unit/test_cisco_asa_emitter.py
@@ -70,6 +70,7 @@ def _make_connection_event(
     orig_bytes=1024,
     resp_bytes=4096,
     firewall=None,
+    nat=None,
     timestamp=None,
 ):
     """Create a connection SecurityEvent for testing."""
@@ -87,6 +88,7 @@ def _make_connection_event(
             resp_bytes=resp_bytes,
         ),
         firewall=firewall,
+        nat=nat,
     )
     event._sensor_hostnames_by_format = {"cisco_asa": ["fw01"]}
     return event
@@ -446,3 +448,215 @@ class TestThreatDetection:
         lines = self._get_output_lines(tmp_path)
         threat_lines = [line for line in lines if "733100" in line]
         assert len(threat_lines) == 0
+
+
+class TestNatRecords:
+    """Tests for NAT translation records (305011/305012) emitted alongside connection logs."""
+
+    def _make_nat_event(
+        self,
+        action="permit",
+        nat_type="dynamic_pat",
+        mapped_src_ip="198.51.100.1",
+        mapped_src_port=12345,
+        mapped_dst_ip="203.0.113.50",
+        mapped_dst_port=443,
+        protocol="tcp",
+        include_nat=True,
+    ):
+        from evidenceforge.events.contexts import NatContext
+
+        fw = FirewallContext(
+            action=action,
+            msg_id=302013 if action == "permit" else 106023,
+            connection_id=100,
+            src_interface="inside",
+            dst_interface="outside",
+        )
+        nat = (
+            NatContext(
+                nat_type=nat_type,
+                mapped_src_ip=mapped_src_ip,
+                mapped_src_port=mapped_src_port,
+                mapped_dst_ip=mapped_dst_ip,
+                mapped_dst_port=mapped_dst_port,
+            )
+            if include_nat
+            else None
+        )
+        return _make_connection_event(protocol=protocol, firewall=fw, nat=nat)
+
+    def _get_output_lines(self, tmp_path):
+        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        return [line for line in output.strip().split("\n") if line]
+
+    def test_built_with_nat_shows_mapped_ips_in_parens(self, asa_emitter, tmp_path):
+        """Built line parenthesized addresses should use NAT-mapped IPs, not real ones."""
+        event = self._make_nat_event()
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+
+        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        # The Built line should show mapped source in parens
+        assert "(198.51.100.1/12345)" in output
+        # Should NOT show the real pre-NAT source in parens
+        assert "(10.0.10.50/54321)" not in output
+
+    def test_built_without_nat_parens_match_real(self, asa_emitter, tmp_path):
+        """Without NatContext, parenthesized addresses should match the real IPs."""
+        event = _make_connection_event()
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+
+        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        # Parens should reflect the real IPs since there is no NAT
+        assert "(10.0.10.50/54321)" in output
+        assert "(203.0.113.50/443)" in output
+
+    def test_305011_emitted_for_nat_permit(self, asa_emitter, tmp_path):
+        """A permitted connection with NatContext should emit a 305011 Built translation record."""
+        event = self._make_nat_event()
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+
+        lines = self._get_output_lines(tmp_path)
+        nat_built_lines = [line for line in lines if "305011" in line]
+        assert len(nat_built_lines) >= 1
+        assert (
+            "Built dynamic TCP translation from inside:10.0.10.50/54321 to outside:198.51.100.1/12345"
+            in nat_built_lines[0]
+        )
+
+    def test_305012_emitted_for_nat_teardown(self, asa_emitter, tmp_path):
+        """A permitted connection with NatContext should emit a 305012 Teardown translation record."""
+        event = self._make_nat_event()
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+
+        lines = self._get_output_lines(tmp_path)
+        nat_teardown_lines = [line for line in lines if "305012" in line]
+        assert len(nat_teardown_lines) >= 1
+        assert "Teardown dynamic TCP translation" in nat_teardown_lines[0]
+
+    def test_no_305011_for_deny(self, asa_emitter, tmp_path):
+        """Deny events should not produce 305011 NAT records, even if NatContext is present."""
+        event = self._make_nat_event(action="deny")
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+
+        lines = self._get_output_lines(tmp_path)
+        nat_lines = [line for line in lines if "305011" in line]
+        assert len(nat_lines) == 0
+
+    def test_no_305011_without_nat(self, asa_emitter, tmp_path):
+        """Permit events without NatContext should not produce 305011 records."""
+        event = self._make_nat_event(include_nat=False)
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+
+        lines = self._get_output_lines(tmp_path)
+        nat_lines = [line for line in lines if "305011" in line]
+        assert len(nat_lines) == 0
+
+    def test_305011_dynamic_vs_static_label(self, asa_emitter, tmp_path):
+        """Static NAT should produce 'Built static' instead of 'Built dynamic'."""
+        event = self._make_nat_event(nat_type="static")
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+
+        lines = self._get_output_lines(tmp_path)
+        nat_built_lines = [line for line in lines if "305011" in line]
+        assert len(nat_built_lines) >= 1
+        assert "Built static" in nat_built_lines[0]
+        assert "Built dynamic" not in nat_built_lines[0]
+
+    def test_305011_protocol_variations(self, asa_emitter, tmp_path):
+        """NAT built messages should reflect the correct protocol for UDP and ICMP."""
+        for proto in ("udp", "icmp"):
+            # Use a fresh emitter for each protocol to avoid cross-contamination
+            fmt = load_format("cisco_asa")
+            sub_dir = tmp_path / f"nat_{proto}"
+            sub_dir.mkdir()
+            emitter = CiscoAsaEmitter(
+                format_def=fmt,
+                output_path=sub_dir,
+                sensor_hostnames=["fw01"],
+            )
+            emitter._segment_config = asa_emitter._segment_config
+            emitter._sensor_interfaces = asa_emitter._sensor_interfaces
+
+            event = self._make_nat_event(protocol=proto)
+            emitter.emit(event)
+            emitter.flush()
+
+            output = (sub_dir / "fw01" / "cisco_asa.log").read_text()
+            nat_built_lines = [line for line in output.strip().split("\n") if "305011" in line]
+            assert len(nat_built_lines) >= 1, f"No 305011 line for {proto}"
+            assert f"Built dynamic {proto.upper()} translation" in nat_built_lines[0]
+
+    def test_305011_inbound_static_nat_shows_dst_translation(self, asa_emitter, tmp_path):
+        """Inbound static NAT: 305011 should show destination VIP -> real server."""
+        from evidenceforge.events.contexts import NatContext
+
+        event = _make_connection_event(
+            src_ip="203.0.113.99",
+            src_port=54321,
+            dst_ip="203.0.113.5",  # Public VIP
+            dst_port=443,
+            firewall=FirewallContext(
+                action="permit",
+                msg_id=302013,
+                connection_id=100,
+                src_interface="outside",
+                dst_interface="dmz",
+            ),
+            nat=NatContext(
+                nat_type="static",
+                mapped_src_ip="203.0.113.99",  # unchanged - no source translation
+                mapped_src_port=54321,  # unchanged
+                mapped_dst_ip="172.16.0.5",  # real DMZ server
+                mapped_dst_port=443,
+            ),
+        )
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+        lines = self._get_output_lines(tmp_path)
+        nat_built = [line for line in lines if "305011" in line]
+        assert len(nat_built) >= 1
+        # Should show the destination translation: VIP -> real server
+        assert "172.16.0.5" in nat_built[0]
+        assert "203.0.113.5" in nat_built[0]
+        # Should NOT show the untranslated source as the translation target
+        assert "203.0.113.99/54321 to" not in nat_built[0]
+
+    def test_305012_inbound_static_nat_shows_dst_translation(self, asa_emitter, tmp_path):
+        """Inbound static NAT: 305012 should show destination VIP -> real server teardown."""
+        from evidenceforge.events.contexts import NatContext
+
+        event = _make_connection_event(
+            src_ip="203.0.113.99",
+            src_port=54321,
+            dst_ip="203.0.113.5",  # Public VIP
+            dst_port=443,
+            firewall=FirewallContext(
+                action="permit",
+                msg_id=302013,
+                connection_id=100,
+                src_interface="outside",
+                dst_interface="dmz",
+            ),
+            nat=NatContext(
+                nat_type="static",
+                mapped_src_ip="203.0.113.99",
+                mapped_src_port=54321,
+                mapped_dst_ip="172.16.0.5",
+                mapped_dst_port=443,
+            ),
+        )
+        asa_emitter.emit(event)
+        asa_emitter.flush()
+        lines = self._get_output_lines(tmp_path)
+        nat_teardown = [line for line in lines if "305012" in line]
+        assert len(nat_teardown) >= 1
+        assert "172.16.0.5" in nat_teardown[0]
+        assert "Teardown static" in nat_teardown[0]

--- a/tests/unit/test_cisco_asa_parser.py
+++ b/tests/unit/test_cisco_asa_parser.py
@@ -172,6 +172,106 @@ class TestParseThreatDetection:
         assert not rec.parse_errors
 
 
+class TestParseNatRecords:
+    def test_parse_305011_dynamic_tcp(self, tmp_path):
+        """305011 Built dynamic TCP translation should parse NAT fields."""
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-305011: Built dynamic TCP translation "
+            "from inside:10.0.10.50/54321 to outside:198.51.100.1/12345\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.fields["msg_id"] == 305011
+        assert rec.fields["severity"] == 6
+        assert rec.fields["nat_type"] == "dynamic"
+        assert rec.fields["protocol"] == "TCP"
+        assert rec.fields["src_interface"] == "inside"
+        assert rec.fields["real_ip"] == "10.0.10.50"
+        assert rec.fields["real_port"] == 54321
+        assert rec.fields["dst_interface"] == "outside"
+        assert rec.fields["mapped_ip"] == "198.51.100.1"
+        assert rec.fields["mapped_port"] == 12345
+        assert not rec.parse_errors
+
+    def test_parse_305011_static_udp(self, tmp_path):
+        """305011 Built static UDP translation should parse correctly."""
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-305011: Built static UDP translation "
+            "from dmz:172.16.0.5/443 to outside:203.0.113.5/443\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.fields["msg_id"] == 305011
+        assert rec.fields["nat_type"] == "static"
+        assert rec.fields["protocol"] == "UDP"
+        assert rec.fields["src_interface"] == "dmz"
+        assert rec.fields["real_ip"] == "172.16.0.5"
+        assert rec.fields["real_port"] == 443
+        assert rec.fields["dst_interface"] == "outside"
+        assert rec.fields["mapped_ip"] == "203.0.113.5"
+        assert rec.fields["mapped_port"] == 443
+        assert not rec.parse_errors
+
+    def test_parse_305012_teardown_with_duration(self, tmp_path):
+        """305012 Teardown translation should parse with duration field."""
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:24:28 fw01 %ASA-6-305012: Teardown dynamic TCP translation "
+            "from inside:10.0.10.50/54321 to outside:198.51.100.1/12345 duration 0:01:23\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.fields["msg_id"] == 305012
+        assert rec.fields["duration"] == "0:01:23"
+        assert rec.fields["real_ip"] == "10.0.10.50"
+        assert rec.fields["mapped_ip"] == "198.51.100.1"
+        assert not rec.parse_errors
+
+    def test_parse_built_with_different_mapped_ips(self, tmp_path):
+        """302013 Built with parenthesized mapped IPs differing from real IPs."""
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-302013: Built outbound TCP connection "
+            "100042 for inside:10.0.10.50/54321 (198.51.100.1/12345) to "
+            "outside:203.0.113.50/443 (203.0.113.50/443)\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.fields["src_ip"] == "10.0.10.50"
+        assert rec.fields["mapped_src_ip"] == "198.51.100.1"
+        assert rec.fields["mapped_src_port"] == 12345
+        assert rec.fields["dst_ip"] == "203.0.113.50"
+        assert rec.fields["mapped_dst_ip"] == "203.0.113.50"
+        assert not rec.parse_errors
+
+    def test_parse_built_identity_nat(self, tmp_path):
+        """302013 Built where parens match real (identity NAT) should not crash."""
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-302013: Built outbound TCP connection "
+            "100042 for inside:10.0.10.50/54321 (10.0.10.50/54321) to "
+            "outside:203.0.113.50/443 (203.0.113.50/443)\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        # Identity NAT: mapped should equal real (or field may not be set)
+        mapped_src = rec.fields.get("mapped_src_ip", rec.fields.get("src_ip"))
+        assert mapped_src == "10.0.10.50"
+        assert not rec.parse_errors
+
+
 class TestMalformedLines:
     def test_garbage_line(self, tmp_path):
         log = tmp_path / "cisco_asa.log"

--- a/tests/unit/test_eval_cross_source.py
+++ b/tests/unit/test_eval_cross_source.py
@@ -405,6 +405,71 @@ class TestResolveHostname:
         assert len(groups_orig) > 0
 
 
+class TestNatCrossSourceCorrelation:
+    """Tests for NAT-aware cross-source indexing."""
+
+    def test_nat_record_indexed_by_both_real_and_mapped_ip(self):
+        """cisco_asa record with mapped_src_ip should be indexed under both IPs."""
+        asa_rec = _record(
+            "cisco_asa",
+            {
+                "hostname": "fw01",
+                "src_ip": "10.0.10.50",
+                "mapped_src_ip": "198.51.100.1",
+                "dst_ip": "203.0.113.50",
+                "msg_id": 302013,
+            },
+            ts=T0,
+        )
+        records = {"cisco_asa": [asa_rec]}
+        scorer = CrossSourceScorer()
+        index = scorer._build_host_time_index(records)
+        bucket = int(T0.timestamp()) // 60
+
+        # Both the real IP and the mapped IP should appear as index keys
+        real_key = f"10.0.10.50|{bucket}"
+        mapped_key = f"198.51.100.1|{bucket}"
+        assert real_key in index, "Real src_ip should be indexed"
+        assert mapped_key in index, "Mapped src_ip should be indexed"
+        assert "cisco_asa" in index[real_key]
+        assert "cisco_asa" in index[mapped_key]
+
+    def test_outside_zeek_correlates_with_asa_via_mapped_ip(self):
+        """Zeek record with orig_h matching ASA mapped_src_ip should share index bucket."""
+        mapped_ip = "198.51.100.1"
+        asa_rec = _record(
+            "cisco_asa",
+            {
+                "hostname": "fw01",
+                "src_ip": "10.0.10.50",
+                "mapped_src_ip": mapped_ip,
+                "dst_ip": "203.0.113.50",
+                "msg_id": 302013,
+            },
+            ts=T0,
+        )
+        zeek_rec = _record(
+            "zeek_conn",
+            {
+                "id.orig_h": mapped_ip,
+                "id.resp_h": "203.0.113.50",
+                "id.orig_p": 12345,
+                "id.resp_p": 443,
+            },
+            ts=T0 + timedelta(seconds=10),
+        )
+        records = {"cisco_asa": [asa_rec], "zeek_conn": [zeek_rec]}
+        scorer = CrossSourceScorer()
+        index = scorer._build_host_time_index(records)
+        bucket = int(T0.timestamp()) // 60
+
+        key = f"{mapped_ip}|{bucket}"
+        assert key in index, "Mapped IP should be indexed"
+        formats_in_bucket = set(index[key].keys())
+        assert "cisco_asa" in formats_in_bucket
+        assert "zeek_conn" in formats_in_bucket
+
+
 class TestFQDNSourceCorrectness:
     """Source correctness should handle FQDN records correctly."""
 

--- a/tests/unit/test_firewall_storyline_events.py
+++ b/tests/unit/test_firewall_storyline_events.py
@@ -322,3 +322,27 @@ class TestSourceOnlyVisibility:
         assert "dmz-zeek" in sensor_names  # inbound on destination segment
         assert "fw01" in sensor_names  # firewall monitors dmz
         assert "inside-zeek" not in sensor_names  # packet didn't reach internal
+
+
+class TestSourceIpOverride:
+    """TDD tests for source_ip field on firewall storyline event specs."""
+
+    def test_port_scan_source_ip_field(self):
+        """PortScanEventSpec should accept source_ip field."""
+        spec = PortScanEventSpec(target_ips=["10.0.10.1"], source_ip="203.0.113.45")
+        assert spec.source_ip == "203.0.113.45"
+
+    def test_port_scan_default_source_ip_empty(self):
+        """PortScanEventSpec without source_ip should default to empty string."""
+        spec = PortScanEventSpec(target_ips=["10.0.10.1"])
+        assert spec.source_ip == ""
+
+    def test_blocked_c2_source_ip_field(self):
+        """BlockedC2EventSpec should accept source_ip field."""
+        spec = BlockedC2EventSpec(dst_ip="198.51.100.30", source_ip="10.0.10.50")
+        assert spec.source_ip == "10.0.10.50"
+
+    def test_blocked_c2_default_source_ip_empty(self):
+        """BlockedC2EventSpec without source_ip should default to empty string."""
+        spec = BlockedC2EventSpec(dst_ip="198.51.100.30")
+        assert spec.source_ip == ""

--- a/tests/unit/test_firewall_validation.py
+++ b/tests/unit/test_firewall_validation.py
@@ -26,6 +26,7 @@ from evidenceforge.models.scenario import (
     BaselineActivity,
     Environment,
     FirewallRule,
+    NatRule,
     NetworkConfig,
     NetworkSegment,
     NetworkSensor,
@@ -224,3 +225,167 @@ class TestFirewallValidation:
         issues = validator.validate()
         iface_issues = [issue for issue in issues if "_default" in issue.message]
         assert len(iface_issues) == 0
+
+
+class TestNatRuleValidation:
+    """Tests for NAT rule validation in firewall config."""
+
+    def test_nat_rule_valid_segment_ref(self):
+        """NAT rule referencing an existing segment should produce no warnings."""
+        scenario = _make_scenario(
+            sensors=[
+                NetworkSensor(
+                    type="firewall",
+                    name="fw01",
+                    monitoring_segments=["internal", "dmz"],
+                    log_formats=["cisco_asa"],
+                    nat_rules=[
+                        NatRule(
+                            type="dynamic_pat",
+                            src="internal",
+                            mapped_ip="198.51.100.1",
+                        ),
+                    ],
+                )
+            ]
+        )
+        validator = ScenarioValidator(scenario)
+        issues = validator.validate()
+        nat_issues = [
+            issue
+            for issue in issues
+            if "nat" in issue.message.lower() or "nat_rule" in issue.field_path
+        ]
+        assert len(nat_issues) == 0
+
+    def test_nat_rule_invalid_segment_warns(self):
+        """NAT rule referencing a nonexistent segment should warn."""
+        scenario = _make_scenario(
+            sensors=[
+                NetworkSensor(
+                    type="firewall",
+                    name="fw01",
+                    monitoring_segments=["internal", "dmz"],
+                    log_formats=["cisco_asa"],
+                    nat_rules=[
+                        NatRule(
+                            type="dynamic_pat",
+                            src="nonexistent",
+                            mapped_ip="198.51.100.1",
+                        ),
+                    ],
+                )
+            ]
+        )
+        validator = ScenarioValidator(scenario)
+        issues = validator.validate()
+        nat_issues = [issue for issue in issues if "nonexistent" in issue.message]
+        assert len(nat_issues) >= 1
+
+    def test_nat_rule_static_missing_real_ip_warns(self):
+        """Static NAT rule without real_ip should warn."""
+        scenario = _make_scenario(
+            sensors=[
+                NetworkSensor(
+                    type="firewall",
+                    name="fw01",
+                    monitoring_segments=["internal", "dmz"],
+                    log_formats=["cisco_asa"],
+                    nat_rules=[
+                        NatRule(
+                            type="static",
+                            src="dmz",
+                            mapped_ip="203.0.113.5",
+                        ),
+                    ],
+                )
+            ]
+        )
+        validator = ScenarioValidator(scenario)
+        issues = validator.validate()
+        nat_issues = [
+            issue
+            for issue in issues
+            if "real_ip" in issue.message.lower() or "static" in issue.message.lower()
+        ]
+        assert len(nat_issues) >= 1
+
+    def test_nat_rule_valid_mapped_ip(self):
+        """NAT rule with a valid mapped_ip should not raise issues."""
+        scenario = _make_scenario(
+            sensors=[
+                NetworkSensor(
+                    type="firewall",
+                    name="fw01",
+                    monitoring_segments=["internal", "dmz"],
+                    log_formats=["cisco_asa"],
+                    nat_rules=[
+                        NatRule(
+                            type="dynamic_pat",
+                            src="internal",
+                            mapped_ip="198.51.100.1",
+                        ),
+                    ],
+                )
+            ]
+        )
+        validator = ScenarioValidator(scenario)
+        issues = validator.validate()
+        nat_issues = [issue for issue in issues if "mapped_ip" in issue.message.lower()]
+        assert len(nat_issues) == 0
+
+    def test_nat_rules_without_cisco_asa_warns(self):
+        """Firewall with nat_rules but no cisco_asa log format should warn."""
+        scenario = _make_scenario(
+            sensors=[
+                NetworkSensor(
+                    type="firewall",
+                    name="fw01",
+                    monitoring_segments=["internal", "dmz"],
+                    log_formats=["zeek"],
+                    nat_rules=[
+                        NatRule(
+                            type="dynamic_pat",
+                            src="internal",
+                            mapped_ip="198.51.100.1",
+                        ),
+                    ],
+                )
+            ]
+        )
+        validator = ScenarioValidator(scenario)
+        issues = validator.validate()
+        nat_issues = [
+            issue
+            for issue in issues
+            if "nat" in issue.message.lower() and "cisco_asa" in issue.message.lower()
+        ]
+        assert len(nat_issues) >= 1
+
+    def test_nat_rules_on_non_firewall_warns(self):
+        """NAT rules on a non-firewall sensor should produce a validation warning."""
+        scenario = _make_scenario(
+            sensors=[
+                NetworkSensor(
+                    type="network",
+                    name="zeek-sensor",
+                    monitoring_segments=["internal"],
+                    log_formats=["zeek"],
+                    nat_rules=[
+                        NatRule(
+                            type="dynamic_pat",
+                            src="internal",
+                            mapped_ip="198.51.100.1",
+                        ),
+                    ],
+                )
+            ]
+        )
+        validator = ScenarioValidator(scenario)
+        issues = validator.validate()
+        nat_issues = [
+            issue
+            for issue in issues
+            if "nat" in issue.message.lower() and "firewall" in issue.message.lower()
+        ]
+        assert len(nat_issues) >= 1

--- a/tests/unit/test_nat_computation.py
+++ b/tests/unit/test_nat_computation.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""TDD tests for compute_nat() on NetworkVisibilityEngine.
+
+These tests define the planned API for NAT computation. All tests will fail
+until the implementation is added.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from evidenceforge.generation.network_visibility import NetworkVisibilityEngine
+from evidenceforge.models.scenario import (
+    NatRule,
+    NetworkConfig,
+    NetworkSegment,
+    NetworkSensor,
+    System,
+)
+
+T0 = datetime(2024, 6, 15, 14, 0, 0, tzinfo=UTC)
+
+
+def _make_segments():
+    """Create test network segments."""
+    return [
+        NetworkSegment(name="workstations", cidr="10.0.10.0/24"),
+        NetworkSegment(name="servers", cidr="10.0.20.0/24"),
+        NetworkSegment(name="dmz", cidr="172.16.0.0/24"),
+    ]
+
+
+def _make_systems():
+    """Create test systems across segments."""
+    return [
+        System(hostname="WS-01", ip="10.0.10.50", os="Windows 10", type="workstation"),
+        System(hostname="SRV-01", ip="10.0.20.5", os="Windows Server 2019", type="server"),
+        System(hostname="WEB-01", ip="172.16.0.5", os="Linux Ubuntu 22.04", type="server"),
+    ]
+
+
+def _make_nat_rules():
+    """Create test NAT rules: one dynamic PAT, one static NAT."""
+    return [
+        NatRule(
+            type="dynamic_pat",
+            src=["workstations", "servers"],
+            mapped_ip="198.51.100.1",
+        ),
+        NatRule(
+            type="static",
+            src="dmz",
+            real_ip="172.16.0.5",
+            mapped_ip="203.0.113.5",
+        ),
+    ]
+
+
+def _make_firewall_sensor(nat_rules=None):
+    """Create a firewall sensor with optional NAT rules."""
+    return NetworkSensor(
+        type="firewall",
+        name="fw01",
+        hostname="fw01",
+        monitoring_segments=["workstations", "servers", "dmz"],
+        log_formats=["cisco_asa"],
+        nat_rules=nat_rules or [],
+    )
+
+
+def _make_engine(nat_rules=None):
+    """Build a NetworkVisibilityEngine with standard test topology and NAT rules."""
+    segments = _make_segments()
+    sensor = _make_firewall_sensor(nat_rules=nat_rules)
+    config = NetworkConfig(segments=segments, sensors=[sensor])
+    systems = _make_systems()
+    return NetworkVisibilityEngine(config, systems)
+
+
+@pytest.fixture
+def engine():
+    """Standard engine with both PAT and static NAT rules."""
+    return _make_engine(nat_rules=_make_nat_rules())
+
+
+@pytest.fixture
+def engine_no_nat():
+    """Engine with no NAT rules configured."""
+    return _make_engine(nat_rules=[])
+
+
+class TestDynamicPat:
+    """Tests for dynamic PAT (many-to-one with port translation)."""
+
+    def test_dynamic_pat_translates_source_ip(self, engine):
+        """Workstation IP should be translated to the PAT mapped IP."""
+        result = engine.compute_nat("10.0.10.50", "203.0.113.50", 54321, 443)
+        assert result is not None
+        assert result.mapped_src_ip == "198.51.100.1"
+
+    def test_dynamic_pat_changes_source_port(self, engine):
+        """PAT should allocate a new source port different from the original."""
+        result = engine.compute_nat("10.0.10.50", "203.0.113.50", 54321, 443)
+        assert result is not None
+        assert result.mapped_src_port != 54321
+
+    def test_pat_port_allocation_increments(self, engine):
+        """Two calls with the same src IP should get different mapped ports."""
+        r1 = engine.compute_nat("10.0.10.50", "203.0.113.50", 54321, 443)
+        r2 = engine.compute_nat("10.0.10.50", "203.0.113.50", 54322, 443)
+        assert r1 is not None and r2 is not None
+        assert r1.mapped_src_port != r2.mapped_src_port
+
+    def test_pat_port_allocation_per_rule(self):
+        """Two PAT rules should each maintain an independent port counter."""
+        rules = [
+            NatRule(type="dynamic_pat", src="workstations", mapped_ip="198.51.100.1"),
+            NatRule(type="dynamic_pat", src="servers", mapped_ip="198.51.100.2"),
+        ]
+        eng = _make_engine(nat_rules=rules)
+        r_ws = eng.compute_nat("10.0.10.50", "203.0.113.50", 54321, 443)
+        r_srv = eng.compute_nat("10.0.20.5", "203.0.113.50", 54321, 443)
+        assert r_ws is not None and r_srv is not None
+        # Both rules start from independent counters so ports may overlap, but the
+        # mapped IPs must come from their respective rules.
+        assert r_ws.mapped_src_ip == "198.51.100.1"
+        assert r_srv.mapped_src_ip == "198.51.100.2"
+
+    def test_multi_segment_src_matches_any(self, engine):
+        """PAT rule with src=[workstations, servers] should match IPs in servers."""
+        result = engine.compute_nat("10.0.20.5", "203.0.113.50", 54321, 443)
+        assert result is not None
+        assert result.mapped_src_ip == "198.51.100.1"
+
+
+class TestStaticNat:
+    """Tests for static NAT (one-to-one IP mapping)."""
+
+    def test_static_nat_outbound_translates_source(self, engine):
+        """DMZ server going outbound should have its source IP translated."""
+        result = engine.compute_nat("172.16.0.5", "203.0.113.99", 443, 80)
+        assert result is not None
+        assert result.mapped_src_ip == "203.0.113.5"
+        # Static NAT preserves ports
+        assert result.mapped_src_port == 443
+
+    def test_static_nat_inbound_translates_dest(self, engine):
+        """Inbound connection to the public IP should translate the dest to real IP."""
+        result = engine.compute_nat("203.0.113.99", "203.0.113.5", 54321, 443)
+        assert result is not None
+        assert result.mapped_dst_ip == "172.16.0.5"
+
+
+class TestNoNat:
+    """Tests for scenarios where NAT should not apply."""
+
+    def test_no_nat_for_same_segment(self, engine):
+        """Traffic within the same segment should not be NATted."""
+        result = engine.compute_nat("10.0.10.50", "10.0.10.100", 54321, 80)
+        assert result is None
+
+    def test_no_nat_when_no_rules(self, engine_no_nat):
+        """Engine with no NAT rules should always return None."""
+        result = engine_no_nat.compute_nat("10.0.10.50", "203.0.113.50", 54321, 443)
+        assert result is None
+
+    def test_no_nat_for_external_to_external(self, engine):
+        """External-to-external traffic should not be NATted."""
+        result = engine.compute_nat("203.0.113.1", "8.8.8.8", 54321, 443)
+        assert result is None
+
+
+class TestRuleOrdering:
+    """Tests for rule matching order."""
+
+    def test_first_matching_rule_wins(self):
+        """When two rules match the same traffic, the first rule should win."""
+        rules = [
+            NatRule(type="dynamic_pat", src="workstations", mapped_ip="198.51.100.1"),
+            NatRule(type="dynamic_pat", src="workstations", mapped_ip="198.51.100.99"),
+        ]
+        eng = _make_engine(nat_rules=rules)
+        result = eng.compute_nat("10.0.10.50", "203.0.113.50", 54321, 443)
+        assert result is not None
+        assert result.mapped_src_ip == "198.51.100.1"
+
+
+class TestMultiFirewallScoping:
+    """NAT rules must be scoped to the firewall in the connection path."""
+
+    def test_multi_firewall_nat_scoped_to_path(self):
+        """fw-ext PAT rule should NOT apply to connections through fw-int."""
+        segments = [
+            NetworkSegment(name="workstations", cidr="10.0.10.0/24"),
+            NetworkSegment(name="servers", cidr="10.0.20.0/24"),
+            NetworkSegment(name="database", cidr="10.0.30.0/24"),
+        ]
+        systems = [
+            System(hostname="WS-01", ip="10.0.10.50", os="Windows 10", type="workstation"),
+            System(hostname="SRV-01", ip="10.0.20.5", os="Linux", type="server"),
+            System(hostname="DB-01", ip="10.0.30.5", os="Linux", type="server"),
+        ]
+        fw_ext = NetworkSensor(
+            type="firewall",
+            name="fw-ext",
+            monitoring_segments=["workstations"],
+            log_formats=["cisco_asa"],
+            nat_rules=[NatRule(type="dynamic_pat", src="workstations", mapped_ip="198.51.100.1")],
+        )
+        fw_int = NetworkSensor(
+            type="firewall",
+            name="fw-int",
+            monitoring_segments=["servers", "database"],
+            log_formats=["cisco_asa"],
+            nat_rules=[],  # No NAT on internal firewall
+        )
+        config = NetworkConfig(segments=segments, sensors=[fw_ext, fw_int])
+        engine = NetworkVisibilityEngine(config, systems)
+
+        # Connection from servers -> external: fw-ext's PAT should NOT match
+        # because fw-ext only monitors workstations, not servers
+        result = engine.compute_nat("10.0.20.5", "203.0.113.50", 54321, 443)
+        assert result is None
+
+    def test_nat_rule_from_correct_firewall_used(self):
+        """Connection from workstations should match fw-ext's PAT rule."""
+        segments = [
+            NetworkSegment(name="workstations", cidr="10.0.10.0/24"),
+            NetworkSegment(name="servers", cidr="10.0.20.0/24"),
+        ]
+        systems = [
+            System(hostname="WS-01", ip="10.0.10.50", os="Windows 10", type="workstation"),
+            System(hostname="SRV-01", ip="10.0.20.5", os="Linux", type="server"),
+        ]
+        fw_ext = NetworkSensor(
+            type="firewall",
+            name="fw-ext",
+            monitoring_segments=["workstations"],
+            log_formats=["cisco_asa"],
+            nat_rules=[NatRule(type="dynamic_pat", src="workstations", mapped_ip="198.51.100.1")],
+        )
+        fw_int = NetworkSensor(
+            type="firewall",
+            name="fw-int",
+            monitoring_segments=["servers"],
+            log_formats=["cisco_asa"],
+            nat_rules=[],
+        )
+        config = NetworkConfig(segments=segments, sensors=[fw_ext, fw_int])
+        engine = NetworkVisibilityEngine(config, systems)
+
+        # Connection from workstations -> external: fw-ext's PAT should match
+        result = engine.compute_nat("10.0.10.50", "203.0.113.50", 54321, 443)
+        assert result is not None
+        assert result.mapped_src_ip == "198.51.100.1"
+
+        # Connection from servers -> servers (through fw-int, no NAT): should return None
+        result = engine.compute_nat("10.0.20.5", "10.0.20.10", 54321, 80)
+        assert result is None

--- a/tests/unit/test_nat_model.py
+++ b/tests/unit/test_nat_model.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""TDD tests for NatRule model, NatContext dataclass, and SecurityEvent.nat field.
+
+These tests define the planned API for the NAT feature. All tests will fail
+until the implementation is added.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.contexts import NatContext
+from evidenceforge.models.scenario import NatRule
+
+T0 = datetime(2024, 6, 15, 14, 0, 0, tzinfo=UTC)
+
+
+class TestNatRuleModel:
+    """Tests for the NatRule pydantic model."""
+
+    def test_nat_rule_dynamic_pat_defaults(self):
+        """Dynamic PAT rule should create successfully with minimal fields."""
+        rule = NatRule(type="dynamic_pat", src="workstations", mapped_ip="198.51.100.1")
+        assert rule.type == "dynamic_pat"
+        assert rule.mapped_ip == "198.51.100.1"
+
+    def test_nat_rule_static_requires_real_ip(self):
+        """Static NAT rule works without real_ip but defaults to empty string."""
+        rule = NatRule(type="static", src="dmz", mapped_ip="203.0.113.5")
+        assert rule.real_ip == ""
+
+        rule_with_real = NatRule(
+            type="static", src="dmz", mapped_ip="203.0.113.5", real_ip="172.16.0.5"
+        )
+        assert rule_with_real.real_ip == "172.16.0.5"
+
+    def test_nat_rule_invalid_type_rejected(self):
+        """NatRule with an invalid type should raise ValidationError."""
+        with pytest.raises(ValidationError):
+            NatRule(type="invalid", src="workstations", mapped_ip="198.51.100.1")
+
+    def test_nat_rule_src_string_normalized_to_list(self):
+        """A single string src should be normalized to a one-element list."""
+        rule = NatRule(type="dynamic_pat", src="workstations", mapped_ip="198.51.100.1")
+        assert rule.src == ["workstations"]
+
+    def test_nat_rule_src_list_accepted(self):
+        """A list of segment names should be accepted as-is."""
+        rule = NatRule(
+            type="dynamic_pat", src=["workstations", "servers"], mapped_ip="198.51.100.1"
+        )
+        assert rule.src == ["workstations", "servers"]
+
+
+class TestNatContext:
+    """Tests for the NatContext dataclass."""
+
+    def test_nat_context_fields(self):
+        """NatContext should store all NAT translation fields."""
+        ctx = NatContext(
+            nat_type="dynamic_pat",
+            mapped_src_ip="198.51.100.1",
+            mapped_src_port=12345,
+            mapped_dst_ip="203.0.113.50",
+            mapped_dst_port=443,
+        )
+        assert ctx.nat_type == "dynamic_pat"
+        assert ctx.mapped_src_ip == "198.51.100.1"
+        assert ctx.mapped_src_port == 12345
+        assert ctx.mapped_dst_ip == "203.0.113.50"
+        assert ctx.mapped_dst_port == 443
+
+
+class TestSecurityEventNatField:
+    """Tests for the nat field on SecurityEvent."""
+
+    def test_security_event_nat_field_default_none(self):
+        """SecurityEvent.nat should default to None."""
+        event = SecurityEvent(timestamp=T0, event_type="connection")
+        assert event.nat is None

--- a/tests/unit/test_realism_quick_wins.py
+++ b/tests/unit/test_realism_quick_wins.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for realism quick-win fixes.
+
+1. RFC 5737 documentation IP exclusion
+2. ASA connection ID non-round start
+3. PAT port gaps (non-sequential)
+4. Snort microsecond timestamps
+5. ASA chronological sort on flush
+"""
+
+import random
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.contexts import IdsContext, NetworkContext
+from evidenceforge.formats import load_format
+from evidenceforge.generation.emitters.cisco_asa import CiscoAsaEmitter
+from evidenceforge.generation.emitters.snort import SnortEmitter
+from evidenceforge.generation.network_visibility import NetworkVisibilityEngine
+from evidenceforge.models.scenario import (
+    NatRule,
+    NetworkConfig,
+    NetworkSegment,
+    NetworkSensor,
+    System,
+)
+
+T0 = datetime(2024, 6, 15, 14, 0, 0, tzinfo=UTC)
+
+# ---------------------------------------------------------------------------
+# Fix 1: RFC 5737 documentation IP exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_generate_external_ip_excludes_rfc5737():
+    """External IPs must not fall in RFC 5737 TEST-NET ranges."""
+    from unittest.mock import MagicMock
+
+    from evidenceforge.generation.engine.emitter_setup import EmitterSetupMixin
+
+    # Use a rigged RNG that would produce RFC 5737 IPs without the exclusion
+    rfc5737_prefixes = [
+        (203, 0, 113),  # TEST-NET-3
+        (198, 51, 100),  # TEST-NET-2
+        (192, 0, 2),  # TEST-NET-1
+    ]
+
+    for first, second, third in rfc5737_prefixes:
+        call_count = 0
+
+        def rigged_randint(lo, hi, _f=first, _s=second, _t=third):
+            nonlocal call_count
+            call_count += 1
+            cycle = (call_count - 1) % 4
+            if cycle == 0:
+                return _f
+            elif cycle == 1:
+                return _s
+            elif cycle == 2:
+                return _t
+            else:
+                return 50  # Last octet
+
+        rng = MagicMock()
+        rng.randint = rigged_randint
+        # The function should loop and never return an RFC 5737 IP.
+        # To avoid infinite loop, patch to return a valid IP after rejection.
+        attempts = [0]
+        saved_rigged = rigged_randint
+
+        def mixed_randint(lo, hi, _f=first, _s=second, _t=third, _att=attempts, _orig=saved_rigged):
+            _att[0] += 1
+            if _att[0] <= 8:  # First two attempts: rigged RFC 5737
+                return _orig(lo, hi)
+            # After rejection, return a normal IP
+            cycle = (_att[0] - 1) % 4
+            if cycle == 0:
+                return 44  # Safe first octet
+            elif cycle == 1:
+                return 100
+            elif cycle == 2:
+                return 200
+            else:
+                return 50
+
+        rng.randint = mixed_randint
+        ip = EmitterSetupMixin._generate_external_client_ip(rng)
+        assert not ip.startswith(f"{first}.{second}.{third}."), (
+            f"RFC 5737 IP {ip} should have been excluded"
+        )
+
+    # Also verify with normal random that no RFC 5737 IPs appear in a large sample
+    rng = random.Random(42)
+    for _ in range(5000):
+        ip = EmitterSetupMixin._generate_external_client_ip(rng)
+        assert not ip.startswith("203.0.113."), f"RFC 5737 TEST-NET-3: {ip}"
+        assert not ip.startswith("198.51.100."), f"RFC 5737 TEST-NET-2: {ip}"
+        assert not ip.startswith("192.0.2."), f"RFC 5737 TEST-NET-1: {ip}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: ASA connection ID non-round start
+# ---------------------------------------------------------------------------
+
+
+def test_asa_conn_id_not_round():
+    """ASA connection IDs should not start at a round 100000."""
+    fmt = load_format("cisco_asa")
+    emitter = CiscoAsaEmitter(
+        format_def=fmt,
+        output_path=pytest.importorskip("pathlib").Path("/tmp/test_asa_conn"),
+        sensor_hostnames=["fw01"],
+    )
+    first_id = emitter._next_conn_id("fw01")
+    assert first_id != 100000, "Connection ID should not start at a round number"
+    assert 100000 <= first_id < 10000000, f"Connection ID {first_id} out of expected range"
+
+    # Second call should be monotonically increasing
+    second_id = emitter._next_conn_id("fw01")
+    assert second_id > first_id
+
+    # Different sensor should get a different starting ID
+    other_id = emitter._next_conn_id("fw02")
+    assert other_id != first_id, "Different sensors should get different starting IDs"
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: PAT port gaps
+# ---------------------------------------------------------------------------
+
+
+def _make_nat_engine():
+    """Create a NetworkVisibilityEngine with a dynamic PAT rule."""
+    segments = [
+        NetworkSegment(name="workstations", cidr="10.0.10.0/24"),
+        NetworkSegment(name="servers", cidr="10.0.20.0/24"),
+        NetworkSegment(name="dmz", cidr="172.16.0.0/24"),
+    ]
+    systems = [
+        System(hostname="WS-01", ip="10.0.10.50", os="Windows 10", type="workstation"),
+        System(hostname="SRV-01", ip="10.0.20.5", os="Windows Server 2019", type="server"),
+    ]
+    nat_rules = [
+        NatRule(type="dynamic_pat", src=["workstations"], mapped_ip="198.51.100.1"),
+    ]
+    sensors = [
+        NetworkSensor(
+            name="fw01",
+            hostname="fw01",
+            type="firewall",
+            monitoring_segments=["workstations", "servers", "dmz"],
+            log_formats=["cisco_asa"],
+            nat_rules=nat_rules,
+        ),
+    ]
+    config = NetworkConfig(segments=segments, sensors=sensors)
+    return NetworkVisibilityEngine(config, systems)
+
+
+def test_pat_ports_have_gaps():
+    """PAT port allocations should have non-sequential gaps."""
+    engine = _make_nat_engine()
+    ports = []
+    for i in range(10):
+        result = engine.compute_nat(
+            src_ip="10.0.10.50",
+            dst_ip="8.8.8.8",
+            src_port=40000 + i,
+            dst_port=443,
+        )
+        assert result is not None, f"NAT should match for workstation IP (iteration {i})"
+        ports.append(result.mapped_src_port)
+
+    # Check that not all gaps are exactly 1
+    gaps = [ports[i + 1] - ports[i] for i in range(len(ports) - 1)]
+    assert not all(g == 1 for g in gaps), (
+        f"All PAT port gaps are exactly 1 — should have varied gaps. Ports: {ports}"
+    )
+    # All gaps should be in [1, 3]
+    assert all(1 <= g <= 3 for g in gaps), f"PAT port gaps out of range [1,3]: {gaps}"
+
+
+def test_pat_port_start_not_round():
+    """PAT port counters should not start at a round number like 10000."""
+    engine = _make_nat_engine()
+    result = engine.compute_nat(
+        src_ip="10.0.10.50",
+        dst_ip="8.8.8.8",
+        src_port=40000,
+        dst_port=443,
+    )
+    assert result is not None
+    assert result.mapped_src_port != 10000, "PAT port should not start at round 10000"
+    assert 1024 <= result.mapped_src_port < 51024, (
+        f"PAT port {result.mapped_src_port} out of expected range [1024, 51024)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: Snort microsecond timestamps
+# ---------------------------------------------------------------------------
+
+
+def test_snort_timestamp_has_microseconds(tmp_path):
+    """Snort alert timestamps should have non-zero microseconds."""
+    fmt = load_format("snort_alert")
+    emitter = SnortEmitter(
+        format_def=fmt,
+        output_path=tmp_path / "snort_alert.log",
+    )
+
+    # Emit several events with different timestamps
+    for i in range(5):
+        ts = T0 + timedelta(seconds=i * 60)
+        event = SecurityEvent(
+            timestamp=ts,
+            event_type="connection",
+            ids=IdsContext(
+                sid=2000000 + i,
+                message=f"Test alert {i}",
+                classification="Attempted Information Leak",
+                priority=2,
+            ),
+            network=NetworkContext(
+                src_ip="10.0.10.50",
+                src_port=40000 + i,
+                dst_ip="192.168.1.1",
+                dst_port=80,
+                protocol="TCP",
+            ),
+        )
+        emitter.emit(event)
+
+    emitter.flush()
+
+    output = (tmp_path / "snort_alert.log").read_text()
+    lines = [line for line in output.strip().split("\n") if line.strip()]
+    assert len(lines) >= 5, f"Expected at least 5 alert lines, got {len(lines)}"
+
+    # Check that at least some timestamps have non-zero millisecond part
+    zero_ms_count = 0
+    for line in lines:
+        # Format: MM/DD-HH:MM:SS.mmm
+        ts_part = line.split("[")[0].strip()
+        ms_part = ts_part.split(".")[-1]
+        if ms_part == "000":
+            zero_ms_count += 1
+
+    assert zero_ms_count < len(lines), (
+        "All Snort timestamps end in .000 — microsecond jitter is not working"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: ASA chronological sort on flush
+# ---------------------------------------------------------------------------
+
+
+def test_asa_output_sorted(tmp_path):
+    """ASA output lines should be chronologically sorted after flush."""
+    fmt = load_format("cisco_asa")
+    emitter = CiscoAsaEmitter(
+        format_def=fmt,
+        output_path=tmp_path,
+        sensor_hostnames=["fw01"],
+    )
+    emitter._segment_config = [
+        {"name": "workstations", "cidr": "10.0.10.0/24"},
+        {"name": "servers", "cidr": "10.0.20.0/24"},
+    ]
+    emitter._sensor_interfaces = {
+        "fw01": {
+            "workstations": "inside",
+            "servers": "inside",
+            "_default": "outside",
+        }
+    }
+
+    # Emit events that will produce out-of-order lines (Built at T, Teardown at T+duration)
+    # The Teardown for the first connection lands AFTER the Built for the second connection
+    for i in range(5):
+        ts = T0 + timedelta(seconds=i * 10)
+        event = SecurityEvent(
+            timestamp=ts,
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.10.50",
+                src_port=40000 + i,
+                dst_ip="8.8.8.8",
+                dst_port=443,
+                protocol="TCP",
+                duration=30.0 + i * 5,  # 30-50 seconds — teardowns interleave with later builts
+                orig_bytes=1000,
+                resp_bytes=2000,
+            ),
+        )
+        emitter.emit(event)
+
+    emitter.flush()
+
+    output_file = tmp_path / "fw01" / "cisco_asa.log"
+    assert output_file.exists(), "ASA output file should exist"
+    lines = [line for line in output_file.read_text().strip().split("\n") if line.strip()]
+    assert len(lines) >= 10, (
+        f"Expected at least 10 ASA lines (5 Built + 5 Teardown), got {len(lines)}"
+    )
+
+    # Verify lines are in lexicographic (= chronological) order
+    for i in range(len(lines) - 1):
+        assert lines[i] <= lines[i + 1], (
+            f"ASA output not sorted at line {i}:\n  {lines[i]}\n  {lines[i + 1]}"
+        )

--- a/tests/unit/test_zeek_nat.py
+++ b/tests/unit/test_zeek_nat.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for per-sensor NAT IP swapping in Zeek conn emitters."""
+
+import json
+from datetime import UTC, datetime
+
+from evidenceforge.formats import load_format
+from evidenceforge.generation.emitters.zeek import ZeekEmitter
+
+T0 = datetime(2024, 6, 15, 14, 23, 5, tzinfo=UTC)
+
+
+def _make_conn_event_data(
+    sensor_hostnames=None,
+    nat_swaps_by_sensor=None,
+    src_ip="10.0.10.50",
+    src_port=54321,
+    dst_ip="203.0.113.50",
+    dst_port=443,
+):
+    """Build a Zeek conn event_data dict with optional NAT swap metadata."""
+    data = {
+        "ts": T0.timestamp(),
+        "uid": "CTest123",
+        "id.orig_h": src_ip,
+        "id.orig_p": src_port,
+        "id.resp_h": dst_ip,
+        "id.resp_p": dst_port,
+        "proto": "tcp",
+        "service": "ssl",
+        "duration": 1.5,
+        "orig_bytes": 100,
+        "resp_bytes": 200,
+        "conn_state": "SF",
+        "history": "ShADad",
+    }
+    if sensor_hostnames is not None:
+        data["_sensor_hostnames"] = sensor_hostnames
+    if nat_swaps_by_sensor is not None:
+        data["_nat_swaps_by_sensor"] = nat_swaps_by_sensor
+    return data
+
+
+def _read_conn_json(base_path, sensor_hostname):
+    """Read the first JSON record from a sensor's conn.json output."""
+    path = base_path / sensor_hostname / "conn.json"
+    assert path.exists(), f"Expected output at {path}"
+    with open(path) as f:
+        return json.loads(f.readline())
+
+
+class TestZeekNatSwaps:
+    """Verify that _nat_swaps_by_sensor causes IP/port field substitution per sensor."""
+
+    def test_inside_sensor_sees_real_ips(self, tmp_path):
+        """A sensor NOT listed in _nat_swaps_by_sensor should see the original IPs."""
+        fmt = load_format("zeek_conn")
+        emitter = ZeekEmitter(fmt, tmp_path, sensor_hostnames=["inside-zeek"])
+
+        event_data = _make_conn_event_data(
+            sensor_hostnames=["inside-zeek"],
+            nat_swaps_by_sensor={"outside-zeek": {"src_ip": "198.51.100.1"}},
+        )
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        record = _read_conn_json(tmp_path, "inside-zeek")
+        assert record["id.orig_h"] == "10.0.10.50"
+        assert record["id.orig_p"] == 54321
+
+    def test_outside_sensor_sees_mapped_src_ip(self, tmp_path):
+        """A sensor listed in _nat_swaps_by_sensor should see the NAT-mapped source IP."""
+        fmt = load_format("zeek_conn")
+        emitter = ZeekEmitter(fmt, tmp_path, sensor_hostnames=["inside-zeek", "outside-zeek"])
+
+        event_data = _make_conn_event_data(
+            sensor_hostnames=["inside-zeek", "outside-zeek"],
+            nat_swaps_by_sensor={"outside-zeek": {"src_ip": "198.51.100.1", "src_port": 12345}},
+        )
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        inside_record = _read_conn_json(tmp_path, "inside-zeek")
+        outside_record = _read_conn_json(tmp_path, "outside-zeek")
+
+        # Inside sensor sees real source IP
+        assert inside_record["id.orig_h"] == "10.0.10.50"
+        # Outside sensor sees NAT-mapped source IP
+        assert outside_record["id.orig_h"] == "198.51.100.1"
+
+    def test_outside_sensor_sees_mapped_src_port(self, tmp_path):
+        """A sensor with src_port in its NAT swap should see the mapped source port."""
+        fmt = load_format("zeek_conn")
+        emitter = ZeekEmitter(fmt, tmp_path, sensor_hostnames=["inside-zeek", "outside-zeek"])
+
+        event_data = _make_conn_event_data(
+            sensor_hostnames=["inside-zeek", "outside-zeek"],
+            nat_swaps_by_sensor={"outside-zeek": {"src_ip": "198.51.100.1", "src_port": 12345}},
+        )
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        inside_record = _read_conn_json(tmp_path, "inside-zeek")
+        outside_record = _read_conn_json(tmp_path, "outside-zeek")
+
+        # Inside sensor sees real source port
+        assert inside_record["id.orig_p"] == 54321
+        # Outside sensor sees NAT-mapped source port
+        assert outside_record["id.orig_p"] == 12345
+
+    def test_dst_ip_swapped_for_inbound_static_nat(self, tmp_path):
+        """A NAT swap with dst_ip should replace id.resp_h for the post-NAT sensor."""
+        fmt = load_format("zeek_conn")
+        emitter = ZeekEmitter(fmt, tmp_path, sensor_hostnames=["inside-zeek", "outside-zeek"])
+
+        event_data = _make_conn_event_data(
+            sensor_hostnames=["inside-zeek", "outside-zeek"],
+            nat_swaps_by_sensor={"outside-zeek": {"dst_ip": "198.51.100.80"}},
+        )
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        inside_record = _read_conn_json(tmp_path, "inside-zeek")
+        outside_record = _read_conn_json(tmp_path, "outside-zeek")
+
+        # Inside sensor sees real destination IP
+        assert inside_record["id.resp_h"] == "203.0.113.50"
+        # Outside sensor sees NAT-mapped destination IP
+        assert outside_record["id.resp_h"] == "198.51.100.80"
+
+    def test_no_swap_when_no_nat_metadata(self, tmp_path):
+        """Without _nat_swaps_by_sensor, all sensors see identical real IPs."""
+        fmt = load_format("zeek_conn")
+        emitter = ZeekEmitter(fmt, tmp_path, sensor_hostnames=["inside-zeek", "outside-zeek"])
+
+        event_data = _make_conn_event_data(
+            sensor_hostnames=["inside-zeek", "outside-zeek"],
+            # No _nat_swaps_by_sensor
+        )
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        inside_record = _read_conn_json(tmp_path, "inside-zeek")
+        outside_record = _read_conn_json(tmp_path, "outside-zeek")
+
+        assert inside_record["id.orig_h"] == "10.0.10.50"
+        assert outside_record["id.orig_h"] == "10.0.10.50"
+        assert inside_record["id.resp_h"] == "203.0.113.50"
+        assert outside_record["id.resp_h"] == "203.0.113.50"


### PR DESCRIPTION
## Summary

- **NAT translation** — Dynamic PAT (many:1 with port translation) and static NAT (1:1 IP mapping) for firewall sensors. Produces 305011/305012 ASA records, mapped IPs in Built message parentheses, and per-sensor Zeek IP swapping (inside sensors see real IPs, outside sensors see translated IPs).
- **NAT code review fixes** — Inbound static NAT 305011/305012 correctly shows destination translation; NAT rules scoped per-firewall path instead of globally flattened; validation warns on nat_rules for non-firewall sensors.
- **source_ip field** — Added to PortScanEventSpec and BlockedC2EventSpec for external attacker scans where the scanner isn't a scenario system.
- **Coverage prompts** — Workstation count tied to user count (1:1) instead of hardcoded mismatched numbers. IT shift workers share in large-scale prompt only.

## Test plan

- [x] 1370 unit/integration tests pass, 14 skipped
- [x] 5 NAT pipeline integration tests (outbound PAT, inbound static, no-NAT regression, deny+NAT, same-segment)
- [x] TDD approach: all tests written before implementation
- [ ] Run full coverage test scenario with NAT rules configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)