### PR TITLE
feat: correlated RSAT sessions for DC admin activity

### DIFF
--- a/commands/eforge/references/config-apps-processes.md
+++ b/commands/eforge/references/config-apps-processes.md
@@ -386,3 +386,47 @@ patterns:
 Offsets are fixed per-host within a generation run (matching real ASLR behavior) but vary across hosts. 8 default patterns cover: direct NtOpenProcess, kernel32 path, RPCRT4, WMI, COM/DCOM, AV/EDR, kernel-mode, and sechost paths.
 
 Overlay replaces the entire `patterns:` list.
+
+---
+
+## rsat_tools.yaml
+
+RSAT (Remote Server Administration Tools) session patterns. The baseline engine generates correlated multi-host event sequences from these definitions: mmc.exe process + DLL loads on the admin workstation, type 3 logon + LDAP/RPC connections on the DC — all within a tight time window.
+
+### Structure
+
+```yaml
+tools:
+  - id: aduc                                         # Unique identifier
+    snap_in: dsa.msc                                 # MMC snap-in filename
+    display_name: "Active Directory Users and Computers"
+    command_line: '"C:\Windows\System32\mmc.exe" "C:\Windows\System32\dsa.msc"'
+    target_ports:                                    # Connections to DC
+      - {port: 389, service: ldap}
+      - {port: 135, service: rpc}
+    loaded_modules:                                  # DLLs loaded by snap-in
+      - {path: 'C:\Windows\System32\dsadmin.dll', signature: "Microsoft Corporation"}
+    weight: 40                                       # Relative frequency
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Unique lowercase identifier |
+| `snap_in` | string | yes | MMC snap-in filename (e.g., `dsa.msc`) |
+| `display_name` | string | no | Human-readable tool name |
+| `command_line` | string | yes | Full mmc.exe command line for process creation |
+| `target_ports` | list[object] | yes | DC connections — each with `port` (int) and `service` (string) |
+| `loaded_modules` | list[object] | no | DLLs loaded (Sysmon Event 7) — each with `path` and optional `signature` |
+| `weight` | int | yes | Relative frequency weight (higher = more common) |
+
+### Overlay
+
+Overlay files go in `.eforge/config/activity/rsat_tools.yaml`. Entries with matching `id` merge fields; new IDs are appended.
+
+### Conventions
+
+- RSAT sessions are auto-generated when the environment has DCs + admin personas (sysadmin/help_desk)
+- Business hours: ~50% chance per hour, 1-3 sessions; off-hours: ~10%, 1 session
+- No scenario YAML configuration needed — purely baseline behavior

--- a/commands/eforge/references/config-host-activity.md
+++ b/commands/eforge/references/config-host-activity.md
@@ -11,6 +11,7 @@ Schema documentation for host-level activity config files. User customizations g
 1. [bash_commands.yaml](#bash_commandsyaml)
 2. [systemd_schedules.yaml](#systemd_schedulesyaml)
 3. [extra_syslog_messages.yaml](#extra_syslog_messagesyaml)
+4. [Domain Controller Baseline Activity](#domain-controller-baseline-activity)
 
 ---
 
@@ -159,3 +160,15 @@ programs:
 | `distro` | string | no | Restrict to `ubuntu` (excluded on RHEL-like) |
 | `roles` | list[string] | no | Required host roles (any match includes the entry) |
 | `transient` | bool | no | If `true`, uses random PID per invocation |
+
+---
+
+## Domain Controller Baseline Activity
+
+Domain controllers receive admin-only baseline activity — no user desktop sessions, browsers, Office apps, or user profile artifacts. This is controlled by two mechanisms:
+
+1. **`system_types` in application_catalog.yaml**: User-facing apps have `system_types: [workstation]`, preventing them from appearing on DCs. DC admin tools (dcdiag, repadmin, etc.) have `system_types: [domain_controller]`. See `config-apps-processes.md` for details.
+
+2. **RSAT sessions from `rsat_tools.yaml`**: The baseline generates correlated cross-host admin sessions where mmc.exe and snap-in DLL loads appear on the admin's workstation, while LDAP/RPC connections and type 3 logons appear on the DC. See the `rsat_tools.yaml` section in `config-apps-processes.md` for the schema.
+
+No scenario YAML configuration is needed. RSAT sessions are auto-generated when the environment contains domain controllers and admin personas (sysadmin/help_desk).

--- a/commands/eforge/references/config-validation.md
+++ b/commands/eforge/references/config-validation.md
@@ -72,6 +72,7 @@ Run `eforge info <field>` to get specific values (e.g., `eforge info paths.activ
 | 28 | sysmon_filters.yaml structure | ERROR | Missing required sections (network_connect, image_loaded, etc.) or invalid types |
 | 29 | edr_pools.yaml structure | ERROR | Missing required sections (file_paths_windows, registry_keys_hkcu, etc.) or empty lists |
 | 30 | calltrace_patterns.yaml structure | ERROR | Patterns list empty, or pattern missing `modules`/`offset_ranges` fields |
