### PR TITLE
fix: harden web_scan preset overlay merge against invalid presets type

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Security: guard web_scan preset overlay merge against non-dict `presets` payloads to prevent malformed overlay crash/DoS
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/config/web_scan_presets.py
+++ b/src/evidenceforge/config/web_scan_presets.py
@@ -9,10 +9,13 @@ a user overlay from .eforge/config/activity/web_scan_presets.yaml if present.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from evidenceforge.config import get_activity_directory
 from evidenceforge.config.overlay import load_with_overlay
+
+logger = logging.getLogger(__name__)
 
 _PRESETS_PATH = get_activity_directory() / "web_scan_presets.yaml"
 _CACHED: dict[str, Any] | None = None
@@ -28,11 +31,23 @@ def _merge_presets(default: dict, overlay: dict) -> dict:
     result = dict(default)
     overlay_presets = overlay.get("presets", {})
     if not isinstance(overlay_presets, dict):
+        logger.warning(
+            "Config overlay: web_scan presets has invalid structure "
+            "(expected dict, got %s) — ignoring overlay presets",
+            type(overlay_presets).__name__,
+        )
         return result
 
     if overlay_presets:
         default_presets = result.get("presets", {})
-        merged = dict(default_presets) if isinstance(default_presets, dict) else {}
+        if not isinstance(default_presets, dict):
+            logger.warning(
+                "Config overlay: web_scan default presets has invalid structure "
+                "(expected dict, got %s) — treating as empty",
+                type(default_presets).__name__,
+            )
+            default_presets = {}
+        merged = dict(default_presets)
         merged.update(overlay_presets)
         result["presets"] = merged
     return result

--- a/src/evidenceforge/config/web_scan_presets.py
+++ b/src/evidenceforge/config/web_scan_presets.py
@@ -27,8 +27,12 @@ def _merge_presets(default: dict, overlay: dict) -> dict:
     """
     result = dict(default)
     overlay_presets = overlay.get("presets", {})
+    if not isinstance(overlay_presets, dict):
+        return result
+
     if overlay_presets:
-        merged = dict(result.get("presets", {}))
+        default_presets = result.get("presets", {})
+        merged = dict(default_presets) if isinstance(default_presets, dict) else {}
         merged.update(overlay_presets)
         result["presets"] = merged
     return result

--- a/tests/unit/test_bulk_events.py
+++ b/tests/unit/test_bulk_events.py
@@ -443,6 +443,21 @@ class TestWebScanPresets:
 
         assert get_preset("nonexistent") is None
 
+    def test_merge_presets_ignores_non_dict_overlay_presets(self):
+        from evidenceforge.config.web_scan_presets import _merge_presets
+
+        default = {"presets": {"nikto": {"paths": ["/admin"]}}}
+
+        assert _merge_presets(default, {"presets": ["bad"]}) == default
+        assert _merge_presets(default, {"presets": "bad"}) == default
+
+    def test_merge_presets_handles_non_dict_default_presets(self):
+        from evidenceforge.config.web_scan_presets import _merge_presets
+
+        merged = _merge_presets({"presets": "bad-default"}, {"presets": {"nikto": {"paths": []}}})
+
+        assert merged["presets"] == {"nikto": {"paths": []}}
+
 
 # ── DgaQueriesEventSpec ───────────────────────────────────────────────────
 

--- a/tests/unit/test_bulk_events.py
+++ b/tests/unit/test_bulk_events.py
@@ -443,20 +443,36 @@ class TestWebScanPresets:
 
         assert get_preset("nonexistent") is None
 
-    def test_merge_presets_ignores_non_dict_overlay_presets(self):
+    def test_merge_presets_ignores_non_dict_overlay_presets(self, caplog):
+        import logging
+
         from evidenceforge.config.web_scan_presets import _merge_presets
 
         default = {"presets": {"nikto": {"paths": ["/admin"]}}}
 
-        assert _merge_presets(default, {"presets": ["bad"]}) == default
-        assert _merge_presets(default, {"presets": "bad"}) == default
+        with caplog.at_level(logging.WARNING, logger="evidenceforge.config.web_scan_presets"):
+            result_list = _merge_presets(default, {"presets": ["bad"]})
+        assert result_list == default
+        assert "invalid structure" in caplog.text
 
-    def test_merge_presets_handles_non_dict_default_presets(self):
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="evidenceforge.config.web_scan_presets"):
+            result_str = _merge_presets(default, {"presets": "bad"})
+        assert result_str == default
+        assert "invalid structure" in caplog.text
+
+    def test_merge_presets_handles_non_dict_default_presets(self, caplog):
+        import logging
+
         from evidenceforge.config.web_scan_presets import _merge_presets
 
-        merged = _merge_presets({"presets": "bad-default"}, {"presets": {"nikto": {"paths": []}}})
+        with caplog.at_level(logging.WARNING, logger="evidenceforge.config.web_scan_presets"):
+            merged = _merge_presets(
+                {"presets": "bad-default"}, {"presets": {"nikto": {"paths": []}}}
+            )
 
         assert merged["presets"] == {"nikto": {"paths": []}}
+        assert "invalid structure" in caplog.text
 
 
 # ── DgaQueriesEventSpec ───────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- A malformed overlay YAML with a non-mapping `presets` value could crash the preset loader via `dict.update`, causing a local denial-of-service when loading web scan presets.  

### Description

- Validate that `overlay["presets"]` is a mapping before merging and return the defaults unchanged when it is not in order to avoid raising `ValueError` in `_merge_presets`.  
- Defensively handle a non-dict default `presets` value by treating it as empty when building the merged result.  
- Add two unit tests for `_merge_presets` covering non-dict overlay `presets` values and non-dict default `presets` handling.  
- Record the fix in `TODO.md` per repo workflow.

### Testing

- Ran linter/formatter checks with `uv run ruff check .` and `uv run ruff format --check .`, and both succeeded.  
- Added unit tests `test_merge_presets_ignores_non_dict_overlay_presets` and `test_merge_presets_handles_non_dict_default_presets` to `tests/unit/test_bulk_events.py` (these are intended to prevent regressions).  
- Attempted to run the preset-focused tests via `pytest` in this environment, but the test execution failed due to missing local test environment dependencies (missing `yaml` and package import setup), so `pytest` could not be completed here; the new tests are expected to run in CI/dev environment where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ef27a6c08325af0617a6e2697b48)