### PR TITLE
fix: prevent blocked_c2 zero-interval infinite loop via schema validation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS
 - [x] Evaluator grace period for causal ordering (logon→process rule skips events within logon_grace_period from scenario start)
 - [x] Evaluator event type detection from typed EventSpec fields (replaces fragile keyword matching) + 9 new record matchers
 - [x] Evaluator per-sub-event indicator accuracy (fixes last-writer-wins IP merge for compound storyline steps) + tighter eCAR FLOW matching

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -43,6 +43,7 @@ from pydantic import (
     ConfigDict,
     Discriminator,
     Field,
+    ValidationInfo,
     field_validator,
     model_validator,
 )
@@ -523,6 +524,23 @@ class BlockedC2EventSpec(_EventSpecBase):
     interval: str = "30m"
     duration: str = "6h"
     jitter: float = Field(default=0.2, ge=0.0, le=1.0)
+
+    @field_validator("interval", "duration")
+    @classmethod
+    def validate_positive_duration(cls, v: str, info: ValidationInfo) -> str:
+        """Validate blocked_c2 interval/duration format and enforce > 0 seconds."""
+        if not re.match(r"^(\d+(ms|[hdms]))+$", v):
+            raise ValueError(
+                f"{info.field_name} must match pattern like '30m', '6h', or '5m30s' "
+                "(digits followed by d/h/m/s/ms units)"
+            )
+
+        from evidenceforge.utils.time import parse_duration
+
+        seconds = parse_duration(v).total_seconds()
+        if seconds <= 0:
+            raise ValueError(f"{info.field_name} must be greater than 0 seconds (got '{v}')")
+        return v
 
 
 class RawEventSpec(_EventSpecBase):

--- a/tests/unit/test_firewall_storyline_events.py
+++ b/tests/unit/test_firewall_storyline_events.py
@@ -98,6 +98,14 @@ class TestBlockedC2EventSpec:
         with pytest.raises((ValueError, ValidationError)):
             BlockedC2EventSpec(dst_ip="198.51.100.30", jitter=1.5)
 
+    def test_interval_must_be_greater_than_zero(self):
+        with pytest.raises((ValueError, ValidationError)):
+            BlockedC2EventSpec(dst_ip="198.51.100.30", interval="0s")
+
+    def test_duration_must_be_greater_than_zero(self):
+        with pytest.raises((ValueError, ValidationError)):
+            BlockedC2EventSpec(dst_ip="198.51.100.30", duration="0s")
+
 
 class TestDropMode:
     def test_default_is_drop(self):


### PR DESCRIPTION
### Motivation
- The `blocked_c2` storyline generation loop advanced time by `interval_sec` but accepted `interval`/`duration` strings that could parse to zero, allowing a scenario to set `interval="0s"` and cause a non-terminating generation loop (DoS).
- Fixing this at the schema level prevents attacker-controlled scenario YAML from supplying zero/invalid durations that would hang the generator.

### Description
- Add `@field_validator` on `BlockedC2EventSpec` for `interval` and `duration` that enforces the duration-string format and requires the parsed value to be strictly greater than 0 seconds (file: `src/evidenceforge/models/scenario.py`).
- Import `ValidationInfo` and use `parse_duration` to compute seconds and raise a `ValueError` for zero or negative durations.
- Add two unit tests to `tests/unit/test_firewall_storyline_events.py` asserting that `interval="0s"` and `duration="0s"` are rejected.
- Mark the TODO tracker entry as completed to record the security hardening work (`TODO.md`).

### Testing
- `uv run ruff check .` succeeded without issues.
- `uv run ruff format --check .` succeeded and reported files already formatted.
- Running `pytest` for the modified unit tests in this execution environment failed to start due to missing runtime test dependencies (import errors for `yaml`/`pydantic` reported by the test harness), so the new tests could not be executed here; they are present and expected to run in CI where runtime dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a4b45883258ae0a530c3cce740)