### PR TITLE
[codex] Improve Windows authentication event realism

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,8 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [ ] **IN PROGRESS** Windows Security/authentication source review — focused baseline eval is complete; fixing high-signal Windows auth realism findings first (4672/session semantics and sparse 4800/4801 rendering), then rerunning focused generation/eval before moving deeper.
+
 - [x] TODO.md reality audit — verified high-signal open realism/code-cleanup findings against the current codebase, marked stale items, and identified the generated-output validation pass needed before deeper realism work.
   Targeted verification: `uv run pytest tests/unit/test_network_realism.py tests/unit/test_activity_helpers.py tests/unit/test_dc_kerberos_logon.py -q --no-cov` passed (25 tests).
 
@@ -127,7 +129,7 @@ Data is structurally correct but the hunt doesn't work — key attack steps are 
 - [x] **RDP lateral movement invisible + zero RDP noise** — added background IT admin RDP connections (1-3/hour) to Windows servers/DCs in baseline. Storyline RDP sessions already produce Zeek conn records via generate_rdp_session().
 - [x] **No DC Kerberos events for compromised user** — generate_logon() now emits 4768 (TGT) + 4769 (service ticket) on the DC for Kerberos-authenticated domain logons, with realistic timing offsets.
 - [x] **No LSASS access events (Sysmon 10)** — added Sysmon Event 10 (ProcessAccess) emitter, format template, and generate_process_access() method. Auto-emits alongside create_remote_thread when target is lsass.exe.
-- [x] **No 4672 (Special Privileges) on Domain Controller** — new `special_privileges` event type emits standalone 4672 on DC during Kerberos authentication for elevated users.
+- [x] **4672 (Special Privileges) target-host semantics** — elevated-session 4672 is auto-emitted alongside the target-host 4624; Kerberos causal expansion emits DC 4768/4769 only.
 - [x] **Storyline events too perfect** — /eforge scenario skill now interviews about attacker sophistication and generates fumbles (mistakes) and dead ends (abandoned paths) appropriate to the chosen level.
 - [x] **C2/exfiltration SNI values are auto-generated CDN names** — replaced `host-x-x-x-x.cdn-provider.net` fallback with 30 plausible SaaS/analytics/CDN domains.
 - [x] **Proxy log issues** — CONNECT entries now use domain names from REVERSE_DNS or plausible random hostnames instead of raw IPs.
@@ -150,6 +152,14 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] Blind HTTP/proxy/network telemetry realism evaluation of `/private/tmp/eforge-http-proxy-review-output/data` — scored highly synthetic due to concrete ASA/Zeek DNS and proxy/client-tap contradictions, with ASA connection-ID artifacts and DNS consistency issues as supporting tells.
 - [x] Fresh blind HTTP/proxy/network telemetry realism evaluation of regenerated `/private/tmp/eforge-http-proxy-review-output/data` — TLS-intercept proxy pattern accepted; remaining high-signal findings were plain HTTP proxy/client status contradiction, OCSP responder/issuer mismatch, and generated-looking Zeek certificate FUID artifact.
 - [x] Fresh blind HTTP/proxy/network telemetry realism evaluation after latest fixes for `/private/tmp/eforge-http-proxy-review-output/data` — prior critical proxy/client and OCSP/public-responder issues were fixed; remaining evidence is medium/high realism polish around Zeek HTTP body length semantics, Let's Encrypt OCSP responder choice, and ASA connection-ID spacing artifacts.
