### PR TITLE
fix: preserve storyline monotonic ordering with typing cadence offsets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [x] Fix storyline typing cadence monotonic time guard (`_prev_event_time`) so subsequent steps cannot move backward relative to intra-step events
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -323,7 +323,6 @@ class StorylineMixin:
             event_time = event_time + jitter
             if _prev_event_time and event_time <= _prev_event_time:
                 event_time = _prev_event_time + timedelta(milliseconds=rng.randint(100, 5000))
-            _prev_event_time = event_time
 
             actor = self._find_actor(storyline_event.actor)
             system = self._find_system(storyline_event.system)
@@ -372,6 +371,11 @@ class StorylineMixin:
                 )
                 if malicious_event:
                     self.malicious_events.append(malicious_event)
+
+            if cadence_offsets:
+                _prev_event_time = event_time + timedelta(seconds=cadence_offsets[-1])
+            else:
+                _prev_event_time = event_time
 
             self._barrier_flush_all_emitters()
 

--- a/tests/unit/test_logonid_scoping.py
+++ b/tests/unit/test_logonid_scoping.py
@@ -22,7 +22,7 @@
 
 """Tests for LogonID system scoping — processes use the correct host's session."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -212,3 +212,85 @@ class TestLogonIdSystemScoping:
         sessions = state_manager.get_sessions_for_user("attacker")
         remaining_systems = {s.system for s in sessions}
         assert "WKS-A" in remaining_systems
+
+
+class _FixedRng:
+    def uniform(self, a: float, b: float) -> float:
+        return 0.0
+
+    def randint(self, a: int, b: int) -> int:
+        return max(a, 1000)
+
+
+def test_execute_storyline_uses_last_intra_step_timestamp_for_monotonic_ordering(
+    state_manager, mock_emitters, system_a, attacker, monkeypatch
+):
+    """Later storyline steps should be scheduled after prior step cadence offsets."""
+    ag = ActivityGenerator(state_manager, mock_emitters)
+    engine = type("FakeEngine", (StorylineMixin,), {}).__new__(
+        type("FakeEngine", (StorylineMixin,), {})
+    )
+    engine.state_manager = state_manager
+    engine.activity_generator = ag
+    engine.dispatcher = ag.dispatcher
+    engine.malicious_events = []
+    engine._created_account_sids = {}
+    engine.scenario = Mock()
+    engine.scenario.environment.systems = [system_a]
+    engine.scenario.environment.users = [attacker]
+    engine._system_pids = {}
+    ag._system_pids = {}
+    engine._report_progress = lambda *args, **kwargs: None
+    engine._barrier_flush_all_emitters = lambda: None
+
+    step_1 = Mock()
+    step_1.time = "2024-03-15T10:00:00Z"
+    step_1.actor = attacker.username
+    step_1.system = system_a.hostname
+    step_1.activity = "step one"
+    step_1.events = [Mock(type="process"), Mock(type="process")]
+
+    step_2 = Mock()
+    step_2.time = "2024-03-15T10:00:05Z"
+    step_2.actor = attacker.username
+    step_2.system = system_a.hostname
+    step_2.activity = "step two"
+    step_2.events = [Mock(type="process")]
+
+    engine.scenario.storyline = [step_1, step_2]
+
+    parsed_times = {
+        step_1.time: datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC),
+        step_2.time: datetime(2024, 3, 15, 10, 0, 5, tzinfo=UTC),
+    }
+    monkeypatch.setattr(engine, "_parse_storyline_time", lambda t: parsed_times[t])
+    monkeypatch.setattr("evidenceforge.generation.engine.storyline._get_rng", lambda: _FixedRng())
+
+    def fake_typing_cadence(count: int, _rng: _FixedRng) -> list[float]:
+        if count == 2:
+            return [0.0, 10.0]
+        return [0.0]
+
+    monkeypatch.setattr("evidenceforge.utils.timing.typing_cadence", fake_typing_cadence)
+
+    observed_times: list[datetime] = []
+
+    def fake_execute_typed_event(
+        *,
+        spec,
+        actor,
+        system,
+        time: datetime,
+        activity: str,
+        explicit_types: set[str],
+    ):
+        observed_times.append(time)
+        return None
+
+    monkeypatch.setattr(engine, "_execute_typed_event", fake_execute_typed_event)
+
+    engine._execute_storyline()
+
+    assert observed_times == sorted(observed_times)
+    assert observed_times[1] == observed_times[0] + timedelta(seconds=10)
+    assert observed_times[2] > observed_times[1]


### PR DESCRIPTION
### Motivation
- Storyline steps that contain multiple intra-step events were using a per-step timestamp guard that ignored per-event typing cadence offsets, allowing subsequent steps to be scheduled before the last intra-step event and producing non-monotonic timeline/state regressions.
- The change ensures timeline monotonicity across storyline steps when `typing_cadence()` adds cumulative intra-step delays.

### Description
- Advance the step-level `_prev_event_time` to the final intra-step event timestamp (step base time + `cadence_offsets[-1]`) after executing a compound step so later steps cannot be scheduled earlier; change applied in `src/evidenceforge/generation/engine/storyline.py`.
- Add a deterministic regression test `test_execute_storyline_uses_last_intra_step_timestamp_for_monotonic_ordering` in `tests/unit/test_logonid_scoping.py` that simulates two adjacent steps and verifies monotonic ordering when cadence introduces multi-second offsets.
- Update `TODO.md` to mark the storyline typing-cadence monotonic time guard fix as resolved.

### Testing
- Ran linter/format checks: `uv run ruff check .` succeeded and `uv run ruff format` reformatted the new test file, after which `uv run ruff format --check .` passed.
- Attempted unit test run with `PYTHONPATH=src uv run pytest tests/unit/test_logonid_scoping.py -q`, but the test run could not complete in this environment due to missing runtime dependency `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`), so full pytest was not executed here; the added test is deterministic and should pass in CI where dependencies are available.
- The change is low-risk and narrowly scoped to storyline scheduling bookkeeping and test coverage for the regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c61aa4ec832596a668c086b05d95)