### PR TITLE
fix(ecar): harden EcarEmitter._render_event against malformed raw payloads

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -85,6 +85,8 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Tier 1: Foundational Correctness
 
+- [x] eCAR raw events missing required keys no longer crash generation — eCAR renderer now defaults missing timestamp/object/action to safe values for malformed raw payloads.
+
 Data is *wrong* — a hunter hits dead ends. Fix these first; several unblock Tier 2 work.
 
 - [x] **LogonIDs leak across hosts** — remote processes on DC/file server use the originating-host LogonID instead of the destination host's 4624 TargetLogonId. Breaks every pivot-based hunting workflow.

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -449,15 +449,20 @@ class EcarEmitter(HostMultiplexEmitter):
         pid/tid always present (-1 sentinel), all property values are strings.
         """
         # Convert timestamp to milliseconds since epoch
-        ts = event_data["timestamp"]
-        timestamp_ms = int(ts.timestamp() * 1000) if isinstance(ts, datetime) else int(ts * 1000)
+        ts = event_data.get("timestamp")
+        if isinstance(ts, datetime):
+            timestamp_ms = int(ts.timestamp() * 1000)
+        elif isinstance(ts, (int, float)):
+            timestamp_ms = int(ts * 1000)
+        else:
+            timestamp_ms = 0
 
         record: dict[str, Any] = {
             "timestamp_ms": timestamp_ms,
             "id": event_data.get("id") or str(uuid.uuid4()),
             "hostname": event_data.get("hostname", ""),
-            "object": event_data["object"],
-            "action": event_data["action"],
+            "object": str(event_data.get("object", "UNKNOWN")),
+            "action": str(event_data.get("action", "UNKNOWN")),
             "objectID": event_data.get("objectID") or str(uuid.uuid4()),
         }
 

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -216,3 +216,21 @@ class TestParentImagePath:
         )
         record = json.loads(rendered)
         assert record["properties"]["parent_image_path"] == "C:\\Windows\\explorer.exe"
+
+
+class TestRawEventHardening:
+    def test_missing_required_keys_do_not_raise(self, emitter):
+        """Malformed raw event should not crash eCAR rendering."""
+        rendered = emitter._render_event({"hostname": "host1"})
+        record = json.loads(rendered)
+        assert record["timestamp_ms"] == 0
+        assert record["object"] == "UNKNOWN"
+        assert record["action"] == "UNKNOWN"
+
+    def test_numeric_timestamp_still_supported(self, emitter):
+        """Numeric timestamp input should remain supported for raw events."""
+        rendered = emitter._render_event(
+            {"timestamp": 1710496800, "object": "FLOW", "action": "CONNECT"}
+        )
+        record = json.loads(rendered)
+        assert record["timestamp_ms"] == 1710496800000


### PR DESCRIPTION
### Motivation

- Prevent untrusted/malformed `raw` eCAR payloads from crashing generation when required keys are missing, which previously caused `KeyError` in `EcarEmitter._render_event`.

### Description

- Use safe accessors in `EcarEmitter._render_event()` so `timestamp`, `object`, and `action` default to benign values and numeric timestamps are supported; `timestamp_ms` now falls back to `0`, and `object`/`action` default to `"UNKNOWN"` when absent.
- Preserve existing eCAR spec behavior for valid inputs (datetime and numeric timestamps, pid/tid/ppid handling, property stringification) and keep `actorID`/`objectID` logic unchanged.
- Add unit tests exercising malformed raw payloads and numeric timestamp handling, and update `TODO.md` to mark the remediation complete.

### Testing

- Ran linting and formatting checks: `uv run ruff check .` passed and `uv run ruff format --check .` passed after formatting.
- Added targeted tests in `tests/unit/test_ecar_spec_compliance.py`; executing the test file in this environment failed due to a missing runtime dependency (`yaml`) in the container, but a direct smoke test using `PYTHONPATH=src` invoked `_render_event()` and verified the fallback behavior (passed).
- Verified repository state and updated `TODO.md` to record the fix as completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a4b6ec8325afb5bd3028179cd8)