+| 31 | rsat_tools.yaml structure | ERROR | Tool missing required fields (`id`, `snap_in`, `command_line`, `target_ports`, `weight`), invalid weight, or target_ports missing `port`/`service` |
 
 ## Output Format
 

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -505,6 +505,7 @@ events:
 - **ProcessAccess after lsass injection** — `create_remote_thread` targeting lsass.exe auto-generates Sysmon Event 10 (1-50ms after)
 - **Audit events from commands** — Process events with admin commands (`net user /add`, `sc create`, `schtasks /create`, `wevtutil cl`) auto-generate the corresponding Windows audit events (4720, 4726, 4728, 4697, 4698, 1102)
 - **DNS for RDP/SSH** — `rdp_session` and `ssh_session` auto-generate DNS + connection events
+- **RSAT sessions for DCs** — When the environment contains domain controllers and admin personas (sysadmin/help_desk), the baseline auto-generates correlated RSAT sessions: mmc.exe + DLL loads on the admin workstation, LDAP/RPC connections from workstation to DC, and type 3 logon on the DC. No scenario configuration needed
 
 **When to manually specify these event types:** Only when they are part of the attack narrative itself — not as prerequisites for another event. For example:
 - DNS tunneling exfiltration → manually declare the DNS `connection` events (they ARE the attack, not a prerequisite)

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -81,6 +81,8 @@ output/
 - Account management events (4720-4738) and group membership events (4728-4757) require storyline triggers; they are not generated in baseline activity
 - SubjectDomainName correctly uses "NT AUTHORITY" for SYSTEM, NETWORK SERVICE, and LOCAL SERVICE accounts
 - 4648 (explicit credentials) fires in baseline for scheduled task execution with randomized counts (2-5/hour) plus storyline lateral movement
+- Domain controllers receive admin-only baseline activity: type 3 logons from RSAT sessions (mmc.exe runs on the admin workstation, not the DC), type 10 RDP for direct admin access, and no user desktop sessions (no browsers, Office, or user profile artifacts)
+- RSAT sessions produce correlated cross-host events: mmc.exe + DLL loads on the workstation, LDAP/RPC connections from workstation to DC, and a type 3 logon on the DC — all within seconds
 
 ---
 

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -1082,6 +1082,57 @@ def validate_config() -> ValidationResult:
                             )
                         )
 
