### PR TITLE
feat: Windows auth enrichment — 4648 breadth + 4800/4801 lock/unlock (Cluster 4)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -427,8 +427,9 @@ Achievable by composing bulk event primitives (beacon, connection, dns_query) ov
 
 Same area of codebase — baseline engine Windows auth generation, persona work schedules.
 
-- [ ] Broader baseline 4648 generation (RunAs, service account delegation, SCCM/GPO, helpdesk remote)
-- [ ] Event IDs 4800/4801 (workstation lock/unlock)
+- [x] Broader baseline 4648 generation (service account delegation, sysadmin RunAs, SCCM/GPO, helpdesk remote)
+- [x] Event IDs 4800/4801 (workstation lock/unlock with persona variance, paired 4624 type 7, failed unlock)
+- [x] Storyline EventSpecs: explicit_credentials, workstation_lock, workstation_unlock
 
 **Exercises:** 5.1 (4800/4801), 5.2 (4648 breadth)
 

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -394,7 +394,7 @@ These are just examples — invent additional realistic variations appropriate t
 
 When building storyline events, each entry needs an `events` list with typed declarations. Be technically specific — the engine uses these fields directly.
 
-**Available event types:** `process`, `logon`, `failed_logon`, `logoff`, `connection`, `ssh_session`, `rdp_session`, `account_created`, `account_deleted`, `group_member_added`, `service_installed`, `scheduled_task_created`, `log_cleared`, `create_remote_thread`, `dhcp_lease`, `port_scan`, `beacon`, `dns_query`, `web_scan`, `credential_spray`, `dga_queries`, `dns_tunnel`, `raw`
+**Available event types:** `process`, `logon`, `failed_logon`, `logoff`, `connection`, `ssh_session`, `rdp_session`, `account_created`, `account_deleted`, `group_member_added`, `service_installed`, `scheduled_task_created`, `log_cleared`, `create_remote_thread`, `dhcp_lease`, `port_scan`, `beacon`, `dns_query`, `web_scan`, `credential_spray`, `dga_queries`, `dns_tunnel`, `explicit_credentials`, `workstation_lock`, `workstation_unlock`, `raw`
 
 **Firewall/network event types:**
 - `port_scan` — Bulk denied connections for recon/scanning. Fields: `target_ips` or `target_segment`+`target_count`, `ports`, `protocol`, `scan_rate`. Produces ASA 106023 denies + correlated Zeek conn entries.
