### PR TITLE
feat: --formats CLI filter for targeted log generation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -412,19 +412,16 @@ Highest impact — unblocks or improves 10 exercises across all 5 days. These ar
 
 High breadth, low cost — makes multi-week generation practical for 5 exercises without deep optimization.
 
-- [ ] `--formats` CLI filter (e.g., `--formats zeek_conn,zeek_dns` or `--formats proxy_access`)
-- [ ] Skip emitters that don't match the filter
+- [x] `--formats` CLI filter with intersection semantics and group name support
+- [x] `format_groups` inventory in `eforge info` output
 
 **Exercises:** 3.1, 3.2, 3.3, 5.1, 5.2 (all need 2-4 week windows)
 
-### Cluster 3: Temporal Baseline Phases
+### Cluster 3: Temporal Baseline Phases — Resolved by Design
 
-Single-exercise blocker, but broadly useful for any multi-week scenario.
+Achievable by composing bulk event primitives (beacon, connection, dns_query) over a stable baseline. Students detect injected activity as statistical outliers. No engine changes needed — documented as a scenario authoring pattern.
 
-- [ ] `phases` section in scenario YAML with per-phase baseline intensity/parameters
-- [ ] Support different baseline behavior across time ranges (e.g., "3x outbound from host X starting day 15")
-
-**Exercises:** 3.2 (gradual behavioral shifts)
+**Exercises:** 3.2 (gradual behavioral shifts — use beacons with start_time offsets and orig_bytes overrides)
 
 ### Cluster 4: Windows Auth Enrichment
 

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -48,6 +48,12 @@ eforge generate <scenario.yaml> [options]
 Options:
   --output, -o <dir>     Override output directory (default: from scenario's output.destination)
   --config, -c <file>    Path to config.yaml
+  --formats, -F <list>   Comma-separated format filter. Only generates formats present in both
+                         this list and the scenario's output.logs. Supports group names (zeek,
+                         windows) and individual format names (zeek_conn, cisco_asa). Use
+                         `eforge info format_groups` to see available groups. Example:
+                         `eforge generate scenario.yaml --formats zeek_conn,zeek_dns` to
+                         generate only Zeek connection and DNS logs.
   --force, -f            Overwrite existing output without prompting
   --verbose, -v          INFO-level logging
   --debug, -d            DEBUG-level logging

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -512,6 +512,12 @@ The validator warns if it detects potentially redundant manual specifications al
 
 Use RFC 5737 documentation IP ranges for external attacker IPs (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24). Use private ranges (10.x, 172.16-31.x, 192.168.x) for internal systems.
 
+### Long Time Windows and Baseline Exercises
+
+For scenarios spanning 2+ weeks (e.g., 30-day baseline exercises), scope `output.logs` to only the formats needed for the exercise. Generating all formats over a long time window produces very large datasets and slow generation; declaring just `format: zeek_conn` instead of the full `zeek` group can cut generation time dramatically. The `--formats` CLI flag can also filter at runtime without editing the YAML.
+
+For baseline deviation exercises (e.g., "spot the change in normal traffic"), use `beacon` events with `start_time` offsets and `orig_bytes`/`resp_bytes` overrides to layer gradual drift on top of a stable baseline, rather than modifying `baseline_activity.intensity`. For example, a beacon starting at `+14d` with increasing `orig_bytes` models a compromised host whose C2 traffic grows over time while the rest of the environment stays consistent.
+
 ### Encoded Payloads Must Be Real
 
 When a storyline event includes base64-encoded data, obfuscated commands, or any other encoded content, the encoding must be accurate and decodable — never fake strings that just "look like" base64. Use the Bash tool to produce real encodings.

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -914,6 +914,12 @@ output:
 
 Supported formats: `windows`, `zeek`, `ecar`, `syslog`, `bash_history`, `snort_alert`, `cisco_asa`, `web_access`, `proxy`.
 
+#### Format Filtering
+
+The `output.logs` list can be scoped to only needed formats for faster generation with long time windows. For example, a 30-day baseline exercise that only needs Zeek conn.log can declare just `format: zeek_conn` instead of the full `zeek` group.
+
+The `--formats` CLI flag provides runtime filtering without modifying the scenario YAML. It intersects with `output.logs` — only formats present in both are generated. Group names (`zeek`, `windows`) are expanded before intersection.
+
 ## Backward Compatibility
 
 Persona fields are optional with null defaults:

--- a/src/evidenceforge/cli/commands.py
+++ b/src/evidenceforge/cli/commands.py
@@ -138,6 +138,14 @@ def generate(
     force: bool = typer.Option(
         False, "--force", "-f", help="Overwrite existing output without prompting"
     ),
+    formats: str | None = typer.Option(
+        None,
+        "--formats",
+        "-F",
+        help="Comma-separated format filter (e.g., 'zeek_conn,zeek_dns' or 'zeek'). "
+        "Only generates formats present in both this list and the scenario. "
+        "Supports group names (zeek, windows). See 'eforge info format_groups'.",
+    ),
 ) -> None:
     """Generate synthetic security logs from a scenario file.
 
@@ -240,6 +248,29 @@ def generate(
         scenario_dir = scenario_file.parent
         data_dir = scenario_dir / "data"
         ground_truth_dir = scenario_dir
+
+    # Apply --formats filter (intersection with scenario output.logs)
+    if formats:
+        from evidenceforge.events.dispatcher import expand_formats
+
+        requested = expand_formats([f.strip() for f in formats.split(",")])
+        scenario_formats = expand_formats(
+            {log["format"] for log in scenario.output.logs if "format" in log}
+        )
+        filtered = requested & scenario_formats
+
+        if requested - scenario_formats:
+            missing = sorted(requested - scenario_formats)
+            console.print(f"[yellow]Warning: formats not in scenario: {missing}[/yellow]")
+
+        if not filtered:
+            console.print(
+                "[bold red]Error:[/bold red] No formats match both --formats and scenario output.logs"
+            )
+            raise typer.Exit(EXIT_INPUT_ERROR)
+
+        scenario.output.logs = [{"format": fmt} for fmt in sorted(filtered)]
+        console.print(f"[dim]Format filter: generating {sorted(filtered)}[/dim]")
 
     console.print(f"\n[bold]Data directory:[/bold] {data_dir}")
     console.print(f"[bold]Ground truth:[/bold] {ground_truth_dir / 'GROUND_TRUTH.md'}")

--- a/src/evidenceforge/cli/info.py
+++ b/src/evidenceforge/cli/info.py
@@ -123,6 +123,13 @@ def _collect_web_scan_presets() -> list[str]:
     return list_preset_names()
 
 
+def _collect_format_groups() -> dict[str, list[str]]:
+    """Collect format group names and their expanded formats."""
+    from evidenceforge.events.dispatcher import FORMAT_GROUPS
+
+    return {k: sorted(v) for k, v in FORMAT_GROUPS.items()}
+
+
 def _gather_lightweight() -> dict[str, Any]:
     """Gather lightweight fields that don't require overlay-backed loaders.
 
@@ -189,6 +196,7 @@ def gather_info(field: str | None = None) -> dict[str, Any]:
         "application_ids": _collect_application_ids,
         "system_roles": _collect_system_roles,
         "web_scan_presets": _collect_web_scan_presets,
+        "format_groups": _collect_format_groups,
     }
     for key, collector in inventories.items():
         try:
@@ -270,6 +278,7 @@ _FIELD_DESCRIPTIONS: dict[str, str] = {
     "application_ids": "Application IDs in the catalog",
     "config_writable": "Whether package config files are directly editable",
     "dns_tags": "Defined valid DNS tags (from dns_registry.yaml valid_tags section)",
+    "format_groups": "Format group names and their expanded formats (for --formats flag)",
     "formats": "Supported log format names",
     "install_type": "Package install type (editable or package)",
     "overlay.exists": "Whether a project-local overlay directory exists",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -29,6 +29,7 @@ from typer.testing import CliRunner
 from evidenceforge.cli.commands import (
     EXIT_ABORTED,
     EXIT_GENERATION_ERROR,
+    EXIT_INPUT_ERROR,
     EXIT_SCHEMA_VALIDATION,
     EXIT_SUCCESS,
     app,
@@ -593,3 +594,94 @@ output:
         assert result.exit_code == EXIT_SUCCESS
         assert "Existing output found" not in result.stdout
         assert mock_engine.generate.called
+
+    @patch("evidenceforge.cli.commands.GenerationEngine")
+    def test_formats_flag_filters_output(self, mock_engine_class, scenarios_dir, tmp_path):
+        """--formats should narrow scenario output.logs to the intersection."""
+        mock_engine = Mock()
+        mock_engine_class.return_value = mock_engine
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "zeek_conn",
+            ],
+        )
+
+        assert result.exit_code == EXIT_SUCCESS
+        # Engine should have been created with narrowed format list
+        call_kwargs = mock_engine_class.call_args.kwargs
+        scenario = call_kwargs["scenario"]
+        fmt_names = {log["format"] for log in scenario.output.logs}
+        assert fmt_names == {"zeek_conn"}
+
+    @patch("evidenceforge.cli.commands.GenerationEngine")
+    def test_formats_flag_supports_groups(self, mock_engine_class, scenarios_dir, tmp_path):
+        """--formats should expand group names before intersecting."""
+        mock_engine = Mock()
+        mock_engine_class.return_value = mock_engine
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "zeek",
+            ],
+        )
+
+        assert result.exit_code == EXIT_SUCCESS
+        call_kwargs = mock_engine_class.call_args.kwargs
+        scenario = call_kwargs["scenario"]
+        fmt_names = {log["format"] for log in scenario.output.logs}
+        assert "zeek_conn" in fmt_names
+        assert "zeek_dns" in fmt_names
+        # Windows should NOT be in the output
+        assert "windows_event_security" not in fmt_names
+
+    @patch("evidenceforge.cli.commands.GenerationEngine")
+    def test_formats_flag_warns_on_mismatch(self, mock_engine_class, scenarios_dir, tmp_path):
+        """--formats with formats not in scenario should warn."""
+        mock_engine = Mock()
+        mock_engine_class.return_value = mock_engine
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "zeek_conn,cisco_asa",
+            ],
+        )
+
+        assert result.exit_code == EXIT_SUCCESS
+        assert "not in scenario" in result.stdout
+        assert "cisco_asa" in result.stdout
+
+    def test_formats_flag_errors_on_empty_intersection(self, scenarios_dir, tmp_path):
+        """--formats with no matching formats should error."""
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "cisco_asa",
+            ],
+        )
+
+        assert result.exit_code == EXIT_INPUT_ERROR
+        assert "No formats match" in result.stdout


### PR DESCRIPTION
## Summary
- Add `--formats / -F` flag to `eforge generate` for format filtering
- Intersection semantics: only generates formats in both `--formats` and scenario `output.logs`
- Supports group names (`zeek`, `windows`) via `expand_formats()`
- Add `format_groups` inventory to `eforge info`
- Document in generate.md, scenario.md, scenario-reference.md
- Resolve Cluster 2 (format filtering) and Cluster 3 (temporal phases — by design)

## Test plan
- [x] 4 new CLI tests (filter, groups, mismatch, empty intersection)
- [x] 1993 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)