+    # --- RSAT tools validation ---
+    from evidenceforge.generation.activity.rsat_tools import load_rsat_tools
+
+    rsat_tools = load_rsat_tools()
+    _RSAT_REQUIRED = {"id", "snap_in", "command_line", "target_ports", "weight"}
+    for tool in rsat_tools:
+        tool_id = tool.get("id", "<unnamed>")
+        missing = _RSAT_REQUIRED - set(tool.keys())
+        if missing:
+            result.issues.append(
+                Issue(
+                    "ERROR",
+                    "rsat_tools.yaml",
+                    f'Tool "{tool_id}" missing fields: {sorted(missing)}',
+                )
+            )
+        if not isinstance(tool.get("weight", 0), int) or tool.get("weight", 0) < 1:
+            result.issues.append(
+                Issue(
+                    "ERROR",
+                    "rsat_tools.yaml",
+                    f'Tool "{tool_id}" weight must be a positive integer',
+                )
+            )
+        for i, port_info in enumerate(tool.get("target_ports", [])):
+            if "port" not in port_info or "service" not in port_info:
+                result.issues.append(
+                    Issue(
+                        "ERROR",
+                        "rsat_tools.yaml",
+                        f'Tool "{tool_id}" target_ports[{i}] missing port or service',
+                    )
+                )
+        for i, mod in enumerate(tool.get("loaded_modules", [])):
+            if "path" not in mod:
+                result.issues.append(
+                    Issue(
+                        "ERROR",
+                        "rsat_tools.yaml",
+                        f'Tool "{tool_id}" loaded_modules[{i}] missing path',
+                    )
+                )
+            elif "\\" not in mod["path"]:
+                result.issues.append(
+                    Issue(
+                        "WARNING",
+                        "rsat_tools.yaml",
+                        f'Tool "{tool_id}" loaded_modules[{i}] path does not look like a Windows path',
+                    )
+                )
+
     seen_issues: set[tuple[str, str, str]] = set()
     deduped: list[Issue] = []
     for issue in result.issues:

--- a/src/evidenceforge/config/activity/rsat_tools.yaml
+++ b/src/evidenceforge/config/activity/rsat_tools.yaml
@@ -1,0 +1,80 @@
+# RSAT (Remote Server Administration Tools) session patterns.
+# Models admin workstation -> domain controller management sessions.
+#
+# Each tool produces a correlated event sequence:
+#   1. mmc.exe process on the admin's workstation (parent: explorer.exe)
+#   2. Snap-in DLL loads on the workstation (Sysmon Event 7)
+#   3. Network connections from workstation to target DC (LDAP/RPC/SMB)
+#   4. Type 3 (network) logon on the DC from the workstation IP
+#
+# To add a new RSAT tool:
+#   - Pick a unique id (lowercase, underscore-separated)
+#   - Set snap_in to the .msc filename
+#   - Set command_line to the full mmc.exe invocation
+#   - List target_ports with the services the snap-in contacts on the DC
+#   - List loaded_modules for DLLs the snap-in loads (for Sysmon Event 7)
+#   - Set weight to control relative frequency (higher = more common)
+#
+# Overlay: place partial file in .eforge/config/activity/rsat_tools.yaml.
+# Overlay entries with matching id merge fields; new ids are appended.
+#
+# Depended on by: baseline.py (_generate_rsat_sessions)
+# Depends on: nothing
+
+tools:
+  - id: aduc
+    snap_in: dsa.msc
+    display_name: "Active Directory Users and Computers"
+    command_line: '"C:\Windows\System32\mmc.exe" "C:\Windows\System32\dsa.msc"'
+    target_ports:
+      - {port: 389, service: ldap}
+      - {port: 135, service: rpc}
+    loaded_modules:
+      - {path: 'C:\Windows\System32\dsadmin.dll', signature: "Microsoft Corporation"}
+      - {path: 'C:\Windows\System32\activeds.dll', signature: "Microsoft Corporation"}
+      - {path: 'C:\Windows\System32\adsldpc.dll', signature: "Microsoft Corporation"}
+    weight: 40
+
+  - id: dns_mgr
+    snap_in: dnsmgmt.msc
+    display_name: "DNS Manager"
+    command_line: '"C:\Windows\System32\mmc.exe" "C:\Windows\System32\dnsmgmt.msc"'
+    target_ports:
+      - {port: 135, service: rpc}
+    loaded_modules:
+      - {path: 'C:\Windows\System32\dnsmgr.dll', signature: "Microsoft Corporation"}
+    weight: 20
+
+  - id: gpmc
+    snap_in: gpmc.msc
+    display_name: "Group Policy Management"
+    command_line: '"C:\Windows\System32\mmc.exe" "C:\Windows\System32\gpmc.msc"'
+    target_ports:
+      - {port: 389, service: ldap}
+      - {port: 135, service: rpc}
+      - {port: 445, service: smb}
+    loaded_modules:
+      - {path: 'C:\Windows\System32\gpmgmt.dll', signature: "Microsoft Corporation"}
+      - {path: 'C:\Windows\System32\activeds.dll', signature: "Microsoft Corporation"}
+    weight: 25
+
+  - id: dhcp_mgr
+    snap_in: dhcpmgmt.msc
+    display_name: "DHCP Manager"
+    command_line: '"C:\Windows\System32\mmc.exe" "C:\Windows\System32\dhcpmgmt.msc"'
+    target_ports:
+      - {port: 135, service: rpc}
+    loaded_modules:
+      - {path: 'C:\Windows\System32\dhcpsnap.dll', signature: "Microsoft Corporation"}
+    weight: 10
+
+  - id: dfs_mgr
+    snap_in: dfsmgmt.msc
+    display_name: "DFS Management"
+    command_line: '"C:\Windows\System32\mmc.exe" "C:\Windows\System32\dfsmgmt.msc"'
+    target_ports:
+      - {port: 445, service: smb}
+      - {port: 135, service: rpc}
+    loaded_modules:
+      - {path: 'C:\Windows\System32\dfsgui.dll', signature: "Microsoft Corporation"}
+    weight: 5

