### PR TITLE
fix: bound/prune ActivityGenerator DNS cache to prevent unbounded growth

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,6 +76,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 ### Tier 0: Infrastructure
 
 - [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
+- [x] Security: bounded/pruned ActivityGenerator DNS cache (60s prune cadence, 600s TTL-horizon eviction, 50k hard cap) to prevent unbounded memory growth from unique `(src_ip, hostname)` keys.
 
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.
 - [x] **`eforge validate` can't find personas in dev mode** — works when installed (`eforge validate`) but not via `uv run eforge validate`. Blocks dev workflow.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -2786,8 +2786,29 @@ class ActivityGenerator:
         # connection is preceded by a DNS query.
         if not hasattr(self, "_dns_cache"):
             self._dns_cache: dict[tuple[str, str], float] = {}
+        if not hasattr(self, "_dns_cache_last_prune"):
+            self._dns_cache_last_prune = 0.0
+
         cache_key = (src_ip, hostname)
         ts_epoch = time.timestamp()
+
+        # Keep the cache bounded: drop entries older than the max TTL horizon,
+        # and enforce a hard cap under high-cardinality/adversarial inputs.
+        if ts_epoch - self._dns_cache_last_prune >= 60 or len(self._dns_cache) > 50_000:
+            max_ttl_window = 600
+            cutoff = ts_epoch - max_ttl_window
+            self._dns_cache = {
+                key: cached_at for key, cached_at in self._dns_cache.items() if cached_at >= cutoff
+            }
+            if len(self._dns_cache) > 50_000:
+                sorted_items = sorted(
+                    self._dns_cache.items(),
+                    key=lambda item: item[1],
+                    reverse=True,
+                )
+                self._dns_cache = dict(sorted_items[:50_000])
+            self._dns_cache_last_prune = ts_epoch
+
         last_query = self._dns_cache.get(cache_key, 0)
         cache_ttl = rng.choice([60, 120, 300, 600])  # Varied TTLs
         if ts_epoch - last_query < cache_ttl:

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -637,3 +637,21 @@ class TestActivityGenerator:
         event = mock_emitters["zeek_conn"].emit.call_args[0][0]
         assert event.network.protocol == "icmp"
         assert event.network.ip_proto == 1
+
+
+def test_emit_dns_lookup_prunes_and_bounds_dns_cache(activity_gen):
+    """_emit_dns_lookup should prune expired entries and enforce a bounded cache size."""
+    now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    ts_now = now.timestamp()
+
+    activity_gen._dns_cache = {
+        (f"10.0.0.{i % 255}", f"host-{i}.example.com"): ts_now - 5 for i in range(50_100)
+    }
+    hot_key = ("10.0.0.5", "active.example.com")
+    activity_gen._dns_cache[hot_key] = ts_now - 1
+    activity_gen._dns_cache_last_prune = 0.0
+
+    activity_gen._emit_dns_lookup(hot_key[0], "93.184.216.34", now, hostname=hot_key[1])
+
+    assert hot_key in activity_gen._dns_cache
+    assert len(activity_gen._dns_cache) <= 50_001


### PR DESCRIPTION
### Motivation

- A per-generator DNS cache in `_emit_dns_lookup()` stored every unique `(src_ip, hostname)` key without eviction, allowing unbounded memory growth and a local DoS risk for high-cardinality or adversarial scenarios. 

### Description

- Added bounded cache maintenance in `src/evidenceforge/generation/activity/generator.py` by recording `_dns_cache_last_prune`, pruning entries older than a 600s TTL horizon on a 60s cadence, and enforcing a hard cap of 50,000 entries while preserving the most-recent entries. 
- Kept existing cache-hit behavior (`cache_ttl` choices remain `[60, 120, 300, 600]`) so DNS emission semantics are unchanged for non-adversarial inputs. 
- Added a focused unit test `test_emit_dns_lookup_prunes_and_bounds_dns_cache` in `tests/unit/test_activity.py` to validate the pruning and bounding behavior. 
- Updated `TODO.md` to record completion of the security hardening task per project workflow. 

### Testing

- Ran `uv run ruff check .` and the linter passed. 
- Ran `uv run ruff format --check .` and formatting checks passed. 
- Attempted `uv run pytest tests/unit/test_activity.py -k dns_cache -q` and `PYTHONPATH=src uv run pytest ...`, but pytest invocations could not complete in this environment due to missing runtime dependencies (`ModuleNotFoundError: No module named 'evidenceforge'` / missing `yaml`), so the new unit test could not be executed here; it is included and should pass in CI or a dev environment with the project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e022a9acb88325b95c7a840a4d2c29)