### PR TITLE
fix: validate per-system timezone overrides in scenario model

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,6 +75,8 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Tier 0: Infrastructure
 
+- [x] Security: validate `environment.timezone.systems` overrides at schema load to prevent runtime `UnknownTimeZoneError` crashes during timezone conversion.
+
 - [x] Security: blocked symlinked `eforge` install target in `install-skills` to prevent arbitrary overwrite/deletion and stale-file cleanup outside target.
 
 - [x] **`uv.lock` not committed** — gitignored, so CI `setup-uv@v4` cache fails. Remove from `.gitignore` and commit.

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -637,6 +637,22 @@ class Timezone(BaseModel):
             raise ValueError(f"Unknown timezone: {v}") from e
         return v
 
+    @field_validator("systems")
+    @classmethod
+    def validate_system_timezones(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        """Validate per-system timezone overrides are valid pytz timezones."""
+        if v is None:
+            return v
+
+        for pattern, timezone_name in v.items():
+            try:
+                pytz.timezone(timezone_name)
+            except pytz.UnknownTimeZoneError as e:
+                raise ValueError(
+                    f"Unknown timezone override for pattern '{pattern}': {timezone_name}"
+                ) from e
+        return v
+
 
 class NetworkSegment(BaseModel):
     """Network segment definition.

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -308,6 +308,11 @@ class TestTimezone:
         with pytest.raises(ValidationError, match="Unknown timezone"):
             Timezone(default="Invalid/Timezone")
 
+    def test_timezone_invalid_system_override(self):
+        """Test that invalid per-system timezone overrides are rejected."""
+        with pytest.raises(ValidationError, match="Unknown timezone override"):
+            Timezone(default="UTC", systems={"WS-.*": "Invalid/Timezone"})
+
 
 class TestEnvironment:
     """Tests for Environment model."""


### PR DESCRIPTION
### Motivation
- Per-system timezone overrides in the `Timezone` model were not validated, allowing invalid timezone strings to be stored and later passed to `pytz.timezone()` during conversion, which can raise `UnknownTimeZoneError` and crash generation.

### Description
- Add a `@field_validator("systems")` on `Timezone` to validate every per-system override using `pytz.timezone(...)` and raise a clear `ValueError` that includes the matching hostname pattern on failure.
- Add a unit test `TestTimezone.test_timezone_invalid_system_override` in `tests/unit/test_models.py` to assert invalid per-system overrides are rejected during model validation.
- Update `TODO.md` to track and mark this security fix completed per project workflow.

### Testing
- Ran `uv run ruff check .` which passed.
- Ran `uv run ruff format --check .` which passed (files already formatted).
- Performed direct import/validation smoke checks with `PYTHONPATH=src` to confirm a valid override is accepted and an invalid override raises `ValidationError`, both of which succeeded.
- Attempting to run the full unit test invocation `uv run pytest tests/unit/test_models.py -q` in this environment failed due to missing test dependency (`PyYAML`), so the added test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e022a8559883259e1246f3c138d834)