--- a/src/evidenceforge/generation/activity/rsat_tools.py
+++ b/src/evidenceforge/generation/activity/rsat_tools.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Loader for RSAT tool configuration.
+
+Loads rsat_tools.yaml from the package config directory, merged with
+a user overlay from .eforge/config/activity/rsat_tools.yaml if present.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from evidenceforge.config import get_activity_directory
+from evidenceforge.config.overlay import load_with_overlay, merge_keyed_list
+
+_RSAT_PATH = get_activity_directory() / "rsat_tools.yaml"
+_CACHED: list[dict[str, Any]] | None = None
+
+
+def _merge_rsat(default: dict, overlay: dict) -> dict:
+    result = dict(default)
+    if "tools" in overlay:
+        result["tools"] = merge_keyed_list(
+            default.get("tools", []),
+            overlay["tools"],
+            key="id",
+        )
+    return result
+
+
+def load_rsat_tools() -> list[dict[str, Any]]:
+    """Load RSAT tool definitions, merged with overlay. Cached after first call."""
+    global _CACHED
+    if _CACHED is not None:
+        return _CACHED
+
+    data = load_with_overlay(
+        _RSAT_PATH,
+        "activity/rsat_tools.yaml",
+        _merge_rsat,
+    )
+    _CACHED = data.get("tools", [])
+    return _CACHED
+
+
+def pick_rsat_tool(rng: random.Random) -> dict[str, Any]:
+    """Pick a random RSAT tool weighted by the ``weight`` field."""
+    tools = load_rsat_tools()
+    weights = [t.get("weight", 1) for t in tools]
+    return rng.choices(tools, weights=weights, k=1)[0]

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -3695,6 +3695,9 @@ class BaselineMixin:
                     allow_existing=True,
                 )
 
+        # RSAT: admin workstation → DC management sessions (mmc.exe + LDAP/RPC)
+        self._generate_rsat_sessions(current_hour, rng, local_dt)
+
         # Service logons (LogonType 5) and ANONYMOUS LOGONs on Windows systems
         for system in self.scenario.environment.systems:
             os_cat_svc = _get_os_category(system.os)
@@ -4442,3 +4445,127 @@ class BaselineMixin:
                             tags=[],
                         ),
                     )
