### PR TITLE
fix: prevent persona activity_intensity divide-by-zero DoS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -84,6 +84,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] **CI runs tests 3 times** — 3 separate pytest invocations (unit, integration, both again for coverage). Consolidate to single run.
 - [x] **No pre-commit hooks** — ruff issues only caught in CI. Add pre-commit framework with ruff check + format hooks.
 - [x] Security: sandboxed Jinja template rendering for YAML-defined format templates (SandboxedEnvironment + StrictUndefined) to block SSTI/code execution while preserving safe field interpolation.
+- [x] Security: guard persona `activity_intensity` normalization against all-zero values to prevent divide-by-zero DoS during generation (all-zero overrides now safely map to floor probability instead of crashing).
 - [ ] **Re-generation appends to existing output** — `GenerationEngine` creates output directories with `exist_ok=True` and emitters append to existing files. Re-running a scenario without manually clearing the output directory produces mixed old+new data. Should clean the output directory (or at least its per-sensor subdirectories) before writing.
 
 ### Tier 1: Foundational Correctness

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3013,12 +3013,25 @@ class ActivityGenerator:
         if not intensity:
             return pattern
 
-        # Normalize intensities to probabilities (cap at 0.95)
-        max_val = max(intensity.values())
+        # Normalize intensities to probabilities (cap at 0.95).
+        # Ignore non-positive values when determining the denominator so an
+        # all-zero (or all-negative) map cannot trigger divide-by-zero.
+        positive_values = [
+            value for activity, value in intensity.items() if activity != "logon" and value > 0
+        ]
+        if not positive_values:
+            for activity, _ in intensity.items():
+                if activity == "logon":
+                    continue  # Already added
+                pattern.append((activity, 0.1))
+            return pattern
+
+        max_val = max(positive_values)
         for activity, value in intensity.items():
             if activity == "logon":
                 continue  # Already added
-            prob = min(0.95, value / max_val * 0.8 + 0.1)
+            normalized = max(value, 0) / max_val
+            prob = min(0.95, normalized * 0.8 + 0.1)
             pattern.append((activity, prob))
 
         return pattern

--- a/tests/unit/test_persona_activity.py
+++ b/tests/unit/test_persona_activity.py
@@ -287,6 +287,22 @@ class TestActivityIntensityOverrides:
         probs = {a: p for a, p in pattern}
         assert probs["process_code"] > probs["connection_web"]
 
+    def test_all_zero_intensity_does_not_crash(self):
+        """All-zero intensity maps should not raise and should return floor probability."""
+        persona = _make_persona(
+            name="developer", activity_intensity={"process_code": 0, "connection_web": 0}
+        )
+        generator = ActivityGenerator(
+            state_manager=Mock(),
+            emitters={},
+        )
+
+        pattern = generator.get_baseline_pattern("developer", persona=persona)
+        probs = {a: p for a, p in pattern}
+
+        assert probs["process_code"] == 0.1
+        assert probs["connection_web"] == 0.1
+
     def test_no_intensity_uses_hardcoded(self):
         """Without activity_intensity, should use hardcoded patterns."""
         persona = _make_persona(name="developer", activity_intensity=None)


### PR DESCRIPTION
### Motivation
- Persona `activity_intensity` overrides were normalized by `max(intensity.values())` without guarding against all-zero or non-positive maps, allowing a crafted persona to raise `ZeroDivisionError` and crash generation.

### Description
- Harden `ActivityGenerator._build_pattern_from_intensity()` to compute the denominator from positive non-logon values and clamp negative inputs to zero before normalization.
- Add a safe fallback that assigns a floor probability (`0.1`) to each activity when no positive values exist so generation continues instead of crashing.
- Add a regression unit test `test_all_zero_intensity_does_not_crash` in `tests/unit/test_persona_activity.py` to verify the fallback behavior.
- Update `TODO.md` to mark the security task as completed.

### Testing
- Ran `uv run ruff check .` which passed.
- Ran `uv run ruff format --check .` and reformatted the single affected test file; subsequent formatting checks passed.
- Attempted `PYTHONPATH=src uv run pytest tests/unit/test_persona_activity.py` in this environment but the run could not complete due to a missing runtime dependency (`yaml` / PyYAML), so the new unit test could not be executed here; CI should run the full test suite where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e022a88d90832587b4e31ca1ec5894)