### PR TITLE
fix: prevent temporal causal-ordering crash on malformed zeek_conn ports

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Harden temporal evaluator `exclude_ports` parsing against malformed `zeek_conn.id.resp_p` values (prevent eval crash on non-numeric ports)
 - [x] Evaluator grace period for causal ordering (logon→process rule skips events within logon_grace_period from scenario start)
 - [x] Evaluator event type detection from typed EventSpec fields (replaces fragile keyword matching) + 9 new record matchers
 - [x] Evaluator per-sub-event indicator accuracy (fixes last-writer-wins IP merge for compound storyline steps) + tighter eCAR FLOW matching

--- a/src/evidenceforge/evaluation/dimensions/temporal.py
+++ b/src/evidenceforge/evaluation/dimensions/temporal.py
@@ -513,8 +513,13 @@ class TemporalRealismScorer(DimensionScorer):
                 # Skip connections on excluded ports (e.g., DNS port 53)
                 if exclude_ports:
                     resp_p = rec.fields.get("id.resp_p")
-                    if resp_p is not None and int(resp_p) in exclude_ports:
-                        continue
+                    if resp_p is not None:
+                        try:
+                            resp_p_int = int(resp_p)
+                        except (TypeError, ValueError):
+                            resp_p_int = None
+                        if resp_p_int in exclude_ports:
+                            continue
 
                 # Skip built-in/machine accounts from causal checks
                 if exclude_accounts:

--- a/tests/unit/test_eval_temporal.py
+++ b/tests/unit/test_eval_temporal.py
@@ -335,6 +335,37 @@ class TestCausalOrdering:
         # Within grace period → skipped → no pairs → perfect score
         assert result.score == 100.0
 
+    def test_dns_rule_handles_non_numeric_zeek_conn_port(self):
+        """Non-numeric zeek_conn id.resp_p should not crash exclude_ports evaluation."""
+        base = T0 + self._AFTER_GRACE
+        records = {
+            "zeek_dns": [
+                _record(
+                    "zeek_dns",
+                    {
+                        "rcode_name": "NOERROR",
+                        "answers": ["93.184.216.34"],
+                    },
+                    ts=base,
+                ),
+            ],
+            "zeek_conn": [
+                _record(
+                    "zeek_conn",
+                    {
+                        "proto": "tcp",
+                        "id.resp_h": "93.184.216.34",
+                        "id.resp_p": "not-a-port",
+                    },
+                    ts=base + timedelta(seconds=5),
+                ),
+            ],
+        }
+        scenario = _make_scenario()
+        scorer = TemporalRealismScorer()
+        result = scorer._score_causal_ordering(records, scenario)
+        assert result.score == 100.0
+
 
 class TestTimingPlausibility:
     def test_reasonable_rate(self):


### PR DESCRIPTION
### Motivation
- The temporal evaluator cast `zeek_conn.id.resp_p` to `int` without validation, which raises `ValueError` on malformed/non-numeric port values and can abort `eforge eval` when processing untrusted logs.

### Description
- Guard `id.resp_p` parsing in `TemporalRealismScorer._score_causal_ordering()` by catching `TypeError`/`ValueError` and treating invalid values as non-excluded instead of raising.
- Added a unit test `test_dns_rule_handles_non_numeric_zeek_conn_port` in `tests/unit/test_eval_temporal.py` that exercises the DNS-before-connection rule with a non-numeric `id.resp_p` to ensure scoring completes without crashing.
- Updated `TODO.md` to mark this hardening task complete.

### Testing
- Static checks passed: `uv run ruff check .` and `uv run ruff format --check .` succeeded.
- Added unit test included in `tests/unit/test_eval_temporal.py`; running `pytest` in this execution environment failed due to a missing optional dependency (`PyYAML`), so the unit test could not be executed here.  The test is included and should run successfully in CI or a developer environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a3d630832588b5d60d0bcff807)