### PR TITLE
fix: add ProcessAccessEventSpec to scenario EventSpec union

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 **Status:** Phase 8.5 (Dual src/dst HostContext) COMPLETE; Pre-MVP quality fixes ongoing
 **Started:** 2026-03-11
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-04-16
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed development history of completed phases.
 
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Fix scenario parsing for `process_access` typed events (Aardvark finding)
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -481,6 +481,14 @@ class CreateRemoteThreadEventSpec(_EventSpecBase):
     target_process: str
 
 
+class ProcessAccessEventSpec(_EventSpecBase):
+    """Process access event (generates Sysmon Event 10)."""
+
+    type: Literal["process_access"] = "process_access"
+    target_process: str = "lsass.exe"
+    access_mask: str = "0x1010"
+
+
 class DhcpLeaseEventSpec(_EventSpecBase):
     """DHCP lease event for rogue/new devices appearing on the network."""
 
@@ -572,6 +580,7 @@ EventSpec = Annotated[
     | ScheduledTaskCreatedEventSpec
     | LogClearedEventSpec
     | CreateRemoteThreadEventSpec
+    | ProcessAccessEventSpec
     | DhcpLeaseEventSpec
     | PortScanEventSpec
     | BlockedC2EventSpec

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -411,6 +411,22 @@ class TestStorylineEvent:
         assert len(event.events) == 1
         assert event.events[0].type == "process"
 
+    def test_storyline_event_with_process_access_event(self):
+        """Test storyline event with process_access typed event."""
+        event = StorylineEvent(
+            id="evt-test-3",
+            time="+45m",
+            actor="jdoe",
+            system="WS-01",
+            activity="Access lsass process",
+            events=[
+                {"type": "process_access", "target_process": "lsass.exe", "access_mask": "0x1010"}
+            ],
+        )
+        assert len(event.events) == 1
+        assert event.events[0].type == "process_access"
+        assert event.events[0].target_process == "lsass.exe"
+
 
 class TestOutputSpec:
     """Tests for OutputSpec model."""


### PR DESCRIPTION
### Motivation
- Validation treats `process_access` as a Windows-only event but the scenario model lacked a corresponding typed spec, causing Pydantic to reject storyline YAML that uses `process_access`.

### Description
- Add a `ProcessAccessEventSpec` model (`type: "process_access"`) with `target_process` and `access_mask` fields and include it in the `EventSpec` discriminated union so `process_access` tags can be parsed.
- Add a unit test `test_storyline_event_with_process_access_event` that constructs a `StorylineEvent` containing a `process_access` event and update `TODO.md` to mark the issue resolved.

### Testing
- Ran `uv run ruff check .` and formatted changed files with `uv run ruff format`, and linter/format checks passed after formatting.
- Attempted `PYTHONPATH=src uv run pytest tests/unit/test_models.py -k "process_access or storyline_event_with_events_list"` but pytest collection failed in this environment due to a missing `yaml` dependency, so the new test was added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c61922308325837e184e674cb293)