### PR TITLE
fix: resolve Linux process_query placeholder expansion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -267,7 +267,7 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] No FILE events on attack hosts — storyline processes now pass ensure_file_event=True, guaranteeing a FILE/CREATE for the process image
 - [x] No USER_SESSION events for server-side RDP lateral movement — generate_rdp_session() calls generate_logon() on target, which dispatches USER_SESSION/LOGIN to eCAR with EdrContext
 - [x] Vary filenames in file operations — expanded _EDR_FILE_PATHS_WIN from 7 to 21 entries, _EDR_FILE_PATHS_LINUX from 5 to 20 entries
-- [ ] Template variable leak — literal `{psql_db}` appearing in eCAR output; unsubstituted template variable in process command line or file path
+- [x] Template variable leak — literal `{psql_db}` appearing in eCAR output; unsubstituted template variable in process command line or file path
 
 **Cross-Source / General:**
 - [ ] Cross-source correlation too perfect — every attack action appears in exactly the expected formats with no gaps

--- a/src/evidenceforge/generation/activity/helpers.py
+++ b/src/evidenceforge/generation/activity/helpers.py
@@ -227,7 +227,7 @@ def _parameterize_command(rng, command_line: str, username: str = "") -> str:
     if username and "{username}" in command_line:
         command_line = command_line.replace("{username}", username)
 
-    all_params = {**_GENERAL_PARAMS, **_QUERY_PARAMS}
+    all_params = {**_GENERAL_PARAMS, **_QUERY_PARAMS, **_QUERY_PARAMS_LINUX}
     for _pass in range(3):  # Max 3 passes to resolve nested placeholders
         changed = False
         for key, values in all_params.items():

--- a/tests/unit/test_activity_helpers.py
+++ b/tests/unit/test_activity_helpers.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for activity helper utilities."""
+
+from random import Random
+
+from evidenceforge.generation.activity.helpers import _parameterize_command
+
+
+def test_parameterize_command_replaces_linux_query_placeholders() -> None:
+    """Linux query placeholders should resolve to concrete command content."""
+    rng = Random(1234)
+
+    mysql_cmd = _parameterize_command(rng, "mysql -u root -p {mysql_db}")
+    psql_cmd = _parameterize_command(rng, "psql -U postgres -d {psql_db}")
+    redis_cmd = _parameterize_command(rng, "{redis_cmd}")
+
+    assert "{mysql_db}" not in mysql_cmd
+    assert "{psql_db}" not in psql_cmd
+    assert "{redis_cmd}" not in redis_cmd


### PR DESCRIPTION
### Motivation
- Linux `process_query` command templates include `{mysql_db}`, `{psql_db}`, and `{redis_cmd}` placeholders that were not being expanded because `_parameterize_command()` merged only `_GENERAL_PARAMS` and `_QUERY_PARAMS` and omitted the Linux-specific `_QUERY_PARAMS_LINUX` pool. This produced literal placeholders in generated command lines.

### Description
- Include the Linux-specific pool by changing `all_params = {**_GENERAL_PARAMS, **_QUERY_PARAMS}` to `all_params = {**_GENERAL_PARAMS, **_QUERY_PARAMS, **_QUERY_PARAMS_LINUX}` in `src/evidenceforge/generation/activity/helpers.py`, add a focused unit test `tests/unit/test_activity_helpers.py` to assert Linux query placeholders are resolved, and mark the corresponding TODO entry in `TODO.md` as completed.

### Testing
- Ran `uv run ruff check .` which passed.
- Ran `uv run ruff format --check .` which reported files already formatted.
- Added `tests/unit/test_activity_helpers.py`; running `PYTHONPATH=src uv run pytest tests/unit/test_activity_helpers.py` in this container failed due to missing runtime dependency (`yaml`) referenced by project test setup, so the unit test could not be executed here (the test itself is deterministic and should pass in CI/dev with dependencies installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c61b6cac83258b5d856a11f5b761)