### PR TITLE
fix: harden evaluation parser discovery against symlink traversal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,6 +75,9 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Tier 0: Infrastructure
 
+- [x] Security: hardened evaluation log discovery against symlink/path traversal in per-sensor directories (reject symlinked dirs/files and enforce resolved-path containment under output_dir).
+
+
 - [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
 
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.

--- a/src/evidenceforge/evaluation/parsers/__init__.py
+++ b/src/evidenceforge/evaluation/parsers/__init__.py
@@ -88,33 +88,56 @@ def discover_log_files(output_dir: Path) -> dict[str, list[Path]]:
         Dict mapping format_name to list of file paths.
     """
     result: dict[str, list[Path]] = {}
+    output_root = output_dir.resolve()
+
+    def _is_safe_directory(path: Path) -> bool:
+        if path.is_symlink() or not path.is_dir():
+            return False
+        try:
+            path.resolve().relative_to(output_root)
+        except ValueError:
+            return False
+        return True
+
+    def _is_safe_file(path: Path) -> bool:
+        if path.is_symlink() or not path.is_file():
+            return False
+        try:
+            path.resolve().relative_to(output_root)
+        except ValueError:
+            return False
+        return True
 
     # Collect all candidate files: top-level + one level of subdirectories
     candidates: list[Path] = []
     for child in output_dir.iterdir():
-        if child.is_file():
+        if _is_safe_file(child):
             candidates.append(child)
-        elif child.is_dir():
+        elif _is_safe_directory(child):
             if child.name == "bash_history":
                 # Special case: bash_history has its own discovery
-                files = list(child.rglob("*.history")) + list(child.rglob("*.bash_history"))
+                files = [
+                    f
+                    for f in list(child.rglob("*.history")) + list(child.rglob("*.bash_history"))
+                    if _is_safe_file(f)
+                ]
                 if files:
                     result["bash_history"] = files
             else:
                 # Per-host FQDN or per-sensor subdirectory
                 for subfile in child.iterdir():
-                    if subfile.is_file():
+                    if _is_safe_file(subfile):
                         candidates.append(subfile)
-                    elif subfile.is_dir():
+                    elif _is_safe_directory(subfile):
                         if subfile.name == "bash_history":
                             # Bash history nested in per-host dir
-                            files = list(subfile.rglob("*.bash_history"))
+                            files = [f for f in subfile.rglob("*.bash_history") if _is_safe_file(f)]
                             if files:
                                 result.setdefault("bash_history", []).extend(files)
                         else:
                             # Deeper subdirectory (e.g., per-sensor logs)
                             for deepfile in subfile.iterdir():
-                                if deepfile.is_file():
+                                if _is_safe_file(deepfile):
                                     candidates.append(deepfile)
 
     for format_name, parser_cls in _PARSER_CLASSES.items():

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -280,6 +280,42 @@ class TestParserDiscovery:
         assert "web_access" in files
         assert "bash_history" in files
 
+    def test_skips_symlinked_sensor_directories(self, tmp_path):
+        from evidenceforge.evaluation.parsers import discover_log_files
+
+        safe_conn = tmp_path / "zeek_conn.json"
+        safe_conn.write_text('{"ts": 1.0}\n', encoding="utf-8")
+
+        outside_dir = tmp_path.parent / "outside_sensor"
+        outside_dir.mkdir(exist_ok=True)
+        (outside_dir / "conn.json").write_text('{"ts": 2.0}\n', encoding="utf-8")
+
+        sensor_link = tmp_path / "zeek-fw01"
+        try:
+            sensor_link.symlink_to(outside_dir, target_is_directory=True)
+        except OSError:
+            return
+
+        files = discover_log_files(tmp_path)
+        discovered = files.get("zeek_conn", [])
+        assert safe_conn in discovered
+        assert all(path.resolve().is_relative_to(tmp_path.resolve()) for path in discovered)
+
+    def test_skips_symlinked_top_level_files(self, tmp_path):
+        from evidenceforge.evaluation.parsers import discover_log_files
+
+        outside_file = tmp_path.parent / "outside_conn.json"
+        outside_file.write_text('{"ts": 3.0}\n', encoding="utf-8")
+
+        linked_file = tmp_path / "zeek_conn.json"
+        try:
+            linked_file.symlink_to(outside_file)
+        except OSError:
+            return
+
+        files = discover_log_files(tmp_path)
+        assert "zeek_conn" not in files
+
     def test_all_parsers_registered(self):
         from evidenceforge.evaluation.parsers import _PARSER_CLASSES
 


### PR DESCRIPTION
### Motivation
- The evaluator's `discover_log_files()` previously descended into per-sensor subdirectories and accepted files via `Path.is_file()`/`is_dir()` without symlink or resolved-path containment checks, allowing symlinked sensor dirs/files to reference arbitrary files outside the evaluation `output_dir`.
- The intent is to prevent accidental or malicious arbitrary file reads during evaluation while preserving the existing file-discovery semantics for legitimate logs under the output directory.

### Description
- Add `output_root = output_dir.resolve()` and helper guards `def _is_safe_directory(path: Path) -> bool` and `def _is_safe_file(path: Path) -> bool` that reject symlinks and require `path.resolve().relative_to(output_root)` containment before accepting entries.
- Replace raw `is_file()`/`is_dir()` checks in `discover_log_files()` with the safe helpers and apply the safety checks to top-level files, per-host/per-sensor directories, nested bash_history discovery, and deeper per-sensor traversal.
- Add unit tests `test_skips_symlinked_sensor_directories` and `test_skips_symlinked_top_level_files` to `tests/unit/test_eval_parsers.py` to validate symlinked dirs and symlinked top-level files are ignored, and update `TODO.md` to mark the security hardening task completed.

### Testing
- Ran linter and formatter checks with `uv run ruff check .` and `uv run ruff format --check .`, which passed after formatting adjustments.
- Reformatted affected files with `uv run ruff format` and committed the changes, and added the new tests under `tests/unit/test_eval_parsers.py`.
- Attempted to run the unit tests with `PYTHONPATH=src uv run pytest tests/unit/test_eval_parsers.py`, but test execution could not complete in this environment due to a missing runtime dependency (`PyYAML` / `yaml`); the tests exercise the new symlink-safety behavior and should run successfully in CI or a developer environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a38a308325aa739049b3c0e234)