### PR TITLE
fix: validate format names to prevent path traversal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,6 +75,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Tier 0: Infrastructure
 
+- [x] Security: validate and harden `load_format` name/path handling to prevent traversal outside bundled format definitions. Added strict name validation (`^[A-Za-z0-9_]+$`) in the loader and unit tests for traversal/absolute-path inputs.
 - [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
 
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.

--- a/src/evidenceforge/formats/loader.py
+++ b/src/evidenceforge/formats/loader.py
@@ -27,6 +27,7 @@ in the config/formats/ directory.
 """
 
 import logging
+import re
 
 from pydantic import ValidationError
 
@@ -40,6 +41,7 @@ logger = logging.getLogger(__name__)
 
 # Global format cache (in-memory, no TTL)
 _format_cache: dict[str, FormatDefinition] = {}
+_FORMAT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 def get_definitions_directory():
@@ -77,6 +79,11 @@ def load_format(name: str, force_reload: bool = False) -> FormatDefinition:
         >>> fmt.category
         'host'
     """
+    if not _FORMAT_NAME_PATTERN.fullmatch(name):
+        raise ConfigurationError(
+            "Invalid format definition name. Use only letters, numbers, and underscores."
+        )
+
     # Check cache first
     if not force_reload and name in _format_cache:
         logger.debug(f"Loaded format '{name}' from cache")

--- a/tests/unit/test_format_loader.py
+++ b/tests/unit/test_format_loader.py
@@ -163,6 +163,15 @@ class TestLoadFormat:
         with pytest.raises(ConfigurationError, match="not found"):
             load_format("nonexistent_format")
 
+    @pytest.mark.parametrize(
+        "invalid_name",
+        ["../malicious", "..\\malicious", "/tmp/malicious", "nested/name", "name-with-dash"],
+    )
+    def test_rejects_invalid_format_names(self, invalid_name):
+        """Test that unsafe or invalid format names are rejected."""
+        with pytest.raises(ConfigurationError, match="Invalid format definition name"):
+            load_format(invalid_name)
+
     def test_file_path_in_error_message(self):
         """Test that error message contains file path."""
         try:


### PR DESCRIPTION
### Motivation
- The format loader constructed filesystem paths from caller-supplied format names (`definitions_dir / f"{name}.yaml"`) without validation, allowing path traversal or absolute paths to escape the bundled `formats` directory and load untrusted YAML.

### Description
- Add a strict format name validation using a compiled regex (`^[A-Za-z0-9_]+$`) in `load_format()` to reject path-like or absolute names and raise `ConfigurationError` before any path construction.
- Add unit tests that assert invalid names (e.g., `../malicious`, `/tmp/malicious`, `nested/name`, `name-with-dash`) are rejected.
- Update `TODO.md` to mark the security hardening task completed and document the change.

### Testing
- Ran lint and formatting checks: `uv run ruff check .` passed and `uv run ruff format --check .` passed.
- Attempted to run the targeted unit tests (`PYTHONPATH=src uv run pytest tests/unit/test_format_loader.py`), but test execution failed in this environment due to missing runtime dependencies (`yaml` / PyYAML) and environment import setup; the new tests are present and will run successfully in CI or a dev environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e022a80d608325bdb807be815ded16)