### PR TITLE
fix: harden temporal causal exclusion for malformed principal types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -268,6 +268,7 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 
 ### Tier 4: Eval Fixes
 
+- [x] Harden temporal causal-account exclusion against non-string SubjectUserName/principal values to prevent evaluator exceptions on malformed logs
 - [ ] Storyline Trace Coverage hostname normalization bug (traces exist but bare vs FQDN mismatch)
 - [ ] Ground truth File IOCs section truncated in GROUND_TRUTH.md output
 

--- a/src/evidenceforge/evaluation/dimensions/temporal.py
+++ b/src/evidenceforge/evaluation/dimensions/temporal.py
@@ -518,14 +518,14 @@ class TemporalRealismScorer(DimensionScorer):
 
                 # Skip built-in/machine accounts from causal checks
                 if exclude_accounts:
-                    subject = rec.fields.get("SubjectUserName", "") or rec.fields.get(
-                        "principal", ""
-                    )
-                    if any(
-                        subject.upper() == ea.upper() or subject.endswith("$")
-                        for ea in exclude_accounts
-                    ):
-                        continue
+                    subject = rec.fields.get("SubjectUserName") or rec.fields.get("principal")
+                    if isinstance(subject, str):
+                        normalized_subject = subject.upper()
+                        if any(
+                            isinstance(ea, str) and normalized_subject == ea.upper()
+                            for ea in exclude_accounts
+                        ) or subject.endswith("$"):
+                            continue
                 if after_field:
                     key_val = rec.fields.get(after_field)
                     if not key_val:

--- a/tests/unit/test_eval_temporal.py
+++ b/tests/unit/test_eval_temporal.py
@@ -335,6 +335,32 @@ class TestCausalOrdering:
         # Within grace period → skipped → no pairs → perfect score
         assert result.score == 100.0
 
+    def test_non_string_principal_does_not_raise(self):
+        """Malformed principal values should not crash exclusion checks."""
+        base = T0 + self._AFTER_GRACE
+        records = {
+            "windows_event_security": [
+                _record(
+                    "windows_event_security",
+                    {"EventID": 4624, "TargetLogonId": "0x1a2b3c"},
+                    ts=base,
+                ),
+            ],
+            "ecar": [
+                _record(
+                    "ecar",
+                    {"event_type": "PROCESS", "action": "CREATE", "principal": {"name": "bad"}},
+                    ts=base + timedelta(seconds=10),
+                ),
+            ],
+        }
+        scenario = _make_scenario()
+        scorer = TemporalRealismScorer()
+
+        result = scorer._score_causal_ordering(records, scenario)
+
+        assert result.score == 100.0
+
 
 class TestTimingPlausibility:
     def test_reasonable_rate(self):


### PR DESCRIPTION
### Motivation
- Prevent `AttributeError` in the Temporal Realism evaluator when parsed `SubjectUserName`/`principal` fields are non-strings (malformed logs) and were previously passed to `.upper()`/`.endswith()` without type checks.

### Description
- Hardened the exclusion logic in `src/evidenceforge/evaluation/dimensions/temporal.py` to extract `subject` safely and only perform `upper()`/`endswith()` comparisons when `subject` is an instance of `str`, and to only compare against string entries in rule `exclude_accounts`.
- Added a regression unit test `test_non_string_principal_does_not_raise` in `tests/unit/test_eval_temporal.py` that supplies a non-string `principal` value to ensure the scorer does not raise on malformed input.
- Updated `TODO.md` to record the completion of this eval hardening task according to the project workflow.

### Testing
- Ran lint/format checks: `uv run ruff check .` and `uv run ruff format --check .`, both completed successfully.
- Attempted to run the focused unit test with `PYTHONPATH=src uv run pytest tests/unit/test_eval_temporal.py -q` but the runtime in this environment is missing the `yaml`/`PyYAML` dependency so pytest did not execute here; the added deterministic unit test should pass in CI or a developer environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a50ee483258c8465ca47ae77be)