### PR TITLE
fix: sandbox emitter templates to block SSTI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -81,6 +81,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] **Coverage threshold mismatch (local 70% vs CI 90%)** — pyproject.toml `fail_under` doesn't match CI's `--cov-fail-under=90`. Devs pass locally, fail in CI.
 - [x] **CI runs tests 3 times** — 3 separate pytest invocations (unit, integration, both again for coverage). Consolidate to single run.
 - [x] **No pre-commit hooks** — ruff issues only caught in CI. Add pre-commit framework with ruff check + format hooks.
+- [x] Security: sandboxed Jinja template rendering for YAML-defined format templates (SandboxedEnvironment + StrictUndefined) to block SSTI/code execution while preserving safe field interpolation.
 - [ ] **Re-generation appends to existing output** — `GenerationEngine` creates output directories with `exist_ok=True` and emitters append to existing files. Re-running a scenario without manually clearing the output directory produces mixed old+new data. Should clean the output directory (or at least its per-sensor subdirectories) before writing.
 
 ### Tier 1: Foundational Correctness

--- a/src/evidenceforge/generation/emitters/base.py
+++ b/src/evidenceforge/generation/emitters/base.py
@@ -30,7 +30,8 @@ from queue import Empty, Full, Queue
 from threading import Event, Lock, Thread
 from typing import Any
 
-from jinja2 import Template
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.formats.format_def import FormatDefinition
@@ -76,7 +77,8 @@ class LogEmitter(ABC):
         self.buffer_size = buffer_size
         self.buffer: list[str] = []
         self.event_count = 0
-        self._template = Template(format_def.output.template)
+        self._template_env = SandboxedEnvironment(undefined=StrictUndefined, autoescape=False)
+        self._template = self._template_env.from_string(format_def.output.template)
         self._header_written = False
         self._file_lock = Lock()  # Thread-safe file I/O and buffer access
 
@@ -244,7 +246,7 @@ class LogEmitter(ABC):
         Private method called while already holding the lock.
         """
         if self.format_def.output.header_template and not self._header_written:
-            header_template = Template(self.format_def.output.header_template)
+            header_template = self._template_env.from_string(self.format_def.output.header_template)
             header = header_template.render()
 
             # Write header to file
@@ -314,9 +316,7 @@ class LogEmitter(ABC):
         """Write footer to output file if format has one."""
         footer_template = getattr(self.format_def.output, "footer_template", None)
         if footer_template and self._header_written:
-            from jinja2 import Template
-
-            tmpl = Template(footer_template)
+            tmpl = self._template_env.from_string(footer_template)
             footer = tmpl.render()
             with self._file_lock:
                 with open(self.output_path, "a", encoding=self.format_def.output.encoding) as f:

--- a/tests/unit/test_template_security.py
+++ b/tests/unit/test_template_security.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Security tests for template rendering in emitters."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jinja2.exceptions import SecurityError
+
+from evidenceforge.formats.format_def import FormatDefinition, OutputTemplate
+from evidenceforge.generation.emitters.base import LogEmitter
+
+
+class _TestEmitter(LogEmitter):
+    """Minimal concrete emitter for template security testing."""
+
+    def emit_event(self, event_data: dict[str, Any]) -> None:
+        rendered = self._render_event(event_data)
+        self._buffer_event(rendered)
+
+    def _render_event(self, event_data: dict[str, Any]) -> str:
+        return self._template.render(**event_data)
+
+
+def _build_format(template: str) -> FormatDefinition:
+    return FormatDefinition(
+        name="test_format",
+        version="1.0",
+        description="Test format",
+        category="host",
+        fields=[],
+        output=OutputTemplate(format="text", template=template, file_extension=".log"),
+    )
+
+
+def test_log_emitter_sandbox_blocks_unsafe_template_access(tmp_path: Path) -> None:
+    """Unsafe template attribute access should be blocked by sandbox."""
+    format_def = _build_format("{{ cycler.__init__.__globals__.os.name }}")
+    emitter = _TestEmitter(format_def, tmp_path / "out.log", buffer_size=1)
+
+    with pytest.raises(SecurityError):
+        emitter.emit_event({})
+
+
+def test_log_emitter_sandbox_allows_normal_field_rendering(tmp_path: Path) -> None:
+    """Safe field interpolation should continue to work."""
+    format_def = _build_format("user={{ username }}")
+    emitter = _TestEmitter(format_def, tmp_path / "out.log", buffer_size=1)
+
+    emitter.emit_event({"username": "alice"})
+    emitter.close()
+
+    assert (tmp_path / "out.log").read_text(encoding="utf-8").strip() == "user=alice"


### PR DESCRIPTION
### Motivation
- Untrusted Jinja2 templates loaded from YAML format definitions were compiled and rendered with `jinja2.Template(...)`, exposing a server-side template injection (SSTI) risk that can lead to arbitrary code execution.

### Description
- Replace direct `Template(...)` usage with a shared `SandboxedEnvironment(undefined=StrictUndefined)` and compile main/header/footer templates via `env.from_string(...)` in `src/evidenceforge/generation/emitters/base.py` to constrain template capabilities.
- Add a focused unit test file `tests/unit/test_template_security.py` that asserts unsafe attribute traversal raises `jinja2.exceptions.SecurityError` and that normal field interpolation still renders.
- Record the security fix as completed in `TODO.md` per repository workflow.

### Testing
- Ran lint checks with `uv run ruff check .` which passed. 
- Ran formatting verification with `uv run ruff format --check .` which passed. 
- Performed a sandbox smoke test using a small Python run of `SandboxedEnvironment` that confirmed an unsafe payload is blocked and safe rendering succeeds. 
- Added unit tests (`tests/unit/test_template_security.py`) but executing the full pytest suite in this environment failed due to missing dev/test tooling being unavailable for download, so those new tests are present but were not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a4ee3c8325b2eb274dd080652d)