### PR TITLE
fix: consolidate 6 Codex PR fixes

### DIFF
--- a/src/evidenceforge/evaluation/parsers/windows.py
+++ b/src/evidenceforge/evaluation/parsers/windows.py
@@ -33,8 +33,9 @@ from . import LogParser, ParsedRecord, register_parser
 # Namespace used in Windows Event XML
 NS = "http://schemas.microsoft.com/win/2004/08/events/event"
 
-# Regex to split XML into individual <Event> blocks
-EVENT_PATTERN = re.compile(r"<Event\s[^>]*>.*?</Event>", re.DOTALL)
+# Regex boundaries used for streaming extraction of individual <Event> blocks
+EVENT_START_PATTERN = re.compile(r"<Event(?:\s|>)")
+EVENT_END_PATTERN = re.compile(r"</Event>")
 
 
 @register_parser
@@ -45,10 +46,29 @@ class WindowsEventParser(LogParser):
         return path.name == "windows_event_security.xml"
 
     def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
-        content = path.read_text(encoding="utf-8")
-        for i, match in enumerate(EVENT_PATTERN.finditer(content), 1):
-            raw = match.group(0)
-            yield self._parse_event(raw, i)
+        event_index = 0
+        in_event = False
+        event_lines: list[str] = []
+
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not in_event and EVENT_START_PATTERN.search(line):
+                    in_event = True
+                    event_lines = [line]
+                    if EVENT_END_PATTERN.search(line):
+                        event_index += 1
+                        yield self._parse_event("".join(event_lines), event_index)
+                        in_event = False
+                        event_lines = []
+                    continue
+
+                if in_event:
+                    event_lines.append(line)
+                    if EVENT_END_PATTERN.search(line):
+                        event_index += 1
+                        yield self._parse_event("".join(event_lines), event_index)
+                        in_event = False
+                        event_lines = []
 
     def _parse_event(self, raw: str, index: int) -> ParsedRecord:
         fields: dict = {}
@@ -56,6 +76,9 @@ class WindowsEventParser(LogParser):
         timestamp = None
 
         try:
+            if "<!DOCTYPE" in raw or "<!ENTITY" in raw:
+                raise ET.ParseError("DOCTYPE and ENTITY declarations are not allowed")
+
             root = ET.fromstring(raw)
 
             # System fields

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -72,6 +72,7 @@ class AuthContext:
     subject_domain: str = ""  # SubjectDomainName (usually NT AUTHORITY)
     subject_logon_id: str = ""  # SubjectLogonId (usually 0x3e7)
     reporting_pid: int = 0  # PID of the process reporting this event (e.g., lsass for logons)
+    process_pid: int = 0  # PID of process using explicit credentials (4648 ProcessId)
     target_server: str = ""  # 4648 TargetServerName (e.g., "fileserver01", "localhost")
     process_name: str = ""  # 4648 ProcessName (process using explicit creds)
 

