### PR TITLE
fix: validate-config schema, spawn rules, regression test

### DIFF
--- a/src/evidenceforge/config/activity/spawn_rules.yaml
+++ b/src/evidenceforge/config/activity/spawn_rules.yaml
@@ -46,6 +46,8 @@ windows:
       - regedit.exe
       - notepad.exe
       - mstsc.exe
+      - ServerManager.exe
+      - perfmon.exe
 
   # Applications that spawn child/utility subprocesses of the same exe name
   chrome.exe:
@@ -126,6 +128,13 @@ windows:
       - ssh.exe
       - npm.cmd
       - dsquery.exe
+      - dcdiag.exe
+      - repadmin.exe
+      - ntdsutil.exe
+      - dnscmd.exe
+      - gpupdate.exe
+      - gpresult.exe
+      - certutil.exe
 
   powershell.exe:
     command_templates:
@@ -162,6 +171,13 @@ windows:
       - ssh.exe
       - npm.cmd
       - dsquery.exe
+      - dcdiag.exe
+      - repadmin.exe
+      - ntdsutil.exe
+      - dnscmd.exe
+      - gpupdate.exe
+      - gpresult.exe
+      - certutil.exe
 
   code.exe:
     command_templates:

--- a/src/evidenceforge/config/schemas.py
+++ b/src/evidenceforge/config/schemas.py
@@ -71,6 +71,7 @@ class ApplicationEntry(BaseModel, extra="forbid"):
     platforms: dict[str, PlatformConfig]
     categories: list[str]
     personas: list[str]
+    system_types: list[str] | None = None
 
 
 # --- Persona ---

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Regression test: eforge validate-config must ship 100% clean."""
+
+from evidenceforge.cli.validate_config import validate_config
+
+
+class TestValidateConfig:
+    def test_validate_config_clean(self):
+        result = validate_config()
+        assert result.issues == [], (
+            f"validate-config has {len(result.issues)} issues:\n"
+            + "\n".join(f"  [{i.severity}] {i.location}: {i.message}" for i in result.issues)
+        )


### PR DESCRIPTION
## Summary
- Add `system_types` field to `ApplicationEntry` Pydantic schema — prior commit added the field to YAML but not to the `extra="forbid"` model, causing 25 validation errors
- Add 9 DC admin tools (dcdiag, repadmin, ntdsutil, dnscmd, gpupdate, gpresult, certutil, ServerManager, perfmon) to spawn_rules.yaml as children of explorer.exe, cmd.exe, and powershell.exe — clears 9 info-level issues
- Add standalone `test_validate_config.py` enforcing zero issues of any severity from `eforge validate-config`

## Test plan
- [x] `uv run eforge validate-config` returns 0 errors, 0 warnings, 0 info
- [x] `uv run pytest tests/unit/test_validate_config.py -x --no-cov` passes
- [x] `uv run pytest tests/unit/test_log_realism_fixes.py tests/unit/test_round3_fixes.py -x --no-cov` — all 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)