### PR TITLE
fix: allow machine-account dollar signs in User validation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -87,6 +87,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 Data is *wrong* — a hunter hits dead ends. Fix these first; several unblock Tier 2 work.
 
+- [x] Stale account usernames with `$` no longer crash baseline generation when converted to `User` objects (aligned `User` username/email validation with stale account pattern)
 - [x] **LogonIDs leak across hosts** — remote processes on DC/file server use the originating-host LogonID instead of the destination host's 4624 TargetLogonId. Breaks every pivot-based hunting workflow.
 - [x] **services.exe PID changes within single boot session** — process tree references a parent PID that was replaced mid-scenario. Child processes become orphaned.
 - [x] **Extend canonical event model to baseline activity** — added SyslogContext, WeirdContext, extended DhcpContext. Syslog emitter renders from SyslogContext exclusively. All internal `generate_raw()` calls eliminated (was 12, now 0). `generate_raw()` exists solely for user-facing `raw` event type in scenario YAML.

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -146,7 +146,7 @@ class User(BaseModel):
     Represents a user in the simulated environment who may generate log activity.
 
     Attributes:
-        username: Username (alphanumeric, dash, underscore only)
+        username: Username (alphanumeric, dot, dollar sign, dash, underscore)
         full_name: User's full name
         email: Email address (basic format validation)
         groups: List of group names this user belongs to
@@ -155,7 +155,7 @@ class User(BaseModel):
         primary_system: Primary system hostname for this user (optional)
     """
 
-    username: str = Field(..., pattern=r"^[a-zA-Z0-9._-]+$")
+    username: str = Field(..., pattern=r"^[a-zA-Z0-9._$-]+$")
     full_name: str
     email: str
     groups: list[str] = Field(default_factory=list)
@@ -172,7 +172,7 @@ class User(BaseModel):
     @classmethod
     def validate_email(cls, v: str) -> str:
         """Basic email validation (format check only)."""
-        if not re.match(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", v):
+        if not re.match(r"^[a-zA-Z0-9._%+$-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", v):
             raise ValueError(f"Invalid email format: {v}")
         return v
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -185,6 +185,16 @@ class TestUser:
         with pytest.raises(ValidationError, match="Invalid email"):
             User(username="jdoe", full_name="John Doe", email="not-an-email")
 
+    def test_user_allows_machine_account_dollar_sign(self):
+        """Machine account usernames/emails containing '$' should validate."""
+        user = User(
+            username="BACKUP$",
+            full_name="BACKUP$",
+            email="BACKUP$@system.local",
+        )
+        assert user.username == "BACKUP$"
+        assert user.email == "BACKUP$@system.local"
+
 
 class TestSystem:
     """Tests for System model."""


### PR DESCRIPTION
### Motivation
- Baseline stale-account noise constructs `User` objects from `StaleAccount.username` (which permits `$`), causing a `pydantic.ValidationError` during generation when machine-account names like `BACKUP$` produce invalid `User.username`/`email` values.

### Description
- Relax `User.username` validation to allow dollar signs by changing the pattern to `^[a-zA-Z0-9._$-]+$` in `src/evidenceforge/models/scenario.py`.
- Relax the `User.email` local-part validator to permit `$` so derived emails like `BACKUP$@system.local` validate; update the `User` docstring accordingly.
- Add a focused regression test `test_user_allows_machine_account_dollar_sign` to `tests/unit/test_models.py` to assert `User` accepts machine-account style names and emails.
- Mark the fix complete in `TODO.md` per project workflow.

### Testing
- Ran linter/format checks: `uv run ruff check .` passed and `uv run ruff format --check .` passed.
- Attempted unit tests: `uv run pytest tests/unit/test_models.py -k "user_allows_machine_account_dollar_sign or stale_account_username_pattern or user_invalid_email"` failed in the current environment due to missing project import/dependency errors (`ModuleNotFoundError: No module named 'evidenceforge'` and later `ModuleNotFoundError: No module named 'yaml'` with `PYTHONPATH=src`), so tests could not be executed here; the added unit test is present and should pass in CI or a properly provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a354c88325ab21ed398dde34b0)