### PR TITLE
fix: DNS provider correctness and OS-aware domain filtering

### DIFF
--- a/src/evidenceforge/config/activity/dns_registry.yaml
+++ b/src/evidenceforge/config/activity/dns_registry.yaml
@@ -25,6 +25,7 @@ valid_tags:
   linux:      "Linux-specific background traffic"
   internal:   "Internal infrastructure (DB servers, etc.)"
   storage:    "Cloud storage (potential exfiltration targets)"
+  os_tags: [windows, linux]  # Tags that trigger OS-aware domain filtering in pick_domain_and_ip()
   dev:        "Developer tool API endpoints"
   social:     "Social media sites"
 
@@ -143,7 +144,7 @@ domains:
     tags: [background, windows]
   - domain: login.microsoftonline.com
     ips: ["40.126.28.17", "40.126.28.19", "20.190.159.64"]
-    tags: [saas, background, windows]
+    tags: [saas, background]
 
   # === Other popular sites ===
   - domain: www.example.com

--- a/src/evidenceforge/config/activity/dns_registry.yaml
+++ b/src/evidenceforge/config/activity/dns_registry.yaml
@@ -419,3 +419,30 @@ ipv6_map:
   "104.16.132.229": "2606:4700::6810:84e5"
   "151.101.1.140": "2a04:4e42::396"
   "93.184.216.34": "2606:2800:220:1:248:1893:25c8:1946"
+
+# IPv6 prefix mapping for AAAA fallback generation.
+# When a domain's IPv4 isn't in the explicit ipv6_map above, the engine
+# derives an IPv6 address using the first octet of the IPv4 to select a
+# provider-appropriate prefix. This prevents Microsoft domains from getting
+# Google IPv6 prefixes, etc.
+#
+# Format: {lo: N, hi: M, prefix: "..."}
+# Matches IPs whose first octet falls in [lo, hi] inclusive.
+# Source: WHOIS lookups on major cloud/CDN provider IP allocations.
+# Extend via .eforge/config/activity/dns_registry.yaml overlay (ranges are concatenated).
+ipv6_prefixes:
+  default: "2a09:bac0"
+  ranges:
+    - {lo: 13, hi: 13, prefix: "2620:1ec"}
+    - {lo: 20, hi: 20, prefix: "2620:1ec"}
+    - {lo: 23, hi: 23, prefix: "2a02:26f0"}
+    - {lo: 40, hi: 40, prefix: "2603:1000"}
+    - {lo: 52, hi: 54, prefix: "2600:1f18"}
+    - {lo: 74, hi: 74, prefix: "2607:f8b0"}
+    - {lo: 104, hi: 104, prefix: "2606:4700"}
+    - {lo: 108, hi: 108, prefix: "2607:f8b0"}
+    - {lo: 140, hi: 140, prefix: "2606:50c0"}
+    - {lo: 142, hi: 142, prefix: "2607:f8b0"}
+    - {lo: 151, hi: 151, prefix: "2a04:4e42"}
+    - {lo: 172, hi: 172, prefix: "2607:f8b0"}
+    - {lo: 209, hi: 209, prefix: "2607:f8b0"}