+- [x] Fresh blind Windows authentication/security telemetry realism evaluation of `/private/tmp/eforge-windows-auth-baseline-output/data` completed; assessed high synthetic likelihood from impossible 4672 logon semantics, documentation IP usage, and malformed sparse Windows events.
+- [x] Fresh blind Windows authentication/security telemetry realism evaluation of regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; TEST-NET artifact no longer present, with remaining synthetic evidence centered on 4672 logon semantics and empty EventData for 1102/4800/4801.
+- [x] Windows 4672 session semantics — removed duplicate DC-side standalone 4672 from Kerberos causal expansion; elevated 4672 now stays tied to the target-host 4624 logon session, and non-service audit fallback logon IDs no longer use SYSTEM's `0x3e7`.
+- [x] Windows 4800/4801 rendering — populated workstation lock/unlock EventData fields in the Windows Security XML template.
+- [x] Blind Windows authentication/security realism evaluation of current `/private/tmp/eforge-windows-auth-baseline-output/data` completed; prior 4672 issues are fixed, 4800/4801 fields are populated, with remaining synthetic indicators in DC 4625/4776 status contradictions and lock/unlock SessionId mismatches.
+- [x] Windows failed-auth DC consistency — failed NTLM validation 4776 now carries the matching failure status instead of success.
+- [x] Windows lock/unlock session consistency — 4800/4801 derive a stable SessionId from TargetLogonId so lock/unlock pairs do not change terminal sessions.
+- [x] Blind Windows authentication/security realism evaluation of latest regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; prior 4672, 4625/4776, and 4800/4801 findings are fixed, with remaining realism concerns around Kerberos 4768 PreAuthType distribution and missing Zeek visibility for external failed-auth source.
 
 **Snort/IDS:**
 - [x] ✓ Snort protocol field randomly assigned (no binding to SID/rule) — restructured `_FP_SIGS` to protocol-keyed dict with per-signature port and direction
@@ -263,7 +273,7 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] Only 2 unique TicketOptions values; zero 4771 pre-auth failures — randomized TicketOptions per event type; boosted stale 4771 probability to 15%; added active-user typo 4771 at 2%/hour
 - [x] File server has no domain user logon events — type 3 logon+logoff pairs for SMB access in baseline traffic profiles and storyline causal expansion
 - [x] NETWORK SERVICE TargetDomainName shows domain instead of "NT AUTHORITY" — _subject_domain() helper in windows.py returns "NT AUTHORITY" for SYSTEM/NETWORK SERVICE/LOCAL SERVICE
-- [x] Event 4672 LogonId 0x3e7 for domain users — stale audit finding: DC-side special privileges now use `_get_user_logon_id(user.username, dc_hostname)` and targeted Kerberos/DC tests pass.
+- [x] Event 4672 LogonId 0x3e7 for domain users — target-host 4672 now shares the 4624 LogonID, and Kerberos causal expansion no longer emits duplicate standalone DC 4672 records.
 
 **Process Trees:**
 - [x] ✓³ explorer.exe parent for everything — spawn_rules.yaml now defines valid parent-child relationships; _resolve_parent() auto-creates intermediate chains (shells for CLI tools, services.exe for system processes, sshd→bash for Linux)

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -43,7 +43,7 @@ output/
 | 4625 | Failed Logon | Authentication | Version 0. Keywords=0x8010 (Audit Failure). Includes Status/SubStatus failure codes. |
 | 4634 | Logoff | Authentication | Paired with 4624 via matching TargetLogonId. |
 | 4648 | Explicit Credentials | Lateral Movement | Fires when RunAs, PsExec, WMIC, or scheduled tasks use alternate credentials. Emitted on the source system. |
-| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
+| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside the target-host 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
 | 4688 | Process Created | Execution | Version 2. Includes CommandLine, ParentProcessName, MandatoryLabel. TokenElevationType indicates UAC status. |
 | 4689 | Process Exited | Execution | Paired with 4688. Status always 0x0. |
 | 4697 | Service Installed | Persistence | ServiceFileName can contain full command lines. ServiceType 0x10=Own Process. |
@@ -66,7 +66,7 @@ output/
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |
-| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). |
+| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). Status reflects validation success or failure. |
 | 5156 | WFP Connection Permitted | Network | Application path uses device format (`\device\harddiskvolume1\...`). Direction: %%14592=Inbound, %%14593=Outbound. |
 
 **Known Limitations:**

--- a/commands/eforge/references/scenario-reference.md
+++ b/commands/eforge/references/scenario-reference.md
@@ -312,7 +312,7 @@ Each event in the `events` list has a `type` field that selects a validated sche
 | Type | Generates | Required Fields | Optional Fields |
 |------|-----------|-----------------|-----------------|
 | `process` | 4688, Sysmon 1, eCAR PROCESS | `process_name` | `command_line`, `supplementary` (auto/none) |
