### PR TITLE
fix: enforce JSON Logic truthiness for field constraints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Security: restored JSON Logic field-constraint truthiness validation so falsey non-boolean outputs (0, "", []) fail validation
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/formats/validator.py
+++ b/src/evidenceforge/formats/validator.py
@@ -207,7 +207,7 @@ def validate_field_constraints(
             # JSON Logic rule has access to the field value as {"value": ...}
             data = {"value": field_value}
             logic_result = jsonLogic(constraints.json_logic, data)
-            if logic_result is False or logic_result is None:
+            if not logic_result:
                 result.add_error(
                     field_name, f"Failed JSON Logic validation: {constraints.json_logic}"
                 )

--- a/tests/unit/test_format_validator.py
+++ b/tests/unit/test_format_validator.py
@@ -24,6 +24,8 @@
 
 from datetime import datetime
 
+import pytest
+
 from evidenceforge.formats.format_def import (
     EventVariant,
     FieldConstraint,
@@ -344,6 +346,14 @@ class TestValidateFieldConstraints:
         """Test simple JSON Logic rule fails."""
         constraints = FieldConstraint(json_logic={"==": [{"var": "value"}, 42]})
         result = validate_field_constraints("field", 99, constraints)
+        assert result.valid is False
+        assert "Failed JSON Logic" in result.errors[0]
+
+    @pytest.mark.parametrize("falsey_result", [0, "", []])
+    def test_json_logic_falsey_non_boolean_invalid(self, falsey_result):
+        """Test JSON Logic falsey non-boolean outputs fail validation."""
+        constraints = FieldConstraint(json_logic={"var": "value"})
+        result = validate_field_constraints("field", falsey_result, constraints)
         assert result.valid is False
         assert "Failed JSON Logic" in result.errors[0]
 


### PR DESCRIPTION
### Motivation

- JSON Logic field constraints were only treated as failures when the evaluator returned literal `False` or `None`, which allowed falsey non-boolean results (`0`, `""`, `[]`) to bypass validation.

### Description

- Change `validate_field_constraints` in `src/evidenceforge/formats/validator.py` to treat any falsey JSON Logic result as a validation failure by using `if not logic_result`.
- Add a regression unit test in `tests/unit/test_format_validator.py` that parametrizes falsey non-boolean values (`0`, `""`, `[]`) and asserts they are rejected by `validate_field_constraints`.
- Update `TODO.md` to mark the JSON Logic truthiness validation fix as completed.

### Testing

- Lint/format checks were run with `uv run ruff check .` and `uv run ruff format --check .` and passed.
- A quick functional check using `PYTHONPATH=src uv run python -c "from evidenceforge.formats.validator import validate_field_constraints; ..."` confirmed the validator now rejects a falsey non-boolean JSON Logic result (`False` printed for the test invocation).
- Attempting to run the full unit test invocation in this environment (`PYTHONPATH=src uv run pytest tests/unit/test_format_validator.py`) was blocked by a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`), so the broader test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c619121883259a0f970b1bcea250)