### PR TITLE
fix: harden Windows eval XML parser against entity expansion DoS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Security: harden eval Windows XML parser against untrusted entity expansion and large-file memory usage
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/evaluation/parsers/windows.py
+++ b/src/evidenceforge/evaluation/parsers/windows.py
@@ -33,8 +33,9 @@ from . import LogParser, ParsedRecord, register_parser
 # Namespace used in Windows Event XML
 NS = "http://schemas.microsoft.com/win/2004/08/events/event"
 
-# Regex to split XML into individual <Event> blocks
-EVENT_PATTERN = re.compile(r"<Event\s[^>]*>.*?</Event>", re.DOTALL)
+# Regex boundaries used for streaming extraction of individual <Event> blocks
+EVENT_START_PATTERN = re.compile(r"<Event(?:\s|>)")
+EVENT_END_PATTERN = re.compile(r"</Event>")
 
 
 @register_parser
@@ -45,10 +46,29 @@ class WindowsEventParser(LogParser):
         return path.name == "windows_event_security.xml"
 
     def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
-        content = path.read_text(encoding="utf-8")
-        for i, match in enumerate(EVENT_PATTERN.finditer(content), 1):
-            raw = match.group(0)
-            yield self._parse_event(raw, i)
+        event_index = 0
+        in_event = False
+        event_lines: list[str] = []
+
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not in_event and EVENT_START_PATTERN.search(line):
+                    in_event = True
+                    event_lines = [line]
+                    if EVENT_END_PATTERN.search(line):
+                        event_index += 1
+                        yield self._parse_event("".join(event_lines), event_index)
+                        in_event = False
+                        event_lines = []
+                    continue
+
+                if in_event:
+                    event_lines.append(line)
+                    if EVENT_END_PATTERN.search(line):
+                        event_index += 1
+                        yield self._parse_event("".join(event_lines), event_index)
+                        in_event = False
+                        event_lines = []
 
     def _parse_event(self, raw: str, index: int) -> ParsedRecord:
         fields: dict = {}
@@ -56,6 +76,9 @@ class WindowsEventParser(LogParser):
         timestamp = None
 
         try:
+            if "<!DOCTYPE" in raw or "<!ENTITY" in raw:
+                raise ET.ParseError("DOCTYPE and ENTITY declarations are not allowed")
+
             root = ET.fromstring(raw)
 
             # System fields

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -76,6 +76,42 @@ class TestWindowsEventParser:
         records = list(parser.parse_file(GOOD_FIXTURES / "windows_event_security.xml"))
         assert all(len(r.parse_errors) == 0 for r in records)
 
+    def test_rejects_doctype_and_entity_declarations(self, tmp_path):
+        from evidenceforge.evaluation.parsers.windows import WindowsEventParser
+
+        parser = WindowsEventParser()
+        payload = """<Events>
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+<!DOCTYPE foo [<!ENTITY xxe "boom">]>
+<System><EventID>4624</EventID></System>
+<EventData><Data Name="TargetUserName">&xxe;</Data></EventData>
+</Event>
+</Events>
+"""
+        path = tmp_path / "windows_event_security.xml"
+        path.write_text(payload, encoding="utf-8")
+
+        records = list(parser.parse_file(path))
+
+        assert len(records) == 1
+        assert records[0].fields == {}
+        assert records[0].parse_errors
+        assert "DOCTYPE and ENTITY declarations are not allowed" in records[0].parse_errors[0]
+
+    def test_parse_file_streams_without_reading_full_content(self, monkeypatch):
+        from evidenceforge.evaluation.parsers.windows import WindowsEventParser
+
+        parser = WindowsEventParser()
+
+        def _fail_read_text(*_args, **_kwargs):
+            raise AssertionError("parse_file should not call Path.read_text()")
+
+        monkeypatch.setattr(Path, "read_text", _fail_read_text)
+
+        records = list(parser.parse_file(GOOD_FIXTURES / "windows_event_security.xml"))
+
+        assert len(records) == 3
+
     def test_can_parse_correct_file(self):
         from evidenceforge.evaluation.parsers.windows import WindowsEventParser
 


### PR DESCRIPTION
### Motivation
- The Windows Event XML parser used `ElementTree.fromstring()` on untrusted event fragments and previously read entire files into memory, enabling entity/DTD-based XML DoS and large-file memory use.
- The change prevents attacker-controlled XML (e.g., nested entity expansions) from being expanded or from causing high memory usage during evaluation.

### Description
- Stream `windows_event_security.xml` line-by-line and extract individual `<Event>` elements without reading the whole file by replacing the global regex/full-file read with `parse_file()` that accumulates lines between `EVENT_START_PATTERN` and `EVENT_END_PATTERN`.
- Detect and explicitly reject unsafe XML declarations by checking for `<!DOCTYPE` or `<!ENTITY` in the extracted fragment before parsing and returning a parse error instead of calling `ElementTree.fromstring()` on dangerous content.
- Add two focused unit tests in `tests/unit/test_eval_parsers.py` to assert rejection of DOCTYPE/entity declarations and to ensure `parse_file()` streams input (does not call `Path.read_text()`).
- Update `TODO.md` to mark the security hardening item completed.

### Testing
- Ran linting and formatting checks: `uv run ruff check src/evidenceforge/evaluation/parsers/windows.py tests/unit/test_eval_parsers.py` passed and `uv run ruff format --check ...` passed after formatting changes.
- Added unit tests `test_rejects_doctype_and_entity_declarations` and `test_parse_file_streams_without_reading_full_content` under `tests/unit/test_eval_parsers.py` (tests are present but full `pytest` runs were blocked in this environment due to missing runtime dependencies and network-restricted package sync).
- Attempted to run `uv run pytest tests/unit/test_eval_parsers.py` but execution was prevented by missing runtime packages in the environment (e.g., `pydantic`, `pyyaml`), so test execution is pending in CI/normal dev environments where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c61ac0c48325bf415f42ebbd79e2)