-| `logon` | 4624, 4672, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
+| `logon` | 4624, target-host 4672 for elevated sessions, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
 | `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent` |

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -514,7 +514,7 @@ events:
 **Causal expansion — auto-generated prerequisite events:** The generation engine automatically emits prerequisite and consequent events with realistic timing offsets. You do NOT need to manually specify these as prerequisites:
 
 - **DNS before connections** — TCP connections auto-generate a DNS lookup (5-80ms before) with caching, SERVFAIL probability, and NXDOMAIN companions. Baseline web/SaaS connections use domain-first selection for consistent DNS/SNI/proxy hostnames. Storyline connections with `hostname` set always emit DNS; connections without `hostname` skip DNS (correct for raw-IP C2)
-- **Kerberos before logons** — Kerberos-authenticated Windows domain logons auto-generate TGT (4768) and TGS (4769) on the DC, plus 4672 for elevated users
+- **Kerberos before logons** — Kerberos-authenticated Windows domain logons auto-generate TGT (4768) and TGS (4769) on the DC; elevated-session 4672 is emitted on the host where the 4624 logon session is created
 - **ProcessAccess after lsass injection** — `create_remote_thread` targeting lsass.exe auto-generates Sysmon Event 10 (1-50ms after)
 - **Audit events from commands** — Process events with admin commands (`net user /add`, `sc create`, `schtasks /create`, `wevtutil cl`) auto-generate the corresponding Windows audit events (4720, 4726, 4728, 4697, 4698, 1102)
 - **DNS for RDP/SSH** — `rdp_session` and `ssh_session` auto-generate DNS + connection events

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,7 +402,7 @@ ActivityGenerator.generate_connection()
 | Rule | Trigger | Emits | Timing |
 |------|---------|-------|--------|
 | `DnsBeforeConnection` | TCP connection (not port 53) | DNS query (UDP/53) | 5-80ms before |
-| `KerberosBeforeLogon` | Kerberos-auth Windows logon (not on DC) | TGT (4768) + TGS (4769) + optional 4672 | TGT 50-200ms before, TGS 20-100ms after TGT |
+| `KerberosBeforeLogon` | Kerberos-auth Windows logon (not on DC) | TGT (4768) + TGS (4769) | TGT 50-200ms before, TGS 20-100ms after TGT; elevated-session 4672 remains tied to the target-host 4624 |
 | `ProcessAccessAfterRemoteThread` | CreateRemoteThread targeting lsass | ProcessAccess (Sysmon 10) | 1-50ms after |
 | `SupplementaryAuditEvents` | Process creation with admin commands | 4720/4726/4728/4697/4698/1102 | 100-500ms after |
 

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -49,7 +49,7 @@ output/
 | 4625 | Failed Logon | Authentication | Version 0. Keywords=0x8010 (Audit Failure). Includes Status/SubStatus failure codes. |
 | 4634 | Logoff | Authentication | Paired with 4624 via matching TargetLogonId. Generated for interactive sessions (type 2/10) at work-day end and for type 3 network logons (including machine account logons on DCs) after short delays. |
 | 4648 | Explicit Credentials | Lateral Movement | Fires when RunAs, PsExec, WMIC, or scheduled tasks use alternate credentials. Emitted on the source system. |
-| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
+| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside the target-host 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
 | 4688 | Process Created | Execution | Version 2. Includes CommandLine, ParentProcessName, MandatoryLabel. TokenElevationType indicates UAC status. |
 | 4689 | Process Exited | Execution | Paired with 4688. Status always 0x0. |
 | 4697 | Service Installed | Persistence | ServiceFileName can contain full command lines. ServiceType 0x10=Own Process. |
@@ -72,7 +72,7 @@ output/
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |
-| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). |
+| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). Status reflects validation success or failure. |
 | 5156 | WFP Connection Permitted | Network | Application path uses device format (`\device\harddiskvolume1\...`). Direction: %%14592=Inbound, %%14593=Outbound. |
 
 **Known Limitations:**

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -420,7 +420,7 @@ Each event in the `events` list has a `type` field that selects a validated sche
 | Type | Generates | Required Fields | Optional Fields |
 |------|-----------|-----------------|-----------------|
 | `process` | 4688, Sysmon 1, eCAR PROCESS | `process_name` | `command_line`, `supplementary` (auto/none) |
-| `logon` | 4624, 4672, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
+| `logon` | 4624, target-host 4672 for elevated sessions, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
 | `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent` |