@@ -404,6 +404,9 @@ When building storyline events, each entry needs an `events` list with typed dec
 - `dns_query` — Standalone DNS query. Fields: `query`, `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR).
 - `dga_queries` — Bulk DGA domain lookups. Fields: `interval`, `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`.
 - `dns_tunnel` — DNS exfiltration via encoded subdomains. Fields: `base_domain`, `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`/`payload_size`.
+- `explicit_credentials` — RunAs / pass-the-hash / service account delegation (4648). Fields: `target_username`, `target_server`, `process_name`, `source_ip`.
+- `workstation_lock` — Lock workstation (4800). No additional fields.
+- `workstation_unlock` — Unlock workstation (4801 + 4624 type 7 re-auth). No additional fields.
 
 The `raw` type targets a specific output format with arbitrary fields — use it for events without a dedicated type (e.g., custom syslog messages, specific Windows events). Requires `target_format` and `fields` dict. Raw events bypass cross-format correlation, so prefer typed events when available.
 

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -419,6 +419,9 @@ Each event in the `events` list has a `type` field that selects a validated sche
 | `credential_spray` | Windows 4625/4776 or syslog auth | `target_accounts`, `interval`, one of `end_time`/`duration`/`count` | `pattern` (spray/brute_force/stuffing), `source_ip`, `logon_type`, `success`, `jitter` |
 | `dga_queries` | Zeek dns.log + conn.log (bulk DGA) | `interval`, one of `end_time`/`duration`/`count` | `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`, `source_ip`, `jitter` |
 | `dns_tunnel` | Zeek dns.log + conn.log (encoded exfil) | `base_domain`, `interval`, one of `end_time`/`duration`/`count` | `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`, `payload_size`, `source_ip`, `jitter` |
+| `explicit_credentials` | Windows 4648 (explicit credential usage) | `target_username` | `target_server`, `process_name`, `source_ip` |
+| `workstation_lock` | Windows 4800 (workstation locked) | | |
+| `workstation_unlock` | Windows 4801 + 4624 type 7 (unlock + re-auth) | | |
 | `raw` | Any single format | `target_format`, `fields` | |
 
 All event types also accept optional `technique` (MITRE ATT&CK ID) and `description` (human-readable detail) fields for GROUND_TRUTH.md enrichment.

--- a/src/evidenceforge/config/formats/windows_event_security.yaml
+++ b/src/evidenceforge/config/formats/windows_event_security.yaml
@@ -484,6 +484,66 @@ variants:
         required: true
         description: "List of assigned special privileges"
 
+  # EventID 4800: The workstation was locked
+  - name: workstation_locked
+    event_id: "4800"
+    description: "Workstation locked"
+    fields:
+      - name: TargetUserSid
+        type: sid
+        required: true
+        description: "SID of the user who locked the workstation"
+
+      - name: TargetUserName
+        type: string
+        required: true
+        description: "Account name of the user"
+
+      - name: TargetDomainName
+        type: string
+        required: true
+        description: "Domain of the user"
+
+      - name: TargetLogonId
+        type: hex_string
+        required: true
+        description: "Logon ID of the locked session"
+
+      - name: SessionId
+        type: integer
+        required: true
+        description: "Terminal Services session ID"
+
+  # EventID 4801: The workstation was unlocked
+  - name: workstation_unlocked
+    event_id: "4801"
+    description: "Workstation unlocked"
+    fields:
+      - name: TargetUserSid
+        type: sid
+        required: true
+        description: "SID of the user who unlocked the workstation"
+
+      - name: TargetUserName
+        type: string
+        required: true
+        description: "Account name of the user"
+
+      - name: TargetDomainName
+        type: string
+        required: true
+        description: "Domain of the user"
+
+      - name: TargetLogonId
+        type: hex_string
+        required: true
+        description: "Logon ID of the unlocked session"
+
+      - name: SessionId
+        type: integer
+        required: true
+        description: "Terminal Services session ID"
+
   # EventID 4689: A process has exited
   - name: process_termination
     event_id: "4689"
@@ -1096,7 +1156,7 @@ output:
         <EventID>{{ EventID }}</EventID>
         <Version>{{ 2 if EventID in [4688, 4624] else 1 if EventID == 5156 else 0 }}</Version>
         <Level>{{ Level }}</Level>
-        <Task>{{ {1102: 104, 4624: 12544, 4625: 12544, 4634: 12545, 4648: 12544, 4672: 12548, 4688: 13312, 4689: 13313, 4697: 12289, 4698: 12804, 4699: 12804, 4700: 12804, 4701: 12804, 4720: 13824, 4723: 13824, 4724: 13824, 4726: 13824, 4728: 13826, 4729: 13826, 4732: 13826, 4733: 13826, 4738: 13824, 4756: 13826, 4757: 13826, 4768: 14339, 4769: 14337, 4770: 14339, 4771: 14339, 4776: 14336, 5156: 12810}.get(EventID, 0) }}</Task>
+        <Task>{{ {1102: 104, 4624: 12544, 4625: 12544, 4634: 12545, 4648: 12544, 4672: 12548, 4688: 13312, 4689: 13313, 4697: 12289, 4698: 12804, 4699: 12804, 4700: 12804, 4701: 12804, 4720: 13824, 4723: 13824, 4724: 13824, 4726: 13824, 4728: 13826, 4729: 13826, 4732: 13826, 4733: 13826, 4738: 13824, 4756: 13826, 4757: 13826, 4768: 14339, 4769: 14337, 4770: 14339, 4771: 14339, 4776: 14336, 4800: 12551, 4801: 12551, 5156: 12810}.get(EventID, 0) }}</Task>
         <Opcode>0</Opcode>
         <Keywords>{{ Keywords | default('0x8020000000000000') }}</Keywords>
         <TimeCreated SystemTime="{{ TimeCreated }}"/>

--- a/src/evidenceforge/evaluation/dimensions/signal_integrity.py
+++ b/src/evidenceforge/evaluation/dimensions/signal_integrity.py
@@ -625,6 +625,18 @@ class SignalIntegrityScorer(DimensionScorer):
             if format_name == "zeek_conn":
                 return f.get("id.resp_p") == 53 and f.get("id.orig_h") == event.system_ip
 
+        elif event_type == "explicit_credentials":
+            target_user = event.details.get("target_username", "")
+            if format_name == "windows_event_security":
+                return f.get("EventID") == 4648 and (
+                    not target_user or f.get("TargetUserName", "") == target_user
+                )
+
+        elif event_type in ("workstation_lock", "workstation_unlock"):
+            expected_id = 4800 if event_type == "workstation_lock" else 4801
+            if format_name == "windows_event_security":
+                return f.get("EventID") == expected_id
+
         return False
 
     def _connection_matches_zeek(self, fields: dict, event: ResolvedEvent) -> bool:

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3818,6 +3818,54 @@ class ActivityGenerator:
         )
         self.dispatcher.dispatch(event)
 
+    def generate_workstation_lock(
+        self,
+        user: User,
+        system: System,
+        time: datetime,
+        logon_id: str,
+    ) -> None:
+        """Generate workstation lock event (4800)."""
+        event = SecurityEvent(
+            timestamp=time,
+            event_type="workstation_locked",
+            dst_host=self._build_host_context(system),
+            auth=AuthContext(
+                username=user.username,
+                user_sid=self._get_sid(user.username),
+                logon_id=logon_id,
+            ),
+        )
+        self.dispatcher.dispatch(event)
+
+    def generate_workstation_unlock(
+        self,
+        user: User,
+        system: System,
+        time: datetime,
+        logon_id: str,
+    ) -> None:
+        """Generate workstation unlock event (4801 + 4624 type 7)."""
+        event = SecurityEvent(
+            timestamp=time,
+            event_type="workstation_unlocked",
+            dst_host=self._build_host_context(system),
+            auth=AuthContext(
+                username=user.username,
+                user_sid=self._get_sid(user.username),
+                logon_id=logon_id,
+            ),
+        )
+        self.dispatcher.dispatch(event)
+        # Unlock is a re-authentication — emit 4624 type 7
+        self.generate_logon(
+            user=user,
+            system=system,
+            time=time + timedelta(milliseconds=50),
+            logon_type=7,
+            source_ip=system.ip,
+        )
+
     def generate_wfp_connection(
         self,
         system: System,

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -104,6 +104,8 @@ class WindowsEventEmitter(LogEmitter):
         "password_change",
         "password_reset",
         "special_privileges",
+        "workstation_locked",
+        "workstation_unlocked",
     }
 
     @staticmethod
@@ -139,6 +141,8 @@ class WindowsEventEmitter(LogEmitter):
         "group_member_removed_local",
         "group_member_added_universal",
         "group_member_removed_universal",
+        "workstation_locked",
+        "workstation_unlocked",
     }
 
     def _get_host(self, event: SecurityEvent) -> "HostContext":
@@ -191,6 +195,8 @@ class WindowsEventEmitter(LogEmitter):
             "password_change": self._render_password_change,
             "password_reset": self._render_password_reset,
             "special_privileges": self._render_special_privileges,
+            "workstation_locked": self._render_workstation_lock,
+            "workstation_unlocked": self._render_workstation_unlock,
         }.get(event.event_type)
         if renderer is None:
             raise NotImplementedError(
@@ -318,6 +324,48 @@ class WindowsEventEmitter(LogEmitter):
             "PrivilegeList": privs,
         }
         self.emit_event(priv_data)
+
+    def _render_workstation_lock(self, event: SecurityEvent) -> None:
+        """Render Windows 4800 (workstation locked)."""
+        rng = random.Random()
+        auth = event.auth
+        host = self._get_host(event)
+        event_data = {
+            "EventID": 4800,
+            "TimeCreated": event.timestamp,
+            "Computer": host.fqdn,
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 500 + rng.randint(0, 100),
+            "ExecutionThreadID": rng.randint(100, 500),
+            "TargetUserSid": auth.user_sid,
+            "TargetUserName": auth.username,
+            "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
+            "TargetLogonId": auth.logon_id or "0x0",
+            "SessionId": rng.randint(1, 5),
+        }
+        self.emit_event(event_data)
+
+    def _render_workstation_unlock(self, event: SecurityEvent) -> None:
+        """Render Windows 4801 (workstation unlocked)."""
+        rng = random.Random()
+        auth = event.auth
+        host = self._get_host(event)
+        event_data = {
+            "EventID": 4801,
+            "TimeCreated": event.timestamp,
+            "Computer": host.fqdn,
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 500 + rng.randint(0, 100),
+            "ExecutionThreadID": rng.randint(100, 500),
+            "TargetUserSid": auth.user_sid,
+            "TargetUserName": auth.username,
+            "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
+            "TargetLogonId": auth.logon_id or "0x0",
+            "SessionId": rng.randint(1, 5),
+        }
+        self.emit_event(event_data)
 
     def _render_logoff(self, event: SecurityEvent) -> None:
         """Render Windows 4634 (logoff)."""

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -525,6 +525,9 @@ class BaselineMixin:
                 for event_time in event_times:
                     self._generate_user_activity(user, event_time)
 
+                # Lock/unlock events for Windows workstation users
+                self._generate_lock_unlock_events(user, current_hour, local_hour, persona_name)
+
         # Pre-decide logoffs so profile traffic can bound persona timestamps
         planned_logoffs = self._plan_logoffs_for_hour(enabled_users, current_hour)
 
@@ -2149,6 +2152,116 @@ class BaselineMixin:
                         ),
                         process_pid=session.explorer_pid if session else 0,
                     )
+
+    def _generate_lock_unlock_events(
+        self,
+        user: User,
+        current_hour: datetime,
+        local_hour: int,
+        persona_name: str | None,
+    ) -> None:
+        """Generate workstation lock/unlock events for Windows interactive sessions."""
+        rng = _get_rng()
+        # Only Windows workstation users with active interactive sessions
+        sessions = self.state_manager.get_sessions_for_user(user.username)
+        session = next(
+            (
+                s
+                for s in sessions
+                if s.logon_type == 2
+                and any(
+                    sys.type == "workstation"
+                    for sys in self.scenario.environment.systems
+                    if sys.hostname == s.system
+                )
+            ),
+            None,
+        )
+        if not session:
+            return
+        system = next(
+            (s for s in self.scenario.environment.systems if s.hostname == session.system),
+            None,
+        )
+        if not system or _get_os_category(system.os) != "windows":
+            return
+
+        # Per-persona lock frequency
+        _pn = (persona_name or "").lower()
+        if _pn in ("security_analyst", "sysadmin"):
+            lock_prob = 0.40  # 3-5 locks/day → ~40% per work hour
+        elif _pn in ("developer",):
+            lock_prob = 0.08  # 0-1 locks/day
+        else:
+            lock_prob = 0.20  # 1-3 locks/day
+
+        # Only during work hours (7-19)
+        if not (7 <= local_hour <= 19):
+            return
+
+        # Lunch lock at hour 12
+        if local_hour == 12 and rng.random() < 0.85:
+            lock_t = current_hour + timedelta(minutes=rng.randint(0, 15))
+            self.state_manager.set_current_time(lock_t)
+            self.activity_generator.generate_workstation_lock(
+                user=user,
+                system=system,
+                time=lock_t,
+                logon_id=session.logon_id,
+            )
+            # Unlock after lunch (30-60 min)
+            unlock_t = lock_t + timedelta(minutes=rng.randint(30, 60))
+            if unlock_t < current_hour + timedelta(hours=1):
+                self.state_manager.set_current_time(unlock_t)
+                # ~15% chance of failed password before unlock
+                if rng.random() < 0.15:
+                    fail_t = unlock_t - timedelta(seconds=rng.randint(3, 15))
+                    self.state_manager.set_current_time(fail_t)
+                    self.activity_generator.generate_failed_logon(
+                        user=user,
+                        system=system,
+                        time=fail_t,
+                        logon_type=7,
+                        source_ip=system.ip,
+                    )
+                self.activity_generator.generate_workstation_unlock(
+                    user=user,
+                    system=system,
+                    time=unlock_t,
+                    logon_id=session.logon_id,
+                )
+            return
+
+        # Random meeting-break lock/unlock
+        if rng.random() < lock_prob:
+            lock_t = current_hour + timedelta(seconds=rng.randint(60, 3500))
+            self.state_manager.set_current_time(lock_t)
+            self.activity_generator.generate_workstation_lock(
+                user=user,
+                system=system,
+                time=lock_t,
+                logon_id=session.logon_id,
+            )
+            gap_minutes = rng.randint(2, 15)
+            unlock_t = lock_t + timedelta(minutes=gap_minutes)
+            if unlock_t < current_hour + timedelta(hours=1):
+                self.state_manager.set_current_time(unlock_t)
+                if rng.random() < 0.15:
+                    fail_t = unlock_t - timedelta(seconds=rng.randint(3, 15))
+                    self.state_manager.set_current_time(fail_t)
+                    self.activity_generator.generate_failed_logon(
+                        user=user,
+                        system=system,
+                        time=fail_t,
+                        logon_type=7,
+                        source_ip=system.ip,
+                    )
+                self.activity_generator.generate_workstation_unlock(
+                    user=user,
+                    system=system,
+                    time=unlock_t,
+                    logon_id=session.logon_id,
+                )
 
     def _get_server_ssh_users(self, system) -> list:
         """Return the subset of admin users who would SSH into this server.

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -2091,6 +2091,65 @@ class BaselineMixin:
                 user=user, system=system, time=t, activity_type=activity_type
             )
 
+        # Persona-driven 4648: sysadmin RunAs and helpdesk remote sessions
+        os_cat = _get_os_category(system.os) if hasattr(system, "os") else "unknown"
+        if os_cat == "windows" and persona_name:
+            _pn = persona_name.lower()
+            servers = [
+                s
+                for s in self.scenario.environment.systems
+                if s.type in ("server", "domain_controller")
+            ]
+            if _pn in ("sysadmin", "security_analyst") and rng.random() < 0.15 and servers:
+                target_server = rng.choice(servers)
+                admin_alias = f"{user.username}-admin"
+                session = next((s for s in sessions if s.system == system.hostname), None)
+                runas_t = event_time + timedelta(seconds=rng.randint(0, 55))
+                self.state_manager.set_current_time(runas_t)
+                self.activity_generator.generate_explicit_credentials(
+                    user=user,
+                    system=system,
+                    time=runas_t,
+                    target_username=admin_alias,
+                    target_server=target_server.hostname,
+                    process_name=rng.choice(
+                        [
+                            r"C:\Windows\System32\runas.exe",
+                            r"C:\Windows\System32\mmc.exe",
+                            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+                        ]
+                    ),
+                    process_pid=session.explorer_pid if session else 0,
+                )
+            elif _pn == "help_desk" and rng.random() < 0.08:
+                non_admins = [
+                    u
+                    for u in self.scenario.environment.users
+                    if u.enabled
+                    and (u.persona or "").lower()
+                    not in ("sysadmin", "security_analyst", "help_desk")
+                    and u.username != user.username
+                ]
+                if non_admins:
+                    target_user = rng.choice(non_admins)
+                    session = next((s for s in sessions if s.system == system.hostname), None)
+                    hd_t = event_time + timedelta(seconds=rng.randint(0, 55))
+                    self.state_manager.set_current_time(hd_t)
+                    self.activity_generator.generate_explicit_credentials(
+                        user=user,
+                        system=system,
+                        time=hd_t,
+                        target_username=target_user.username,
+                        target_server=target_user.primary_system or "",
+                        process_name=rng.choice(
+                            [
+                                r"C:\Windows\System32\mstsc.exe",
+                                r"C:\Windows\System32\msra.exe",
+                            ]
+                        ),
+                        process_pid=session.explorer_pid if session else 0,
+                    )
+
     def _get_server_ssh_users(self, system) -> list:
         """Return the subset of admin users who would SSH into this server.
 
@@ -3267,6 +3326,49 @@ class BaselineMixin:
                         parent_pid=parent_pid,
                         username="SYSTEM",
                     )
+
+            # Service account delegation: svc accounts auth to remote servers
+            if os_cat == "windows" and self.scenario.environment.service_accounts:
+                all_systems = self.scenario.environment.systems
+                servers = [s for s in all_systems if s.type in ("server", "domain_controller")]
+                for svc_name in self.scenario.environment.service_accounts:
+                    if rng.random() < 0.3:
+                        target_sys = rng.choice(servers) if servers else None
+                        if target_sys and target_sys.hostname != system.hostname:
+                            svc_ts = current_hour + timedelta(seconds=rng.uniform(0, 3599))
+                            self.state_manager.set_current_time(svc_ts)
+                            self.activity_generator.generate_explicit_credentials(
+                                user=_SYSTEM_USER,
+                                system=system,
+                                time=svc_ts,
+                                target_username=svc_name,
+                                target_server=target_sys.hostname,
+                                process_name=r"C:\Windows\System32\services.exe",
+                                process_pid=sys_pids.get("services", 0),
+                            )
+
+            # GPO application: periodic SYSTEM credential usage to DC
+            if os_cat == "windows" and system.type == "workstation":
+                gpo_phase = _stable_seed(f"gpo_phase_{system.hostname}") % 4
+                if (current_hour.hour + gpo_phase) % 3 == 0:
+                    dcs = [
+                        s
+                        for s in self.scenario.environment.systems
+                        if s.type == "domain_controller"
+                    ]
+                    if dcs:
+                        dc = dcs[_stable_seed(f"gpo_dc_{system.hostname}") % len(dcs)]
+                        gpo_ts = current_hour + timedelta(seconds=rng.uniform(60, 300))
+                        self.state_manager.set_current_time(gpo_ts)
+                        self.activity_generator.generate_explicit_credentials(
+                            user=_SYSTEM_USER,
+                            system=system,
+                            time=gpo_ts,
+                            target_username="SYSTEM",
+                            target_server=dc.hostname,
+                            process_name=r"C:\Windows\System32\svchost.exe",
+                            process_pid=sys_pids.get("svchost_netsvcs", 0),
+                        )
 
             # Sysmon Event 8 (CreateRemoteThread) baseline noise — Windows only
             if os_cat == "windows":

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1784,6 +1784,42 @@ class StorylineMixin:
             malicious_event["total_queries"] = query_count
             malicious_event["bytes_exfiltrated"] = total_bytes
 
+        elif spec.type == "explicit_credentials":
+            self.activity_generator.generate_explicit_credentials(
+                user=actor,
+                system=system,
+                time=time,
+                target_username=spec.target_username,
+                target_server=spec.target_server or system.hostname,
+                process_name=spec.process_name or r"C:\Windows\System32\runas.exe",
+                process_pid=getattr(self, "_last_storyline_pid", -1) or 0,
+                source_ip=spec.source_ip or system.ip,
+            )
+            malicious_event["target_username"] = spec.target_username
+            malicious_event["target_server"] = spec.target_server
+
+        elif spec.type == "workstation_lock":
+            sessions = self.state_manager.get_sessions_for_user(actor.username)
+            session = next((s for s in sessions if s.system == system.hostname), None)
+            logon_id = session.logon_id if session else "0x0"
+            self.activity_generator.generate_workstation_lock(
+                user=actor,
+                system=system,
+                time=time,
+                logon_id=logon_id,
+            )
+
+        elif spec.type == "workstation_unlock":
+            sessions = self.state_manager.get_sessions_for_user(actor.username)
+            session = next((s for s in sessions if s.system == system.hostname), None)
+            logon_id = session.logon_id if session else "0x0"
+            self.activity_generator.generate_workstation_unlock(
+                user=actor,
+                system=system,
+                time=time,
+                logon_id=logon_id,
+            )
+
         elif spec.type == "raw":
             self.activity_generator.generate_raw(
                 time=time,

--- a/src/evidenceforge/generation/ground_truth.py
+++ b/src/evidenceforge/generation/ground_truth.py
@@ -280,6 +280,15 @@ class GroundTruthGenerator:
             exfil = event.get("bytes_exfiltrated", 0)
             return f"DNS tunnel via {domain} ({enc}, {queries} queries, {exfil} bytes exfiltrated)"
 
+        elif event_type == "explicit_credentials":
+            target = event.get("target_username", "N/A")
+            server = event.get("target_server", "N/A")
+            return f"Explicit credentials: RunAs {target} on {server}"
+
+        elif event_type in ("workstation_lock", "workstation_unlock"):
+            action = "Locked" if event_type == "workstation_lock" else "Unlocked"
+            return f"Workstation {action}"
+
         else:
             return event.get("activity", "N/A")
 
@@ -411,6 +420,11 @@ class GroundTruthGenerator:
                 base = event.get("base_domain", "")
                 if base:
                     iocs["network"].add(f"{base} (DNS Tunnel Endpoint)")
+
+            elif event["type"] == "explicit_credentials":
+                target = event.get("target_username", "")
+                if target:
+                    iocs["users"].add(f"{target} (Explicit Credential Target)")
 
         # Remove empty categories
         iocs = {category: values for category, values in iocs.items() if values}

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -852,6 +852,32 @@ class DnsTunnelEventSpec(_PeriodicEventBase):
         return self
 
 
+class ExplicitCredentialsEventSpec(_EventSpecBase):
+    """Explicit credential usage event (generates Windows 4648).
+
+    Models RunAs, pass-the-hash, service account delegation, and other
+    scenarios where credentials are explicitly provided for authentication.
+    """
+
+    type: Literal["explicit_credentials"] = "explicit_credentials"
+    target_username: str
+    target_server: str | None = None
+    process_name: str | None = None
+    source_ip: str | None = None
+
+
+class WorkstationLockEventSpec(_EventSpecBase):
+    """Workstation lock event (generates Windows 4800)."""
+
+    type: Literal["workstation_lock"] = "workstation_lock"
+
+
+class WorkstationUnlockEventSpec(_EventSpecBase):
+    """Workstation unlock event (generates Windows 4801 + 4624 type 7)."""
+
+    type: Literal["workstation_unlock"] = "workstation_unlock"
+
+
 class RawEventSpec(_EventSpecBase):
     """Raw event targeting a specific emitter with arbitrary fields.
 
@@ -890,6 +916,9 @@ EventSpec = Annotated[
     | CredentialSprayEventSpec
     | DgaQueriesEventSpec
     | DnsTunnelEventSpec
+    | ExplicitCredentialsEventSpec
+    | WorkstationLockEventSpec
+    | WorkstationUnlockEventSpec
     | RawEventSpec,
     Discriminator("type"),
 ]

--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -84,6 +84,9 @@ _WINDOWS_EVENT_TYPES = {
     "log_cleared",
     "create_remote_thread",
     "process_access",
+    "explicit_credentials",
+    "workstation_lock",
+    "workstation_unlock",
 }
 
 # Event types that imply Linux/SSH

--- a/tests/integration/test_format_definitions.py
+++ b/tests/integration/test_format_definitions.py
@@ -48,7 +48,7 @@ class TestWindowsEventFormat:
     def test_has_event_variants(self):
         """Test that format has expected EventID variants."""
         assert self.format.variants is not None
-        assert len(self.format.variants) == 21
+        assert len(self.format.variants) == 23
         variant_names = [v.name for v in self.format.variants]
         assert "logon" in variant_names
         assert "logoff" in variant_names
@@ -437,7 +437,7 @@ class TestLoadAllFormats:
         windows_fmt = formats["windows_event_security"]
         assert windows_fmt.name == "windows_event_security"
         assert windows_fmt.category == "host"
-        assert len(windows_fmt.variants) == 21
+        assert len(windows_fmt.variants) == 23
 
         # Verify Zeek JSON format
         zeek_fmt = formats["zeek_conn"]

--- a/tests/unit/test_bulk_events.py
+++ b/tests/unit/test_bulk_events.py
@@ -16,7 +16,10 @@ from evidenceforge.models.scenario import (
     DgaQueriesEventSpec,
     DnsQueryEventSpec,
     DnsTunnelEventSpec,
+    ExplicitCredentialsEventSpec,
     WebScanEventSpec,
+    WorkstationLockEventSpec,
+    WorkstationUnlockEventSpec,
     _PeriodicEventBase,
 )
 
@@ -592,3 +595,43 @@ class TestDnsTunnelEventSpec:
                 count=10,
             )
             assert spec.encoding == enc
+
+
+# ── ExplicitCredentialsEventSpec ──────────────────────────────────────────
+
+
+class TestExplicitCredentialsEventSpec:
+    def test_defaults(self):
+        spec = ExplicitCredentialsEventSpec(target_username="admin")
+        assert spec.type == "explicit_credentials"
+        assert spec.target_username == "admin"
+        assert spec.target_server is None
+        assert spec.process_name is None
+        assert spec.source_ip is None
+
+    def test_all_fields(self):
+        spec = ExplicitCredentialsEventSpec(
+            target_username="svc_backup",
+            target_server="FILE-SRV-01",
+            process_name=r"C:\Windows\System32\runas.exe",
+            source_ip="10.0.1.5",
+        )
+        assert spec.target_server == "FILE-SRV-01"
+        assert spec.process_name == r"C:\Windows\System32\runas.exe"
+
+    def test_requires_target_username(self):
+        with pytest.raises(ValidationError):
+            ExplicitCredentialsEventSpec()
+
+
+# ── WorkstationLockEventSpec / WorkstationUnlockEventSpec ─────────────────
+
+
+class TestWorkstationLockUnlockEventSpec:
+    def test_lock_defaults(self):
+        spec = WorkstationLockEventSpec()
+        assert spec.type == "workstation_lock"
+
+    def test_unlock_defaults(self):
+        spec = WorkstationUnlockEventSpec()
+        assert spec.type == "workstation_unlock"


### PR DESCRIPTION
## Summary
Complete Cluster 4 (Windows auth enrichment) for Day 5 exercises:

**Broader baseline 4648 events (Ex 5.2):**
- Service account delegation to remote servers (role-based, periodic)
- Sysadmin RunAs with inferred admin alias (persona-driven)
- SCCM/GPO deployments to DC (periodic)
- Helpdesk remote sessions (persona-driven)
- New `explicit_credentials` storyline EventSpec for attack injection

**Workstation lock/unlock 4800/4801 (Ex 5.1):**
- Persona-driven variance (security-conscious 3-5x/day, developers 0-1x)
- Lunch lock + meeting-break locks with 2-15 min gaps
- Paired 4624 type 7 re-authentication on unlock
- ~15% failed password before unlock (mistype after break)
- New `workstation_lock`/`workstation_unlock` storyline EventSpecs

**Integration:** Ground truth, signal integrity matchers, validator
OS checks, format definitions, docs, scenario skill.

## Test plan
- [x] 1998 passed, 0 failures
- [x] 5 new model tests
- [x] Format variant count updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)