### PR TITLE
fix: sanitize host routing keys for host-multiplexed emitters (prevent path traversal)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -92,6 +92,7 @@ Data is *wrong* — a hunter hits dead ends. Fix these first; several unblock Ti
 - [x] **Migrate eCAR FLOW to SecurityEvent dispatch** — already complete: `"connection"` in `_supported_types`, `_render_connection()` implemented, all connections dispatch through SecurityEvent. `pid:-1` for system traffic is correct behavior.
 - [x] **No 4625 on DC for password spray** — sprays against domain accounts should produce 4625/4776 on the DC, not just the originating workstation. DC-focused Sigma/Splunk rules won't fire.
 - [x] **Ground truth Zeek UIDs missing from logs** — UIDs listed in GROUND_TRUTH.md IOC section don't exist in any sensor's conn.json. Answer key references evidence that isn't there.
+- [x] Raw storyline events path traversal hardening — sanitized host routing keys for host-multiplexed emitters and Windows per-host writers so raw event fields cannot escape output directory; unsafe keys now fall back to flat-file output.
 
 ### Tier 2: Huntability & Detection
 

--- a/src/evidenceforge/generation/emitters/host_base.py
+++ b/src/evidenceforge/generation/emitters/host_base.py
@@ -31,6 +31,7 @@ host's FQDN. Each host gets its own subdirectory:
 """
 
 import logging
+import re
 from pathlib import Path
 from queue import Empty
 from threading import Lock
@@ -40,6 +41,33 @@ from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 
 logger = logging.getLogger(__name__)
+
+
+_HOST_ROUTING_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def sanitize_host_routing_key(host_fqdn: str) -> str:
+    """Sanitize host routing key used for host-multiplexed output paths.
+
+    Returns an empty string when host_fqdn is unsafe so emitters fall back
+    to flat-file output under the configured base directory.
+    """
+    candidate = host_fqdn.strip()
+    if not candidate:
+        return ""
+    if "/" in candidate or "\\" in candidate:
+        logger.warning("Unsafe host routing key rejected: contains path separator")
+        return ""
+    if ".." in candidate:
+        logger.warning("Unsafe host routing key rejected: contains traversal sequence")
+        return ""
+    if candidate in {".", ".."}:
+        logger.warning("Unsafe host routing key rejected: invalid path token")
+        return ""
+    if not _HOST_ROUTING_RE.fullmatch(candidate):
+        logger.warning("Unsafe host routing key rejected: invalid characters")
+        return ""
+    return candidate
 
 
 class _SingleHostWriter:
@@ -130,15 +158,16 @@ class HostMultiplexEmitter(LogEmitter):
         super().__init__(format_def, output_path, buffer_size, threaded)
 
     def _get_writer(self, host_fqdn: str) -> _SingleHostWriter:
-        writer = self._writers.get(host_fqdn)
+        safe_host_fqdn = sanitize_host_routing_key(host_fqdn)
+        writer = self._writers.get(safe_host_fqdn)
         if writer is not None:
             return writer
         with self._writers_lock:
-            writer = self._writers.get(host_fqdn)
+            writer = self._writers.get(safe_host_fqdn)
             if writer is not None:
                 return writer
-            if host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / host_fqdn / self._log_filename
+            if safe_host_fqdn and not self._direct_file_mode:
+                path = self._base_dir / safe_host_fqdn / self._log_filename
             elif self._direct_file_path:
                 path = self._direct_file_path
             else:
@@ -146,7 +175,7 @@ class HostMultiplexEmitter(LogEmitter):
                 path = self._base_dir / flat_name
             sort = self._sort_flat_file
             writer = _SingleHostWriter(path, self._buffer_size, sort_on_flush=sort)
-            self._writers[host_fqdn] = writer
+            self._writers[safe_host_fqdn] = writer
             logger.debug(f"Created host writer: {path}")
             return writer
 

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -39,7 +39,7 @@ from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext
 from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
-from evidenceforge.generation.emitters.host_base import _SingleHostWriter
+from evidenceforge.generation.emitters.host_base import _SingleHostWriter, sanitize_host_routing_key
 
 win_logger = logging.getLogger(__name__)
 
@@ -967,15 +967,16 @@ class WindowsEventEmitter(LogEmitter):
         self._record_id_counters: dict[str, int] = {}
 
     def _get_host_writer(self, host_fqdn: str) -> _SingleHostWriter:
-        writer = self._host_writers.get(host_fqdn)
+        safe_host_fqdn = sanitize_host_routing_key(host_fqdn)
+        writer = self._host_writers.get(safe_host_fqdn)
         if writer is not None:
             return writer
         with self._host_writers_lock:
-            writer = self._host_writers.get(host_fqdn)
+            writer = self._host_writers.get(safe_host_fqdn)
             if writer is not None:
                 return writer
-            if host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / host_fqdn / "windows_event_security.xml"
+            if safe_host_fqdn and not self._direct_file_mode:
+                path = self._base_dir / safe_host_fqdn / "windows_event_security.xml"
             elif self._direct_file_path:
                 path = self._direct_file_path
             else:
@@ -985,7 +986,7 @@ class WindowsEventEmitter(LogEmitter):
             header = self.format_def.output.header_template
             if header:
                 writer.write_header(header)
-            self._host_writers[host_fqdn] = writer
+            self._host_writers[safe_host_fqdn] = writer
             return writer
 
     def _buffer_event(self, rendered: str) -> None:
@@ -1053,7 +1054,7 @@ class WindowsEventEmitter(LogEmitter):
 
         # Assign per-computer EventRecordIDs in sorted order
         for event in self._event_dicts:
-            computer = event.get("Computer", "")
+            computer = sanitize_host_routing_key(event.get("Computer", ""))
             counter_key = computer.split(".")[0] if "." in computer else computer
             if counter_key not in self._record_id_counters:
                 rng = random.Random(f"erid_{counter_key}")

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -29,6 +29,7 @@ import pytest
 
 from evidenceforge.formats import load_format
 from evidenceforge.generation.emitters import WindowsEventEmitter, ZeekEmitter
+from evidenceforge.generation.emitters.host_base import sanitize_host_routing_key
 from evidenceforge.utils import generate_zeek_uid
 
 
@@ -785,6 +786,41 @@ class TestWindowsEventEmitter:
         content = temp_output.read_text()
         assert "<EventID>4738</EventID>" in content
         assert '<Data Name="Dummy">-</Data>' in content  # 4738 unique Dummy field
+
+    def test_emit_event_with_unsafe_computer_routes_to_flat_output(self, format_def, tmp_path):
+        """Unsafe Computer values must not create traversing per-host paths."""
+        output_dir = tmp_path / "output"
+        emitter = WindowsEventEmitter(format_def, output_dir, buffer_size=1)
+        event_data = {
+            "EventID": 4624,
+            "TimeCreated": datetime(2024, 1, 15, 10, 30, 45, 0, tzinfo=UTC),
+            "Computer": "../../escape",
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 4,
+            "ExecutionThreadID": 100,
+            "TargetUserName": "jsmith",
+            "TargetDomainName": "CORP",
+            "TargetLogonId": "0x3e7abc",
+            "LogonType": 2,
+            "WorkstationName": "WIN-TEST-01",
+            "IpAddress": "192.168.1.100",
+            "LogonProcessName": "User32",
+            "AuthenticationPackageName": "Negotiate",
+        }
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        assert (output_dir / "windows_event_security.xml").exists()
+        assert not (tmp_path / "escape" / "windows_event_security.xml").exists()
+
+
+def test_sanitize_host_routing_key_rejects_path_traversal() -> None:
+    """Path traversal and separators must be rejected for host routing keys."""
+    assert sanitize_host_routing_key("../../pwned") == ""
+    assert sanitize_host_routing_key("..\\..\\pwned") == ""
+    assert sanitize_host_routing_key("host/child") == ""
+    assert sanitize_host_routing_key("safe-host.corp.local") == "safe-host.corp.local"
 
 
 class TestZeekEmitter:


### PR DESCRIPTION
### Motivation
- Raw/storyline `raw` events allowed attacker-controlled fields (e.g., `_host_fqdn` / `Computer`) to be used directly when building per-host output paths, enabling directory traversal and arbitrary file writes outside the configured output directory.
- The change hardens host-based emitters by validating/sanitizing routing keys before they are used to create directories or file paths.

### Description
- Add `sanitize_host_routing_key()` to `src/evidenceforge/generation/emitters/host_base.py` to reject host routing keys that contain path separators, traversal tokens (`..`), invalid characters, or otherwise look unsafe; unsafe keys return an empty string so emitters fall back to flat-file output.
- Use the sanitizer in `HostMultiplexEmitter._get_writer()` so writers are indexed and created only with safe routing keys (fallback to flat output when sanitized key is empty).
- Apply the same sanitization in `WindowsEventEmitter` for per-host writer selection and for per-computer RecordID key derivation so attacker-controlled `Computer` values cannot influence path construction or writer lookup.
- Add unit coverage in `tests/unit/test_emitters.py` to assert traversal rejection and that unsafe `Computer` values route to the flat output file, and update `TODO.md` to mark the hardening task complete.

### Testing
- Ran linter/format checks: `uv run ruff check .` passed and `uv run ruff format --check .` reported files formatted; both succeeded.
- Attempted to run the targeted unit tests with `PYTHONPATH=src uv run pytest tests/unit/test_emitters.py -q`, but the test run failed early due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`) in this environment, so the new tests could not be executed here; test assertions were added to the repository for CI/local runs where dependencies are present.
- Changes are limited to emitter routing and tests and do not alter higher-level generation logic or event validation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb72270e483258a9b961e55f8b002)