### PR TITLE
Bound ASA threat-detection timestamp tracking to prevent unbounded memory/CPU growth

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -238,6 +238,7 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] DHCP shows full discovery instead of renewals in mid-scenario windows — initial leases emitted during warm-up (suppressed); periodic REQUEST/ACK renewals at T/2 in _generate_system_traffic()
 
 **Cisco ASA:**
+- [x] Security: bound threat-detection deny timestamp tracking window to prevent unbounded memory/CPU growth
 - [ ] ASA Built/Teardown counts perfectly balanced — real logs have orphans from log rotation boundaries
 - [ ] ASA message type diversity limited to 106023/302013-16/305011-12 — missing 111008, 113004, 733100, 106001, 725001, 304001
 - [ ] ASA deny baseline uniformly spaced (3-7s) — real scans arrive in bursty patterns

--- a/src/evidenceforge/generation/emitters/cisco_asa.py
+++ b/src/evidenceforge/generation/emitters/cisco_asa.py
@@ -31,6 +31,7 @@ Per-sensor directory routing: each firewall sensor gets its own cisco_asa.log.
 
 import hashlib
 import ipaddress
+from collections import deque
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -102,7 +103,7 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         self._vip_to_real_ip: dict[str, str] = {}
 
         # Threat detection: per-(sensor, src_ip) deny rate tracking
-        self._deny_timestamps: dict[tuple[str, str], list[datetime]] = {}
+        self._deny_timestamps: dict[tuple[str, str], deque[datetime]] = {}
         self._last_alert_time: dict[tuple[str, str], datetime | None] = {}
         # Configurable thresholds (ASA defaults for scanning detection)
         self._td_burst_threshold: int = 10  # drops/sec to trigger burst alert
@@ -504,23 +505,32 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         key = (sensor_hostname, src_ip)
 
         # Track this deny
-        self._deny_timestamps.setdefault(key, []).append(timestamp)
+        timestamps = self._deny_timestamps.setdefault(key, deque())
+        timestamps.append(timestamp)
+
+        # Keep only the data needed for active burst/average windows.
+        # This bounds memory growth for sustained deny traffic.
+        max_window = max(self._td_burst_window, self._td_avg_window)
+        max_cutoff = timestamp - timedelta(seconds=max_window)
+        while timestamps and timestamps[0] < max_cutoff:
+            timestamps.popleft()
 
         # Cooldown check: don't fire more than once per burst period
         last_alert = self._last_alert_time.get(key)
         if last_alert and (timestamp - last_alert).total_seconds() < self._td_cooldown:
             return
 
-        timestamps = self._deny_timestamps[key]
-
         # Calculate burst rate (drops in last burst_window seconds)
         burst_cutoff = timestamp - timedelta(seconds=self._td_burst_window)
-        burst_count = sum(1 for t in timestamps if t >= burst_cutoff)
-        burst_rate = burst_count / self._td_burst_window
-
-        # Calculate average rate (drops in last avg_window seconds)
         avg_cutoff = timestamp - timedelta(seconds=self._td_avg_window)
-        avg_count = sum(1 for t in timestamps if t >= avg_cutoff)
+        burst_count = 0
+        avg_count = 0
+        for deny_ts in timestamps:
+            if deny_ts >= avg_cutoff:
+                avg_count += 1
+            if deny_ts >= burst_cutoff:
+                burst_count += 1
+        burst_rate = burst_count / self._td_burst_window
         avg_rate = avg_count / self._td_avg_window
 
         # Both rates must exceed thresholds (matching real ASA behavior)

--- a/tests/unit/test_cisco_asa_emitter.py
+++ b/tests/unit/test_cisco_asa_emitter.py
@@ -449,6 +449,29 @@ class TestThreatDetection:
         threat_lines = [line for line in lines if "733100" in line]
         assert len(threat_lines) == 0
 
+    def test_threat_detection_prunes_old_timestamps(self, asa_emitter):
+        """Deny timestamp state should stay bounded to configured tracking windows."""
+        from datetime import timedelta
+
+        asa_emitter._td_burst_window = 10
+        asa_emitter._td_avg_window = 30
+        asa_emitter._td_burst_threshold = 9999
+        asa_emitter._td_avg_threshold = 9999
+
+        for i in range(120):
+            event = self._make_deny_event(
+                "198.51.100.1",
+                "10.0.10.50",
+                445,
+                T0 + timedelta(seconds=i),
+            )
+            asa_emitter.emit(event)
+
+        key = ("fw01", "198.51.100.1")
+        assert key in asa_emitter._deny_timestamps
+        # max_window=30 seconds, inclusive cutoff allows at most 31 one-second events
+        assert len(asa_emitter._deny_timestamps[key]) <= 31
+
 
 class TestNatRecords:
     """Tests for NAT translation records (305011/305012) emitted alongside connection logs."""


### PR DESCRIPTION
### Motivation
- The ASA emitter's threat-detection logic appended every deny timestamp and scanned the full history on each deny, allowing unbounded memory growth and O(n) scans per event which can be abused by large or malicious scenarios to cause DoS.

### Description
- Replace per-(sensor, src_ip) timestamp storage from a `list` to a `deque` and append new denies to the right.
- Prune timestamps older than `max(burst_window, avg_window)` on each deny to bound memory to the active detection window.  
- Compute burst and average counts in a single pass over the bounded deque to preserve original semantics while avoiding full-history scans.  
- Add a unit test `test_threat_detection_prunes_old_timestamps` that verifies timestamp state remains bounded for long deny sequences and mark the TODO security item complete.

Files changed: `src/evidenceforge/generation/emitters/cisco_asa.py`, `tests/unit/test_cisco_asa_emitter.py`, `TODO.md`.

### Testing
- Ran linter/format checks with `uv run ruff check .` and `uv run ruff format --check .`, both succeeded.  
- Attempted to run the targeted unit tests with `uv run pytest tests/unit/test_cisco_asa_emitter.py -q`, but execution in this environment failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`), so the new test could not be executed here; the change is a focused, low-risk refactor and the added test exercises the pruning behavior explicitly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a3ded08325aec58a74ac6da3b1)