### PR TITLE
fix: guard provider-aware DNS detection against invalid/IPv6 dst_ip input

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -87,6 +87,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 Data is *wrong* — a hunter hits dead ends. Fix these first; several unblock Tier 2 work.
 
+- [x] Harden provider-aware DNS hostname generation against invalid/IPv6 storyline `dst_ip` values to prevent generation-time crashes (invalid/non-IPv4 inputs now fall back to `generic` provider safely).
 - [x] **LogonIDs leak across hosts** — remote processes on DC/file server use the originating-host LogonID instead of the destination host's 4624 TargetLogonId. Breaks every pivot-based hunting workflow.
 - [x] **services.exe PID changes within single boot session** — process tree references a parent PID that was replaced mid-scenario. Child processes become orphaned.
 - [x] **Extend canonical event model to baseline activity** — added SyslogContext, WeirdContext, extended DhcpContext. Syslog emitter renders from SyslogContext exclusively. All internal `generate_raw()` calls eliminated (was 12, now 0). `generate_raw()` exists solely for user-facing `raw` event type in scenario YAML.

--- a/src/evidenceforge/generation/activity/network.py
+++ b/src/evidenceforge/generation/activity/network.py
@@ -158,8 +158,19 @@ def _generate_internal_hostname(rng, ip: str, domain: str = "corp.local") -> str
 
 
 def _detect_ip_provider(ip: str) -> str:
-    """Detect the cloud/CDN provider for an IP based on first-octet ranges."""
-    first = int(ip.split(".")[0])
+    """Detect cloud/CDN provider for a public IPv4 address.
+
+    Returns "generic" for invalid inputs and non-IPv4 addresses.
+    """
+    try:
+        parsed_ip = ipaddress.ip_address(ip)
+    except ValueError:
+        return "generic"
+
+    if not isinstance(parsed_ip, ipaddress.IPv4Address):
+        return "generic"
+
+    first = int(str(parsed_ip).split(".")[0])
     if first in (172, 142, 209, 74, 108):
         return "google"
     if first in (140, 185) and ip.startswith("140.82."):
@@ -172,9 +183,8 @@ def _detect_ip_provider(ip: str) -> str:
         return "aws"
     if first in (13, 20, 40, 204) and not ip.startswith("13.108."):
         return "microsoft"
-    if (
-        first in (104,)
-        and ip.startswith("104.16.")
+    if first in (104,) and (
+        ip.startswith("104.16.")
         or ip.startswith("104.18.")
         or ip.startswith("104.21.")
         or ip.startswith("104.26.")

--- a/tests/unit/test_phase5_network_diversity.py
+++ b/tests/unit/test_phase5_network_diversity.py
@@ -33,6 +33,7 @@ from evidenceforge.generation.activity import (
     EXTERNAL_IPS,
     REVERSE_DNS,
     ActivityGenerator,
+    _detect_ip_provider,
     _generate_random_external_ip,
     _generate_random_hostname,
 )
@@ -121,6 +122,16 @@ class TestRandomIPGenerator:
         hostname = _generate_random_hostname(rng, "52.84.100.50")
         assert "." in hostname  # Has a domain
         assert len(hostname) > 5
+
+
+class TestProviderDetection:
+    """Test provider detection robustness for untrusted IP input."""
+
+    def test_detect_ip_provider_invalid_input_returns_generic(self):
+        assert _detect_ip_provider("not-an-ip") == "generic"
+
+    def test_detect_ip_provider_ipv6_returns_generic(self):
+        assert _detect_ip_provider("2001:db8::1") == "generic"
 
 
 class TestDnsLookupEmission:


### PR DESCRIPTION
### Motivation
- Prevent generation-time crashes when untrusted storyline `details.dst_ip` contains IPv6 or malformed strings that caused `_detect_ip_provider` to raise `ValueError` during provider-aware hostname generation.

### Description
- Hardened `_detect_ip_provider` in `src/evidenceforge/generation/activity/network.py` to parse the input with `ipaddress.ip_address()` and return `"generic"` for invalid or non-IPv4 inputs, and added focused unit tests in `tests/unit/test_phase5_network_diversity.py` plus a tracking update to `TODO.md`.

### Testing
- Ran lint/format checks with `uv run ruff check .` and `uv run ruff format --check .`, which passed after formatting.
- Added unit tests and attempted to run `PYTHONPATH=src uv run pytest tests/unit/test_phase5_network_diversity.py`, but test execution could not complete in this environment due to a missing runtime dependency (`yaml` / PyYAML); the failure is environmental and not a test assertion failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017a3b2e4832599c245442955e153)