@@ -487,7 +487,7 @@ The generation engine automatically emits prerequisite events for certain event 
 | Trigger Event | Auto-Generated Prerequisites | Timing |
 |---|---|---|
 | `connection` (TCP, not port 53) | DNS query (UDP/53) for destination hostname | 5-80ms before |
-| `logon` (Kerberos auth, Windows, not on DC) | Kerberos TGT (4768) + TGS (4769) on DC, optional 4672 for elevated users | TGT 50-200ms before, TGS 20-100ms after TGT |
+| `logon` (Kerberos auth, Windows, not on DC) | Kerberos TGT (4768) + TGS (4769) on DC | TGT 50-200ms before, TGS 20-100ms after TGT. Elevated-session 4672 is emitted with the target-host 4624. |
 | `rdp_session` | DNS query + connection (port 3389) + logon (type 10) | Connection at event time, logon 50-200ms after |
 | `ssh_session` | DNS query + connection (port 22) + syslog auth | Connection at event time |
 | `process` (with admin commands) | Supplementary audit events (4720, 4726, 4728, 4697, 4698, 1102) inferred from command-line patterns | 100-500ms after |

--- a/src/evidenceforge/config/formats/windows_event_security.yaml
+++ b/src/evidenceforge/config/formats/windows_event_security.yaml
@@ -1400,6 +1400,12 @@ output:
         {% if EventID in [4723, 4726] %}
         <Data Name="PrivilegeList">{{ PrivilegeList | default('-') }}</Data>
         {% endif %}
+        {% elif EventID in [4800, 4801] %}
+        <Data Name="TargetUserSid">{{ TargetUserSid }}</Data>
+        <Data Name="TargetUserName">{{ TargetUserName }}</Data>
+        <Data Name="TargetDomainName">{{ TargetDomainName }}</Data>
+        <Data Name="TargetLogonId">{{ TargetLogonId }}</Data>
+        <Data Name="SessionId">{{ SessionId }}</Data>
         {% elif EventID == 5156 %}
         <Data Name="ProcessID">{{ ProcessID }}</Data>
         <Data Name="Application">{{ Application }}</Data>

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -1824,8 +1824,9 @@ class ActivityGenerator:
             )
 
         # Emit DC-side Kerberos events for domain logons via causal expansion.
-        # The KerberosBeforeLogon rule handles TGT (4768), TGS (4769), and
-        # optional 4672 for elevated users.
+        # The target-host 4624 renderer owns 4672 for elevated sessions because
+        # that privilege assignment belongs to the host where the logon session
+        # is created, not to the DC ticket request itself.
         auth_package_name = auth_pkg.get("AuthenticationPackageName", "Negotiate")
         self._expand_and_emit(
             "logon",
@@ -1979,22 +1980,6 @@ class ActivityGenerator:
             time=tgs_time,
         )
 
-        # 4672 Special Privileges on DC for elevated users (domain admins)
-        if self._should_elevate(user):
-            priv_time = tgt_time + timedelta(milliseconds=rng.randint(1, 10))
-            priv_event = SecurityEvent(
-                timestamp=priv_time,
-                event_type="special_privileges",
-                dst_host=self._build_dc_host_context(dc_hostname),
-                auth=AuthContext(
-                    username=user.username,
-                    user_sid=self._get_sid(user.username),
-                    logon_id=self._get_user_logon_id(user.username, dc_hostname),
-                    reporting_pid=self._get_system_pid(dc_hostname, "lsass", 0x2E0),
-                ),
-            )
-            self.dispatcher.dispatch(priv_event)
-
     def generate_failed_logon(
         self,
         user: User,
@@ -2118,6 +2103,7 @@ class ActivityGenerator:
                 workstation=system.hostname,
                 dc_hostname=dc_system.hostname,
                 time=time,
+                status=substatus,
             )
 
             # 4771 Kerberos pre-authentication failure on DC
@@ -5271,6 +5257,7 @@ class ActivityGenerator:
         workstation: str,
         dc_hostname: str,
         time: datetime,
+        status: str = "0x0",
     ) -> None:
         """Generate NTLM credential validation event (4776) on the DC."""
         event = SecurityEvent(
@@ -5280,6 +5267,7 @@ class ActivityGenerator:
             auth=AuthContext(
                 username=username,
                 source_ip=workstation,  # SourceWorkstation stored in source_ip
+                failure_status=status,
             ),
         )
 