+
+    def _generate_rsat_sessions(self, current_hour: datetime, rng, local_dt) -> None:
+        """Generate correlated RSAT sessions from admin workstations to DCs.
+
+        Produces a temporally-correlated multi-host event sequence for each
+        session: mmc.exe + DLL loads on the workstation, type 3 logon + LDAP/RPC
+        connections on the DC — all within a tight time window.
+        """
+        from evidenceforge.generation.activity import _get_os_category
+        from evidenceforge.generation.activity.rsat_tools import load_rsat_tools, pick_rsat_tool
+
+        systems = self.scenario.environment.systems
+        dcs = [s for s in systems if s.type == "domain_controller"]
+        if not dcs:
+            return
+
+        workstations = [
+            s for s in systems if s.type == "workstation" and _get_os_category(s.os) == "windows"
+        ]
+        if not workstations:
+            return
+
+        if not load_rsat_tools():
+            return
+
+        admin_personas = {"sysadmin", "help_desk"}
+        admin_users = [
+            u
+            for u in self.scenario.environment.users
+            if u.enabled and (u.persona or "").lower() in admin_personas
+        ]
+        if not admin_users:
+            return
+
+        local_hour = local_dt.hour
+        is_business_hours = 8 <= local_hour <= 18
+        base_prob = 0.50 if is_business_hours else 0.10
+        if rng.random() > base_prob:
+            return
+
+        num_sessions = rng.randint(1, 3) if is_business_hours else 1
+
+        for _ in range(num_sessions):
+            admin = rng.choice(admin_users)
+            dc = rng.choice(dcs)
+            tool = pick_rsat_tool(rng)
+
+            ws = self._resolve_rsat_workstation(admin, workstations, rng)
+            if ws is None:
+                continue
+
+            offset = rng.uniform(0, 3599)
+            base_time = current_hour + timedelta(seconds=offset)
+            self.state_manager.set_current_time(base_time)
+
+            logon_id = self._ensure_session_on_system(admin, ws, base_time, rng)
+
+            sessions = self.state_manager.get_sessions_for_user(admin.username)
+            ws_session = next((s for s in sessions if s.system == ws.hostname), None)
+            parent_pid = ws_session.explorer_pid if ws_session and ws_session.explorer_pid else 4
+
+            mmc_time = base_time
+            mmc_pid = self.activity_generator.generate_process(
+                user=admin,
+                system=ws,
+                time=mmc_time,
+                logon_id=logon_id,
+                process_name=r"C:\Windows\System32\mmc.exe",
+                command_line=tool["command_line"],
+                parent_pid=parent_pid,
+            )
+
+            for module in tool.get("loaded_modules", []):
+                dll_time = mmc_time + timedelta(seconds=rng.uniform(0.1, 1.5))
+                self.state_manager.set_current_time(dll_time)
+                self.activity_generator.generate_image_load(
+                    user=admin,
+                    system=ws,
+                    time=dll_time,
+                    pid=mmc_pid,
+                    image=r"C:\Windows\System32\mmc.exe",
+                    dll_path=module["path"],
+                    signed=True,
+                    signature=module.get("signature", "Microsoft Corporation"),
+                    signature_status="Valid",
+                )
+
+            dc_logon_time = mmc_time + timedelta(seconds=rng.uniform(0.5, 2.0))
+            self.state_manager.set_current_time(dc_logon_time)
+            self.activity_generator.generate_logon(
+                user=admin,
+                system=dc,
+                time=dc_logon_time,
+                logon_type=3,
+                source_ip=ws.ip,
+            )
+
+            for port_info in tool["target_ports"]:
+                conn_time = mmc_time + timedelta(seconds=rng.uniform(1.0, 5.0))
+                self.state_manager.set_current_time(conn_time)
+                self.activity_generator.generate_connection(
+                    src_ip=ws.ip,
+                    dst_ip=dc.ip,
+                    time=conn_time,
+                    dst_port=port_info["port"],
+                    proto="tcp",
+                    service=port_info.get("service"),
+                    duration=rng.uniform(0.5, 30.0),
+                    orig_bytes=rng.randint(500, 5000),
+                    resp_bytes=rng.randint(1000, 50000),
+                    pid=mmc_pid,
+                    source_system=ws,
+                )
+
+    def _resolve_rsat_workstation(self, admin, workstations, rng):
+        """Find the admin's Windows workstation for RSAT sessions."""
+        if hasattr(admin, "primary_system") and admin.primary_system:
+            match = [s for s in workstations if s.hostname == admin.primary_system]
+            if match:
+                return match[0]
+        assigned = [s for s in workstations if getattr(s, "assigned_user", None) == admin.username]
+        if assigned:
+            return assigned[0]
+        return rng.choice(workstations) if workstations else None

