### PR TITLE
fix: block Zeek sensor hostname path traversal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 **Status:** Phase 8.5 (Dual src/dst HostContext) COMPLETE; Pre-MVP quality fixes ongoing
 **Started:** 2026-03-11
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-04-15
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed development history of completed phases.
 
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Prevent sensor hostname path traversal in Zeek SensorMultiplexEmitter output routing — reject unsafe sensor hostnames (path separators, dot segments, invalid chars) and fall back to flat output routing
 - [x] Evaluator grace period for causal ordering (logon→process rule skips events within logon_grace_period from scenario start)
 - [x] Evaluator event type detection from typed EventSpec fields (replaces fragile keyword matching) + 9 new record matchers
 - [x] Evaluator per-sub-event indicator accuracy (fixes last-writer-wins IP merge for compound storyline steps) + tighter eCAR FLOW matching

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -38,6 +38,7 @@ When no sensors are configured (backward compat), writes directly to:
 
 import json
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from queue import Empty
@@ -48,6 +49,7 @@ from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 
 logger = logging.getLogger(__name__)
+_SENSOR_HOSTNAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 class _SingleZeekWriter:
@@ -130,15 +132,16 @@ class SensorMultiplexEmitter(LogEmitter):
         super().__init__(format_def, output_path, buffer_size, threaded)
 
     def _get_writer(self, sensor_hostname: str) -> _SingleZeekWriter:
-        writer = self._writers.get(sensor_hostname)
+        normalized_hostname = self._normalize_sensor_hostname(sensor_hostname)
+        writer = self._writers.get(normalized_hostname)
         if writer is not None:
             return writer
         with self._writers_lock:
-            writer = self._writers.get(sensor_hostname)
+            writer = self._writers.get(normalized_hostname)
             if writer is not None:
                 return writer
-            if sensor_hostname:
-                path = self._base_dir / sensor_hostname / self._log_filename
+            if normalized_hostname:
+                path = self._base_dir / normalized_hostname / self._log_filename
             elif self._direct_file_path:
                 # Direct file mode (test/simple usage): output_path was a file
                 path = self._direct_file_path
@@ -152,9 +155,27 @@ class SensorMultiplexEmitter(LogEmitter):
                 sort_before_flush=self._sort_before_flush,
                 sort_key=getattr(self, "_sort_key_func", None),
             )
-            self._writers[sensor_hostname] = writer
+            self._writers[normalized_hostname] = writer
             logger.debug(f"Created Zeek writer: {path}")
             return writer
+
+    def _normalize_sensor_hostname(self, sensor_hostname: str) -> str:
+        """Return a safe sensor directory name or empty string for fallback routing."""
+        if not sensor_hostname:
+            return ""
+        if (
+            sensor_hostname in {".", ".."}
+            or "/" in sensor_hostname
+            or "\\" in sensor_hostname
+            or not _SENSOR_HOSTNAME_PATTERN.fullmatch(sensor_hostname)
+        ):
+            logger.warning(
+                "Ignoring unsafe sensor hostname %s for %s; routing to flat output",
+                sensor_hostname,
+                self.format_def.name,
+            )
+            return ""
+        return sensor_hostname
 
     def _get_default_writer(self) -> _SingleZeekWriter:
         """Get the backward-compat flat writer (no sensor subdirectory)."""

--- a/tests/unit/test_zeek_multiplex.py
+++ b/tests/unit/test_zeek_multiplex.py
@@ -91,6 +91,30 @@ class TestPerSensorDirectoryRouting:
             emitter.close()
             assert (base / "sensor-1" / "conn.json").exists()
 
+    def test_unsafe_sensor_hostname_routes_to_flat_output(self):
+        """Unsafe sensor hostnames are rejected to prevent path traversal."""
+        fmt = load_format("zeek_conn")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            emitter = ZeekEmitter(fmt, base, sensor_hostnames=["../../escape"])
+            emitter.emit_event(
+                {
+                    "ts": datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                    "uid": "CTest123456789ab",
+                    "id.orig_h": "10.0.0.1",
+                    "id.orig_p": 50000,
+                    "id.resp_h": "8.8.8.8",
+                    "id.resp_p": 443,
+                    "proto": "tcp",
+                    "conn_state": "SF",
+                    "_sensor_hostnames": ["../../escape"],
+                }
+            )
+            emitter.close()
+
+            assert (base / "zeek_conn.json").exists()
+            assert not (base.parent / "escape" / "conn.json").exists()
+
     def test_no_sensors_flat_output(self):
         """No sensors configured → flat output using _flat_filename."""
         fmt = load_format("zeek_conn")


### PR DESCRIPTION
### Motivation
- Prevent path traversal and arbitrary file writes when scenario-controlled sensor names are used as filesystem path components by the Zeek sensor multiplexing logic. 
- The vulnerability arose because sensor hostnames flowed from `EventDispatcher` into `SensorMultiplexEmitter` and were concatenated into output paths without sanitization. 

### Description
- Add hostname normalization to `SensorMultiplexEmitter` in `src/evidenceforge/generation/emitters/zeek_base.py` by introducing `_normalize_sensor_hostname` and a `_SENSOR_HOSTNAME_PATTERN` regex to validate safe names. 
- Use the normalized hostname when creating per-sensor writers and fall back to flat output when a hostname is unsafe (rejects `.`/`..`, path separators, or names with invalid characters) while emitting a warning. 
- Add a unit test `test_unsafe_sensor_hostname_routes_to_flat_output` in `tests/unit/test_zeek_multiplex.py` that verifies a malicious name like `"../../escape"` does not write outside the configured base directory. 
- Update `TODO.md` to record the security fix per the project workflow. 

### Testing
- Lint/format checks for the changed files passed with `ruff check` and `ruff format --check` on the modified files. 
- Added unit test `tests/unit/test_zeek_multiplex.py::TestPerSensorDirectoryRouting::test_unsafe_sensor_hostname_routes_to_flat_output`, but a full `uv`-driven test run could not be completed due to the environment failing to resolve build dependencies (could not fetch `hatchling` from PyPI). 
- Direct `pytest` runs in this environment were blocked by missing third-party runtime dependencies (e.g., `yaml`), so the new test could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0167796048325957fd5d0de6e0b72)