### PR TITLE
fix: prevent inbound profile crash when outbound traffic is empty

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Evaluator grace period for causal ordering (logon→process rule skips events within logon_grace_period from scenario start)
 - [x] Evaluator event type detection from typed EventSpec fields (replaces fragile keyword matching) + 9 new record matchers
 - [x] Evaluator per-sub-event indicator accuracy (fixes last-writer-wins IP merge for compound storyline steps) + tighter eCAR FLOW matching

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -2338,16 +2338,17 @@ class BaselineMixin:
             if not roles:
                 roles = [(system.type or "workstation").lower()]
 
+        # Use scenario-local time for business-hour gating, not UTC.
+        _local = local_dt if local_dt is not None else current_hour
+        dow = _local.weekday()
+        hour = _local.hour
+        is_business = 0 <= dow <= 4 and 7 <= hour <= 19
+
         # --- Role traffic (system-level, 24/7) ---
         role_conns = get_role_connections(roles, os_cat)
         if role_conns:
             weights = [c.get("weight", 1) for c in role_conns]
             # Scale connection count by time-of-day (fewer at night)
-            # Use scenario-local time for business-hour gating, not UTC
-            _local = local_dt if local_dt is not None else current_hour
-            dow = _local.weekday()
-            hour = _local.hour
-            is_business = 0 <= dow <= 4 and 7 <= hour <= 19
             base_count = rng.randint(8, 20) if is_business else rng.randint(2, 6)
 
             for _ in range(base_count):

--- a/tests/unit/test_inbound_traffic.py
+++ b/tests/unit/test_inbound_traffic.py
@@ -3,12 +3,17 @@
 
 """Tests for inbound traffic profile generation."""
 
+from datetime import UTC, datetime
+from random import Random
+from types import SimpleNamespace
+
 from evidenceforge.generation.activity.traffic_profiles import (
     get_persona_connections,
     get_role_connections,
     get_role_inbound_connections,
     load_traffic_profiles,
 )
+from evidenceforge.generation.engine.baseline import BaselineMixin
 
 
 class TestTrafficProfileSchema:
@@ -125,3 +130,71 @@ class TestEnsureConnectionProcessCommandLine:
         assert "applications" in catalog, "Catalog should have 'applications' key"
         assert "apps" not in catalog, "Catalog should NOT have 'apps' key"
         assert len(catalog["applications"]) > 0
+
+
+class TestInboundGenerationRegression:
+    """Regression tests for inbound generation edge cases."""
+
+    def test_inbound_only_profile_does_not_raise_when_outbound_is_empty(self, monkeypatch):
+        """Inbound generation should not depend on outbound profile count."""
+
+        class _FakeActivityGenerator:
+            def __init__(self) -> None:
+                self._ip_to_system = {}
+                self.calls = 0
+
+            def generate_connection(self, **kwargs) -> None:
+                self.calls += 1
+
+        class _FakeStateManager:
+            def set_current_time(self, _time) -> None:
+                return None
+
+            def get_sessions_on_system(self, _hostname):
+                return []
+
+        class _FakeBaseline(BaselineMixin):
+            def _resolve_role(self, *args, **kwargs):
+                return ("198.51.100.20", "external-client.example")
+
+            def _get_system_exposure(self, _system):
+                return "external"
+
+        monkeypatch.setattr(
+            "evidenceforge.generation.activity.traffic_profiles.get_role_connections",
+            lambda _roles, _os_cat: [],
+        )
+        monkeypatch.setattr(
+            "evidenceforge.generation.activity.traffic_profiles.get_role_inbound_connections",
+            lambda _roles, _os_cat: [{"role": "_external", "port": 443, "proto": "tcp"}],
+        )
+        monkeypatch.setattr(
+            "evidenceforge.generation.activity.traffic_profiles.get_persona_connections",
+            lambda _persona, _os_cat: [],
+        )
+
+        engine = object.__new__(_FakeBaseline)
+        engine.activity_generator = _FakeActivityGenerator()
+        engine.state_manager = _FakeStateManager()
+        engine.scenario = SimpleNamespace(
+            environment=SimpleNamespace(users=[], network=None),
+        )
+
+        system = SimpleNamespace(
+            hostname="WEB-01",
+            ip="172.16.0.10",
+            roles=["web_server"],
+            type="server",
+            public_hostnames=["www.example.com"],
+            assigned_user=None,
+        )
+
+        engine._generate_profile_traffic(
+            current_hour=datetime(2026, 4, 13, 13, tzinfo=UTC),
+            system=system,
+            rng=Random(7),
+            os_cat="linux",
+            local_dt=datetime(2026, 4, 13, 13, tzinfo=UTC),
+        )
+
+        assert engine.activity_generator.calls > 0


### PR DESCRIPTION
### Motivation

- The inbound traffic loop referenced `is_business` only set inside the outbound role-traffic block, allowing an `UnboundLocalError` when outbound role connections were empty and inbound entries existed.

### Description

- Initialize business-hour gating (`is_business`) once near the top of `_generate_profile_traffic()` so it is always defined for outbound, inbound, and persona loops in `src/evidenceforge/generation/engine/baseline.py`.
- Add a regression test `test_inbound_only_profile_does_not_raise_when_outbound_is_empty` in `tests/unit/test_inbound_traffic.py` that simulates an inbound-only profile and verifies inbound connections are generated without crashing.
- Update `TODO.md` to record this fix in the implementation tracker.

### Testing

- Ran linting with `uv run ruff check .` which passed.  
- Ran formatting verification with `uv run ruff format --check .` which passed.  
- Attempted to run the touched unit test module with `PYTHONPATH=src uv run pytest tests/unit/test_inbound_traffic.py -q`, but test collection failed in this environment due to missing runtime test dependencies (`PyYAML` and `Jinja2`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a4bd508325a2f9eaec25422605)