--- a/tests/unit/test_rsat_sessions.py
+++ b/tests/unit/test_rsat_sessions.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Tests for RSAT (Remote Server Administration Tools) session generation."""
+
+import random
+
+from evidenceforge.generation.activity.rsat_tools import load_rsat_tools, pick_rsat_tool
+
+
+class TestRsatConfig:
+    def test_config_loads(self):
+        tools = load_rsat_tools()
+        assert len(tools) >= 5
+
+    def test_required_fields_present(self):
+        required = {"id", "snap_in", "command_line", "target_ports", "weight"}
+        for tool in load_rsat_tools():
+            missing = required - set(tool.keys())
+            assert not missing, f"Tool {tool.get('id')} missing {missing}"
+
+    def test_target_ports_have_port_and_service(self):
+        for tool in load_rsat_tools():
+            for port_info in tool["target_ports"]:
+                assert "port" in port_info, f"{tool['id']} port_info missing port"
+                assert "service" in port_info, f"{tool['id']} port_info missing service"
+
+    def test_loaded_modules_have_windows_paths(self):
+        for tool in load_rsat_tools():
+            for mod in tool.get("loaded_modules", []):
+                assert "\\" in mod["path"], f"{tool['id']} module path not a Windows path"
+
+
+class TestRsatToolSelection:
+    def test_pick_returns_valid_tool(self):
+        rng = random.Random(42)
+        tool = pick_rsat_tool(rng)
+        assert "id" in tool
+        assert "command_line" in tool
+
+    def test_weighted_selection_favors_high_weight(self):
+        rng = random.Random(42)
+        counts: dict[str, int] = {}
+        for _ in range(1000):
+            tool = pick_rsat_tool(rng)
+            counts[tool["id"]] = counts.get(tool["id"], 0) + 1
+        assert counts.get("aduc", 0) > counts.get("dfs_mgr", 0), (
+            "aduc (weight 40) should appear more often than dfs_mgr (weight 5)"
+        )
+
+    def test_all_tools_selectable(self):
+        rng = random.Random(42)
+        seen = set()
+        for _ in range(500):
+            seen.add(pick_rsat_tool(rng)["id"])
+        tools = load_rsat_tools()
+        assert seen == {t["id"] for t in tools}


### PR DESCRIPTION
## Summary
- New `_generate_rsat_sessions()` in baseline produces temporally-correlated cross-host event sequences for realistic DC admin activity
- Per session: mmc.exe + DLL loads on admin's workstation, then type 3 logon + LDAP/RPC connections on the DC — all within a ~5s window
- Data-driven: 5 snap-in definitions (ADUC, DNS Manager, GPMC, DHCP Manager, DFS Management) in new `rsat_tools.yaml` with overlay support
- Adds validate-config check (rsat_tools.yaml structure) and 7 unit tests covering config loading, field validation, and weighted selection
- Docs: `config-apps-processes.md` (schema), `config-host-activity.md` (DC baseline activity), `config-validation.md` (check #31), `scenario.md` (auto-generation note), `EVIDENCE_FORMATS.md`

## Context
The expert panel flagged that DC admin activity on generated data looked uncorrelated: type 3 logons existed on DCs, LDAP/RPC connections existed in lateral movement noise, and admin tools spawned on workstations — but they were not temporally linked. Real RSAT usage produces a tight multi-host cluster. This PR ties them together.

The storyline engine has no RSAT event type yet. That is tracked as a P1 post-MVP followup.

## Test plan
- [x] `uv run pytest tests/unit/` — 2001 tests pass (7 new)
- [x] `uv run eforge validate-config` — 0 errors, 0 warnings, 0 info across 59 files
- [x] `uv run ruff check` + `ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)