### PR TITLE
fix: prevent baseline failed-logon account-selection hangs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -84,6 +84,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] **CI runs tests 3 times** — 3 separate pytest invocations (unit, integration, both again for coverage). Consolidate to single run.
 - [x] **No pre-commit hooks** — ruff issues only caught in CI. Add pre-commit framework with ruff check + format hooks.
 - [x] Security: sandboxed Jinja template rendering for YAML-defined format templates (SandboxedEnvironment + StrictUndefined) to block SSTI/code execution while preserving safe field interpolation.
+- [x] Security: bound baseline failed-logon synthetic service account selection loops to prevent scenario-controlled infinite loops/DoS.
 - [ ] **Re-generation appends to existing output** — `GenerationEngine` creates output directories with `exist_ok=True` and emitters append to existing files. Re-running a scenario without manually clearing the output directory produces mixed old+new data. Should clean the output directory (or at least its per-sensor subdirectories) before writing.
 
 ### Tier 1: Foundational Correctness

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -94,6 +94,36 @@ _HAWKES_RISK_PARAMS = {
 }
 
 
+def _pick_non_colliding_account_name(
+    rng: random.Random,
+    existing_accounts: set[str],
+    base_names: list[str],
+    max_numeric_suffix: int = 9,
+) -> str:
+    """Pick a synthetic account name that does not collide with scenario-defined accounts.
+
+    Selection is deterministic for a given RNG state and never loops forever:
+    1. Choose from base names and base+numeric suffix candidates when available.
+    2. Fall back to deterministic underscore suffixes with a bounded search.
+    """
+    candidate_pool = [*base_names]
+    for base_name in base_names:
+        candidate_pool.extend(f"{base_name}{suffix}" for suffix in range(1, max_numeric_suffix + 1))
+
+    available = [candidate for candidate in candidate_pool if candidate not in existing_accounts]
+    if available:
+        return rng.choice(available)
+
+    fallback_base = base_names[0]
+    for suffix in range(1, 10_001):
+        candidate = f"{fallback_base}_{suffix}"
+        if candidate not in existing_accounts:
+            return candidate
+
+    msg = "Unable to select non-colliding synthetic account name after bounded fallback search"
+    raise ValueError(msg)
+
+
 def _hawkes_params_from_persona(persona: Persona | None) -> dict:
     """Derive Hawkes kernel parameters from persona risk_profile.
 
@@ -733,13 +763,15 @@ class BaselineMixin:
         _sched_seed = _stable_seed(self.scenario.name + "_sched_fail")
         _sched_rng = random.Random(_sched_seed)
         _svc_names = ["svc_backup", "svc_monitor", "svc_report", "svc_deploy", "svc_scan"]
-        _sched_acct = _sched_rng.choice(_svc_names)
         # Ensure no collision with actual scenario accounts
         _existing = {u.username for u in self.scenario.environment.users} | set(
             self.scenario.environment.service_accounts
         )
-        while _sched_acct in _existing:
-            _sched_acct = _sched_rng.choice(_svc_names) + str(_sched_rng.randint(1, 9))
+        _sched_acct = _pick_non_colliding_account_name(
+            rng=_sched_rng,
+            existing_accounts=_existing,
+            base_names=_svc_names,
+        )
         _sched_user = User(
             username=_sched_acct,
             full_name=_sched_acct,
@@ -773,9 +805,11 @@ class BaselineMixin:
         is_business = 0 <= _local.weekday() <= 4 and 8 <= _local.hour <= 17
         # Fire at ~10am and ~2pm (deterministic per scenario)
         if is_business and _local.hour in (10, 14) and rng.random() < 0.5:
-            _mgmt_acct = "svc_mgmt"
-            while _mgmt_acct in _existing:
-                _mgmt_acct = f"svc_mgmt{rng.randint(1, 9)}"
+            _mgmt_acct = _pick_non_colliding_account_name(
+                rng=rng,
+                existing_accounts=_existing,
+                base_names=["svc_mgmt"],
+            )
             _mgmt_user = User(
                 username=_mgmt_acct,
                 full_name=_mgmt_acct,

--- a/tests/unit/test_remaining_expert_review.py
+++ b/tests/unit/test_remaining_expert_review.py
@@ -1,5 +1,8 @@
 # Tests for remaining expert review fixes (#15, #34).
 
+import random
+
+from evidenceforge.generation.engine.baseline import _pick_non_colliding_account_name
 from evidenceforge.utils.rng import _stable_seed
 
 
@@ -43,20 +46,42 @@ class TestBaselineFailedLogonPatterns:
 
     def test_scheduled_task_account_not_collides(self):
         """Scheduled task account names should not collide with scenario accounts."""
-        import random
-
         _existing = {"alice.admin", "bob.dev", "svc_backup"}
-        _svc_names = ["svc_backup", "svc_monitor", "svc_report", "svc_deploy", "svc_scan"]
         _sched_rng = random.Random(42)
-        _sched_acct = _sched_rng.choice(_svc_names)
-        while _sched_acct in _existing:
-            _sched_acct = _sched_rng.choice(_svc_names) + str(_sched_rng.randint(1, 9))
+        _sched_acct = _pick_non_colliding_account_name(
+            rng=_sched_rng,
+            existing_accounts=_existing,
+            base_names=["svc_backup", "svc_monitor", "svc_report", "svc_deploy", "svc_scan"],
+        )
         assert _sched_acct not in _existing
+
+    def test_scheduled_task_account_bounded_when_default_pool_exhausted(self):
+        """Account selection should terminate with fallback naming if default pool is exhausted."""
+        _svc_names = ["svc_backup", "svc_monitor", "svc_report", "svc_deploy", "svc_scan"]
+        _existing = {name for name in _svc_names}
+        _existing.update(f"{name}{digit}" for name in _svc_names for digit in range(1, 10))
+
+        acct = _pick_non_colliding_account_name(
+            rng=random.Random(42),
+            existing_accounts=_existing,
+            base_names=_svc_names,
+        )
+
+        assert acct not in _existing
+        assert acct.startswith("svc_backup_")
+
+    def test_management_sweep_account_bounded_when_default_pool_exhausted(self):
+        """Management sweep account selection should terminate when svc_mgmt and 1-9 are reserved."""
+        _existing = {"svc_mgmt", *(f"svc_mgmt{digit}" for digit in range(1, 10))}
+        acct = _pick_non_colliding_account_name(
+            rng=random.Random(42),
+            existing_accounts=_existing,
+            base_names=["svc_mgmt"],
+        )
+        assert acct == "svc_mgmt_1"
 
     def test_management_sweep_targets_multiple_hosts(self):
         """Management sweep should target 5-15 servers."""
-        import random
-
         rng = random.Random(42)
         servers = [f"SRV-{i:02d}" for i in range(20)]
         n_targets = min(rng.randint(5, 15), len(servers))


### PR DESCRIPTION
### Motivation
- Close a DoS vector where baseline failed-logon generation used unbounded `while` loops to pick synthetic service account names, which can hang when a scenario pre-defines all candidate names. 

### Description
- Add a bounded helper `_pick_non_colliding_account_name(...)` that builds a finite candidate pool (base names + numeric suffixes), selects a non-colliding name when available, and falls back to a bounded underscore-suffix search before raising a clear error. 
- Replace the unbounded loops in scheduled-task and management-sweep account selection with calls to `_pick_non_colliding_account_name(...)` in `src/evidenceforge/generation/engine/baseline.py`. 
- Add regression tests in `tests/unit/test_remaining_expert_review.py` that cover exhausted default pools and verify the selection terminates and avoids collisions. 
- Update `TODO.md` to record the security fix completion. 

### Testing
- Ran lint/format checks: `uv run ruff check .` and `uv run ruff format --check .`, both succeeded. 
- Attempted to run the unit test file with `PYTHONPATH=src uv run pytest tests/unit/test_remaining_expert_review.py`, but test execution failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`), which prevented the pytest run from completing here; the added tests exercise `_pick_non_colliding_account_name` and should pass in an environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e022a907fc8325bc143e99b9d67946)