### PR TITLE
fix: prevent DLL profile loader crash on malformed loaded_modules entries

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Security: harden DLL profile loader against non-dict loaded_modules overlay entries (prevent AttributeError/TypeError DoS)
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/generation/activity/dll_load_profiles.py
+++ b/src/evidenceforge/generation/activity/dll_load_profiles.py
@@ -33,9 +33,24 @@ def _apply_defaults(entry: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _validate_entry(entry: dict[str, Any], source: str) -> bool:
+def _validate_entry(entry: Any, source: str) -> bool:
     """Validate a single loaded_modules entry. Returns True if valid."""
+    if not isinstance(entry, dict):
+        logger.warning(
+            "DLL profile entry in %s must be a mapping, got %s — skipping",
+            source,
+            type(entry).__name__,
+        )
+        return False
+
     path = entry.get("path", "")
+    if not isinstance(path, str):
+        logger.warning(
+            "DLL profile entry in %s has non-string path %r — skipping",
+            source,
+            path,
+        )
+        return False
     if not path:
         logger.warning("DLL profile entry in %s has empty path — skipping", source)
         return False

--- a/tests/unit/test_dll_load_profiles.py
+++ b/tests/unit/test_dll_load_profiles.py
@@ -111,6 +111,18 @@ class TestValidation:
     def test_empty_path_fails(self):
         assert _validate_entry({"path": ""}, "test") is False
 
+    def test_non_mapping_entry_fails(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _validate_entry("not-a-dict", "test")
+        assert result is False
+        assert "must be a mapping" in caplog.text
+
+    def test_non_string_path_fails(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _validate_entry({"path": None}, "test")
+        assert result is False
+        assert "non-string path" in caplog.text
+
     def test_non_windows_path_fails(self, caplog):
         with caplog.at_level(logging.WARNING):
             result = _validate_entry({"path": "/usr/lib/libfoo.so"}, "test")


### PR DESCRIPTION
### Motivation

- The DLL profile loader assumed every `loaded_modules` list item was a mapping and accessed fields with `entry.get(...)` / `entry["path"]`, which can raise `AttributeError`/`TypeError` when overlays contain non-dict items and crash generation.

### Description

- Harden `src/evidenceforge/generation/activity/dll_load_profiles.py` by making `_validate_entry` accept `entry: Any` and early-return `False` with a logged warning when `entry` is not a mapping or when `path` is not a string, preventing attribute access on non-dict values.
- Kept default-application behavior in `_apply_defaults` unchanged and preserved merging/duplicate-detection logic in `load_dll_profiles()` so runtime behavior is unaffected for valid inputs.
- Added unit tests in `tests/unit/test_dll_load_profiles.py` covering non-mapping entries and non-string `path` values to verify the loader now skips malformed entries safely.
- Updated `TODO.md` per project workflow to record the security hardening task as completed.

### Testing

- Ran `uv run ruff check .` which passed successfully.
- Ran `uv run ruff format --check .` which reported files are formatted (no failures).
- Attempted `uv run pytest tests/unit/test_dll_load_profiles.py` but the container lacked runtime dependencies (`ModuleNotFoundError: yaml`), causing the local pytest run to fail; the new unit tests were added and are expected to pass in a correctly provisioned CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2549add588325bd8f19ced9693083)