### PR TITLE
fix: avoid IPv6 crash in DNS AAAA fallback (preserve IPv6 literals)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,6 +76,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 ### Tier 0: Infrastructure
 
 - [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
+- [x] Security: prevent IPv6 scenario DoS in DNS AAAA fallback (`_ipv4_to_fake_ipv6` no longer evaluates for IPv6 destination IPs; AAAA uses mapped IPv6 or preserves IPv6 literal).
 
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.
 - [x] **`eforge validate` can't find personas in dev mode** — works when installed (`eforge validate`) but not via `uv run eforge validate`. Blocks dev workflow.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -2859,7 +2859,14 @@ class ActivityGenerator:
             # AAAA record: hostname → IPv6
             qtype, qtype_name = 28, "AAAA"
             query = hostname
-            answers = [_IPV6_MAP.get(dst_ip, _ipv4_to_fake_ipv6(dst_ip))]
+            ipv6_answer = _IPV6_MAP.get(dst_ip)
+            if ipv6_answer is not None:
+                answers = [ipv6_answer]
+            elif ":" in dst_ip:
+                # Already IPv6 (not present in registry map) — use as-is.
+                answers = [dst_ip]
+            else:
+                answers = [_ipv4_to_fake_ipv6(dst_ip)]
         elif qtype_roll < 0.93:
             # PTR record: reversed IP → rDNS name
             qtype, qtype_name = 12, "PTR"

--- a/tests/unit/test_phase5_network_diversity.py
+++ b/tests/unit/test_phase5_network_diversity.py
@@ -270,6 +270,36 @@ class TestDnsQueryTypeSemantics:
                     return  # Found at least one AAAA
         # It's probabilistic, so we might not see AAAA in 100 tries, but very unlikely
 
+    def test_aaaa_query_handles_ipv6_destination(self, activity_gen, mock_emitters, monkeypatch):
+        """AAAA lookup should not crash when destination IP is already IPv6."""
+        import random
+
+        import evidenceforge.generation.activity.generator as generator_module
+
+        rng = random.Random(42)
+        random_values = iter([0.5, 0.7])  # not SERVFAIL, then AAAA branch
+
+        def _fixed_random() -> float:
+            try:
+                return next(random_values)
+            except StopIteration:
+                return 0.7
+
+        monkeypatch.setattr(rng, "random", _fixed_random)
+        monkeypatch.setattr(generator_module, "_get_rng", lambda: rng)
+
+        activity_gen._emit_dns_lookup(
+            src_ip="10.0.10.1",
+            dst_ip="2001:db8::1",
+            time=datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC),
+            hostname="example.test",
+        )
+
+        assert mock_emitters["zeek_dns"].emit_raw.called
+        event = mock_emitters["zeek_dns"].emit_raw.call_args_list[0][0][0]
+        assert event["qtype_name"] == "AAAA"
+        assert event["answers"] == ["2001:db8::1"]
+
     def test_ptr_uses_in_addr_arpa(self, activity_gen, state_manager, mock_emitters):
         """PTR queries must use in-addr.arpa format."""
         for _ in range(200):


### PR DESCRIPTION
### Motivation
- The AAAA DNS answer path previously used `_IPV6_MAP.get(dst_ip, _ipv4_to_fake_ipv6(dst_ip))`, which eagerly calls `_ipv4_to_fake_ipv6()` and raises `ValueError` when `dst_ip` is a valid IPv6 literal, causing a denial-of-service during generation.
- The intent is to ensure DNS AAAA answers are produced deterministically without crashing when scenarios include IPv6 addresses.

### Description
- Changed AAAA answer selection in `ActivityGenerator._emit_dns_lookup()` so it: uses `_IPV6_MAP` when present, preserves an unmapped IPv6 literal (`':' in dst_ip`), and only calls `_ipv4_to_fake_ipv6(dst_ip)` for IPv4 destinations (`src/evidenceforge/generation/activity/generator.py`).
- Added a regression unit test `test_aaaa_query_handles_ipv6_destination` to `tests/unit/test_phase5_network_diversity.py` that forces the AAAA branch for an IPv6 `dst_ip` and asserts the DNS event emits successfully with the IPv6 answer.
- Updated `TODO.md` to record this security fix per project workflow.

### Testing
- Ran lint checks: `uv run ruff check .` succeeded.
- Ran format checks: `uv run ruff format --check .` succeeded.
- Attempted to run the focused unit test suite with `PYTHONPATH=src uv run pytest tests/unit/test_phase5_network_diversity.py -k "aaaa"`, but the environment is missing runtime dependencies (`yaml`), causing an import-time failure before the tests could execute; the regression test was added and is ready to run in CI or a fully provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e022a9028c8325bd624ea607a27312)