@@ -5563,14 +5551,24 @@ class ActivityGenerator:
     def _get_user_logon_id(self, username: str, hostname: str) -> str:
         """Look up the user's active session LogonID on the given host.
 
-        Returns the session LogonID if found, or '0x3e7' (SYSTEM) as fallback.
+        Returns the session LogonID if found. Well-known service identities use
+        their canonical logon IDs. Human/domain accounts without an active
+        session fall back to 0x0 rather than SYSTEM's 0x3e7.
         """
+        canonical_logon_ids = {
+            "SYSTEM": "0x3e7",
+            "LOCAL SERVICE": "0x3e5",
+            "NETWORK SERVICE": "0x3e4",
+        }
+        if username in canonical_logon_ids:
+            return canonical_logon_ids[username]
+
         sessions = self.state_manager.get_sessions_for_user(username)
         if sessions:
             active = next((s for s in sessions if s.system == hostname), None)
             if active:
                 return active.logon_id
-        return "0x3e7"
+        return "0x0"
 
     def generate_log_cleared(
         self,

--- a/src/evidenceforge/generation/causal/rules.py
+++ b/src/evidenceforge/generation/causal/rules.py
@@ -64,8 +64,9 @@ class KerberosBeforeLogon(ExpansionRule):
 
     Reproduces the logic from ActivityGenerator._emit_dc_kerberos_for_logon().
     Fires when auth_package is "Kerberos", target is Windows, and the target
-    system is not a DC. Delegates to the existing method which handles TGT,
-    TGS, and optional 4672 Special Privileges emission.
+    system is not a DC. Delegates to the existing method which handles TGT
+    and TGS emission. Elevated-session 4672 events are emitted with the
+    target-host 4624, where the logon session is created.
     """
 
     name: str = field(default="kerberos_before_logon")

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -41,6 +41,7 @@ from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 from evidenceforge.generation.emitters.host_base import _SingleHostWriter
 from evidenceforge.utils.paths import sanitize_path_component
+from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import ensure_utc
 
 win_logger = logging.getLogger(__name__)
@@ -290,8 +291,9 @@ class WindowsEventEmitter(LogEmitter):
     def _render_special_privileges(self, event: SecurityEvent) -> None:
         """Render standalone Windows 4672 (Special Privileges Assigned).
 
-        Used for DC-side privilege assignment during Kerberos authentication,
-        where the DC logs 4672 independently of the target host's logon event.
+        Used for explicit standalone 4672 events. Normal elevated logons render
+        4672 from _render_logon() so the privilege event shares the target
+        host and LogonID with its 4624.
         """
         rng = random.Random()
         auth = event.auth
@@ -341,6 +343,7 @@ class WindowsEventEmitter(LogEmitter):
         rng = random.Random()
         auth = event.auth
         host = self._get_host(event)
+        session_id = self._session_id_for_logon(auth.logon_id)
         event_data = {
             "EventID": 4800,
             "TimeCreated": event.timestamp,
@@ -353,7 +356,7 @@ class WindowsEventEmitter(LogEmitter):
             "TargetUserName": auth.username,
             "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
             "TargetLogonId": auth.logon_id or "0x0",
-            "SessionId": rng.randint(1, 5),
+            "SessionId": session_id,
         }
         self.emit_event(event_data)
 
@@ -362,6 +365,7 @@ class WindowsEventEmitter(LogEmitter):
         rng = random.Random()
         auth = event.auth
         host = self._get_host(event)
+        session_id = self._session_id_for_logon(auth.logon_id)
         event_data = {
             "EventID": 4801,
             "TimeCreated": event.timestamp,
@@ -374,7 +378,7 @@ class WindowsEventEmitter(LogEmitter):
             "TargetUserName": auth.username,
             "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
             "TargetLogonId": auth.logon_id or "0x0",
-            "SessionId": rng.randint(1, 5),
+            "SessionId": session_id,
         }
         self.emit_event(event_data)
 
@@ -695,7 +699,7 @@ class WindowsEventEmitter(LogEmitter):
             "PackageName": "MICROSOFT_AUTHENTICATION_PACKAGE_V1_0",
             "TargetUserName": auth.username,
             "Workstation": auth.source_ip,  # workstation stored in source_ip
-            "Status": "0x0",
+            "Status": auth.failure_status or "0x0",
         }
         self.emit_event(event_data)
 
@@ -770,6 +774,11 @@ class WindowsEventEmitter(LogEmitter):
         if path and len(path) > 2 and path[1] == ":":
             return f"\\device\\harddiskvolume1\\{path[3:]}".lower()
         return path.lower()
+
+    @staticmethod
+    def _session_id_for_logon(logon_id: str) -> int:
+        """Return a stable Terminal Services session ID for a LogonID."""
+        return 1 + (_stable_seed(f"windows_session_id_{logon_id or '0x0'}") % 5)
 
     # --- Phase 1: Kerberos Pre-Auth Failed (4771) ---
 

--- a/tests/unit/test_dc_kerberos_logon.py
+++ b/tests/unit/test_dc_kerberos_logon.py
@@ -242,8 +242,10 @@ class TestDCKerberosOnLogon:
         assert "kerberos_tgt" not in event_types
         assert "kerberos_service" not in event_types
 
-    def test_dc_4672_for_elevated_user(self, activity_gen, mock_emitters, windows_system):
-        """Elevated users should get 4672 (Special Privileges) on the DC during Kerberos auth."""
+    def test_elevated_user_4672_stays_on_logon_target(
+        self, activity_gen, mock_emitters, windows_system
+    ):
+        """Elevated users get 4672 on the host where the logon session is created."""
         # Use a sysadmin persona which has ~80% elevation rate
         from evidenceforge.models.scenario import User
 
@@ -254,7 +256,7 @@ class TestDCKerberosOnLogon:
             persona="sysadmin",
         )
 
-        special_priv_count = 0
+        elevated_logon_count = 0
         total_kerberos_count = 0
 
         for i in range(30):
@@ -275,22 +277,26 @@ class TestDCKerberosOnLogon:
 
             if "kerberos_tgt" in event_types:
                 total_kerberos_count += 1
-                if "special_privileges" in event_types:
-                    special_priv_count += 1
-                    # Verify 4672 is on the DC
-                    priv_event = next(e for e in events if e.event_type == "special_privileges")
-                    assert priv_event.dst_host.hostname == "DC-01"
-                    assert priv_event.auth.username == "admin.user"
+                logon_event = next(e for e in events if e.event_type == "logon")
+                if logon_event.auth.elevated:
+                    elevated_logon_count += 1
+                    assert logon_event.dst_host.hostname == "WKS-01"
+                    assert logon_event.auth.username == "admin.user"
+                    assert logon_event.auth.logon_id not in {"", "0x0", "0x3e7"}
+                assert not any(
+                    e.event_type == "special_privileges" and e.dst_host.hostname == "DC-01"
+                    for e in events
+                )
 
-        # Should have at least some Kerberos logons with 4672
+        # Should have at least some Kerberos logons with elevated target-host sessions.
         assert total_kerberos_count > 0, "No Kerberos logons in 30 attempts"
-        assert special_priv_count > 0, "No DC 4672 events for admin in Kerberos logons"
+        assert elevated_logon_count > 0, "No elevated target-host logons for admin"
 
     def test_no_dc_4672_for_regular_user(
         self, activity_gen, mock_emitters, windows_system, test_user
     ):
-        """Regular users should rarely get 4672 on DC (only ~5% elevation rate)."""
-        special_priv_count = 0
+        """Regular users should rarely get 4672 (only ~5% elevation rate)."""
+        elevated_logon_count = 0
 
         for i in range(30):
             mock_emitters["windows_event_security"].emit.reset_mock()
@@ -306,14 +312,50 @@ class TestDCKerberosOnLogon:
             events = [
                 call[0][0] for call in mock_emitters["windows_event_security"].emit.call_args_list
             ]
-            if any(e.event_type == "special_privileges" for e in events):
-                special_priv_count += 1
+            logon_event = next(e for e in events if e.event_type == "logon")
+            if logon_event.auth.elevated:
+                elevated_logon_count += 1
+            assert not any(e.event_type == "special_privileges" for e in events)
 
         # Regular users have ~5% elevation rate, so most runs should have very few
         # With 30 attempts * 70% Kerberos * 5% elevation = ~1 expected
-        assert special_priv_count < 15, (
-            f"Too many DC 4672 events for regular user: {special_priv_count}"
+        assert elevated_logon_count < 15, (
+            f"Too many elevated logons for regular user: {elevated_logon_count}"
         )
+
+    def test_dc_kerberos_expansion_does_not_emit_standalone_4672(
+        self, activity_gen, mock_emitters, windows_system
+    ):
+        """DC Kerberos expansion emits 4768/4769 but not a separate DC-side 4672."""
+        admin_user = User(
+            username="admin.user",
+            full_name="Admin User",
+            email="admin.user@corp.com",
+            persona="sysadmin",
+        )
+
+        for i in range(30):
+            mock_emitters["windows_event_security"].emit.reset_mock()
+            ts = datetime(2024, 3, 15, 11, i, 0, tzinfo=UTC)
+            activity_gen.state_manager.set_current_time(ts)
+            activity_gen.generate_logon(
+                user=admin_user,
+                system=windows_system,
+                time=ts,
+                logon_type=3,
+                source_ip="10.10.10.50",
+            )
+            events = [
+                call[0][0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+            ]
+            if any(e.event_type == "kerberos_tgt" for e in events):
+                assert not any(
+                    e.event_type == "special_privileges" and e.dst_host.hostname == "DC-01"
+                    for e in events
+                )
+                return
+
+        pytest.fail("No Kerberos logons generated in 30 attempts")
 
     def test_no_dc_kerberos_when_no_dc_configured(
         self, state_manager, mock_emitters, windows_system, test_user

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -549,6 +549,95 @@ class TestWindowsEventEmitter:
         assert "UserData" in content
         assert "EventData" not in content or content.count("EventData") == 0
 
+    def test_emit_workstation_lock_contains_event_data(self, format_def, temp_output):
+        """Test emitting 4800 (workstation locked) with populated EventData fields."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)
+        event_data = {
+            "EventID": 4800,
+            "TimeCreated": datetime(2024, 1, 15, 10, 30, 0, 0, tzinfo=UTC),
+            "Computer": "WKS-01.corp.local",
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 540,
+            "ExecutionThreadID": 112,
+            "TargetUserSid": "S-1-5-21-123-456-789-1001",
+            "TargetUserName": "jsmith",
+            "TargetDomainName": "CORP",
+            "TargetLogonId": "0x4f2a1b",
+            "SessionId": 2,
+        }
+        emitter.emit_event(event_data)
+        emitter.close()
+        content = temp_output.read_text()
+        assert "<EventID>4800</EventID>" in content
+        assert '<Data Name="TargetUserName">jsmith</Data>' in content
+        assert '<Data Name="TargetLogonId">0x4f2a1b</Data>' in content
+        assert '<Data Name="SessionId">2</Data>' in content
+
+    def test_emit_workstation_unlock_contains_event_data(self, format_def, temp_output):
+        """Test emitting 4801 (workstation unlocked) with populated EventData fields."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)
+        event_data = {
+            "EventID": 4801,
+            "TimeCreated": datetime(2024, 1, 15, 10, 35, 0, 0, tzinfo=UTC),
+            "Computer": "WKS-01.corp.local",
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 541,
+            "ExecutionThreadID": 113,
+            "TargetUserSid": "S-1-5-21-123-456-789-1001",
+            "TargetUserName": "jsmith",
+            "TargetDomainName": "CORP",
+            "TargetLogonId": "0x4f2a1b",
+            "SessionId": 2,
+        }
+        emitter.emit_event(event_data)
+        emitter.close()
+        content = temp_output.read_text()
+        assert "<EventID>4801</EventID>" in content
+        assert '<Data Name="TargetUserName">jsmith</Data>' in content
+        assert '<Data Name="TargetLogonId">0x4f2a1b</Data>' in content
+        assert '<Data Name="SessionId">2</Data>' in content
+
+    def test_lock_unlock_share_stable_session_id(self, format_def, temp_output):
+        """4800 and 4801 for the same LogonID should share the same SessionId."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)
+        host = HostContext(
+            hostname="WKS-01",
+            fqdn="WKS-01.corp.local",
+            ip="10.0.0.50",
+            os="Windows 11",
+            os_category="windows",
+            system_type="workstation",
+            netbios_domain="CORP",
+        )
+        auth = AuthContext(
+            username="jsmith",
+            user_sid="S-1-5-21-123-456-789-1001",
+            logon_id="0x4f2a1b",
+        )
+        emitter.emit(
+            SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 30, 0, 0, tzinfo=UTC),
+                event_type="workstation_locked",
+                dst_host=host,
+                auth=auth,
+            )
+        )
+        emitter.emit(
+            SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 35, 0, 0, tzinfo=UTC),
+                event_type="workstation_unlocked",
+                dst_host=host,
+                auth=auth,
+            )
+        )
+        emitter.close()
+        content = temp_output.read_text()
+        session_lines = [line for line in content.splitlines() if 'Data Name="SessionId"' in line]
+        assert len(session_lines) == 2
+        assert session_lines[0] == session_lines[1]
+
     def test_emit_service_installed(self, format_def, temp_output):
         """Test emitting 4697 (service installed)."""
         emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)

