### PR TITLE
fix: sanitize host multiplex routing keys to prevent path traversal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -81,6 +81,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] **Coverage threshold mismatch (local 70% vs CI 90%)** — pyproject.toml `fail_under` doesn't match CI's `--cov-fail-under=90`. Devs pass locally, fail in CI.
 - [x] **CI runs tests 3 times** — 3 separate pytest invocations (unit, integration, both again for coverage). Consolidate to single run.
 - [x] **No pre-commit hooks** — ruff issues only caught in CI. Add pre-commit framework with ruff check + format hooks.
+- [x] **Prevent path traversal in HostMultiplexEmitter host routing** — sanitize `_host_fqdn` / host routing keys before path construction (reject absolute paths, traversal segments, separators, and drive-like keys), fall back to flat-file routing for invalid keys, and add unit coverage for traversal rejection + valid host routing.
 - [ ] **Re-generation appends to existing output** — `GenerationEngine` creates output directories with `exist_ok=True` and emitters append to existing files. Re-running a scenario without manually clearing the output directory produces mixed old+new data. Should clean the output directory (or at least its per-sensor subdirectories) before writing.
 
 ### Tier 1: Foundational Correctness

--- a/src/evidenceforge/generation/emitters/host_base.py
+++ b/src/evidenceforge/generation/emitters/host_base.py
@@ -129,16 +129,43 @@ class HostMultiplexEmitter(LogEmitter):
         self._buffer_size = buffer_size
         super().__init__(format_def, output_path, buffer_size, threaded)
 
+    @staticmethod
+    def _sanitize_host_key(host_fqdn: str) -> str:
+        """Return a safe host key for directory routing.
+
+        Invalid values (absolute paths, traversal segments, or path separators)
+        are rejected and mapped to flat-file routing.
+        """
+        host_key = host_fqdn.strip()
+        if not host_key:
+            return ""
+
+        if "\\" in host_key or ":" in host_key:
+            logger.warning("Invalid host routing key rejected: %s", host_fqdn)
+            return ""
+
+        path = Path(host_key)
+        if (
+            path.is_absolute()
+            or len(path.parts) != 1
+            or any(part in {".", ".."} for part in path.parts)
+        ):
+            logger.warning("Invalid host routing key rejected: %s", host_fqdn)
+            return ""
+
+        return host_key
+
     def _get_writer(self, host_fqdn: str) -> _SingleHostWriter:
-        writer = self._writers.get(host_fqdn)
+        safe_host_key = self._sanitize_host_key(host_fqdn)
+        writer = self._writers.get(safe_host_key)
         if writer is not None:
             return writer
         with self._writers_lock:
-            writer = self._writers.get(host_fqdn)
+            writer = self._writers.get(safe_host_key)
             if writer is not None:
                 return writer
-            if host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / host_fqdn / self._log_filename
+            if safe_host_key and not self._direct_file_mode:
+                path = self._base_dir / safe_host_key / self._log_filename
             elif self._direct_file_path:
                 path = self._direct_file_path
             else:
@@ -146,7 +173,7 @@ class HostMultiplexEmitter(LogEmitter):
                 path = self._base_dir / flat_name
             sort = self._sort_flat_file
             writer = _SingleHostWriter(path, self._buffer_size, sort_on_flush=sort)
-            self._writers[host_fqdn] = writer
+            self._writers[safe_host_key] = writer
             logger.debug(f"Created host writer: {path}")
             return writer
 

--- a/tests/unit/test_host_multiplex_security.py
+++ b/tests/unit/test_host_multiplex_security.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Security tests for host-based emitter routing."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from evidenceforge.formats import load_format
+from evidenceforge.generation.emitters.web import WebEmitter
+
+
+class TestHostMultiplexRoutingSecurity:
+    """Validate host routing does not allow path traversal."""
+
+    def test_web_emitter_rejects_path_traversal_host_key(self, tmp_path: Path) -> None:
+        fmt = load_format("web_access")
+        emitter = WebEmitter(fmt, tmp_path)
+
+        escape_dir = "escape_should_not_be_created"
+        emitter.emit_event(
+            {
+                "timestamp": datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+                "client_ip": "10.0.0.5",
+                "username": "-",
+                "method": "GET",
+                "path": "/",
+                "protocol": "HTTP/1.1",
+                "status_code": 200,
+                "bytes_sent": 128,
+                "referer": "-",
+                "user_agent": "Mozilla/5.0",
+                "_host_fqdn": f"../../{escape_dir}",
+            }
+        )
+        emitter.close()
+
+        assert (tmp_path / "web_access.log").exists()
+        assert not (tmp_path.parent / escape_dir / "web_access.log").exists()
+
+    def test_web_emitter_keeps_valid_host_routing(self, tmp_path: Path) -> None:
+        fmt = load_format("web_access")
+        emitter = WebEmitter(fmt, tmp_path)
+
+        emitter.emit_event(
+            {
+                "timestamp": datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+                "client_ip": "10.0.0.5",
+                "username": "-",
+                "method": "GET",
+                "path": "/app",
+                "protocol": "HTTP/1.1",
+                "status_code": 200,
+                "bytes_sent": 128,
+                "referer": "-",
+                "user_agent": "Mozilla/5.0",
+                "_host_fqdn": "web-01.corp.local",
+            }
+        )
+        emitter.close()
+
+        assert (tmp_path / "web-01.corp.local" / "web_access.log").exists()


### PR DESCRIPTION
### Motivation
- Host-based emitters used untrusted `_host_fqdn` values directly when constructing filesystem paths, allowing path traversal or absolute-path payloads in scenarios to escape the configured output directory.
- The goal is to prevent arbitrary file writes while preserving per-host routing behavior and backward-compatible flat-file/direct-file modes.

### Description
- Add `HostMultiplexEmitter._sanitize_host_key()` to validate and normalize routing keys, rejecting absolute paths, traversal segments (`.`/`..`), path separators, and drive-like tokens and mapping invalid keys to flat-file routing.
- Update `_get_writer()` to use the sanitized host key for writer lookup, writer cache keys, and path construction so unsafe `_host_fqdn` values cannot influence output paths.
- Emit a warning when an invalid host routing key is rejected so operators can detect suspicious scenario input.
- Add `tests/unit/test_host_multiplex_security.py` covering rejection of a traversal payload and correct per-host routing for valid FQDNs, and update `TODO.md` to mark the task completed.

### Testing
- Ran lint and formatting checks with `uv run ruff check .` and `uv run ruff format --check .`, both passed after formatting the changed file.
- Executed a small smoke check via `PYTHONPATH=src python -c "from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter; ..."` that demonstrates the sanitizer rejects traversal input and accepts valid host keys.
- Added unit tests that exercise traversal rejection and valid routing, but `pytest` in this container failed to bootstrap tests due to a missing test dependency (`yaml`) in the environment; the new tests are included and will run in CI where dependencies are satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a3edc08325926c40128e8a13f2)