--- a/src/evidenceforge/formats/validator.py
+++ b/src/evidenceforge/formats/validator.py
@@ -207,7 +207,7 @@ def validate_field_constraints(
             # JSON Logic rule has access to the field value as {"value": ...}
             data = {"value": field_value}
             logic_result = jsonLogic(constraints.json_logic, data)
-            if logic_result is False or logic_result is None:
+            if not logic_result:
                 result.add_error(
                     field_name, f"Failed JSON Logic validation: {constraints.json_logic}"
                 )

--- a/src/evidenceforge/generation/activity/edr_pools.py
+++ b/src/evidenceforge/generation/activity/edr_pools.py
@@ -9,13 +9,17 @@ a user overlay from .eforge/config/activity/edr_pools.yaml if present.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+import yaml
 
 from evidenceforge.config import get_activity_directory
 from evidenceforge.config.overlay import load_with_overlay
 
 _EDR_POOLS_PATH = get_activity_directory() / "edr_pools.yaml"
 _CACHED: dict[str, Any] | None = None
+logger = logging.getLogger(__name__)
 
 
 def _merge_edr_pools(default: dict, overlay: dict) -> dict:
@@ -37,12 +41,55 @@ def load_edr_pools() -> dict[str, Any]:
     if _CACHED is not None:
         return _CACHED
 
-    _CACHED = load_with_overlay(
+    with open(_EDR_POOLS_PATH) as f:
+        defaults = yaml.safe_load(f)
+
+    merged = load_with_overlay(
         _EDR_POOLS_PATH,
         "activity/edr_pools.yaml",
         _merge_edr_pools,
     )
+    _CACHED = _sanitize_edr_pools(defaults, merged)
     return _CACHED
+
+
+def _is_valid_string_list(value: Any) -> bool:
+    return (
+        isinstance(value, list) and len(value) > 0 and all(isinstance(item, str) for item in value)
+    )
+
+
+def _is_valid_registry_pool(value: Any) -> bool:
+    if not isinstance(value, list) or len(value) == 0:
+        return False
+    for item in value:
+        if not isinstance(item, list | tuple) or len(item) != 3:
+            return False
+        if not all(isinstance(field, str) and field for field in item):
+            return False
+    return True
+
+
+def _sanitize_edr_pools(defaults: dict[str, Any], merged: dict[str, Any]) -> dict[str, Any]:
+    """Validate merged EDR pools and fall back to defaults for malformed sections."""
+    validators: dict[str, Any] = {
+        "file_paths_windows": _is_valid_string_list,
+        "file_paths_linux": _is_valid_string_list,
+        "dll_pool": _is_valid_string_list,
+        "registry_keys_hkcu": _is_valid_registry_pool,
+        "registry_keys_hklm": _is_valid_registry_pool,
+    }
+    sanitized = dict(defaults)
+    for key, validator in validators.items():
+        candidate = merged.get(key)
+        if validator(candidate):
+            sanitized[key] = candidate
+        else:
+            logger.warning(
+                "Invalid EDR pool section %s in overlay-merged config; falling back to package defaults",
+                key,
+            )
+    return sanitized
 
 
 def get_file_paths(os_category: str) -> list[str]:

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3809,6 +3809,7 @@ class ActivityGenerator:
                 subject_logon_id=subject_logon_id,
                 logon_guid="{00000000-0000-0000-0000-000000000000}",
                 reporting_pid=reporting_pid,
+                process_pid=process_pid,
                 target_server=target_server,
                 process_name=process_name,
                 source_ip=source_ip or "-",

--- a/src/evidenceforge/generation/activity/helpers.py
+++ b/src/evidenceforge/generation/activity/helpers.py
@@ -227,7 +227,7 @@ def _parameterize_command(rng, command_line: str, username: str = "") -> str:
     if username and "{username}" in command_line:
         command_line = command_line.replace("{username}", username)
 
-    all_params = {**_GENERAL_PARAMS, **_QUERY_PARAMS}
+    all_params = {**_GENERAL_PARAMS, **_QUERY_PARAMS, **_QUERY_PARAMS_LINUX}
     for _pass in range(3):  # Max 3 passes to resolve nested placeholders
         changed = False
         for key, values in all_params.items():

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -664,7 +664,7 @@ class WindowsEventEmitter(LogEmitter):
             "TargetLogonGuid": "{00000000-0000-0000-0000-000000000000}",
             "TargetServerName": auth.target_server or "localhost",
             "TargetInfo": auth.target_server or "localhost",
-            "ProcessId": f"0x{auth.reporting_pid:x}" if auth.reporting_pid else "0x0",
+            "ProcessId": f"0x{auth.process_pid:x}" if auth.process_pid else "0x0",
             "ProcessName": auth.process_name or r"C:\Windows\System32\svchost.exe",
             "IpAddress": auth.source_ip or "-",
             "IpPort": auth.source_port or 0,

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -481,6 +481,14 @@ class CreateRemoteThreadEventSpec(_EventSpecBase):
     target_process: str
 
 
+class ProcessAccessEventSpec(_EventSpecBase):
+    """Process access event (generates Sysmon Event 10)."""
+
+    type: Literal["process_access"] = "process_access"
+    target_process: str = "lsass.exe"
+    access_mask: str = "0x1010"
+
+
 class DhcpLeaseEventSpec(_EventSpecBase):
     """DHCP lease event for rogue/new devices appearing on the network."""
 
@@ -873,6 +881,7 @@ EventSpec = Annotated[
     | ScheduledTaskCreatedEventSpec
     | LogClearedEventSpec
     | CreateRemoteThreadEventSpec
+    | ProcessAccessEventSpec
     | DhcpLeaseEventSpec
     | PortScanEventSpec
     | BeaconEventSpec

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -231,6 +231,29 @@ class TestActivityGenerator:
         assert event.process.image == process_name
         assert event.process.command_line == command_line
 
+    def test_generate_explicit_credentials_uses_supplied_process_pid(
+        self, activity_gen, test_user, test_system, state_manager, mock_emitters
+    ):
+        """generate_explicit_credentials should preserve explicit credential process PID."""
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        state_manager.set_current_time(timestamp)
+
+        activity_gen.generate_explicit_credentials(
+            user=test_user,
+            system=test_system,
+            time=timestamp,
+            target_username="admin01",
+            target_server="dc01.corp.local",
+            process_name=r"C:\Windows\System32\runas.exe",
+            process_pid=4242,
+            source_ip="10.0.0.50",
+            source_port=50123,
+        )
+
+        event = mock_emitters["windows_event_security"].emit.call_args[0][0]
+        assert event.event_type == "explicit_credentials"
+        assert event.auth.process_pid == 4242
+
     def test_generate_process_with_parent_pid(
         self, activity_gen, test_user, test_system, state_manager, mock_emitters
     ):

--- a/tests/unit/test_activity_helpers.py
+++ b/tests/unit/test_activity_helpers.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for activity helper utilities."""
+
+from random import Random
+
+from evidenceforge.generation.activity.helpers import _parameterize_command
+
+
+def test_parameterize_command_replaces_linux_query_placeholders() -> None:
+    """Linux query placeholders should resolve to concrete command content."""
+    rng = Random(1234)
+
+    mysql_cmd = _parameterize_command(rng, "mysql -u root -p {mysql_db}")
+    psql_cmd = _parameterize_command(rng, "psql -U postgres -d {psql_db}")
+    redis_cmd = _parameterize_command(rng, "{redis_cmd}")
+
+    assert "{mysql_db}" not in mysql_cmd
+    assert "{psql_db}" not in psql_cmd
+    assert "{redis_cmd}" not in redis_cmd

--- a/tests/unit/test_edr_pools.py
+++ b/tests/unit/test_edr_pools.py
@@ -4,6 +4,7 @@
 """Unit tests for EDR pools YAML loader."""
 
 from evidenceforge.generation.activity.edr_pools import (
+    _sanitize_edr_pools,
     get_dll_pool,
     get_file_paths,
     get_registry_keys_hkcu,
@@ -97,3 +98,36 @@ class TestDllPool:
         dll_names = [d.rsplit("\\", 1)[-1].lower() for d in dlls]
         assert "ntdll.dll" in dll_names
         assert "kernel32.dll" in dll_names
+
+
+class TestOverlayValidation:
+    """Test fallback behavior for malformed overlay-provided pools."""
+
+    def test_sanitize_empty_string_pools_falls_back_to_defaults(self):
+        defaults = {
+            "file_paths_windows": [r"C:\\Windows\\Temp\\x.tmp"],
+            "file_paths_linux": ["/tmp/x.tmp"],
+            "dll_pool": [r"C:\\Windows\\System32\\kernel32.dll"],
+            "registry_keys_hkcu": [["HKCU\\Software\\X", "Enabled", "DWORD (0x00000001)"]],
+            "registry_keys_hklm": [["HKLM\\Software\\X", "Enabled", "DWORD (0x00000001)"]],
+        }
+        merged = {**defaults, "file_paths_windows": [], "dll_pool": []}
+
+        sanitized = _sanitize_edr_pools(defaults, merged)
+
+        assert sanitized["file_paths_windows"] == defaults["file_paths_windows"]
+        assert sanitized["dll_pool"] == defaults["dll_pool"]
+
+    def test_sanitize_malformed_registry_pool_falls_back_to_defaults(self):
+        defaults = {
+            "file_paths_windows": [r"C:\\Windows\\Temp\\x.tmp"],
+            "file_paths_linux": ["/tmp/x.tmp"],
+            "dll_pool": [r"C:\\Windows\\System32\\kernel32.dll"],
+            "registry_keys_hkcu": [["HKCU\\Software\\X", "Enabled", "DWORD (0x00000001)"]],
+            "registry_keys_hklm": [["HKLM\\Software\\X", "Enabled", "DWORD (0x00000001)"]],
+        }
+        merged = {**defaults, "registry_keys_hkcu": {"bad": "shape"}}
+
+        sanitized = _sanitize_edr_pools(defaults, merged)
+
+        assert sanitized["registry_keys_hkcu"] == defaults["registry_keys_hkcu"]

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -76,6 +76,42 @@ class TestWindowsEventParser:
         records = list(parser.parse_file(GOOD_FIXTURES / "windows_event_security.xml"))
         assert all(len(r.parse_errors) == 0 for r in records)
 
+    def test_rejects_doctype_and_entity_declarations(self, tmp_path):
+        from evidenceforge.evaluation.parsers.windows import WindowsEventParser
+
+        parser = WindowsEventParser()
+        payload = """<Events>
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+<!DOCTYPE foo [<!ENTITY xxe "boom">]>
+<System><EventID>4624</EventID></System>
+<EventData><Data Name="TargetUserName">&xxe;</Data></EventData>
+</Event>
+</Events>
+"""
+        path = tmp_path / "windows_event_security.xml"
+        path.write_text(payload, encoding="utf-8")
+
+        records = list(parser.parse_file(path))
+
+        assert len(records) == 1
+        assert records[0].fields == {}
+        assert records[0].parse_errors
+        assert "DOCTYPE and ENTITY declarations are not allowed" in records[0].parse_errors[0]
+
+    def test_parse_file_streams_without_reading_full_content(self, monkeypatch):
+        from evidenceforge.evaluation.parsers.windows import WindowsEventParser
+
+        parser = WindowsEventParser()
+
+        def _fail_read_text(*_args, **_kwargs):
+            raise AssertionError("parse_file should not call Path.read_text()")
+
+        monkeypatch.setattr(Path, "read_text", _fail_read_text)
+
+        records = list(parser.parse_file(GOOD_FIXTURES / "windows_event_security.xml"))
+
+        assert len(records) == 3
+
     def test_can_parse_correct_file(self):
         from evidenceforge.evaluation.parsers.windows import WindowsEventParser
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -207,6 +207,7 @@ class TestAuthContext:
         assert ctx.subject_username == ""
         assert ctx.subject_domain == ""
         assert ctx.subject_logon_id == ""
+        assert ctx.process_pid == 0
 
 
 class TestProcessContext:

--- a/tests/unit/test_format_validator.py
+++ b/tests/unit/test_format_validator.py
@@ -24,6 +24,8 @@
 
 from datetime import datetime
 
+import pytest
+
 from evidenceforge.formats.format_def import (
     EventVariant,
     FieldConstraint,
@@ -344,6 +346,14 @@ class TestValidateFieldConstraints:
         """Test simple JSON Logic rule fails."""
         constraints = FieldConstraint(json_logic={"==": [{"var": "value"}, 42]})
         result = validate_field_constraints("field", 99, constraints)
+        assert result.valid is False
+        assert "Failed JSON Logic" in result.errors[0]
+
+    @pytest.mark.parametrize("falsey_result", [0, "", []])
+    def test_json_logic_falsey_non_boolean_invalid(self, falsey_result):
+        """Test JSON Logic falsey non-boolean outputs fail validation."""
+        constraints = FieldConstraint(json_logic={"var": "value"})
+        result = validate_field_constraints("field", falsey_result, constraints)
         assert result.valid is False
         assert "Failed JSON Logic" in result.errors[0]
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -411,6 +411,22 @@ class TestStorylineEvent:
         assert len(event.events) == 1
         assert event.events[0].type == "process"
 
+    def test_storyline_event_with_process_access_event(self):
+        """Test storyline event with process_access typed event."""
+        event = StorylineEvent(
+            id="evt-test-3",
+            time="+45m",
+            actor="jdoe",
+            system="WS-01",
+            activity="Access lsass process",
+            events=[
+                {"type": "process_access", "target_process": "lsass.exe", "access_mask": "0x1010"}
+            ],
+        )
+        assert len(event.events) == 1
+        assert event.events[0].type == "process_access"
+        assert event.events[0].target_process == "lsass.exe"
+
 
 class TestOutputSpec:
     """Tests for OutputSpec model."""


### PR DESCRIPTION
## Summary
Cherry-picks and consolidates fixes from 6 open Codex PRs into a single merge:

- **PR #51**: Linux query param placeholder expansion (`_QUERY_PARAMS_LINUX`)
- **PR #52**: `ProcessAccessEventSpec` added to `EventSpec` union
- **PR #56**: 4648 `process_pid` field for explicit credential process PID
- **PR #57**: XML entity expansion DoS protection in eval parser (security)
- **PR #58**: JSON Logic falsey validation for field constraints
- **PR #61**: EDR overlay pool runtime validation with fallback to defaults

## Test plan
- [x] `uv run pytest` — 1985 passed
- [x] `uv run ruff check && ruff format` — clean
- [x] All 6 PR test suites included

Closes #51, #52, #56, #57, #58, #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)