### PR TITLE
fix: prevent mixed-timezone session lookup crash

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Evaluator grace period for causal ordering (logon→process rule skips events within logon_grace_period from scenario start)
 - [x] Evaluator event type detection from typed EventSpec fields (replaces fragile keyword matching) + 9 new record matchers
 - [x] Evaluator per-sub-event indicator accuracy (fixes last-writer-wins IP merge for compound storyline steps) + tighter eCAR FLOW matching

--- a/src/evidenceforge/generation/world_model.py
+++ b/src/evidenceforge/generation/world_model.py
@@ -12,7 +12,7 @@ exists. This module adds the missing "why would this happen here?" layer:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from evidenceforge.generation.activity.generator import _ephemeral_port
@@ -902,8 +902,16 @@ class WorldPlanner:
         if session_kind:
             exact = [s for s in host_sessions if s.session_kind == session_kind]
             if exact:
-                return max(exact, key=lambda s: s.start_time)
-        return max(host_sessions, key=lambda s: s.start_time)
+                return max(exact, key=self._session_start_sort_key)
+        return max(host_sessions, key=self._session_start_sort_key)
+
+    @staticmethod
+    def _session_start_sort_key(session: ActiveSession) -> datetime:
+        """Normalize session start_time so mixed aware/naive datetimes can be ordered safely."""
+        start_time = session.start_time
+        if start_time.tzinfo is None:
+            return start_time.replace(tzinfo=UTC)
+        return start_time.astimezone(UTC)
 
     def _bootstrap_ssh_session(
         self,

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -316,3 +316,31 @@ def test_world_planner_bootstraps_rdp_session_with_owned_state(
     assert rdp_connections[0].protocol == "tcp"
     assert rdp_connections[0].initiating_pid > 0
     assert rdp_connections[0].source_system == "WKS-01"
+
+
+def test_find_user_session_handles_mixed_timezone_start_times(
+    planner: WorldPlanner,
+    state_manager: StateManager,
+) -> None:
+    """Session lookup should not crash when start_time mixes naive and aware datetimes."""
+    state_manager.set_current_time(datetime(2024, 1, 15, 10, 0, 0))
+    state_manager.create_session(
+        username="alice.admin",
+        system="APP-01",
+        logon_type=3,
+        source_ip="10.10.10.50",
+        session_kind="network",
+    )
+    state_manager.set_current_time(datetime(2024, 1, 15, 10, 5, 0, tzinfo=UTC))
+    latest_id = state_manager.create_session(
+        username="alice.admin",
+        system="APP-01",
+        logon_type=10,
+        source_ip="10.10.10.50",
+        session_kind="rdp",
+    )
+
+    selected = planner._find_user_session("alice.admin", "APP-01")
+
+    assert selected is not None
+    assert selected.logon_id == latest_id


### PR DESCRIPTION
### Motivation
- `_find_user_session` used `max(..., key=<start_time>)` to select the newest session, which raises `TypeError` when session `start_time` values mix timezone-aware and timezone-naive datetimes coming from scenario/storyline input. This can crash generation and act as a deterministic denial-of-service. 

### Description
- Use a UTC-normalized sort key by replacing `max(..., key=lambda s: s.start_time)` with `max(..., key=self._session_start_sort_key)` so comparisons never mix aware/naive datetimes. 
- Add the helper static method `WorldPlanner._session_start_sort_key` that returns a UTC-aware `datetime` for a session by replacing naive timestamps with `tzinfo=UTC` or converting aware timestamps via `astimezone(UTC)`. 
- Add a focused regression test `test_find_user_session_handles_mixed_timezone_start_times` in `tests/unit/test_world_model.py` that creates one naive and one UTC-aware session and verifies the planner returns the latest session. 
- Mark the issue resolved in `TODO.md` per project workflow. 

### Testing
- Ran `uv run ruff check .` and it passed. 
- Ran `uv run ruff format --check .` and formatting checks passed. 
- Added a unit test, but running `PYTHONPATH=src uv run pytest tests/unit/test_world_model.py` in this environment failed due to a missing dependency (`yaml` / `PyYAML`), so full `pytest` could not be executed here; the test is included and will be exercised in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a381988325a00fb64220a2e7f9)