### PR TITLE
Merge dev into main — Windows auth enrichment + format filtering + fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -427,8 +427,9 @@ Achievable by composing bulk event primitives (beacon, connection, dns_query) ov
 
 Same area of codebase — baseline engine Windows auth generation, persona work schedules.
 
-- [ ] Broader baseline 4648 generation (RunAs, service account delegation, SCCM/GPO, helpdesk remote)
-- [ ] Event IDs 4800/4801 (workstation lock/unlock)
+- [x] Broader baseline 4648 generation (service account delegation, sysadmin RunAs, SCCM/GPO, helpdesk remote)
+- [x] Event IDs 4800/4801 (workstation lock/unlock with persona variance, paired 4624 type 7, failed unlock)
+- [x] Storyline EventSpecs: explicit_credentials, workstation_lock, workstation_unlock
 
 **Exercises:** 5.1 (4800/4801), 5.2 (4648 breadth)
 

--- a/TODO.md
+++ b/TODO.md
@@ -412,19 +412,16 @@ Highest impact — unblocks or improves 10 exercises across all 5 days. These ar
 
 High breadth, low cost — makes multi-week generation practical for 5 exercises without deep optimization.
 
-- [ ] `--formats` CLI filter (e.g., `--formats zeek_conn,zeek_dns` or `--formats proxy_access`)
-- [ ] Skip emitters that don't match the filter
+- [x] `--formats` CLI filter with intersection semantics and group name support
+- [x] `format_groups` inventory in `eforge info` output
 
 **Exercises:** 3.1, 3.2, 3.3, 5.1, 5.2 (all need 2-4 week windows)
 
-### Cluster 3: Temporal Baseline Phases
+### Cluster 3: Temporal Baseline Phases — Resolved by Design
 
-Single-exercise blocker, but broadly useful for any multi-week scenario.
+Achievable by composing bulk event primitives (beacon, connection, dns_query) over a stable baseline. Students detect injected activity as statistical outliers. No engine changes needed — documented as a scenario authoring pattern.
 
-- [ ] `phases` section in scenario YAML with per-phase baseline intensity/parameters
-- [ ] Support different baseline behavior across time ranges (e.g., "3x outbound from host X starting day 15")
-
-**Exercises:** 3.2 (gradual behavioral shifts)
+**Exercises:** 3.2 (gradual behavioral shifts — use beacons with start_time offsets and orig_bytes overrides)
 
 ### Cluster 4: Windows Auth Enrichment
 

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -48,6 +48,12 @@ eforge generate <scenario.yaml> [options]
 Options:
   --output, -o <dir>     Override output directory (default: from scenario's output.destination)
   --config, -c <file>    Path to config.yaml
+  --formats, -F <list>   Comma-separated format filter. Only generates formats present in both
+                         this list and the scenario's output.logs. Supports group names (zeek,
+                         windows) and individual format names (zeek_conn, cisco_asa). Use
+                         `eforge info format_groups` to see available groups. Example:
+                         `eforge generate scenario.yaml --formats zeek_conn,zeek_dns` to
+                         generate only Zeek connection and DNS logs.
   --force, -f            Overwrite existing output without prompting
   --verbose, -v          INFO-level logging
   --debug, -d            DEBUG-level logging

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -512,6 +512,12 @@ The validator warns if it detects potentially redundant manual specifications al
 
 Use RFC 5737 documentation IP ranges for external attacker IPs (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24). Use private ranges (10.x, 172.16-31.x, 192.168.x) for internal systems.
 
+### Long Time Windows and Baseline Exercises
+
+For scenarios spanning 2+ weeks (e.g., 30-day baseline exercises), scope `output.logs` to only the formats needed for the exercise. Generating all formats over a long time window produces very large datasets and slow generation; declaring just `format: zeek_conn` instead of the full `zeek` group can cut generation time dramatically. The `--formats` CLI flag can also filter at runtime without editing the YAML.
+
+For baseline deviation exercises (e.g., "spot the change in normal traffic"), use `beacon` events with `start_time` offsets and `orig_bytes`/`resp_bytes` overrides to layer gradual drift on top of a stable baseline, rather than modifying `baseline_activity.intensity`. For example, a beacon starting at `+14d` with increasing `orig_bytes` models a compromised host whose C2 traffic grows over time while the rest of the environment stays consistent.
+
 ### Encoded Payloads Must Be Real
 
 When a storyline event includes base64-encoded data, obfuscated commands, or any other encoded content, the encoding must be accurate and decodable — never fake strings that just "look like" base64. Use the Bash tool to produce real encodings.

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -394,7 +394,7 @@ These are just examples — invent additional realistic variations appropriate t
 
 When building storyline events, each entry needs an `events` list with typed declarations. Be technically specific — the engine uses these fields directly.
 
-**Available event types:** `process`, `logon`, `failed_logon`, `logoff`, `connection`, `ssh_session`, `rdp_session`, `account_created`, `account_deleted`, `group_member_added`, `service_installed`, `scheduled_task_created`, `log_cleared`, `create_remote_thread`, `dhcp_lease`, `port_scan`, `beacon`, `dns_query`, `web_scan`, `credential_spray`, `dga_queries`, `dns_tunnel`, `raw`
+**Available event types:** `process`, `logon`, `failed_logon`, `logoff`, `connection`, `ssh_session`, `rdp_session`, `account_created`, `account_deleted`, `group_member_added`, `service_installed`, `scheduled_task_created`, `log_cleared`, `create_remote_thread`, `dhcp_lease`, `port_scan`, `beacon`, `dns_query`, `web_scan`, `credential_spray`, `dga_queries`, `dns_tunnel`, `explicit_credentials`, `workstation_lock`, `workstation_unlock`, `raw`
 
 **Firewall/network event types:**
 - `port_scan` — Bulk denied connections for recon/scanning. Fields: `target_ips` or `target_segment`+`target_count`, `ports`, `protocol`, `scan_rate`. Produces ASA 106023 denies + correlated Zeek conn entries.
