### PR TITLE
fix: prevent dict-valued bash command pools from persona selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,6 +75,8 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Tier 0: Infrastructure
 
+- [x] Security: restricted custom persona bash command pools to list-valued entries to avoid dict-key DoS crash in `pick_bash_command()`; added regression test for persona name `params`.
+
 - [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
 
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.

--- a/src/evidenceforge/generation/activity/bash_commands.py
+++ b/src/evidenceforge/generation/activity/bash_commands.py
@@ -105,8 +105,10 @@ def _get_role_pool(persona: str, server_role: str) -> str:
         return "sysadmin"
 
     # Exact match: persona has its own command pool in the YAML
-    # (custom/overlay personas, or stock personas like sysadmin)
-    if persona_lower in data:
+    # (custom/overlay personas, or stock personas like sysadmin).
+    # Restrict to list-valued entries to avoid selecting helper mappings
+    # such as "params" or "keyboard_adjacency".
+    if persona_lower in data and isinstance(data[persona_lower], list):
         return persona_lower
 
     return "sysadmin"  # Default for unknown personas without a custom pool

--- a/tests/unit/test_expert_round4.py
+++ b/tests/unit/test_expert_round4.py
@@ -9,6 +9,7 @@ from evidenceforge.generation.activity.application_catalog import (
     pick_app_and_command,
 )
 from evidenceforge.generation.activity.bash_commands import (
+    _get_role_pool,
     _get_user_pool,
     load_bash_commands,
 )
@@ -102,6 +103,15 @@ class TestPerUserToolAffinity:
         # Just verify they're both subsets of the original
         assert all(cmd in pool for cmd in pool_a)
         assert all(cmd in pool for cmd in pool_b)
+
+
+class TestBashRolePoolSelection:
+    """Ensure persona-to-pool selection only returns command list pools."""
+
+    def test_non_list_yaml_sections_are_not_used_as_role_pool(self):
+        """Dict-valued metadata sections should not be selected as command pools."""
+        pool = _get_role_pool("params", "generic")
+        assert pool == "sysadmin"
 
 
 class TestPerUserBrowserAffinity:


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service crash where `_get_role_pool()` could return non-command YAML sections (e.g., `params` or `keyboard_adjacency`) which then flow to `random.choice()` and raise `KeyError` when generation is run with a crafted persona name.

### Description
- Constrain exact-match persona lookup in `_get_role_pool()` to only return keys whose YAML value is a list (`isinstance(data[persona_lower], list)`), add a unit test `TestBashRolePoolSelection.test_non_list_yaml_sections_are_not_used_as_role_pool` asserting persona `params` falls back to `sysadmin`, and update `TODO.md` to mark the security fix complete.

### Testing
- Ran lint/format checks: `uv run ruff check .` passed and `uv run ruff format --check .` passed; added unit test is present under `tests/unit/test_expert_round4.py`; running `PYTHONPATH=src uv run pytest tests/unit/test_expert_round4.py -q` in this environment failed to start due to a missing optional dependency (`yaml`) causing an import error, not due to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e022aa008c8325bffa1725862c199e)