### PR TITLE
fix: use explicit credential process PID for Windows 4648

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] SubjectLogonId hardcoded to SYSTEM (0x3e7) on 4720/4728/4697/4698/1102
 - [x] 4728 MemberSid doesn't match 4720 TargetSid across storyline events
 - [x] 4648 SubjectLogonId is SYSTEM (0x3e7) for domain user
+- [x] 4648 ProcessId now uses explicit-credential process PID (auth.process_pid) instead of LSASS reporting PID
 - [x] Missing Snort IDS baseline alerts for single-system segments
 - [x] Sysmon 8 TargetProcessId hardcoded to 4 (System kernel PID)
 - [x] Network logon (type 3) processes parented by explorer.exe instead of services/svchost

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -72,6 +72,7 @@ class AuthContext:
     subject_domain: str = ""  # SubjectDomainName (usually NT AUTHORITY)
     subject_logon_id: str = ""  # SubjectLogonId (usually 0x3e7)
     reporting_pid: int = 0  # PID of the process reporting this event (e.g., lsass for logons)
+    process_pid: int = 0  # PID of process using explicit credentials (4648 ProcessId)
     target_server: str = ""  # 4648 TargetServerName (e.g., "fileserver01", "localhost")
     process_name: str = ""  # 4648 ProcessName (process using explicit creds)
 

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3701,6 +3701,7 @@ class ActivityGenerator:
                 subject_logon_id=subject_logon_id,
                 logon_guid="{00000000-0000-0000-0000-000000000000}",
                 reporting_pid=reporting_pid,
+                process_pid=process_pid,
                 target_server=target_server,
                 process_name=process_name,
                 source_ip=source_ip or "-",

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -664,7 +664,7 @@ class WindowsEventEmitter(LogEmitter):
             "TargetLogonGuid": "{00000000-0000-0000-0000-000000000000}",
             "TargetServerName": auth.target_server or "localhost",
             "TargetInfo": auth.target_server or "localhost",
-            "ProcessId": f"0x{auth.reporting_pid:x}" if auth.reporting_pid else "0x0",
+            "ProcessId": f"0x{auth.process_pid:x}" if auth.process_pid else "0x0",
             "ProcessName": auth.process_name or r"C:\Windows\System32\svchost.exe",
             "IpAddress": auth.source_ip or "-",
             "IpPort": auth.source_port or 0,

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -231,6 +231,29 @@ class TestActivityGenerator:
         assert event.process.image == process_name
         assert event.process.command_line == command_line
 
+    def test_generate_explicit_credentials_uses_supplied_process_pid(
+        self, activity_gen, test_user, test_system, state_manager, mock_emitters
+    ):
+        """generate_explicit_credentials should preserve explicit credential process PID."""
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        state_manager.set_current_time(timestamp)
+
+        activity_gen.generate_explicit_credentials(
+            user=test_user,
+            system=test_system,
+            time=timestamp,
+            target_username="admin01",
+            target_server="dc01.corp.local",
+            process_name=r"C:\Windows\System32\runas.exe",
+            process_pid=4242,
+            source_ip="10.0.0.50",
+            source_port=50123,
+        )
+
+        event = mock_emitters["windows_event_security"].emit.call_args[0][0]
+        assert event.event_type == "explicit_credentials"
+        assert event.auth.process_pid == 4242
+
     def test_generate_process_with_parent_pid(
         self, activity_gen, test_user, test_system, state_manager, mock_emitters
     ):

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -207,6 +207,7 @@ class TestAuthContext:
         assert ctx.subject_username == ""
         assert ctx.subject_domain == ""
         assert ctx.subject_logon_id == ""
+        assert ctx.process_pid == 0
 
 
 class TestProcessContext:


### PR DESCRIPTION
### Motivation
- Fix incorrect ProcessId attribution in Windows 4648 explicit-credentials events where the emitted `ProcessId` was derived from the LSASS reporting PID instead of the actual process that performed the explicit-credential operation.

### Description
- Add `process_pid` to `AuthContext` so explicit-credential events can carry the originating process PID separately from the reporting PID (`reporting_pid`).
- Persist the provided `process_pid` in `ActivityGenerator.generate_explicit_credentials()` when building the `SecurityEvent` auth context (`AuthContext.process_pid`).
- Change the Windows 4648 renderer to emit `ProcessId` from `auth.process_pid` while keeping `ExecutionProcessID` as the reporting process where appropriate.
- Add unit test coverage to verify the new `process_pid` default and propagation (`tests/unit/test_events.py` and `tests/unit/test_activity.py`) and update `TODO.md` to reflect the fix.

### Testing
- Ran linter/format checks: `uv run ruff check .` succeeded and `uv run ruff format --check .` succeeded.
- Attempted unit test run with `PYTHONPATH=src uv run pytest tests/unit/test_activity.py tests/unit/test_events.py tests/unit/test_emitters.py`, but test bootstrap failed in this environment due to a missing test dependency (`yaml` module), preventing full pytest verification here.
- New/updated unit tests were added to assert `AuthContext.process_pid` default and that `generate_explicit_credentials()` preserves the supplied `process_pid` (tests available in the repo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c6193b0c83258b30032c3cb6b95f)