### PR TITLE
fix: route Linux logon syslog events to destination host

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Fix syslog host routing for Linux↔Linux network logons (ensure destination host receives sshd syslog entry)
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -54,7 +54,19 @@ class SyslogEmitter(HostMultiplexEmitter):
 
     @staticmethod
     def _linux_host(event: SecurityEvent) -> "HostContext | None":
-        """Return whichever host has os_category == 'linux'."""
+        """Return the Linux host that owns the syslog event.
+
+        For logon events, SyslogContext is attached to the destination host
+        (target of the authentication), so prefer ``dst_host`` to ensure
+        per-host routing writes to the correct host directory.
+        """
+        if event.event_type == "logon":
+            if event.dst_host and event.dst_host.os_category == "linux":
+                return event.dst_host
+            if event.src_host and event.src_host.os_category == "linux":
+                return event.src_host
+            return None
+
         if event.src_host and event.src_host.os_category == "linux":
             return event.src_host
         if event.dst_host and event.dst_host.os_category == "linux":

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -419,6 +419,37 @@ class TestCanHandleDefault:
                 emitter.emit_raw(data)
                 mock_emit.assert_called_once_with(data)
 
+    def test_syslog_linux_host_prefers_destination_for_logon(self):
+        """Syslog logon events route to destination Linux host when both hosts are Linux."""
+        from evidenceforge.events.contexts import HostContext, SyslogContext
+        from evidenceforge.generation.emitters.syslog import SyslogEmitter
+
+        src_host = HostContext(
+            hostname="SRC-LNX",
+            ip="10.0.0.10",
+            os="Ubuntu 22.04",
+            os_category="linux",
+            system_type="server",
+        )
+        dst_host = HostContext(
+            hostname="DST-LNX",
+            ip="10.0.0.20",
+            os="Ubuntu 22.04",
+            os_category="linux",
+            system_type="server",
+        )
+        event = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="logon",
+            src_host=src_host,
+            dst_host=dst_host,
+            syslog=SyslogContext(app_name="sshd", pid=1234, message="Accepted password for bob"),
+        )
+
+        host = SyslogEmitter._linux_host(event)
+        assert host is not None
+        assert host.hostname == "DST-LNX"
+
 
 class TestBuildHostContext:
     """Tests for ActivityGenerator._build_host_context()."""


### PR DESCRIPTION
### Motivation
- Correct a regression in the dual `src_host`/`dst_host` model where Linux `logon` SyslogContext (attached to the destination host) could be routed to the source host because the emitter previously preferred `src_host` first.

### Description
- Update `SyslogEmitter._linux_host()` to prefer `dst_host` for `logon` events, add a focused unit test verifying Linux→Linux `logon` routing to the destination host, and mark the fix as completed in `TODO.md`.

### Testing
- Ran static checks: `uv run ruff check .` and `uv run ruff format --check .` (both passed); a new unit test was added but running `PYTHONPATH=src uv run pytest tests/unit/test_dispatcher.py -k syslog_linux_host_prefers_destination_for_logon` was blocked in this environment due to a missing dependency (`yaml` / PyYAML) so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c619577c8325aaad16793e1ba695)