### PR TITLE
fix: sanitize sensor output directory names to prevent path traversal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,6 +75,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Tier 0: Infrastructure
 
+- [x] Security: sanitized sensor-hostname-based output paths to prevent traversal outside output_dir (path separators/traversal tokens now normalized to safe subdirectory names in SensorMultiplexEmitter; added unit tests).
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.
 - [x] **`eforge validate` can't find personas in dev mode** — works when installed (`eforge validate`) but not via `uv run eforge validate`. Blocks dev workflow.
 - [x] **511 ruff lint errors + 102 formatting issues** — CI lint job fails immediately. Auto-fix + suppress false positives (B008 for Typer, N806 for lookup tables, B904 for typer.Exit).

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -38,6 +38,7 @@ When no sensors are configured (backward compat), writes directly to:
 
 import json
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from queue import Empty
@@ -48,6 +49,7 @@ from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 
 logger = logging.getLogger(__name__)
+_SENSOR_DIR_SAFE_CHARS_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
 class _SingleZeekWriter:
@@ -130,15 +132,16 @@ class SensorMultiplexEmitter(LogEmitter):
         super().__init__(format_def, output_path, buffer_size, threaded)
 
     def _get_writer(self, sensor_hostname: str) -> _SingleZeekWriter:
-        writer = self._writers.get(sensor_hostname)
+        writer_key = self._sanitize_sensor_dir_name(sensor_hostname) if sensor_hostname else ""
+        writer = self._writers.get(writer_key)
         if writer is not None:
             return writer
         with self._writers_lock:
-            writer = self._writers.get(sensor_hostname)
+            writer = self._writers.get(writer_key)
             if writer is not None:
                 return writer
             if sensor_hostname:
-                path = self._base_dir / sensor_hostname / self._log_filename
+                path = self._base_dir / writer_key / self._log_filename
             elif self._direct_file_path:
                 # Direct file mode (test/simple usage): output_path was a file
                 path = self._direct_file_path
@@ -152,9 +155,15 @@ class SensorMultiplexEmitter(LogEmitter):
                 sort_before_flush=self._sort_before_flush,
                 sort_key=getattr(self, "_sort_key_func", None),
             )
-            self._writers[sensor_hostname] = writer
+            self._writers[writer_key] = writer
             logger.debug(f"Created Zeek writer: {path}")
             return writer
+
+    @staticmethod
+    def _sanitize_sensor_dir_name(sensor_hostname: str) -> str:
+        """Normalize user-provided sensor hostnames into safe output directory names."""
+        sanitized = _SENSOR_DIR_SAFE_CHARS_RE.sub("_", sensor_hostname).strip("._-")
+        return sanitized or "sensor"
 
     def _get_default_writer(self) -> _SingleZeekWriter:
         """Get the backward-compat flat writer (no sensor subdirectory)."""

--- a/tests/unit/test_zeek_multiplex.py
+++ b/tests/unit/test_zeek_multiplex.py
@@ -91,6 +91,56 @@ class TestPerSensorDirectoryRouting:
             emitter.close()
             assert (base / "sensor-1" / "conn.json").exists()
 
+    def test_sensor_hostname_path_traversal_is_sanitized(self):
+        """Traversal strings must not escape the configured base directory."""
+        fmt = load_format("zeek_conn")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            emitter = ZeekEmitter(fmt, base, sensor_hostnames=["../../pwned_dir"])
+            emitter.emit_event(
+                {
+                    "ts": datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                    "uid": "CTest123456789ab",
+                    "id.orig_h": "10.0.0.1",
+                    "id.orig_p": 50000,
+                    "id.resp_h": "8.8.8.8",
+                    "id.resp_p": 443,
+                    "proto": "tcp",
+                    "conn_state": "SF",
+                    "_sensor_hostnames": ["../../pwned_dir"],
+                }
+            )
+            emitter.close()
+
+            expected_path = base / "pwned_dir" / "conn.json"
+            assert expected_path.exists()
+            assert expected_path.resolve().is_relative_to(base.resolve())
+
+    def test_sensor_hostname_absolute_path_is_sanitized(self):
+        """Absolute-path-like hostnames must be reduced to a safe local subdirectory."""
+        fmt = load_format("zeek_conn")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            emitter = ZeekEmitter(fmt, base, sensor_hostnames=["/tmp/evil"])
+            emitter.emit_event(
+                {
+                    "ts": datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                    "uid": "CTest123456789ab",
+                    "id.orig_h": "10.0.0.1",
+                    "id.orig_p": 50000,
+                    "id.resp_h": "8.8.8.8",
+                    "id.resp_p": 443,
+                    "proto": "tcp",
+                    "conn_state": "SF",
+                    "_sensor_hostnames": ["/tmp/evil"],
+                }
+            )
+            emitter.close()
+
+            expected_path = base / "tmp_evil" / "conn.json"
+            assert expected_path.exists()
+            assert expected_path.resolve().is_relative_to(base.resolve())
+
     def test_no_sensors_flat_output(self):
         """No sensors configured → flat output using _flat_filename."""
         fmt = load_format("zeek_conn")


### PR DESCRIPTION
### Motivation
- Per-sensor Zeek output used the raw `NetworkSensor.hostname` as a directory component, allowing crafted hostnames like `../../...` or absolute paths to write outside the configured output directory. 
- The change prevents an attacker-controlled scenario field from influencing filesystem paths and eliminates arbitrary file write/overwrite risk during generation.

### Description
- Normalize sensor directory names in `SensorMultiplexEmitter` by adding a sanitizer that replaces unsafe characters with underscores and trims leading/trailing dots/sep, and use the sanitized key for writer caching and path construction (`src/evidenceforge/generation/emitters/zeek_base.py`).
- Route writer cache and file paths by the sanitized name so traversal tokens or absolute-path-like inputs cannot escape the output base directory (`_sanitize_sensor_dir_name` + using `writer_key`).
- Add unit tests that assert traversal-style (`"../../pwned_dir"`) and absolute-path-like (`"/tmp/evil"`) sensor hostnames are reduced to safe subdirectories and that files remain under the configured base (`tests/unit/test_zeek_multiplex.py`).
- Update `TODO.md` to mark the security item as completed following project workflow.

### Testing
- Ran linting and formatting checks with `uv run ruff check .` and `uv run ruff format --check .`, both of which passed. 
- Added and exercised unit tests in `tests/unit/test_zeek_multiplex.py` locally; however running `uv run pytest tests/unit/test_zeek_multiplex.py` in this environment failed to start due to a missing runtime dependency (`PyYAML` / `yaml` import error) before tests execute. 
- The change is limited and unit-focused (sanitizer + tests) and should be covered by the added tests when the test environment includes the project runtime deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a492a883259bc034412f0127e9)