--- a/tests/unit/test_phase5_failed_logon.py
+++ b/tests/unit/test_phase5_failed_logon.py
@@ -254,7 +254,7 @@ class TestFailedLogonDC:
         assert "DC-01" in hosts, "Missing 4625/4776 on DC"
 
     def test_failed_logon_dc_gets_4776(self, state_manager, mock_emitters, timestamp):
-        """DC should receive an NTLM validation (4776) event."""
+        """DC should receive a failed NTLM validation (4776) event."""
         ag = ActivityGenerator(state_manager, mock_emitters)
         state_manager.set_current_time(timestamp)
 
@@ -277,6 +277,8 @@ class TestFailedLogonDC:
         ]
         event_types = {e.event_type for e in dc_events}
         assert "ntlm_validation" in event_types, "Missing 4776 on DC"
+        ntlm_event = next(e for e in dc_events if e.event_type == "ntlm_validation")
+        assert ntlm_event.auth.failure_status != "0x0"
 
     def test_no_dc_no_extra_events(self, state_manager, mock_emitters, timestamp):
         """Without dc_system, only workstation events are emitted."""

--- a/tests/unit/test_phase6_p1_realism.py
+++ b/tests/unit/test_phase6_p1_realism.py
@@ -318,6 +318,20 @@ class TestKerberosEvents:
         assert event.event_type == "ntlm_validation"
         assert event.auth.username == "WKS-01$"
         assert event.auth.source_ip == "WKS-01"  # workstation stored in source_ip
