### PR TITLE
fix: cap NetworkSensor.deny_ratio to prevent baseline DoS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,6 +76,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 ### Tier 0: Infrastructure
 
 - [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
+- [x] Security: cap firewall deny baseline amplification (`deny_ratio`/hourly deny volume) to prevent scenario-driven local DoS — `NetworkSensor.deny_ratio` now enforces `<= 50.0`.
 
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.
 - [x] **`eforge validate` can't find personas in dev mode** — works when installed (`eforge validate`) but not via `uv run eforge validate`. Blocks dev workflow.

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -744,7 +744,15 @@ class NetworkSensor(BaseModel):
     interfaces: dict[str, str] = Field(default_factory=dict)
     policy: list[FirewallRule] = Field(default_factory=list)
     default_action: str = Field(default="deny", pattern="^(deny|permit)$")
-    deny_ratio: float = Field(default=5.0, ge=0.0)
+    deny_ratio: float = Field(
+        default=5.0,
+        ge=0.0,
+        le=50.0,
+        description=(
+            "For firewall sensors, deny events generated per estimated allow event. "
+            "Capped at 50.0 to prevent runaway baseline generation."
+        ),
+    )
     drop_mode: str = Field(default="drop", pattern="^(drop|reject)$")
     threat_detection_rate: int = Field(
         default=10,

--- a/tests/unit/test_firewall_baseline.py
+++ b/tests/unit/test_firewall_baseline.py
@@ -22,6 +22,9 @@
 
 """Tests for firewall deny baseline generation and FirewallRule model."""
 
+import pytest
+from pydantic import ValidationError
+
 from evidenceforge.models.scenario import FirewallRule, NetworkSensor
 
 
@@ -96,3 +99,12 @@ class TestNetworkSensorFirewallFields:
         # Fields exist but are at defaults
         assert sensor.policy == []
         assert sensor.default_action == "deny"
+
+    def test_deny_ratio_rejects_excessive_values(self):
+        with pytest.raises(ValidationError):
+            NetworkSensor(
+                type="firewall",
+                name="fw01",
+                monitoring_segments=["internal"],
+                deny_ratio=100.0,
+            )


### PR DESCRIPTION
### Motivation

- Prevent untrusted scenario YAML from amplifying firewall deny baseline generation into runaway event volume by capping the `deny_ratio` used to compute per-hour deny event counts.

### Description

- Add an upper bound to the `NetworkSensor.deny_ratio` Pydantic field (`le=50.0`) and document the cap in the field description to avoid unbounded amplification in `_generate_firewall_deny_baseline`.
- Add a unit test `test_deny_ratio_rejects_excessive_values` that asserts a `ValidationError` is raised for excessive `deny_ratio` values.
- Update `TODO.md` to record the completed security hardening task per the project workflow.

### Testing

- Ran `uv run ruff check .` and the check passed.
- Ran `uv run ruff format --check .` and formatting was already compliant.
- Attempted `uv run pytest tests/unit/test_firewall_baseline.py`, but pytest could not complete in this environment because runtime dependencies/import setup are missing (running with `PYTHONPATH=src` then exposed a missing `yaml` dependency), so the test could not be fully exercised here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0217283a48325b4d4c4d8fa2b3ab4)