### PR TITLE
fix: sanitize host-based emitter routing keys to block path traversal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -82,6 +82,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] **CI runs tests 3 times** — 3 separate pytest invocations (unit, integration, both again for coverage). Consolidate to single run.
 - [x] **No pre-commit hooks** — ruff issues only caught in CI. Add pre-commit framework with ruff check + format hooks.
 - [ ] **Re-generation appends to existing output** — `GenerationEngine` creates output directories with `exist_ok=True` and emitters append to existing files. Re-running a scenario without manually clearing the output directory produces mixed old+new data. Should clean the output directory (or at least its per-sensor subdirectories) before writing.
+- [x] Security fix: sanitize host-based emitter routing keys to prevent path traversal from scenario-derived FQDN values (proxy_access and any `_host_fqdn` routes).
 
 ### Tier 1: Foundational Correctness
 

--- a/src/evidenceforge/generation/emitters/host_base.py
+++ b/src/evidenceforge/generation/emitters/host_base.py
@@ -130,15 +130,16 @@ class HostMultiplexEmitter(LogEmitter):
         super().__init__(format_def, output_path, buffer_size, threaded)
 
     def _get_writer(self, host_fqdn: str) -> _SingleHostWriter:
-        writer = self._writers.get(host_fqdn)
+        routed_host = self._sanitize_host_fqdn(host_fqdn) if host_fqdn else ""
+        writer = self._writers.get(routed_host)
         if writer is not None:
             return writer
         with self._writers_lock:
-            writer = self._writers.get(host_fqdn)
+            writer = self._writers.get(routed_host)
             if writer is not None:
                 return writer
-            if host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / host_fqdn / self._log_filename
+            if routed_host and not self._direct_file_mode:
+                path = self._base_dir / routed_host / self._log_filename
             elif self._direct_file_path:
                 path = self._direct_file_path
             else:
@@ -146,9 +147,23 @@ class HostMultiplexEmitter(LogEmitter):
                 path = self._base_dir / flat_name
             sort = self._sort_flat_file
             writer = _SingleHostWriter(path, self._buffer_size, sort_on_flush=sort)
-            self._writers[host_fqdn] = writer
+            self._writers[routed_host] = writer
             logger.debug(f"Created host writer: {path}")
             return writer
+
+    @staticmethod
+    def _sanitize_host_fqdn(host_fqdn: str) -> str:
+        """Sanitize host routing key before using it as a path component."""
+        sanitized = "".join(
+            character if character.isalnum() or character in "._-" else "_"
+            for character in host_fqdn.strip()
+        )
+        sanitized = sanitized.strip(" .")
+        while ".." in sanitized:
+            sanitized = sanitized.replace("..", ".")
+        if sanitized in {"", ".", ".."}:
+            return "unknown-host"
+        return sanitized
 
     def emit_to_host(self, rendered: str, host_fqdn: str = "") -> None:
         """Route a rendered line to the appropriate host writer."""

--- a/tests/unit/test_host_base_sanitization.py
+++ b/tests/unit/test_host_base_sanitization.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Security tests for host-based emitter path routing."""
+
+from evidenceforge.formats import load_format
+from evidenceforge.generation.emitters.proxy import ProxyEmitter
+
+
+def test_emit_to_host_sanitizes_path_traversal(tmp_path):
+    """Malicious host routing values cannot escape the configured output directory."""
+    emitter = ProxyEmitter(load_format("proxy_access"), tmp_path, buffer_size=1)
+
+    emitter.emit_to_host("test-line", "../../.ssh")
+    emitter.close()
+
+    escaped_path = tmp_path.parent / ".ssh" / "proxy_access.log"
+    assert not escaped_path.exists()
+
+    sanitized_path = tmp_path / "_.ssh" / "proxy_access.log"
+    assert sanitized_path.exists()


### PR DESCRIPTION
### Motivation

- Close a path traversal/arbitrary file-write vector where scenario-supplied domain/FQDN strings (e.g., `proxy_fqdn`) were used directly as filesystem path components in host-multiplexed emitters.

### Description

- Sanitize routing keys in `HostMultiplexEmitter._get_writer()` by calling a new `HostMultiplexEmitter._sanitize_host_fqdn()` helper and key the writer cache by the sanitized value instead of the raw input.
- Implement `_sanitize_host_fqdn()` to replace unsafe characters, collapse `..` sequences, trim leading/trailing dots/spaces, and fall back to `unknown-host` for empty/invalid results.
- Update path construction to use the sanitized host directory when creating per-host writer paths.
- Add a unit test `tests/unit/test_host_base_sanitization.py` that attempts to route to `"../../.ssh"` and asserts no files are written outside the configured output directory, and update `TODO.md` to reflect the security fix.

### Testing

- Ran linter/format checks with `uv run ruff check .` and `uv run ruff format --check .`, both succeeded.
- Added a focused unit test for path sanitization; attempted to run `PYTHONPATH=src uv run pytest tests/unit/test_host_base_sanitization.py -q` but execution in this environment failed due to a missing test dependency (`yaml`), so the test could not be executed here.
- Changes were validated locally via code inspection and an automated test was added to enforce the behavior in CI where full dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a5004483258eef31a282d37a1b)