--- a/src/evidenceforge/generation/activity/__init__.py
+++ b/src/evidenceforge/generation/activity/__init__.py
@@ -58,7 +58,6 @@ from .network import (
     _CDN_RANGES,
     _HTTP_URI_STATUS_CACHE,
     _IPV6_MAP,
-    _PROVIDER_IP_GROUPS,
     _SRV_PORT_MAP,
     EXTERNAL_IPS,
     REVERSE_DNS,

--- a/src/evidenceforge/generation/activity/dns_registry.py
+++ b/src/evidenceforge/generation/activity/dns_registry.py
@@ -139,6 +139,7 @@ def pick_domain_and_ip(
     rng: random.Random,
     *tags: str,
     src_host: str = "",
+    include_os: str | None = None,
 ) -> tuple[str, str]:
     """Pick a domain by tag(s) and select a deterministic primary IP.
 
@@ -150,11 +151,24 @@ def pick_domain_and_ip(
         rng: Random instance for domain selection.
         *tags: Tags to filter domains by (e.g., "web", or "background", "windows").
         src_host: Source hostname for deterministic IP selection.
+        include_os: Source host OS category ("windows" or "linux"). When set,
+            domains tagged for a different OS are excluded. Domains with no
+            OS tag are always included.
 
     Returns:
         (domain, ip) tuple.
     """
     entries = get_domains_by_tag(*tags)
+
+    if include_os and entries:
+        data = load_dns_registry()
+        os_tags = set(data.get("valid_tags", {}).get("os_tags", ["windows", "linux"]))
+        entries = [
+            entry
+            for entry in entries
+            if not (os_tags & set(entry.get("tags", []))) or include_os in entry.get("tags", [])
+        ]
+
     if not entries:
         # Fallback: generate a long-tail domain
         data = load_dns_registry()

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -59,7 +59,6 @@ from .helpers import _get_os_category, _get_rng, _parameterize_command
 from .network import (
     _AD_SRV_QUERIES,
     _IPV6_MAP,
-    _PROVIDER_IP_GROUPS,
     _SRV_PORT_MAP,
     EXTERNAL_IPS,
     REVERSE_DNS,
@@ -2999,11 +2998,10 @@ class ActivityGenerator:
             query = hostname
             # Multi-answer: CDNs/clouds return multiple A records (40% chance)
             if not is_internal and rng.random() < 0.40:
-                sibling_ips = []
-                for provider_ips in _PROVIDER_IP_GROUPS:
-                    if dst_ip in provider_ips:
-                        sibling_ips = [ip for ip in provider_ips if ip != dst_ip]
-                        break
+                from evidenceforge.generation.activity.dns_registry import get_domain_ips
+
+                domain_ips = get_domain_ips(hostname) if hostname else []
+                sibling_ips = [ip for ip in domain_ips if ip != dst_ip]
                 if sibling_ips:
                     extra = rng.sample(sibling_ips, min(rng.randint(1, 2), len(sibling_ips)))
                     answers = [dst_ip] + extra

--- a/src/evidenceforge/generation/activity/network.py
+++ b/src/evidenceforge/generation/activity/network.py
@@ -76,12 +76,6 @@ for _act_type, _tag in _TAG_TO_ACTIVITY.items():
         _ips.extend(_e["ips"])
     EXTERNAL_IPS[_act_type] = list(dict.fromkeys(_ips))  # Deduplicate, preserve order
 
-# Per-domain IP groups for DNS multi-answer responses
-# Replaces the old per-provider _PROVIDER_IP_GROUPS with exact per-domain pools
-_PROVIDER_IP_GROUPS: list[list[str]] = [
-    entry["ips"] for entry in load_dns_registry().get("domains", []) if len(entry["ips"]) > 1
-]
-
 # CDN ranges and IPv6 map from registry
 _CDN_RANGES = [tuple(r) for r in get_cdn_ranges()]
 _IPV6_MAP: dict[str, str] = get_ipv6_map()
@@ -105,31 +99,37 @@ _SRV_PORT_MAP = {
 }
 
 
+_CACHED_IPV6_PREFIXES: dict | None = None
+
+
+def _load_ipv6_prefixes() -> dict:
+    """Load IPv6 prefix config from dns_registry.yaml (cached)."""
+    global _CACHED_IPV6_PREFIXES
+    if _CACHED_IPV6_PREFIXES is not None:
+        return _CACHED_IPV6_PREFIXES
+    data = load_dns_registry()
+    _CACHED_IPV6_PREFIXES = data.get("ipv6_prefixes", {"default": "2a09:bac0", "ranges": []})
+    return _CACHED_IPV6_PREFIXES
+
+
 def _ipv4_to_fake_ipv6(ipv4: str) -> str:
     """Generate a deterministic plausible IPv6 address from an IPv4 address.
 
-    Uses diverse prefixes from real providers based on the first octet.
+    Uses provider-specific prefixes loaded from dns_registry.yaml ipv6_prefixes
+    section, keyed by first octet of the IPv4 address.
     """
     octets = ipv4.split(".")
     o0, o1, o2, o3 = int(octets[0]), int(octets[1]), int(octets[2]), int(octets[3])
-    # Select prefix based on first octet range to simulate different providers
-    prefixes = {
-        (13, 13): "2620:1ec",  # Microsoft Azure
-        (23, 23): "2a02:26f0",  # Akamai
-        (52, 54): "2600:1f18",  # AWS
-        (104, 104): "2606:4700",  # Cloudflare
-        (142, 142): "2607:f8b0",  # Google
-        (151, 151): "2a04:4e42",  # Fastly
-        (172, 172): "2607:f8b0",  # Google
-    }
-    # Private IPs get ULA prefix (fd00::/8), not documentation 2001:db8::/32
+
+    # Private IPs get ULA prefix (fd00::/8)
     if o0 == 10 or (o0 == 172 and 16 <= o1 <= 31) or (o0 == 192 and o1 == 168):
         return f"fd00:{o1:02x}{o2:02x}:{o3:04x}::1"
 
-    prefix = "2a00:1450"  # default (generic, not documentation)
-    for (lo, hi), pfx in prefixes.items():
-        if lo <= o0 <= hi:
-            prefix = pfx
+    config = _load_ipv6_prefixes()
+    prefix = config.get("default", "2a09:bac0")
+    for entry in config.get("ranges", []):
+        if entry["lo"] <= o0 <= entry["hi"]:
+            prefix = entry["prefix"]
             break
     return f"{prefix}:{o1:02x}{o2:02x}:{o3:04x}::1"
 

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -2387,7 +2387,7 @@ class BaselineMixin:
                 tags = self._SERVICE_DNS_DEFAULTS[service]
             else:
                 tags = ("background", os_cat)
-            domain, ip = pick_domain_and_ip(rng, *tags, src_host=src_host)
+            domain, ip = pick_domain_and_ip(rng, *tags, src_host=src_host, include_os=os_cat)
             return ip, domain
 
         if hasattr(self, "world_model"):

--- a/tests/unit/test_log_realism_fixes.py
+++ b/tests/unit/test_log_realism_fixes.py
@@ -282,3 +282,77 @@ class TestEcarNatAwareIp:
         assert inbound_call["dst_ip"] == "10.10.3.10", (
             f"eCAR should use real IP 10.10.3.10, got {inbound_call['dst_ip']}"
         )
+
+
+# ── DNS multi-answer correctness ────────────────────────────────────────
+
+
+class TestDnsMultiAnswer:
+    def test_get_domain_ips_returns_correct_provider(self):
+        from evidenceforge.generation.activity.dns_registry import get_domain_ips
+
+        ips = get_domain_ips("mx.office365.com")
+        if ips:
+            for ip in ips:
+                assert ip.startswith("40.107."), (
+                    f"mx.office365.com should only have Microsoft IPs (40.107.x), got {ip}"
+                )
+
+    def test_get_domain_ips_empty_for_unknown(self):
+        from evidenceforge.generation.activity.dns_registry import get_domain_ips
+
+        assert get_domain_ips("nonexistent.example.com") == []
+
+
+# ── IPv6 prefix correctness ─────────────────────────────────────────────
+
+
+class TestIpv6PrefixCorrectness:
+    def test_microsoft_ip_gets_microsoft_prefix(self):
+        from evidenceforge.generation.activity.network import _ipv4_to_fake_ipv6
+
+        result = _ipv4_to_fake_ipv6("40.107.22.53")
+        assert result.startswith("2603:"), (
+            f"Microsoft IP 40.107.22.53 should get 2603: prefix, got {result}"
+        )
+
+    def test_google_ip_gets_google_prefix(self):
+        from evidenceforge.generation.activity.network import _ipv4_to_fake_ipv6
+
+        result = _ipv4_to_fake_ipv6("142.250.80.46")
+        assert result.startswith("2607:f8b0:"), (
+            f"Google IP 142.250.80.46 should get 2607:f8b0: prefix, got {result}"
+        )
+
+    def test_default_is_not_google(self):
+        from evidenceforge.generation.activity.network import _ipv4_to_fake_ipv6
+
+        result = _ipv4_to_fake_ipv6("77.88.55.88")
+        assert not result.startswith("2a00:1450"), (
+            f"Unknown IP should NOT default to Google 2a00:1450, got {result}"
+        )
+        assert not result.startswith("2607:f8b0"), (
+            f"Unknown IP should NOT default to Google 2607:f8b0, got {result}"
+        )
+
+    def test_private_ip_gets_ula_prefix(self):
+        from evidenceforge.generation.activity.network import _ipv4_to_fake_ipv6
+
+        result = _ipv4_to_fake_ipv6("10.10.1.50")
+        assert result.startswith("fd00:"), f"Private IP should get fd00: ULA prefix, got {result}"
+
+    def test_aws_ip_gets_aws_prefix(self):
+        from evidenceforge.generation.activity.network import _ipv4_to_fake_ipv6
+
+        result = _ipv4_to_fake_ipv6("52.95.110.1")
+        assert result.startswith("2600:1f18:"), (
+            f"AWS IP 52.x should get 2600:1f18: prefix, got {result}"
+        )
+
+    def test_ipv6_prefixes_loaded_from_yaml(self):
+        from evidenceforge.generation.activity.network import _load_ipv6_prefixes
+
+        config = _load_ipv6_prefixes()
+        assert "default" in config
+        assert "ranges" in config
+        assert len(config["ranges"]) >= 10

--- a/tests/unit/test_log_realism_fixes.py
+++ b/tests/unit/test_log_realism_fixes.py
@@ -356,3 +356,65 @@ class TestIpv6PrefixCorrectness:
         assert "default" in config
         assert "ranges" in config
         assert len(config["ranges"]) >= 10
+
+
+# ── OS-aware domain filtering ────────────────────────────────────────────
+
+
+class TestOsAwareDomainFiltering:
+    def test_include_os_linux_excludes_windows_domains(self):
+        from evidenceforge.generation.activity.dns_registry import pick_domain_and_ip
+
+        rng = random.Random(42)
+        for _ in range(50):
+            domain, ip = pick_domain_and_ip(rng, "background", include_os="linux")
+            from evidenceforge.generation.activity.dns_registry import get_domains_by_tag
+
+            all_bg = get_domains_by_tag("background")
+            entry = next((e for e in all_bg if e["domain"] == domain), None)
+            if entry:
+                assert "windows" not in entry.get("tags", []), (
+                    f"Linux host got Windows domain: {domain}"
+                )
+
+    def test_include_os_windows_can_return_windows_domains(self):
+        from evidenceforge.generation.activity.dns_registry import pick_domain_and_ip
+
+        rng = random.Random(42)
+        domains = set()
+        for _ in range(200):
+            domain, _ = pick_domain_and_ip(rng, "background", include_os="windows")
+            domains.add(domain)
+        from evidenceforge.generation.activity.dns_registry import get_domains_by_tag
+
+        windows_bg = get_domains_by_tag("background", "windows")
+        windows_domain_names = {e["domain"] for e in windows_bg}
+        assert domains & windows_domain_names, (
+            "Windows host should be able to get Windows-tagged domains"
+        )
+
+    def test_no_include_os_returns_all(self):
+        from evidenceforge.generation.activity.dns_registry import pick_domain_and_ip
+
+        rng = random.Random(42)
+        domains = set()
+        for _ in range(200):
+            domain, _ = pick_domain_and_ip(rng, "background")
+            domains.add(domain)
+        from evidenceforge.generation.activity.dns_registry import get_domains_by_tag
+
+        windows_bg = get_domains_by_tag("background", "windows")
+        windows_domain_names = {e["domain"] for e in windows_bg}
+        assert domains & windows_domain_names, (
+            "Without include_os, Windows domains should be reachable"
+        )
+
+    def test_untagged_domains_always_available(self):
+        from evidenceforge.generation.activity.dns_registry import pick_domain_and_ip
+
+        rng = random.Random(42)
+        domains = set()
+        for _ in range(200):
+            domain, _ = pick_domain_and_ip(rng, "web", include_os="linux")
+            domains.add(domain)
+        assert len(domains) > 0, "Linux host should get web domains (most are OS-neutral)"


### PR DESCRIPTION
## Summary

Two deferred fixes from the log realism improvement loop, addressing expert panel P0/P1 findings.

### DNS multi-answer IPs from correct provider
- `pick_domain_and_ip()` → `get_domain_ips(hostname)` for multi-answer A records, ensuring `mx.office365.com` only returns Microsoft sibling IPs (never Google)
- IPv6 AAAA prefix map moved from hardcoded Python dict to `dns_registry.yaml` `ipv6_prefixes` section (data-driven, overlay-compatible)
- Expanded from 7 to 13 provider ranges; default changed from `2a00:1450` (Google) to `2a09:bac0` (neutral)
- Removed dead code: `_PROVIDER_IP_GROUPS`

### OS-aware domain filtering
- Added `include_os` parameter to `pick_domain_and_ip()` — domains tagged for a different OS are excluded; OS-neutral domains always included
- Uses inclusion semantics (scales to macOS/Android without code changes)
- Recognized OS tags defined in `dns_registry.yaml` `valid_tags.os_tags` (overlay-extensible)
- Removed `windows` tag from `login.microsoftonline.com` (cross-platform SaaS)

## Test plan

- [x] 2027 tests pass (12 new across DNS and OS filtering)
- [x] `ruff check` + `ruff format` clean
- [x] DNS tests verify: Microsoft IPs stay with Microsoft domains, Google with Google, unknown IPs get neutral prefix, private IPs get ULA
- [x] OS filter tests verify: Linux excludes Windows domains, Windows includes them, untagged domains available to all

🤖 Generated with [Claude Code](https://claude.com/claude-code)