### PR TITLE
security: prevent install-skills from following symlinked eforge target

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,6 +75,8 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Tier 0: Infrastructure
 
+- [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
+
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.
 - [x] **`eforge validate` can't find personas in dev mode** — works when installed (`eforge validate`) but not via `uv run eforge validate`. Blocks dev workflow.
 - [x] **511 ruff lint errors + 102 formatting issues** — CI lint job fails immediately. Auto-fix + suppress false positives (B008 for Typer, N806 for lookup tables, B904 for typer.Exit).

--- a/src/evidenceforge/cli/install_skills.py
+++ b/src/evidenceforge/cli/install_skills.py
@@ -23,6 +23,7 @@
 """Install EvidenceForge Claude Code commands to .claude/commands/ directory."""
 
 import importlib.resources
+import os
 import shutil
 from pathlib import Path
 
@@ -157,6 +158,31 @@ def _remove_stale_files(eforge_dir: Path, manifest: dict[str, Path]) -> list[str
     return removed
 
 
+def _ensure_safe_eforge_directory(target_dir: Path) -> Path:
+    """Create or validate a safe install directory for eforge skills.
+
+    Rejects symlinked destination directories to prevent writes/deletes from
+    being redirected outside the intended install location.
+    """
+    eforge_dir = target_dir / "eforge"
+    if eforge_dir.exists() and eforge_dir.is_symlink():
+        raise PermissionError(f"Refusing to install skills into symlinked directory: {eforge_dir}")
+
+    ensure_directory(target_dir)
+    eforge_dir.mkdir(parents=True, exist_ok=True)
+
+    # Check again after creation to avoid races where the path is swapped.
+    if eforge_dir.is_symlink():
+        raise PermissionError(f"Refusing to install skills into symlinked directory: {eforge_dir}")
+
+    target_real = target_dir.resolve()
+    eforge_real = eforge_dir.resolve()
+    if os.path.commonpath([str(eforge_real), str(target_real)]) != str(target_real):
+        raise PermissionError(f"Refusing to install skills outside target directory: {eforge_dir}")
+
+    return eforge_dir
+
+
 def install_skills(target_dir: Path) -> tuple[list[str], list[str]]:
     """Install EvidenceForge skills to the target directory.
 
@@ -175,7 +201,7 @@ def install_skills(target_dir: Path) -> tuple[list[str], list[str]]:
     if not manifest:
         raise FileNotFoundError("No skill files found to install.")
 
-    eforge_dir = ensure_directory(target_dir / "eforge")
+    eforge_dir = _ensure_safe_eforge_directory(target_dir)
 
     # Copy all files from manifest
     installed = []

--- a/tests/unit/test_install_skills.py
+++ b/tests/unit/test_install_skills.py
@@ -24,6 +24,7 @@
 
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from evidenceforge.cli.commands import EXIT_SUCCESS, app
@@ -126,6 +127,15 @@ class TestInstallSkills:
 
         assert outside_file.exists(), "File outside eforge/ should not be touched"
 
+    def test_rejects_symlinked_eforge_directory(self, tmp_path):
+        """install_skills rejects a symlinked eforge/ directory."""
+        victim_dir = tmp_path / "victim"
+        victim_dir.mkdir()
+        (tmp_path / "eforge").symlink_to(victim_dir, target_is_directory=True)
+
+        with pytest.raises(PermissionError, match="symlinked directory"):
+            install_skills(tmp_path)
+
     def test_returns_installed_and_removed_lists(self, tmp_path):
         """install_skills returns lists of installed and removed files."""
         installed, removed = install_skills(tmp_path)
@@ -173,3 +183,15 @@ class TestInstallSkillsCli:
         assert "generate.md" in result.stdout
         assert "validate.md" in result.stdout
         assert "installed" in result.stdout.lower() or "Installed" in result.stdout
+
+    def test_install_skills_rejects_symlink_target(self, tmp_path, monkeypatch):
+        """CLI returns input error when eforge target is a symlink."""
+        monkeypatch.chdir(tmp_path)
+        commands_dir = tmp_path / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "eforge").symlink_to(tmp_path / "victim", target_is_directory=True)
+
+        result = runner.invoke(app, ["install-skills"])
+
+        assert result.exit_code == 1
+        assert "symlinked directory" in result.stdout


### PR DESCRIPTION
### Motivation
- `install_skills()` previously resolved and created the target `eforge/` directory via `ensure_directory()` and then copied files and removed stale files, which allowed a crafted symlink at the install target to redirect writes/deletes outside the intended directory.
- This posed a high-impact local security risk (arbitrary overwrite/deletion) when running `eforge install-skills` against a symlinked `.claude/commands/eforge`.

### Description
- Added a safety gate `_ensure_safe_eforge_directory()` in `src/evidenceforge/cli/install_skills.py` that rejects symlinked `eforge` targets, creates the directory without following a symlink, re-checks for races, and verifies the resolved install path is contained within the requested target directory.
- `install_skills()` now uses `_ensure_safe_eforge_directory()` instead of calling `ensure_directory(target_dir / "eforge")` to avoid following symlinks and to ensure path containment.
- The function raises `PermissionError` on unsafe targets (symlinked or outside the target), preventing the subsequent copy + stale-file cleanup from affecting arbitrary locations.
- Added regression tests in `tests/unit/test_install_skills.py` to cover both the API (`test_rejects_symlinked_eforge_directory`) and the CLI (`test_install_skills_rejects_symlink_target`), and updated `TODO.md` to record the security fix.

### Testing
- Ran static checks: `uv run ruff check .` passed after formatting, and `uv run ruff format` was applied to reformat the changed files, after which format checks passed.
- Attempted to run the targeted unit tests via `PYTHONPATH=src uv run pytest tests/unit/test_install_skills.py`, but the test run failed in this environment due to a missing runtime dependency (`PyYAML`), so the pytest run could not complete here; the added tests are unit-level and should pass in CI or a developer environment with project dependencies installed.
- Lint/format checks succeeded in this environment; recommend CI run the full test matrix to validate the new tests under the normal project test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfba6b342c83258bf58817426fe12b)