+        assert event.auth.failure_status == "0x0"
+
+    def test_failed_ntlm_validation_carries_status(self, activity_gen, mock_emitters):
+        ts = datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC)
+        activity_gen.generate_ntlm_validation(
+            username="jsmith",
+            workstation="WKS-01",
+            dc_hostname="DC-01",
+            time=ts,
+            status="0xc000006a",
+        )
+        event = mock_emitters["windows_event_security"].emit.call_args_list[0][0][0]
+        assert event.event_type == "ntlm_validation"
+        assert event.auth.failure_status == "0xc000006a"
 
 
 class TestInfrastructureDetection:


### PR DESCRIPTION
## Summary

- Fix Windows 4672 special-privilege semantics so elevated sessions stay tied to the target-host 4624 instead of duplicate DC-side Kerberos artifacts.
- Populate workstation lock/unlock EventData and keep 4800/4801 SessionId stable for the same TargetLogonId.
- Align failed DC NTLM validation 4776 Status with the failed auth attempt instead of always rendering success.
- Update docs, skill references, TODO notes, and focused unit coverage for the corrected behavior.

## Root Cause

The Kerberos causal expansion path emitted a standalone DC 4672 and looked up user sessions on the DC, which could fall back to SYSTEM's 0x3e7 or reuse unrelated session state. Separately, 4800/4801 fields were omitted from the XML template, lock/unlock SessionId was generated independently per event, and 4776 always rendered Status=0x0.

## Validation

- `uv run pytest tests/unit/test_dc_kerberos_logon.py tests/unit/test_emitters.py tests/unit/test_phase5_failed_logon.py tests/unit/test_phase6_p1_realism.py -q --no-cov`
- `uv run ruff check .`
- `uv run ruff format --check .`
- Regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` and probed for the prior concrete findings; all targeted counts were zero.
- Blind realism eval improved from 84% synthetic baseline to 63% synthetic after the fixes.