### PR TITLE
fix: sanitize host-routed emitter paths to prevent traversal writes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,8 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
+- [x] Security fix: sanitize host FQDN-derived output paths to prevent path traversal writes outside output directory (added sink-side sanitization in host multiplex, Windows/Sysmon, and bash history emitters + path safety tests)
+
 **Goal:** Fix all expert-identified issues that would cause an analyst to reject the data. Consolidated from 6 blind expert panel improvement loops (Threat Hunter, DFIR, Network Eng, Detection Eng) plus infrastructure issues. Work top to bottom.
 
 ### World Model Refactor

--- a/src/evidenceforge/generation/emitters/bash_history.py
+++ b/src/evidenceforge/generation/emitters/bash_history.py
@@ -38,6 +38,7 @@ from jinja2 import Template
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
+from evidenceforge.generation.emitters.path_safety import sanitize_host_directory_name
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +188,8 @@ class BashHistoryEmitter(LogEmitter):
             if writer is not None:
                 return writer
             # Nest under host FQDN dir: <base>/<fqdn>/bash_history/<user>.bash_history
-            path = self._base_dir / host_fqdn / "bash_history" / f"{username}.bash_history"
+            safe_host = sanitize_host_directory_name(host_fqdn)
+            path = self._base_dir / safe_host / "bash_history" / f"{username}.bash_history"
             writer = _SingleHistoryWriter(path, self._template, self._buffer_size)
             self._writers[key] = writer
             logger.debug(f"Created bash_history writer: {path}")

--- a/src/evidenceforge/generation/emitters/host_base.py
+++ b/src/evidenceforge/generation/emitters/host_base.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
+from evidenceforge.generation.emitters.path_safety import host_output_path
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +139,7 @@ class HostMultiplexEmitter(LogEmitter):
             if writer is not None:
                 return writer
             if host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / host_fqdn / self._log_filename
+                path = host_output_path(self._base_dir, host_fqdn, self._log_filename)
             elif self._direct_file_path:
                 path = self._direct_file_path
             else:

--- a/src/evidenceforge/generation/emitters/path_safety.py
+++ b/src/evidenceforge/generation/emitters/path_safety.py
@@ -1,0 +1,24 @@
+"""Path safety helpers for host-routed emitters."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_UNSAFE_PATH_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+_DEFAULT_HOST_DIRECTORY = "unknown-host"
+
+
+def sanitize_host_directory_name(host_fqdn: str) -> str:
+    """Sanitize host identifier for safe use as a single directory name."""
+    raw = host_fqdn.strip().replace("/", "_").replace("\\", "_")
+    sanitized = _UNSAFE_PATH_CHARS.sub("_", raw).strip()
+    sanitized = sanitized.lstrip(".")
+    if not sanitized or sanitized in {".", ".."}:
+        return _DEFAULT_HOST_DIRECTORY
+    return sanitized
+
+
+def host_output_path(base_dir: Path, host_fqdn: str, filename: str) -> Path:
+    """Build a safe per-host output path under ``base_dir``."""
+    return base_dir / sanitize_host_directory_name(host_fqdn) / filename

--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -39,6 +39,7 @@ from evidenceforge.events.base import SecurityEvent
 from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 from evidenceforge.generation.emitters.host_base import _SingleHostWriter
+from evidenceforge.generation.emitters.path_safety import host_output_path
 from evidenceforge.utils.rng import _stable_seed
 
 
@@ -679,7 +680,7 @@ class SysmonEventEmitter(LogEmitter):
             if writer is not None:
                 return writer
             if host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / host_fqdn / "windows_event_sysmon.xml"
+                path = host_output_path(self._base_dir, host_fqdn, "windows_event_sysmon.xml")
             elif self._direct_file_path:
                 path = self._direct_file_path
             else:

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -40,6 +40,7 @@ from evidenceforge.events.contexts import HostContext
 from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 from evidenceforge.generation.emitters.host_base import _SingleHostWriter
+from evidenceforge.generation.emitters.path_safety import host_output_path
 
 win_logger = logging.getLogger(__name__)
 
@@ -975,7 +976,7 @@ class WindowsEventEmitter(LogEmitter):
             if writer is not None:
                 return writer
             if host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / host_fqdn / "windows_event_security.xml"
+                path = host_output_path(self._base_dir, host_fqdn, "windows_event_security.xml")
             elif self._direct_file_path:
                 path = self._direct_file_path
             else:

--- a/tests/unit/test_emitter_path_safety.py
+++ b/tests/unit/test_emitter_path_safety.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for secure host directory routing in emitters."""
+
+from evidenceforge.formats import load_format
+from evidenceforge.generation.emitters.bash_history import BashHistoryEmitter
+from evidenceforge.generation.emitters.path_safety import sanitize_host_directory_name
+from evidenceforge.generation.emitters.syslog import SyslogEmitter
+from evidenceforge.generation.emitters.windows import WindowsEventEmitter
+
+
+def test_sanitize_host_directory_name_blocks_traversal() -> None:
+    """Traversal and separators are normalized to a safe single directory name."""
+    assert sanitize_host_directory_name("../../.ssh") == "______ssh"
+    assert sanitize_host_directory_name("host/../../escape") == "host_.._.._escape"
+
+
+def test_host_multiplex_writer_path_stays_under_base_dir(tmp_path) -> None:
+    """HostMultiplexEmitter-derived writers never escape output directory."""
+    emitter = SyslogEmitter(load_format("syslog"), tmp_path / "syslog", buffer_size=1)
+    writer = emitter._get_writer("../../escape")
+
+    assert writer.output_path.resolve().is_relative_to((tmp_path / "syslog").resolve())
+
+
+def test_windows_writer_path_stays_under_base_dir(tmp_path) -> None:
+    """WindowsEventEmitter host writers never escape output directory."""
+    emitter = WindowsEventEmitter(load_format("windows_event_security"), tmp_path / "windows")
+    writer = emitter._get_host_writer("../../escape")
+
+    assert writer.output_path.resolve().is_relative_to((tmp_path / "windows").resolve())
+
+
+def test_bash_history_writer_path_stays_under_base_dir(tmp_path) -> None:
+    """BashHistoryEmitter host writers never escape output directory."""
+    emitter = BashHistoryEmitter(load_format("bash_history"), tmp_path / "bash_history")
+    writer = emitter._get_writer("alice", "../../escape")
+
+    assert writer.output_path.resolve().is_relative_to((tmp_path / "bash_history").resolve())


### PR DESCRIPTION
### Motivation
- Prevent path traversal / arbitrary file writes when scenario-derived host FQDNs (or environment domains) contain separators or traversal sequences that could escape the configured output directory. 

### Description
- Add a centralized path-safety helper `src/evidenceforge/generation/emitters/path_safety.py` that normalizes a host identifier into a single safe directory component and constructs per-host output paths. 
- Route per-host path construction through the helper in `HostMultiplexEmitter` (covers syslog/ecar/web/proxy/etc.), `WindowsEventEmitter`, and `SysmonEventEmitter` so writers are created under sanitized subdirectories. 
- Apply sanitization for nested writers in `BashHistoryEmitter` by normalizing host names before composing nested `bash_history/<user>` paths. 
- Add `tests/unit/test_emitter_path_safety.py` exercising traversal-like host values and asserting writer output paths remain inside the configured base output directory, and mark the TODO entry for this security fix as completed. 

### Testing
- Ran static/format checks: `uv run ruff check .` and `uv run ruff format --check .`, both succeeded. 
- Performed smoke validation by instantiating `SyslogEmitter`, `WindowsEventEmitter`, and `BashHistoryEmitter` with traversal-like host values and asserting resolved writer paths are contained under the emitter base directories, and the smoke checks passed. 
- Added unit test `tests/unit/test_emitter_path_safety.py` covering sanitization and path containment; running `pytest` in the current environment was not possible (test runner/dependency constraints), so the test file is included but full `uv run pytest` was not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a5a4208325b37c72d28288a00c)