@@ -404,6 +404,9 @@ When building storyline events, each entry needs an `events` list with typed dec
 - `dns_query` — Standalone DNS query. Fields: `query`, `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR).
 - `dga_queries` — Bulk DGA domain lookups. Fields: `interval`, `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`.
 - `dns_tunnel` — DNS exfiltration via encoded subdomains. Fields: `base_domain`, `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`/`payload_size`.
+- `explicit_credentials` — RunAs / pass-the-hash / service account delegation (4648). Fields: `target_username`, `target_server`, `process_name`, `source_ip`.
+- `workstation_lock` — Lock workstation (4800). No additional fields.
+- `workstation_unlock` — Unlock workstation (4801 + 4624 type 7 re-auth). No additional fields.
 
 The `raw` type targets a specific output format with arbitrary fields — use it for events without a dedicated type (e.g., custom syslog messages, specific Windows events). Requires `target_format` and `fields` dict. Raw events bypass cross-format correlation, so prefer typed events when available.
 

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -419,6 +419,9 @@ Each event in the `events` list has a `type` field that selects a validated sche
 | `credential_spray` | Windows 4625/4776 or syslog auth | `target_accounts`, `interval`, one of `end_time`/`duration`/`count` | `pattern` (spray/brute_force/stuffing), `source_ip`, `logon_type`, `success`, `jitter` |
 | `dga_queries` | Zeek dns.log + conn.log (bulk DGA) | `interval`, one of `end_time`/`duration`/`count` | `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`, `source_ip`, `jitter` |
 | `dns_tunnel` | Zeek dns.log + conn.log (encoded exfil) | `base_domain`, `interval`, one of `end_time`/`duration`/`count` | `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`, `payload_size`, `source_ip`, `jitter` |
+| `explicit_credentials` | Windows 4648 (explicit credential usage) | `target_username` | `target_server`, `process_name`, `source_ip` |
+| `workstation_lock` | Windows 4800 (workstation locked) | | |
+| `workstation_unlock` | Windows 4801 + 4624 type 7 (unlock + re-auth) | | |
 | `raw` | Any single format | `target_format`, `fields` | |
 
 All event types also accept optional `technique` (MITRE ATT&CK ID) and `description` (human-readable detail) fields for GROUND_TRUTH.md enrichment.

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -914,6 +914,12 @@ output:
 
 Supported formats: `windows`, `zeek`, `ecar`, `syslog`, `bash_history`, `snort_alert`, `cisco_asa`, `web_access`, `proxy`.
 
+#### Format Filtering
+
+The `output.logs` list can be scoped to only needed formats for faster generation with long time windows. For example, a 30-day baseline exercise that only needs Zeek conn.log can declare just `format: zeek_conn` instead of the full `zeek` group.
+
+The `--formats` CLI flag provides runtime filtering without modifying the scenario YAML. It intersects with `output.logs` — only formats present in both are generated. Group names (`zeek`, `windows`) are expanded before intersection.
+
 ## Backward Compatibility
 
 Persona fields are optional with null defaults:

--- a/src/evidenceforge/cli/commands.py
+++ b/src/evidenceforge/cli/commands.py
@@ -290,6 +290,12 @@ def generate(
         for item in existing:
             console.print(item)
 
+        if formats:
+            console.print(
+                "[yellow]Warning: --formats replaces the entire data/ directory. "
+                "Previously generated formats not in the filter will be deleted.[/yellow]"
+            )
+
         if not force:
             try:
                 typer.confirm("\nOverwrite existing output?", abort=True)

--- a/src/evidenceforge/cli/commands.py
+++ b/src/evidenceforge/cli/commands.py
@@ -138,6 +138,14 @@ def generate(
     force: bool = typer.Option(
         False, "--force", "-f", help="Overwrite existing output without prompting"
     ),
+    formats: str | None = typer.Option(
+        None,
+        "--formats",
+        "-F",
+        help="Comma-separated format filter (e.g., 'zeek_conn,zeek_dns' or 'zeek'). "
+        "Only generates formats present in both this list and the scenario. "
+        "Supports group names (zeek, windows). See 'eforge info format_groups'.",
+    ),
 ) -> None:
     """Generate synthetic security logs from a scenario file.
 
@@ -240,6 +248,29 @@ def generate(
         scenario_dir = scenario_file.parent
         data_dir = scenario_dir / "data"
         ground_truth_dir = scenario_dir
+
+    # Apply --formats filter (intersection with scenario output.logs)
+    if formats:
+        from evidenceforge.events.dispatcher import expand_formats
+
+        requested = expand_formats([f.strip() for f in formats.split(",")])
+        scenario_formats = expand_formats(
+            {log["format"] for log in scenario.output.logs if "format" in log}
+        )
+        filtered = requested & scenario_formats
+
+        if requested - scenario_formats:
+            missing = sorted(requested - scenario_formats)
+            console.print(f"[yellow]Warning: formats not in scenario: {missing}[/yellow]")
+
+        if not filtered:
+            console.print(
+                "[bold red]Error:[/bold red] No formats match both --formats and scenario output.logs"
+            )
+            raise typer.Exit(EXIT_INPUT_ERROR)
+
+        scenario.output.logs = [{"format": fmt} for fmt in sorted(filtered)]
+        console.print(f"[dim]Format filter: generating {sorted(filtered)}[/dim]")
 
     console.print(f"\n[bold]Data directory:[/bold] {data_dir}")
     console.print(f"[bold]Ground truth:[/bold] {ground_truth_dir / 'GROUND_TRUTH.md'}")

--- a/src/evidenceforge/cli/info.py
+++ b/src/evidenceforge/cli/info.py
@@ -123,6 +123,13 @@ def _collect_web_scan_presets() -> list[str]:
     return list_preset_names()
 
 
+def _collect_format_groups() -> dict[str, list[str]]:
+    """Collect format group names and their expanded formats."""
+    from evidenceforge.events.dispatcher import FORMAT_GROUPS
+
+    return {k: sorted(v) for k, v in FORMAT_GROUPS.items()}
+
+
 def _gather_lightweight() -> dict[str, Any]:
     """Gather lightweight fields that don't require overlay-backed loaders.
 
@@ -189,6 +196,7 @@ def gather_info(field: str | None = None) -> dict[str, Any]:
         "application_ids": _collect_application_ids,
         "system_roles": _collect_system_roles,
         "web_scan_presets": _collect_web_scan_presets,
+        "format_groups": _collect_format_groups,
     }
     for key, collector in inventories.items():
         try:
@@ -270,6 +278,7 @@ _FIELD_DESCRIPTIONS: dict[str, str] = {
     "application_ids": "Application IDs in the catalog",
     "config_writable": "Whether package config files are directly editable",
     "dns_tags": "Defined valid DNS tags (from dns_registry.yaml valid_tags section)",
+    "format_groups": "Format group names and their expanded formats (for --formats flag)",
     "formats": "Supported log format names",
     "install_type": "Package install type (editable or package)",
     "overlay.exists": "Whether a project-local overlay directory exists",

--- a/src/evidenceforge/config/formats/windows_event_security.yaml
+++ b/src/evidenceforge/config/formats/windows_event_security.yaml
@@ -484,6 +484,66 @@ variants:
         required: true
         description: "List of assigned special privileges"
 
+  # EventID 4800: The workstation was locked
+  - name: workstation_locked
+    event_id: "4800"
+    description: "Workstation locked"
+    fields:
+      - name: TargetUserSid
+        type: sid
+        required: true
+        description: "SID of the user who locked the workstation"
+
+      - name: TargetUserName
+        type: string
+        required: true
+        description: "Account name of the user"
+
+      - name: TargetDomainName
+        type: string
+        required: true
+        description: "Domain of the user"
+
+      - name: TargetLogonId
+        type: hex_string
+        required: true
+        description: "Logon ID of the locked session"
+
+      - name: SessionId
+        type: integer
+        required: true
+        description: "Terminal Services session ID"
+
+  # EventID 4801: The workstation was unlocked
+  - name: workstation_unlocked
+    event_id: "4801"
+    description: "Workstation unlocked"
+    fields:
+      - name: TargetUserSid
+        type: sid
+        required: true
+        description: "SID of the user who unlocked the workstation"
+
+      - name: TargetUserName
+        type: string
+        required: true
+        description: "Account name of the user"
+
+      - name: TargetDomainName
+        type: string
+        required: true
+        description: "Domain of the user"
+
+      - name: TargetLogonId
+        type: hex_string
+        required: true
+        description: "Logon ID of the unlocked session"
+
+      - name: SessionId
+        type: integer
+        required: true
+        description: "Terminal Services session ID"
+
   # EventID 4689: A process has exited
   - name: process_termination
     event_id: "4689"
@@ -1096,7 +1156,7 @@ output:
         <EventID>{{ EventID }}</EventID>
         <Version>{{ 2 if EventID in [4688, 4624] else 1 if EventID == 5156 else 0 }}</Version>
         <Level>{{ Level }}</Level>
-        <Task>{{ {1102: 104, 4624: 12544, 4625: 12544, 4634: 12545, 4648: 12544, 4672: 12548, 4688: 13312, 4689: 13313, 4697: 12289, 4698: 12804, 4699: 12804, 4700: 12804, 4701: 12804, 4720: 13824, 4723: 13824, 4724: 13824, 4726: 13824, 4728: 13826, 4729: 13826, 4732: 13826, 4733: 13826, 4738: 13824, 4756: 13826, 4757: 13826, 4768: 14339, 4769: 14337, 4770: 14339, 4771: 14339, 4776: 14336, 5156: 12810}.get(EventID, 0) }}</Task>
+        <Task>{{ {1102: 104, 4624: 12544, 4625: 12544, 4634: 12545, 4648: 12544, 4672: 12548, 4688: 13312, 4689: 13313, 4697: 12289, 4698: 12804, 4699: 12804, 4700: 12804, 4701: 12804, 4720: 13824, 4723: 13824, 4724: 13824, 4726: 13824, 4728: 13826, 4729: 13826, 4732: 13826, 4733: 13826, 4738: 13824, 4756: 13826, 4757: 13826, 4768: 14339, 4769: 14337, 4770: 14339, 4771: 14339, 4776: 14336, 4800: 12551, 4801: 12551, 5156: 12810}.get(EventID, 0) }}</Task>
         <Opcode>0</Opcode>
         <Keywords>{{ Keywords | default('0x8020000000000000') }}</Keywords>
         <TimeCreated SystemTime="{{ TimeCreated }}"/>

--- a/src/evidenceforge/evaluation/dimensions/signal_integrity.py
+++ b/src/evidenceforge/evaluation/dimensions/signal_integrity.py
@@ -625,6 +625,18 @@ class SignalIntegrityScorer(DimensionScorer):
             if format_name == "zeek_conn":
                 return f.get("id.resp_p") == 53 and f.get("id.orig_h") == event.system_ip
 
+        elif event_type == "explicit_credentials":
+            target_user = event.details.get("target_username", "")
+            if format_name == "windows_event_security":
+                return f.get("EventID") == 4648 and (
+                    not target_user or f.get("TargetUserName", "") == target_user
+                )
+
+        elif event_type in ("workstation_lock", "workstation_unlock"):
+            expected_id = 4800 if event_type == "workstation_lock" else 4801
+            if format_name == "windows_event_security":
+                return f.get("EventID") == expected_id
+
         return False
 
     def _connection_matches_zeek(self, fields: dict, event: ResolvedEvent) -> bool:

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3818,6 +3818,54 @@ class ActivityGenerator:
         )
         self.dispatcher.dispatch(event)
 
+    def generate_workstation_lock(
+        self,
+        user: User,
+        system: System,
+        time: datetime,
+        logon_id: str,
+    ) -> None:
+        """Generate workstation lock event (4800)."""
+        event = SecurityEvent(
+            timestamp=time,
+            event_type="workstation_locked",
+            dst_host=self._build_host_context(system),
+            auth=AuthContext(
+                username=user.username,
+                user_sid=self._get_sid(user.username),
+                logon_id=logon_id,
+            ),
+        )
+        self.dispatcher.dispatch(event)
+
+    def generate_workstation_unlock(
+        self,
+        user: User,
+        system: System,
+        time: datetime,
+        logon_id: str,
+    ) -> None:
+        """Generate workstation unlock event (4801 + 4624 type 7)."""
+        event = SecurityEvent(
+            timestamp=time,
+            event_type="workstation_unlocked",
+            dst_host=self._build_host_context(system),
+            auth=AuthContext(
+                username=user.username,
+                user_sid=self._get_sid(user.username),
+                logon_id=logon_id,
+            ),
+        )
+        self.dispatcher.dispatch(event)
+        # Unlock is a re-authentication — emit 4624 type 7
+        self.generate_logon(
+            user=user,
+            system=system,
+            time=time + timedelta(milliseconds=50),
+            logon_type=7,
+            source_ip=system.ip,
+        )
+
     def generate_wfp_connection(
         self,
         system: System,

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3857,13 +3857,14 @@ class ActivityGenerator:
             ),
         )
         self.dispatcher.dispatch(event)
-        # Unlock is a re-authentication — emit 4624 type 7
+        # Unlock is a re-authentication — emit 4624 type 7 with same session
         self.generate_logon(
             user=user,
             system=system,
             time=time + timedelta(milliseconds=50),
             logon_type=7,
             source_ip=system.ip,
+            logon_id=logon_id,
         )
 
     def generate_wfp_connection(

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -104,6 +104,8 @@ class WindowsEventEmitter(LogEmitter):
         "password_change",
         "password_reset",
         "special_privileges",
+        "workstation_locked",
+        "workstation_unlocked",
     }
 
     @staticmethod
@@ -139,6 +141,8 @@ class WindowsEventEmitter(LogEmitter):
         "group_member_removed_local",
         "group_member_added_universal",
         "group_member_removed_universal",
+        "workstation_locked",
+        "workstation_unlocked",
     }
 
     def _get_host(self, event: SecurityEvent) -> "HostContext":
@@ -191,6 +195,8 @@ class WindowsEventEmitter(LogEmitter):
             "password_change": self._render_password_change,
             "password_reset": self._render_password_reset,
             "special_privileges": self._render_special_privileges,
+            "workstation_locked": self._render_workstation_lock,
+            "workstation_unlocked": self._render_workstation_unlock,
         }.get(event.event_type)
         if renderer is None:
             raise NotImplementedError(
@@ -318,6 +324,48 @@ class WindowsEventEmitter(LogEmitter):
             "PrivilegeList": privs,
         }
         self.emit_event(priv_data)
+
+    def _render_workstation_lock(self, event: SecurityEvent) -> None:
+        """Render Windows 4800 (workstation locked)."""
+        rng = random.Random()
+        auth = event.auth
+        host = self._get_host(event)
+        event_data = {
+            "EventID": 4800,
+            "TimeCreated": event.timestamp,
+            "Computer": host.fqdn,
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 500 + rng.randint(0, 100),
+            "ExecutionThreadID": rng.randint(100, 500),
+            "TargetUserSid": auth.user_sid,
+            "TargetUserName": auth.username,
+            "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
+            "TargetLogonId": auth.logon_id or "0x0",
+            "SessionId": rng.randint(1, 5),
+        }
+        self.emit_event(event_data)
+
+    def _render_workstation_unlock(self, event: SecurityEvent) -> None:
+        """Render Windows 4801 (workstation unlocked)."""
+        rng = random.Random()
+        auth = event.auth
+        host = self._get_host(event)
+        event_data = {
+            "EventID": 4801,
+            "TimeCreated": event.timestamp,
+            "Computer": host.fqdn,
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 500 + rng.randint(0, 100),
+            "ExecutionThreadID": rng.randint(100, 500),
+            "TargetUserSid": auth.user_sid,
+            "TargetUserName": auth.username,
+            "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
+            "TargetLogonId": auth.logon_id or "0x0",
+            "SessionId": rng.randint(1, 5),
+        }
+        self.emit_event(event_data)
 
     def _render_logoff(self, event: SecurityEvent) -> None:
         """Render Windows 4634 (logoff)."""

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -525,6 +525,9 @@ class BaselineMixin:
                 for event_time in event_times:
                     self._generate_user_activity(user, event_time)
 
+                # Lock/unlock events for Windows workstation users
+                self._generate_lock_unlock_events(user, current_hour, local_hour, persona_name)
+
         # Pre-decide logoffs so profile traffic can bound persona timestamps
         planned_logoffs = self._plan_logoffs_for_hour(enabled_users, current_hour)
 
@@ -2149,6 +2152,116 @@ class BaselineMixin:
                         ),
                         process_pid=session.explorer_pid if session else 0,
                     )
+
+    def _generate_lock_unlock_events(
+        self,
+        user: User,
+        current_hour: datetime,
+        local_hour: int,
+        persona_name: str | None,
+    ) -> None:
+        """Generate workstation lock/unlock events for Windows interactive sessions."""
+        rng = _get_rng()
+        # Only Windows workstation users with active interactive sessions
+        sessions = self.state_manager.get_sessions_for_user(user.username)
+        session = next(
+            (
+                s
+                for s in sessions
+                if s.logon_type == 2
+                and any(
+                    sys.type == "workstation"
+                    for sys in self.scenario.environment.systems
+                    if sys.hostname == s.system
+                )
+            ),
+            None,
+        )
+        if not session:
+            return
+        system = next(
+            (s for s in self.scenario.environment.systems if s.hostname == session.system),
+            None,
+        )
+        if not system or _get_os_category(system.os) != "windows":
+            return
+
+        # Per-persona lock frequency
+        _pn = (persona_name or "").lower()
+        if _pn in ("security_analyst", "sysadmin"):
+            lock_prob = 0.40  # 3-5 locks/day → ~40% per work hour
+        elif _pn in ("developer",):
+            lock_prob = 0.08  # 0-1 locks/day
+        else:
+            lock_prob = 0.20  # 1-3 locks/day
+
+        # Only during work hours (7-19)
+        if not (7 <= local_hour <= 19):
+            return
+
+        # Lunch lock at hour 12
+        if local_hour == 12 and rng.random() < 0.85:
+            lock_t = current_hour + timedelta(minutes=rng.randint(0, 15))
+            self.state_manager.set_current_time(lock_t)
+            self.activity_generator.generate_workstation_lock(
+                user=user,
+                system=system,
+                time=lock_t,
+                logon_id=session.logon_id,
+            )
+            # Unlock after lunch (30-60 min)
+            unlock_t = lock_t + timedelta(minutes=rng.randint(30, 60))
+            if unlock_t < current_hour + timedelta(hours=1):
+                self.state_manager.set_current_time(unlock_t)
+                # ~15% chance of failed password before unlock
+                if rng.random() < 0.15:
+                    fail_t = unlock_t - timedelta(seconds=rng.randint(3, 15))
+                    self.state_manager.set_current_time(fail_t)
+                    self.activity_generator.generate_failed_logon(
+                        user=user,
+                        system=system,
+                        time=fail_t,
+                        logon_type=7,
+                        source_ip=system.ip,
+                    )
+                self.activity_generator.generate_workstation_unlock(
+                    user=user,
+                    system=system,
+                    time=unlock_t,
+                    logon_id=session.logon_id,
+                )
+            return
+
+        # Random meeting-break lock/unlock
+        if rng.random() < lock_prob:
+            lock_t = current_hour + timedelta(seconds=rng.randint(60, 3500))
+            self.state_manager.set_current_time(lock_t)
+            self.activity_generator.generate_workstation_lock(
+                user=user,
+                system=system,
+                time=lock_t,
+                logon_id=session.logon_id,
+            )
+            gap_minutes = rng.randint(2, 15)
+            unlock_t = lock_t + timedelta(minutes=gap_minutes)
+            if unlock_t < current_hour + timedelta(hours=1):
+                self.state_manager.set_current_time(unlock_t)
+                if rng.random() < 0.15:
+                    fail_t = unlock_t - timedelta(seconds=rng.randint(3, 15))
+                    self.state_manager.set_current_time(fail_t)
+                    self.activity_generator.generate_failed_logon(
+                        user=user,
+                        system=system,
+                        time=fail_t,
+                        logon_type=7,
+                        source_ip=system.ip,
+                    )
+                self.activity_generator.generate_workstation_unlock(
+                    user=user,
+                    system=system,
+                    time=unlock_t,
+                    logon_id=session.logon_id,
+                )
 
     def _get_server_ssh_users(self, system) -> list:
         """Return the subset of admin users who would SSH into this server.

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -2091,6 +2091,65 @@ class BaselineMixin:
                 user=user, system=system, time=t, activity_type=activity_type
             )
 
+        # Persona-driven 4648: sysadmin RunAs and helpdesk remote sessions
+        os_cat = _get_os_category(system.os) if hasattr(system, "os") else "unknown"
+        if os_cat == "windows" and persona_name:
+            _pn = persona_name.lower()
+            servers = [
+                s
+                for s in self.scenario.environment.systems
+                if s.type in ("server", "domain_controller")
+            ]
+            if _pn in ("sysadmin", "security_analyst") and rng.random() < 0.15 and servers:
+                target_server = rng.choice(servers)
+                admin_alias = f"{user.username}-admin"
+                session = next((s for s in sessions if s.system == system.hostname), None)
+                runas_t = event_time + timedelta(seconds=rng.randint(0, 55))
+                self.state_manager.set_current_time(runas_t)
+                self.activity_generator.generate_explicit_credentials(
+                    user=user,
+                    system=system,
+                    time=runas_t,
+                    target_username=admin_alias,
+                    target_server=target_server.hostname,
+                    process_name=rng.choice(
+                        [
+                            r"C:\Windows\System32\runas.exe",
+                            r"C:\Windows\System32\mmc.exe",
+                            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+                        ]
+                    ),
+                    process_pid=session.explorer_pid if session else 0,
+                )
+            elif _pn == "help_desk" and rng.random() < 0.08:
+                non_admins = [
+                    u
+                    for u in self.scenario.environment.users
+                    if u.enabled
+                    and (u.persona or "").lower()
+                    not in ("sysadmin", "security_analyst", "help_desk")
+                    and u.username != user.username
+                ]
+                if non_admins:
+                    target_user = rng.choice(non_admins)
+                    session = next((s for s in sessions if s.system == system.hostname), None)
+                    hd_t = event_time + timedelta(seconds=rng.randint(0, 55))
+                    self.state_manager.set_current_time(hd_t)
+                    self.activity_generator.generate_explicit_credentials(
+                        user=user,
+                        system=system,
+                        time=hd_t,
+                        target_username=target_user.username,
+                        target_server=target_user.primary_system or "",
+                        process_name=rng.choice(
+                            [
+                                r"C:\Windows\System32\mstsc.exe",
+                                r"C:\Windows\System32\msra.exe",
+                            ]
+                        ),
+                        process_pid=session.explorer_pid if session else 0,
+                    )
+
     def _get_server_ssh_users(self, system) -> list:
         """Return the subset of admin users who would SSH into this server.
 
@@ -3267,6 +3326,49 @@ class BaselineMixin:
                         parent_pid=parent_pid,
                         username="SYSTEM",
                     )
+
+            # Service account delegation: svc accounts auth to remote servers
+            if os_cat == "windows" and self.scenario.environment.service_accounts:
+                all_systems = self.scenario.environment.systems
+                servers = [s for s in all_systems if s.type in ("server", "domain_controller")]
+                for svc_name in self.scenario.environment.service_accounts:
+                    if rng.random() < 0.3:
+                        target_sys = rng.choice(servers) if servers else None
+                        if target_sys and target_sys.hostname != system.hostname:
+                            svc_ts = current_hour + timedelta(seconds=rng.uniform(0, 3599))
+                            self.state_manager.set_current_time(svc_ts)
+                            self.activity_generator.generate_explicit_credentials(
+                                user=_SYSTEM_USER,
+                                system=system,
+                                time=svc_ts,
+                                target_username=svc_name,
+                                target_server=target_sys.hostname,
+                                process_name=r"C:\Windows\System32\services.exe",
+                                process_pid=sys_pids.get("services", 0),
+                            )
+
+            # GPO application: periodic SYSTEM credential usage to DC
+            if os_cat == "windows" and system.type == "workstation":
+                gpo_phase = _stable_seed(f"gpo_phase_{system.hostname}") % 4
+                if (current_hour.hour + gpo_phase) % 3 == 0:
+                    dcs = [
+                        s
+                        for s in self.scenario.environment.systems
+                        if s.type == "domain_controller"
+                    ]
+                    if dcs:
+                        dc = dcs[_stable_seed(f"gpo_dc_{system.hostname}") % len(dcs)]
+                        gpo_ts = current_hour + timedelta(seconds=rng.uniform(60, 300))
+                        self.state_manager.set_current_time(gpo_ts)
+                        self.activity_generator.generate_explicit_credentials(
+                            user=_SYSTEM_USER,
+                            system=system,
+                            time=gpo_ts,
+                            target_username="SYSTEM",
+                            target_server=dc.hostname,
+                            process_name=r"C:\Windows\System32\svchost.exe",
+                            process_pid=sys_pids.get("svchost_netsvcs", 0),
+                        )
 
             # Sysmon Event 8 (CreateRemoteThread) baseline noise — Windows only
             if os_cat == "windows":

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -568,6 +568,9 @@ class BaselineMixin:
         enabled_users = [u for u in self.scenario.environment.users if u.enabled]
         logger.info(f"Generating baseline for {len(enabled_users)} enabled users")
 
+        # Initialize pending unlocks for cross-hour lock/unlock persistence
+        self._pending_unlocks: dict[str, tuple] = {}
+
         # Emit initial DHCP leases (during warm-up they're suppressed from output
         # but establish lease state for periodic renewals)
         self._emit_dhcp_leases()
@@ -2153,6 +2156,33 @@ class BaselineMixin:
                         process_pid=session.explorer_pid if session else 0,
                     )
 
+    def _emit_unlock(self, user, system, unlock_t, logon_id, rng) -> None:
+        """Emit an unlock event, optionally preceded by a failed password attempt."""
+        self.state_manager.set_current_time(unlock_t)
+        if rng.random() < 0.15:
+            fail_t = unlock_t - timedelta(seconds=rng.randint(3, 15))
+            self.state_manager.set_current_time(fail_t)
+            self.activity_generator.generate_failed_logon(
+                user=user,
+                system=system,
+                time=fail_t,
+                logon_type=7,
+                source_ip=system.ip,
+            )
+            self.state_manager.set_current_time(unlock_t)
+        self.activity_generator.generate_workstation_unlock(
+            user=user,
+            system=system,
+            time=unlock_t,
+            logon_id=logon_id,
+        )
+
+    def _defer_unlock(self, username, unlock_t, logon_id) -> None:
+        """Store a pending unlock for emission in a future hour."""
+        if not hasattr(self, "_pending_unlocks"):
+            self._pending_unlocks = {}
+        self._pending_unlocks[username] = (unlock_t, logon_id)
+
     def _generate_lock_unlock_events(
         self,
         user: User,
@@ -2162,6 +2192,8 @@ class BaselineMixin:
     ) -> None:
         """Generate workstation lock/unlock events for Windows interactive sessions."""
         rng = _get_rng()
+        hour_end = current_hour + timedelta(hours=1)
+
         # Only Windows workstation users with active interactive sessions
         sessions = self.state_manager.get_sessions_for_user(user.username)
         session = next(
@@ -2186,16 +2218,22 @@ class BaselineMixin:
         if not system or _get_os_category(system.os) != "windows":
             return
 
+        # Emit any pending unlock from a prior hour
+        pending = getattr(self, "_pending_unlocks", {})
+        if user.username in pending:
+            unlock_t, pending_logon_id = pending.pop(user.username)
+            if unlock_t < hour_end:
+                self._emit_unlock(user, system, unlock_t, pending_logon_id, rng)
+
         # Per-persona lock frequency
         _pn = (persona_name or "").lower()
         if _pn in ("security_analyst", "sysadmin"):
-            lock_prob = 0.40  # 3-5 locks/day → ~40% per work hour
+            lock_prob = 0.40
         elif _pn in ("developer",):
-            lock_prob = 0.08  # 0-1 locks/day
+            lock_prob = 0.08
         else:
-            lock_prob = 0.20  # 1-3 locks/day
+            lock_prob = 0.20
 
-        # Only during work hours (7-19)
         if not (7 <= local_hour <= 19):
             return
 
@@ -2209,27 +2247,11 @@ class BaselineMixin:
                 time=lock_t,
                 logon_id=session.logon_id,
             )
-            # Unlock after lunch (30-60 min)
             unlock_t = lock_t + timedelta(minutes=rng.randint(30, 60))
-            if unlock_t < current_hour + timedelta(hours=1):
-                self.state_manager.set_current_time(unlock_t)
-                # ~15% chance of failed password before unlock
-                if rng.random() < 0.15:
-                    fail_t = unlock_t - timedelta(seconds=rng.randint(3, 15))
-                    self.state_manager.set_current_time(fail_t)
-                    self.activity_generator.generate_failed_logon(
-                        user=user,
-                        system=system,
-                        time=fail_t,
-                        logon_type=7,
-                        source_ip=system.ip,
-                    )
-                self.activity_generator.generate_workstation_unlock(
-                    user=user,
-                    system=system,
-                    time=unlock_t,
-                    logon_id=session.logon_id,
-                )
+            if unlock_t < hour_end:
+                self._emit_unlock(user, system, unlock_t, session.logon_id, rng)
+            else:
+                self._defer_unlock(user.username, unlock_t, session.logon_id)
             return
 
         # Random meeting-break lock/unlock
@@ -2242,26 +2264,11 @@ class BaselineMixin:
                 time=lock_t,
                 logon_id=session.logon_id,
             )
-            gap_minutes = rng.randint(2, 15)
-            unlock_t = lock_t + timedelta(minutes=gap_minutes)
-            if unlock_t < current_hour + timedelta(hours=1):
-                self.state_manager.set_current_time(unlock_t)
-                if rng.random() < 0.15:
-                    fail_t = unlock_t - timedelta(seconds=rng.randint(3, 15))
-                    self.state_manager.set_current_time(fail_t)
-                    self.activity_generator.generate_failed_logon(
-                        user=user,
-                        system=system,
-                        time=fail_t,
-                        logon_type=7,
-                        source_ip=system.ip,
-                    )
-                self.activity_generator.generate_workstation_unlock(
-                    user=user,
-                    system=system,
-                    time=unlock_t,
-                    logon_id=session.logon_id,
-                )
+            unlock_t = lock_t + timedelta(minutes=rng.randint(2, 15))
+            if unlock_t < hour_end:
+                self._emit_unlock(user, system, unlock_t, session.logon_id, rng)
+            else:
+                self._defer_unlock(user.username, unlock_t, session.logon_id)
 
     def _get_server_ssh_users(self, system) -> list:
         """Return the subset of admin users who would SSH into this server.

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1784,6 +1784,42 @@ class StorylineMixin:
             malicious_event["total_queries"] = query_count
             malicious_event["bytes_exfiltrated"] = total_bytes
 
+        elif spec.type == "explicit_credentials":
+            self.activity_generator.generate_explicit_credentials(
+                user=actor,
+                system=system,
+                time=time,
+                target_username=spec.target_username,
+                target_server=spec.target_server or system.hostname,
+                process_name=spec.process_name or r"C:\Windows\System32\runas.exe",
+                process_pid=getattr(self, "_last_storyline_pid", -1) or 0,
+                source_ip=spec.source_ip or system.ip,
+            )
+            malicious_event["target_username"] = spec.target_username
+            malicious_event["target_server"] = spec.target_server
+
+        elif spec.type == "workstation_lock":
+            sessions = self.state_manager.get_sessions_for_user(actor.username)
+            session = next((s for s in sessions if s.system == system.hostname), None)
+            logon_id = session.logon_id if session else "0x0"
+            self.activity_generator.generate_workstation_lock(
+                user=actor,
+                system=system,
+                time=time,
+                logon_id=logon_id,
+            )
+
+        elif spec.type == "workstation_unlock":
+            sessions = self.state_manager.get_sessions_for_user(actor.username)
+            session = next((s for s in sessions if s.system == system.hostname), None)
+            logon_id = session.logon_id if session else "0x0"
+            self.activity_generator.generate_workstation_unlock(
+                user=actor,
+                system=system,
+                time=time,
+                logon_id=logon_id,
+            )
+
         elif spec.type == "raw":
             self.activity_generator.generate_raw(
                 time=time,

--- a/src/evidenceforge/generation/ground_truth.py
+++ b/src/evidenceforge/generation/ground_truth.py
@@ -280,6 +280,15 @@ class GroundTruthGenerator:
             exfil = event.get("bytes_exfiltrated", 0)
             return f"DNS tunnel via {domain} ({enc}, {queries} queries, {exfil} bytes exfiltrated)"
 
+        elif event_type == "explicit_credentials":
+            target = event.get("target_username", "N/A")
+            server = event.get("target_server", "N/A")
+            return f"Explicit credentials: RunAs {target} on {server}"
+
+        elif event_type in ("workstation_lock", "workstation_unlock"):
+            action = "Locked" if event_type == "workstation_lock" else "Unlocked"
+            return f"Workstation {action}"
+
         else:
             return event.get("activity", "N/A")
 
@@ -411,6 +420,11 @@ class GroundTruthGenerator:
                 base = event.get("base_domain", "")
                 if base:
                     iocs["network"].add(f"{base} (DNS Tunnel Endpoint)")
+
+            elif event["type"] == "explicit_credentials":
+                target = event.get("target_username", "")
+                if target:
+                    iocs["users"].add(f"{target} (Explicit Credential Target)")
 
         # Remove empty categories
         iocs = {category: values for category, values in iocs.items() if values}

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -852,6 +852,32 @@ class DnsTunnelEventSpec(_PeriodicEventBase):
         return self
 
 
+class ExplicitCredentialsEventSpec(_EventSpecBase):
+    """Explicit credential usage event (generates Windows 4648).
+
+    Models RunAs, pass-the-hash, service account delegation, and other
+    scenarios where credentials are explicitly provided for authentication.
+    """
+
+    type: Literal["explicit_credentials"] = "explicit_credentials"
+    target_username: str
+    target_server: str | None = None
+    process_name: str | None = None
+    source_ip: str | None = None
+
+
+class WorkstationLockEventSpec(_EventSpecBase):
+    """Workstation lock event (generates Windows 4800)."""
+
+    type: Literal["workstation_lock"] = "workstation_lock"
+
+
+class WorkstationUnlockEventSpec(_EventSpecBase):
+    """Workstation unlock event (generates Windows 4801 + 4624 type 7)."""
+
+    type: Literal["workstation_unlock"] = "workstation_unlock"
+
+
 class RawEventSpec(_EventSpecBase):
     """Raw event targeting a specific emitter with arbitrary fields.
 
@@ -890,6 +916,9 @@ EventSpec = Annotated[
     | CredentialSprayEventSpec
     | DgaQueriesEventSpec
     | DnsTunnelEventSpec
+    | ExplicitCredentialsEventSpec
+    | WorkstationLockEventSpec
+    | WorkstationUnlockEventSpec
     | RawEventSpec,
     Discriminator("type"),
 ]

--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -84,6 +84,9 @@ _WINDOWS_EVENT_TYPES = {
     "log_cleared",
     "create_remote_thread",
     "process_access",
+    "explicit_credentials",
+    "workstation_lock",
+    "workstation_unlock",
 }
 
 # Event types that imply Linux/SSH

--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -565,6 +565,7 @@ class ScenarioValidator:
         """Validate output.logs format names."""
         from evidenceforge.events.dispatcher import FORMAT_GROUPS
 
+        # Accept both group names (zeek, windows) and individual format names (zeek_conn)
         known_output_formats = set(FORMAT_GROUPS.keys()) | {
             "ecar",
             "syslog",
@@ -574,23 +575,12 @@ class ScenarioValidator:
             "web_access",
             "proxy_access",
         }
-        _group_members = {}
-        for group, members in FORMAT_GROUPS.items():
-            for member in members:
-                _group_members[member] = group
+        for members in FORMAT_GROUPS.values():
+            known_output_formats.update(members)
 
         for idx, log_spec in enumerate(self.scenario.output.logs):
             fmt = log_spec.get("format", "")
-            if fmt in _group_members:
-                self.issues.append(
-                    ValidationIssue(
-                        severity="error",
-                        field_path=f"output.logs.{idx}.format",
-                        message=f"Individual format '{fmt}' not allowed in output.logs",
-                        suggestion=f"Use the group name '{_group_members[fmt]}' instead",
-                    )
-                )
-            elif fmt and fmt not in known_output_formats:
+            if fmt and fmt not in known_output_formats:
                 self.issues.append(
                     ValidationIssue(
                         severity="warning",

--- a/tests/integration/test_format_definitions.py
+++ b/tests/integration/test_format_definitions.py
@@ -48,7 +48,7 @@ class TestWindowsEventFormat:
     def test_has_event_variants(self):
         """Test that format has expected EventID variants."""
         assert self.format.variants is not None
-        assert len(self.format.variants) == 21
+        assert len(self.format.variants) == 23
         variant_names = [v.name for v in self.format.variants]
         assert "logon" in variant_names
         assert "logoff" in variant_names
@@ -437,7 +437,7 @@ class TestLoadAllFormats:
         windows_fmt = formats["windows_event_security"]
         assert windows_fmt.name == "windows_event_security"
         assert windows_fmt.category == "host"
-        assert len(windows_fmt.variants) == 21
+        assert len(windows_fmt.variants) == 23
 
         # Verify Zeek JSON format
         zeek_fmt = formats["zeek_conn"]

--- a/tests/unit/test_bulk_events.py
+++ b/tests/unit/test_bulk_events.py
@@ -16,7 +16,10 @@ from evidenceforge.models.scenario import (
     DgaQueriesEventSpec,
     DnsQueryEventSpec,
     DnsTunnelEventSpec,
+    ExplicitCredentialsEventSpec,
     WebScanEventSpec,
+    WorkstationLockEventSpec,
+    WorkstationUnlockEventSpec,
     _PeriodicEventBase,
 )
 
@@ -592,3 +595,43 @@ class TestDnsTunnelEventSpec:
                 count=10,
             )
             assert spec.encoding == enc
+
+
+# ── ExplicitCredentialsEventSpec ──────────────────────────────────────────
+
+
+class TestExplicitCredentialsEventSpec:
+    def test_defaults(self):
+        spec = ExplicitCredentialsEventSpec(target_username="admin")
+        assert spec.type == "explicit_credentials"
+        assert spec.target_username == "admin"
+        assert spec.target_server is None
+        assert spec.process_name is None
+        assert spec.source_ip is None
+
+    def test_all_fields(self):
+        spec = ExplicitCredentialsEventSpec(
+            target_username="svc_backup",
+            target_server="FILE-SRV-01",
+            process_name=r"C:\Windows\System32\runas.exe",
+            source_ip="10.0.1.5",
+        )
+        assert spec.target_server == "FILE-SRV-01"
+        assert spec.process_name == r"C:\Windows\System32\runas.exe"
+
+    def test_requires_target_username(self):
+        with pytest.raises(ValidationError):
+            ExplicitCredentialsEventSpec()
+
+
+# ── WorkstationLockEventSpec / WorkstationUnlockEventSpec ─────────────────
+
+
+class TestWorkstationLockUnlockEventSpec:
+    def test_lock_defaults(self):
+        spec = WorkstationLockEventSpec()
+        assert spec.type == "workstation_lock"
+
+    def test_unlock_defaults(self):
+        spec = WorkstationUnlockEventSpec()
+        assert spec.type == "workstation_unlock"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -29,6 +29,7 @@ from typer.testing import CliRunner
 from evidenceforge.cli.commands import (
     EXIT_ABORTED,
     EXIT_GENERATION_ERROR,
+    EXIT_INPUT_ERROR,
     EXIT_SCHEMA_VALIDATION,
     EXIT_SUCCESS,
     app,
@@ -593,3 +594,94 @@ output:
         assert result.exit_code == EXIT_SUCCESS
         assert "Existing output found" not in result.stdout
         assert mock_engine.generate.called
+
+    @patch("evidenceforge.cli.commands.GenerationEngine")
+    def test_formats_flag_filters_output(self, mock_engine_class, scenarios_dir, tmp_path):
+        """--formats should narrow scenario output.logs to the intersection."""
+        mock_engine = Mock()
+        mock_engine_class.return_value = mock_engine
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "zeek_conn",
+            ],
+        )
+
+        assert result.exit_code == EXIT_SUCCESS
+        # Engine should have been created with narrowed format list
+        call_kwargs = mock_engine_class.call_args.kwargs
+        scenario = call_kwargs["scenario"]
+        fmt_names = {log["format"] for log in scenario.output.logs}
+        assert fmt_names == {"zeek_conn"}
+
+    @patch("evidenceforge.cli.commands.GenerationEngine")
+    def test_formats_flag_supports_groups(self, mock_engine_class, scenarios_dir, tmp_path):
+        """--formats should expand group names before intersecting."""
+        mock_engine = Mock()
+        mock_engine_class.return_value = mock_engine
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "zeek",
+            ],
+        )
+
+        assert result.exit_code == EXIT_SUCCESS
+        call_kwargs = mock_engine_class.call_args.kwargs
+        scenario = call_kwargs["scenario"]
+        fmt_names = {log["format"] for log in scenario.output.logs}
+        assert "zeek_conn" in fmt_names
+        assert "zeek_dns" in fmt_names
+        # Windows should NOT be in the output
+        assert "windows_event_security" not in fmt_names
+
+    @patch("evidenceforge.cli.commands.GenerationEngine")
+    def test_formats_flag_warns_on_mismatch(self, mock_engine_class, scenarios_dir, tmp_path):
+        """--formats with formats not in scenario should warn."""
+        mock_engine = Mock()
+        mock_engine_class.return_value = mock_engine
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "zeek_conn,cisco_asa",
+            ],
+        )
+
+        assert result.exit_code == EXIT_SUCCESS
+        assert "not in scenario" in result.stdout
+        assert "cisco_asa" in result.stdout
+
+    def test_formats_flag_errors_on_empty_intersection(self, scenarios_dir, tmp_path):
+        """--formats with no matching formats should error."""
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--formats",
+                "cisco_asa",
+            ],
+        )
+
+        assert result.exit_code == EXIT_INPUT_ERROR
+        assert "No formats match" in result.stdout


### PR DESCRIPTION
## Summary
- Windows auth enrichment (Cluster 4): broader 4648 baseline, 4800/4801 lock/unlock
- Format filtering: --formats CLI flag
- Adversarial review fixes: unlock LogonId correlation, cross-hour lock persistence
- All exercise data gaps resolved (0 critical, 0 major remaining)
- 2011 tests passing (including slow), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)