### PR TITLE
fix: cap dns_tunnel payload inputs to mitigate OOM DoS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 **Status:** Phase 8.5 (Dual src/dst HostContext) COMPLETE; Pre-MVP quality fixes ongoing
 **Started:** 2026-03-11
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-04-22
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed development history of completed phases.
 
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Security: cap `dns_tunnel` payload/payload_size to 1 MiB to prevent memory exhaustion from untrusted scenarios
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -593,6 +593,7 @@ def _validate_duration_string(v: str, field_name: str) -> str:
 
 _VALID_QTYPES = {"A", "AAAA", "TXT", "CNAME", "MX", "NULL", "SRV", "PTR"}
 _VALID_RCODES = {"NOERROR", "NXDOMAIN", "SERVFAIL", "REFUSED"}
+_MAX_DNS_TUNNEL_PAYLOAD_BYTES = 1024 * 1024
 
 
 class _PeriodicEventBase(_EventSpecBase):
@@ -886,8 +887,15 @@ class DnsTunnelEventSpec(_PeriodicEventBase):
     encoding: Literal["base32", "base64", "hex"] = "hex"
     qtype: str = "TXT"  # TXT, NULL, CNAME
     label_length: int = Field(default=30, ge=1, le=63)
-    payload: str | None = None  # Fixed payload to encode
-    payload_size: int = Field(default=256, ge=1)  # Random payload size if no payload
+    payload: str | None = Field(
+        default=None,
+        max_length=_MAX_DNS_TUNNEL_PAYLOAD_BYTES,
+    )  # Fixed payload to encode
+    payload_size: int = Field(
+        default=256,
+        ge=1,
+        le=_MAX_DNS_TUNNEL_PAYLOAD_BYTES,
+    )  # Random payload size if no payload
 
     @field_validator("qtype")
     @classmethod

--- a/tests/unit/test_bulk_events.py
+++ b/tests/unit/test_bulk_events.py
@@ -596,6 +596,24 @@ class TestDnsTunnelEventSpec:
             )
             assert spec.encoding == enc
 
+    def test_payload_size_upper_bound(self):
+        with pytest.raises(ValidationError, match="payload_size"):
+            DnsTunnelEventSpec(
+                base_domain="tunnel.evil.com",
+                interval="5s",
+                count=10,
+                payload_size=(1024 * 1024) + 1,
+            )
+
+    def test_payload_upper_bound(self):
+        with pytest.raises(ValidationError, match="payload"):
+            DnsTunnelEventSpec(
+                base_domain="tunnel.evil.com",
+                interval="5s",
+                count=10,
+                payload="a" * ((1024 * 1024) + 1),
+            )
+
 
 # ── ExplicitCredentialsEventSpec ──────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- A denial-of-service vector was introduced by `dns_tunnel` allowing unbounded `payload_size` (and unbounded `payload`) which can force large in-memory allocations during generation and crash the tool.  
- The goal is a minimal, early (schema-level) remediation that prevents untrusted scenarios from requesting arbitrarily large payloads while preserving existing generation behavior for reasonable inputs.

### Description
- Add a module-level constant `_MAX_DNS_TUNNEL_PAYLOAD_BYTES = 1024 * 1024` and apply it to the `DnsTunnelEventSpec` schema.  
- Constrain `payload_size` with `le=_MAX_DNS_TUNNEL_PAYLOAD_BYTES` and constrain `payload` with `max_length=_MAX_DNS_TUNNEL_PAYLOAD_BYTES` so oversized requests are rejected at validation time.  
- Add unit tests (`tests/unit/test_bulk_events.py`) to assert both the `payload_size` and `payload` upper bounds raise `ValidationError`.  
- Update `TODO.md` to mark the security hardening task completed and bump the last-updated date.

### Testing
- Ran lint/format checks: `uv run ruff check .` passed and `uv run ruff format --check .` passed.  
- Added unit tests that exercise the new schema bounds, but running `PYTHONPATH=src uv run pytest tests/unit/test_bulk_events.py -q` in this environment failed to load project tests due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`), so the new tests could not be executed here.  
- Changes were committed on the current branch with the commit message `fix: bound dns_tunnel payload size to prevent memory exhaustion`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8edc39ae08325a6986a491117b94c)