### PR TITLE
[codex] Add data-driven Kerberos pre-auth realism

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -160,6 +160,8 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] Windows failed-auth DC consistency — failed NTLM validation 4776 now carries the matching failure status instead of success.
 - [x] Windows lock/unlock session consistency — 4800/4801 derive a stable SessionId from TargetLogonId so lock/unlock pairs do not change terminal sessions.
 - [x] Blind Windows authentication/security realism evaluation of latest regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; prior 4672, 4625/4776, and 4800/4801 findings are fixed, with remaining realism concerns around Kerberos 4768 PreAuthType distribution and missing Zeek visibility for external failed-auth source.
+- [x] Windows Kerberos 4768 pre-auth realism — moved TGT PreAuthType/ticket/encryption distributions into `kerberos_realism.yaml`, added overlay-aware loader and `eforge validate-config` schema/coherence checks, and verified generation now produces mostly encrypted timestamp pre-auth with rare populated PKINIT certificate fields.
+- [x] Blind Windows authentication/security realism evaluation of latest regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; Kerberos PreAuthType=15 empty-cert issue is fixed, with remaining lower-confidence tells in one repeated 4672 on unlock and absent Zeek visibility for external failed auth.
 
 **Snort/IDS:**
 - [x] ✓ Snort protocol field randomly assigned (no binding to SID/rule) — restructured `_FP_SIGS` to protocol-keyed dict with per-signature port and direction

--- a/commands/eforge/references/config-dependency-graph.md
+++ b/commands/eforge/references/config-dependency-graph.md
@@ -49,6 +49,13 @@ Each row is a file; columns show what it depends on and what depends on it.
 | depends on | nothing | Standalone rate table |
 | **depended on by** | Engine (runtime) | Drives all baseline traffic rate calculations (user activity, web, DNS, SMB, Kerberos, LDAP, persona connections) |
 
+### kerberos_realism.yaml
+| Direction | File | Relationship |
+|-----------|------|-------------|
+| depends on | nothing | Standalone Kerberos field-distribution profile |
+| **depended on by** | Engine (runtime) | Drives Windows 4768 TGT PreAuthType, TicketOptions, TicketEncryptionType, and PKINIT certificate fields |
+| validated by | `eforge validate-config` | Enforces coherent combinations: PKINIT requires a certificate profile, non-PKINIT must not emit certificate fields, and no-preauth/PKINIT/RC4 weights stay bounded |
+
 ### proxy_uri_templates.yaml
 | Direction | File | Relationship |
 |-----------|------|-------------|

--- a/commands/eforge/references/config-host-activity.md
+++ b/commands/eforge/references/config-host-activity.md
@@ -11,7 +11,8 @@ Schema documentation for host-level activity config files. User customizations g
 1. [bash_commands.yaml](#bash_commandsyaml)
 2. [systemd_schedules.yaml](#systemd_schedulesyaml)
 3. [extra_syslog_messages.yaml](#extra_syslog_messagesyaml)
-4. [Domain Controller Baseline Activity](#domain-controller-baseline-activity)
+4. [kerberos_realism.yaml](#kerberos_realismyaml)
+5. [Domain Controller Baseline Activity](#domain-controller-baseline-activity)
 
 ---
 
@@ -160,6 +161,55 @@ programs:
 | `distro` | string | no | Restrict to `ubuntu` (excluded on RHEL-like) |
 | `roles` | list[string] | no | Required host roles (any match includes the entry) |
 | `transient` | bool | no | If `true`, uses random PID per invocation |
+
+---
+
+## kerberos_realism.yaml
+
+Data-driven Kerberos field distributions for Windows Security authentication events. The generator uses this file for successful 4768 TGT requests.
+
+### Structure
+
+```yaml
+tgt_success:
+  pre_auth_types:
+    encrypted_timestamp:
+      value: 2
+      weight: 96
+      certificate_required: false
+    pkinit:
+      value: 15
+      weight: 3
+      certificate_required: true
+      certificate_profile: enterprise_user
+    none_or_legacy:
+      value: 0
+      weight: 1
+      certificate_required: false
+  ticket_options:
+    forwardable_renewable_canonicalize:
+      value: "0x40810010"
+      weight: 60
+  encryption_types:
+    aes256:
+      value: "0x12"
+      weight: 70
+
+certificate_profiles:
+  enterprise_user:
+    issuer_names:
+      - "CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"
+    serial_hex_bytes: 16
+    thumbprint_hex_chars: 40
+```
+
+### Conventions
+
+- `PreAuthType: 2` is the normal encrypted timestamp case and should dominate default profiles.
+- `PreAuthType: 15` models PKINIT/certificate pre-auth and must reference a certificate profile so 4768 cert fields are populated.
+- `PreAuthType: 0` is rare legacy/no-preauth behavior.
+- Supported encryption types are `0x12` (AES-256), `0x11` (AES-128), and `0x17` (RC4-HMAC).
+- Run `eforge validate-config` after changes; it rejects invalid PKINIT/certificate combinations and excessively high no-preauth, PKINIT, or RC4 weights.
 
 ---
 

--- a/commands/eforge/references/config-validation.md
+++ b/commands/eforge/references/config-validation.md
@@ -78,6 +78,7 @@ Run `eforge info <field>` to get specific values (e.g., `eforge info paths.activ
 | 33 | process_access_patterns.yaml structure | ERROR | Baseline pair missing source/target PID keys, image paths, or positive weighted hex access masks |
 | 34 | create_remote_thread_patterns.yaml structure | ERROR | Baseline pair missing source/target PID keys, image paths, or positive weight |
 | 35 | smb_file_transfers.yaml structure | ERROR | Missing SMB file-analysis thresholds/probabilities, invalid probability ranges, empty MIME/analyzer lists, invalid filename templates, or non-positive weights |
+| 36 | kerberos_realism.yaml structure | ERROR | Invalid Kerberos 4768 pre-auth/ticket/encryption distribution, unsupported hex values, PKINIT without certificate profile, non-PKINIT with certificate fields, excessive no-preauth/PKINIT/RC4 weights, or malformed certificate profile fields |
 
 ## Scenario Validation: traffic_rates
 

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -62,7 +62,7 @@ output/
 | 4738 | User Account Changed | Account Management | Has unique leading `Dummy` field (always "-"). Full account property fields. |
 | 4756 | Member Added to Universal Group | Privilege Escalation | e.g., Enterprise Admins. |
 | 4757 | Member Removed from Universal Group | Privilege Escalation | No sample data verification (identical structure to 4756). |
-| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. CertIssuerName/CertSerialNumber/CertThumbprint always empty. |
+| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. Successful TGTs use data-driven PreAuthType/TicketOptions/encryption distributions; PKINIT (`PreAuthType=15`) populates CertIssuerName/CertSerialNumber/CertThumbprint. |
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |

--- a/docs/reference/CUSTOMIZING_CONFIG.md
+++ b/docs/reference/CUSTOMIZING_CONFIG.md
@@ -156,6 +156,7 @@ Configuration files are interconnected. When you add an entry to one file, other
 | A new domain | `proxy_uri_templates.yaml` (URI paths), `site_maps.yaml` (browsing depth) |
 | New proxy User-Agent behavior | `proxy_user_agents.yaml` (workstation/server UA pools, package-manager host bindings, domain-specific update/cert/telemetry overrides) |
 | New TLS OCSP responder behavior | `tls_realism.yaml` (`ocsp.responders`) plus `dns_registry.yaml` for each responder hostname |
+| Kerberos TGT pre-auth realism | `kerberos_realism.yaml` (`tgt_success.pre_auth_types`, ticket options, encryption types, and PKINIT certificate profiles). Run `eforge validate-config`; PKINIT (`PreAuthType: 15`) requires populated certificate profile support. |
 | Public NTP fallback servers | `network_params.yaml` (`public_ntp_servers`; scenario-defined internal/domain NTP servers still take precedence) |
 | A new application | `spawn_rules.yaml` (process tree), `process_network_map.yaml` (if it generates traffic) |
 | A DLL load profile | Add `loaded_modules` to the app in `application_catalog.yaml`, or to the process entry in `system_processes.yaml`. Overlay entries extend the DLL pool (deep merge adds new modules alongside defaults). |

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -68,7 +68,7 @@ output/
 | 4738 | User Account Changed | Account Management | Has unique leading `Dummy` field (always "-"). Full account property fields. |
 | 4756 | Member Added to Universal Group | Privilege Escalation | e.g., Enterprise Admins. |
 | 4757 | Member Removed from Universal Group | Privilege Escalation | No sample data verification (identical structure to 4756). |
-| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. CertIssuerName/CertSerialNumber/CertThumbprint always empty. |
+| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. Successful TGTs use data-driven PreAuthType/TicketOptions/encryption distributions; PKINIT (`PreAuthType=15`) populates CertIssuerName/CertSerialNumber/CertThumbprint. |
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -1018,6 +1018,7 @@ def validate_config() -> ValidationResult:
         ConnectionEntry,
         CreateRemoteThreadPatternEntry,
         DnsEntry,
+        KerberosRealismConfig,
         OuiEntry,
         PersonaEntry,
         ProcessAccessPatternEntry,
@@ -1125,6 +1126,15 @@ def validate_config() -> ValidationResult:
     tls_realism_data = load_tls_realism()
     if tls_realism_data:
         _SCHEMA_CHECKS.append(([tls_realism_data], TlsRealismConfig, "tls_realism.yaml"))
+
+    # kerberos_realism.yaml
+    from evidenceforge.generation.activity.kerberos_realism import load_kerberos_realism
+
+    kerberos_realism_data = load_kerberos_realism()
+    if kerberos_realism_data:
+        _SCHEMA_CHECKS.append(
+            ([kerberos_realism_data], KerberosRealismConfig, "kerberos_realism.yaml")
+        )
 
     # smb_file_transfers.yaml
     from evidenceforge.generation.activity.smb_file_transfers import load_smb_file_transfers

--- a/src/evidenceforge/config/activity/README.md
+++ b/src/evidenceforge/config/activity/README.md
@@ -19,6 +19,7 @@ caches data after first load. Two files (`network_params.yaml`,
 | `system_processes.yaml` | `system_processes.py` | Baseline Windows scheduled tasks and system services (svchost, MpCmdRun, etc.). |
 | `tls_issuers.yaml` | `tls_issuers.py` | Certificate issuer configs (Let's Encrypt, DigiCert, etc.) with validity periods and key types. |
 | `tls_realism.yaml` | `tls_realism.py` | TLS SAN, OCSP, certificate-chain, and destination-profile settings with overlay support. |
+| `kerberos_realism.yaml` | `kerberos_realism.py` | Kerberos 4768 TGT PreAuthType, TicketOptions, encryption, and PKINIT certificate field distributions with overlay support. |
 | `proxy_uri_templates.yaml` | `proxy_uri.py` | Per-domain URI path templates for proxy logs (Windows Update, CRL, OCSP, Azure AD, etc.). |
 | `network_params.yaml` | `engine/emitter_setup.py` | MAC address OUI prefixes (Dell, HP, VMware, etc.) for realistic MAC generation. |
 | `systemd_schedules.yaml` | `engine/baseline.py` | Systemd timer and cron job schedules (logrotate, fstrim, apt-daily, etc.). |

--- a/src/evidenceforge/config/activity/kerberos_realism.yaml
+++ b/src/evidenceforge/config/activity/kerberos_realism.yaml
@@ -1,0 +1,62 @@
+# Kerberos realism knobs for Windows Security authentication events.
+#
+# User customizations go in:
+#   .eforge/config/activity/kerberos_realism.yaml
+#
+# Overlay behavior: nested dicts merge and lists extend. Prefer overriding
+# weights by profile key instead of adding duplicate profile values.
+
+tgt_success:
+  pre_auth_types:
+    encrypted_timestamp:
+      value: 2
+      weight: 96
+      certificate_required: false
+      description: "Encrypted timestamp pre-auth; common for password and machine TGT requests."
+    pkinit:
+      value: 15
+      weight: 3
+      certificate_required: true
+      certificate_profile: enterprise_user
+      description: "PKINIT/smart-card or certificate-based pre-auth."
+    none_or_legacy:
+      value: 0
+      weight: 1
+      certificate_required: false
+      description: "No pre-auth/legacy edge cases; intentionally rare."
+
+  ticket_options:
+    forwardable_renewable_canonicalize:
+      value: "0x40810010"
+      weight: 60
+    forwardable_renewable:
+      value: "0x40810000"
+      weight: 20
+    renewable_canonicalize:
+      value: "0x40000010"
+      weight: 10
+    renewable_ok_as_delegate:
+      value: "0x50800000"
+      weight: 5
+    canonicalize_only:
+      value: "0x10"
+      weight: 5
+
+  encryption_types:
+    aes256:
+      value: "0x12"
+      weight: 70
+    aes128:
+      value: "0x11"
+      weight: 20
+    rc4_hmac:
+      value: "0x17"
+      weight: 10
+
+certificate_profiles:
+  enterprise_user:
+    issuer_names:
+      - "CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"
+      - "CN=Acme Enterprise Smartcard CA, O=Acme Corp, C=US"
+    serial_hex_bytes: 16
+    thumbprint_hex_chars: 40

--- a/src/evidenceforge/config/formats/windows_event_security.yaml
+++ b/src/evidenceforge/config/formats/windows_event_security.yaml
@@ -1286,7 +1286,7 @@ output:
         <Data Name="TicketOptions">{{ TicketOptions }}</Data>
         <Data Name="Status">{{ Status }}</Data>
         <Data Name="TicketEncryptionType">{{ TicketEncryptionType }}</Data>
-        <Data Name="PreAuthType">{{ PreAuthType | default(15) }}</Data>
+        <Data Name="PreAuthType">{{ PreAuthType | default(2) }}</Data>
         <Data Name="IpAddress">{{ IpAddress }}</Data>
         <Data Name="IpPort">{{ IpPort | default(0) }}</Data>
         <Data Name="CertIssuerName">{{ CertIssuerName | default('') }}</Data>

--- a/src/evidenceforge/config/schemas.py
+++ b/src/evidenceforge/config/schemas.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # --- DNS Registry ---
 
@@ -319,6 +319,183 @@ class TlsRealismConfig(BaseModel, extra="forbid"):
     ocsp: TlsOcspConfig
     certificate_chains: TlsCertificateChainConfig
     destinations: TlsDestinationsConfig
+
+
+# --- Kerberos Realism ---
+
+
+class KerberosWeightedHexValue(BaseModel, extra="forbid"):
+    """Weighted hex value used by kerberos_realism.yaml."""
+
+    value: str
+    weight: int
+
+    @field_validator("value")
+    @classmethod
+    def value_hex(cls, v: str) -> str:
+        if not v.startswith("0x"):
+            raise ValueError("value must be a hex string beginning with 0x")
+        int(v, 16)
+        return v
+
+    @field_validator("weight")
+    @classmethod
+    def weight_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("weight must be positive")
+        return v
+
+
+class KerberosPreAuthTypeEntry(BaseModel, extra="forbid"):
+    """Weighted Kerberos pre-auth type profile."""
+
+    value: int
+    weight: int
+    certificate_required: bool
+    certificate_profile: str | None = None
+    description: str = ""
+
+    @field_validator("value")
+    @classmethod
+    def allowed_pre_auth_type(cls, v: int) -> int:
+        if v not in {0, 2, 15}:
+            raise ValueError("pre-auth value must be one of 0, 2, or 15")
+        return v
+
+    @field_validator("weight")
+    @classmethod
+    def weight_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("weight must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def coherent_certificate_flags(self) -> KerberosPreAuthTypeEntry:
+        if self.value == 15 and not self.certificate_required:
+            raise ValueError("PreAuthType 15 must set certificate_required=true")
+        if self.certificate_required and self.value != 15:
+            raise ValueError("certificate_required=true is only valid for PreAuthType 15")
+        if self.value == 15 and not self.certificate_profile:
+            raise ValueError("PreAuthType 15 must reference a certificate_profile")
+        if self.value != 15 and self.certificate_profile:
+            raise ValueError("certificate_profile is only valid for PreAuthType 15")
+        return self
+
+
+class KerberosTgtSuccessConfig(BaseModel, extra="forbid"):
+    """Successful 4768 field distributions."""
+
+    pre_auth_types: dict[str, KerberosPreAuthTypeEntry]
+    ticket_options: dict[str, KerberosWeightedHexValue]
+    encryption_types: dict[str, KerberosWeightedHexValue]
+
+    @field_validator("pre_auth_types", "ticket_options", "encryption_types")
+    @classmethod
+    def weighted_profiles_non_empty(cls, v: dict) -> dict:
+        if not v:
+            raise ValueError("weighted profile dict must not be empty")
+        if sum(entry.weight for entry in v.values()) <= 0:
+            raise ValueError("weighted profile dict must have a positive total weight")
+        return v
+
+    @field_validator("ticket_options")
+    @classmethod
+    def allowed_ticket_options(
+        cls, v: dict[str, KerberosWeightedHexValue]
+    ) -> dict[str, KerberosWeightedHexValue]:
+        allowed = {"0x40810010", "0x40810000", "0x40000010", "0x50800000", "0x10"}
+        invalid = sorted({entry.value for entry in v.values()} - allowed)
+        if invalid:
+            raise ValueError(f"ticket_options contains unsupported values: {invalid}")
+        return v
+
+    @field_validator("encryption_types")
+    @classmethod
+    def allowed_encryption_types(
+        cls, v: dict[str, KerberosWeightedHexValue]
+    ) -> dict[str, KerberosWeightedHexValue]:
+        allowed = {"0x12", "0x11", "0x17"}
+        invalid = sorted({entry.value for entry in v.values()} - allowed)
+        if invalid:
+            raise ValueError(f"encryption_types contains unsupported values: {invalid}")
+        return v
+
+    @model_validator(mode="after")
+    def realistic_weights(self) -> KerberosTgtSuccessConfig:
+        pre_auth_weight_by_value: dict[int, int] = {}
+        for entry in self.pre_auth_types.values():
+            pre_auth_weight_by_value[entry.value] = (
+                pre_auth_weight_by_value.get(entry.value, 0) + entry.weight
+            )
+        total_pre_auth = sum(pre_auth_weight_by_value.values())
+        if pre_auth_weight_by_value.get(2, 0) == 0:
+            raise ValueError("PreAuthType 2 must be present for normal encrypted timestamp TGTs")
+        if pre_auth_weight_by_value.get(15, 0) / total_pre_auth > 0.20:
+            raise ValueError("PreAuthType 15 PKINIT weight must not exceed 20% by default")
+        if pre_auth_weight_by_value.get(0, 0) / total_pre_auth > 0.05:
+            raise ValueError("PreAuthType 0/no-preauth weight must not exceed 5%")
+
+        encryption_weight_by_value: dict[str, int] = {}
+        for entry in self.encryption_types.values():
+            encryption_weight_by_value[entry.value] = (
+                encryption_weight_by_value.get(entry.value, 0) + entry.weight
+            )
+        total_encryption = sum(encryption_weight_by_value.values())
+        if encryption_weight_by_value.get("0x17", 0) / total_encryption > 0.30:
+            raise ValueError("RC4 encryption type 0x17 weight must not exceed 30%")
+        return self
+
+
+class KerberosCertificateProfile(BaseModel, extra="forbid"):
+    """Certificate field generation profile for Kerberos PKINIT events."""
+
+    issuer_names: list[str]
+    serial_hex_bytes: int = 16
+    thumbprint_hex_chars: int = 40
+
+    @field_validator("issuer_names")
+    @classmethod
+    def issuer_names_non_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("issuer_names must not be empty")
+        if any(not issuer for issuer in v):
+            raise ValueError("issuer_names entries must be non-empty")
+        return v
+
+    @field_validator("serial_hex_bytes")
+    @classmethod
+    def serial_bytes_range(cls, v: int) -> int:
+        if not 8 <= v <= 20:
+            raise ValueError("serial_hex_bytes must be between 8 and 20")
+        return v
+
+    @field_validator("thumbprint_hex_chars")
+    @classmethod
+    def thumbprint_length_valid(cls, v: int) -> int:
+        if v not in {40, 64}:
+            raise ValueError("thumbprint_hex_chars must be 40 (SHA-1) or 64 (SHA-256)")
+        return v
+
+
+class KerberosRealismConfig(BaseModel, extra="forbid"):
+    """Root schema for kerberos_realism.yaml."""
+
+    tgt_success: KerberosTgtSuccessConfig
+    certificate_profiles: dict[str, KerberosCertificateProfile] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def referenced_certificate_profiles_exist(self) -> KerberosRealismConfig:
+        profile_names = set(self.certificate_profiles)
+        missing = sorted(
+            {
+                entry.certificate_profile
+                for entry in self.tgt_success.pre_auth_types.values()
+                if entry.certificate_profile and entry.certificate_profile not in profile_names
+            }
+        )
+        if missing:
+            raise ValueError(f"unknown certificate_profile references: {missing}")
+        return self
 
 
 # --- SMB File Transfers ---

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -230,6 +230,9 @@ class KerberosContext:
     ticket_status: str = "0x0"
     encryption_type: str = ""  # e.g., "0x12" (AES-256)
     pre_auth_type: int = 0  # 4768 only
+    cert_issuer_name: str = ""  # 4768 PKINIT only
+    cert_serial_number: str = ""  # 4768 PKINIT only
+    cert_thumbprint: str = ""  # 4768 PKINIT only
     source_ip: str = ""  # IPv6-mapped: "::ffff:x.x.x.x"
     source_port: int = 0
     reporting_pid: int = 0  # PID of lsass.exe that wrote this event

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -5154,6 +5154,9 @@ class ActivityGenerator:
         # Kerberos realm is always the DNS FQDN in uppercase, never NetBIOS short name
         domain = domain or getattr(self, "_ad_domain", "corp.local").upper()
         rng = _get_rng()
+        from evidenceforge.generation.activity.kerberos_realism import pick_tgt_success_fields
+
+        tgt_fields = pick_tgt_success_fields(rng)
 
         event = SecurityEvent(
             timestamp=time,
@@ -5165,13 +5168,12 @@ class ActivityGenerator:
                 target_sid=self._get_sid(username),
                 service_name="krbtgt",
                 service_sid=self._get_sid("krbtgt"),
-                ticket_options=rng.choices(
-                    ["0x40810010", "0x40810000", "0x40000010", "0x50800000", "0x10"],
-                    weights=[60, 20, 10, 5, 5],
-                    k=1,
-                )[0],
-                encryption_type=rng.choices(["0x12", "0x11", "0x17"], weights=[70, 15, 15], k=1)[0],
-                pre_auth_type=15,
+                ticket_options=tgt_fields["ticket_options"],
+                encryption_type=tgt_fields["encryption_type"],
+                pre_auth_type=tgt_fields["pre_auth_type"],
+                cert_issuer_name=tgt_fields["cert_issuer_name"],
+                cert_serial_number=tgt_fields["cert_serial_number"],
+                cert_thumbprint=tgt_fields["cert_thumbprint"],
                 source_ip=f"::ffff:{source_ip}",
                 source_port=_ephemeral_port(rng, self._os_for_ip(source_ip)),
             ),

--- a/src/evidenceforge/generation/activity/kerberos_realism.py
+++ b/src/evidenceforge/generation/activity/kerberos_realism.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Kerberos realism configuration loader and pickers."""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from evidenceforge.config import get_activity_directory
+from evidenceforge.config.overlay import deep_merge_dict, load_with_overlay
+
+_CONFIG_PATH = get_activity_directory() / "kerberos_realism.yaml"
+_CACHED_DATA: dict[str, Any] | None = None
+
+
+def _merge_kerberos_realism(default: dict, overlay: dict) -> dict:
+    """Merge Kerberos realism overlay with package defaults."""
+    return deep_merge_dict(default, overlay)
+
+
+def load_kerberos_realism() -> dict[str, Any]:
+    """Load Kerberos realism config from YAML, merged with overlay."""
+    global _CACHED_DATA
+    if _CACHED_DATA is not None:
+        return _CACHED_DATA
+
+    _CACHED_DATA = load_with_overlay(
+        _CONFIG_PATH,
+        "activity/kerberos_realism.yaml",
+        _merge_kerberos_realism,
+    )
+    return _CACHED_DATA
+
+
+def reset_kerberos_realism_cache() -> None:
+    """Clear cached Kerberos realism config. Intended for tests."""
+    global _CACHED_DATA
+    _CACHED_DATA = None
+
+
+def pick_tgt_success_fields(rng: random.Random) -> dict[str, Any]:
+    """Pick coherent 4768 success fields from Kerberos realism config."""
+    cfg = load_kerberos_realism()
+    tgt_success = cfg.get("tgt_success", {})
+    pre_auth = _pick_weighted_profile(tgt_success.get("pre_auth_types", {}), rng)
+    certificate_fields = _certificate_fields(pre_auth, rng)
+    return {
+        "ticket_options": _pick_weighted_value(tgt_success.get("ticket_options", {}), rng),
+        "encryption_type": _pick_weighted_value(tgt_success.get("encryption_types", {}), rng),
+        "pre_auth_type": int(pre_auth.get("value", 2)),
+        **certificate_fields,
+    }
+
+
+def _pick_weighted_value(profiles: dict[str, dict[str, Any]], rng: random.Random) -> str:
+    """Pick a configured weighted profile and return its value."""
+    profile = _pick_weighted_profile(profiles, rng)
+    return str(profile.get("value", ""))
+
+
+def _pick_weighted_profile(
+    profiles: dict[str, dict[str, Any]], rng: random.Random
+) -> dict[str, Any]:
+    """Pick one profile from a keyed weighted profile dict."""
+    valid_profiles = [
+        profile
+        for profile in profiles.values()
+        if isinstance(profile, dict) and int(profile.get("weight", 0)) > 0
+    ]
+    if not valid_profiles:
+        return {}
+    weights = [int(profile.get("weight", 1)) for profile in valid_profiles]
+    return rng.choices(valid_profiles, weights=weights, k=1)[0]
+
+
+def _certificate_fields(pre_auth: dict[str, Any], rng: random.Random) -> dict[str, str]:
+    """Return 4768 certificate fields for certificate-based pre-auth."""
+    if not pre_auth.get("certificate_required", False):
+        return {
+            "cert_issuer_name": "",
+            "cert_serial_number": "",
+            "cert_thumbprint": "",
+        }
+
+    cfg = load_kerberos_realism()
+    profile_name = str(pre_auth.get("certificate_profile", ""))
+    profile = cfg.get("certificate_profiles", {}).get(profile_name, {})
+    issuer_names = profile.get("issuer_names", [])
+    issuer_name = rng.choice(issuer_names) if issuer_names else ""
+    serial_hex_bytes = int(profile.get("serial_hex_bytes", 16))
+    thumbprint_hex_chars = int(profile.get("thumbprint_hex_chars", 40))
+    serial = "".join(f"{rng.randrange(256):02X}" for _ in range(serial_hex_bytes))
+    thumbprint = "".join(rng.choice("0123456789ABCDEF") for _ in range(thumbprint_hex_chars))
+    return {
+        "cert_issuer_name": issuer_name,
+        "cert_serial_number": serial,
+        "cert_thumbprint": thumbprint,
+    }

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -623,6 +623,9 @@ class WindowsEventEmitter(LogEmitter):
             "PreAuthType": krb.pre_auth_type,
             "IpAddress": krb.source_ip,
             "IpPort": krb.source_port,
+            "CertIssuerName": krb.cert_issuer_name,
+            "CertSerialNumber": krb.cert_serial_number,
+            "CertThumbprint": krb.cert_thumbprint,
         }
         self.emit_event(event_data)
 

--- a/tests/unit/test_kerberos_realism.py
+++ b/tests/unit/test_kerberos_realism.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Tests for data-driven Kerberos realism profiles."""
+
+import random
+
+from evidenceforge.generation.activity import kerberos_realism
+
+
+def test_default_tgt_success_profile_mostly_uses_encrypted_timestamp():
+    rng = random.Random(7)
+
+    counts: dict[int, int] = {}
+    for _ in range(1000):
+        fields = kerberos_realism.pick_tgt_success_fields(rng)
+        counts[fields["pre_auth_type"]] = counts.get(fields["pre_auth_type"], 0) + 1
+
+    assert counts[2] > 900
+    assert counts.get(15, 0) < 60
+
+
+def test_pkinit_profile_populates_certificate_fields(monkeypatch):
+    def load_pkinit_only_config():
+        return {
+            "tgt_success": {
+                "pre_auth_types": {
+                    "pkinit": {
+                        "value": 15,
+                        "weight": 1,
+                        "certificate_required": True,
+                        "certificate_profile": "enterprise_user",
+                    }
+                },
+                "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+            },
+            "certificate_profiles": {
+                "enterprise_user": {
+                    "issuer_names": ["CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"],
+                    "serial_hex_bytes": 16,
+                    "thumbprint_hex_chars": 40,
+                }
+            },
+        }
+
+    monkeypatch.setattr(kerberos_realism, "load_kerberos_realism", load_pkinit_only_config)
+
+    fields = kerberos_realism.pick_tgt_success_fields(random.Random(3))
+
+    assert fields["pre_auth_type"] == 15
+    assert fields["cert_issuer_name"] == "CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"
+    assert len(fields["cert_serial_number"]) == 32
+    assert len(fields["cert_thumbprint"]) == 40
+
+
+def test_non_pkinit_profile_leaves_certificate_fields_empty(monkeypatch):
+    def load_encrypted_timestamp_only_config():
+        return {
+            "tgt_success": {
+                "pre_auth_types": {
+                    "encrypted_timestamp": {
+                        "value": 2,
+                        "weight": 1,
+                        "certificate_required": False,
+                    }
+                },
+                "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+            },
+            "certificate_profiles": {},
+        }
+
+    monkeypatch.setattr(
+        kerberos_realism, "load_kerberos_realism", load_encrypted_timestamp_only_config
+    )
+
+    fields = kerberos_realism.pick_tgt_success_fields(random.Random(3))
+
+    assert fields["pre_auth_type"] == 2
+    assert fields["cert_issuer_name"] == ""
+    assert fields["cert_serial_number"] == ""
+    assert fields["cert_thumbprint"] == ""
+
+
+def test_kerberos_realism_overlay_overrides_nested_weight(tmp_path, monkeypatch):
+    overlay_dir = tmp_path / ".eforge" / "config" / "activity"
+    overlay_dir.mkdir(parents=True)
+    (overlay_dir / "kerberos_realism.yaml").write_text(
+        "tgt_success:\n  pre_auth_types:\n    encrypted_timestamp:\n      weight: 1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    kerberos_realism.reset_kerberos_realism_cache()
+
+    data = kerberos_realism.load_kerberos_realism()
+
+    assert data["tgt_success"]["pre_auth_types"]["encrypted_timestamp"]["value"] == 2
+    assert data["tgt_success"]["pre_auth_types"]["encrypted_timestamp"]["weight"] == 1
+    kerberos_realism.reset_kerberos_realism_cache()

--- a/tests/unit/test_phase6_p1_realism.py
+++ b/tests/unit/test_phase6_p1_realism.py
@@ -291,6 +291,15 @@ class TestKerberosEvents:
         event = mock_emitters["windows_event_security"].emit.call_args_list[0][0][0]
         assert event.event_type == "kerberos_tgt"
         assert event.kerberos.service_name == "krbtgt"
+        assert event.kerberos.pre_auth_type in {0, 2, 15}
+        if event.kerberos.pre_auth_type == 15:
+            assert event.kerberos.cert_issuer_name
+            assert event.kerberos.cert_serial_number
+            assert event.kerberos.cert_thumbprint
+        else:
+            assert event.kerberos.cert_issuer_name == ""
+            assert event.kerberos.cert_serial_number == ""
+            assert event.kerberos.cert_thumbprint == ""
         assert event.dst_host.fqdn.startswith("DC-01.")
 
     def test_service_ticket_emits_4769(self, activity_gen, mock_emitters):

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -50,3 +50,72 @@ class TestValidateConfig:
             in issue.message
             for issue in result.issues
         )
+
+    def test_validate_config_rejects_pkinit_without_certificate_profile(self, monkeypatch):
+        from evidenceforge.generation.activity import kerberos_realism
+
+        def load_invalid_kerberos_realism():
+            return {
+                "tgt_success": {
+                    "pre_auth_types": {
+                        "pkinit": {
+                            "value": 15,
+                            "weight": 1,
+                            "certificate_required": True,
+                        }
+                    },
+                    "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                    "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+                },
+                "certificate_profiles": {},
+            }
+
+        monkeypatch.setattr(
+            kerberos_realism, "load_kerberos_realism", load_invalid_kerberos_realism
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "kerberos_realism.yaml"
+            and "PreAuthType 15 must reference a certificate_profile" in issue.message
+            for issue in result.issues
+        )
+
+    def test_validate_config_rejects_improbable_preauth_distribution(self, monkeypatch):
+        from evidenceforge.generation.activity import kerberos_realism
+
+        def load_invalid_kerberos_realism():
+            return {
+                "tgt_success": {
+                    "pre_auth_types": {
+                        "encrypted_timestamp": {
+                            "value": 2,
+                            "weight": 1,
+                            "certificate_required": False,
+                        },
+                        "none_or_legacy": {
+                            "value": 0,
+                            "weight": 1,
+                            "certificate_required": False,
+                        },
+                    },
+                    "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                    "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+                },
+                "certificate_profiles": {},
+            }
+
+        monkeypatch.setattr(
+            kerberos_realism, "load_kerberos_realism", load_invalid_kerberos_realism
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "kerberos_realism.yaml"
+            and "PreAuthType 0/no-preauth weight must not exceed 5%" in issue.message
+            for issue in result.issues
+        )


### PR DESCRIPTION
## Summary

- Add `kerberos_realism.yaml` plus an overlay-aware loader for Windows 4768 TGT field distributions.
- Move successful TGT PreAuthType, TicketOptions, and encryption selection out of hardcoded generator lists.
- Populate Kerberos PKINIT certificate fields when `PreAuthType=15` is selected, while normal encrypted timestamp TGTs keep certificate fields empty.
- Extend `eforge validate-config` coverage for invalid/improbable Kerberos combinations and update docs, skill references, and tests.

## Root Cause

The generator hardcoded successful 4768 events to `PreAuthType=15` while leaving certificate fields empty. That made every TGT look like PKINIT/certificate pre-auth without PKINIT certificate evidence, which blind review flagged as a high-confidence synthetic tell.

## Validation

- `uv run pytest tests/unit/test_kerberos_realism.py tests/unit/test_validate_config.py tests/unit/test_phase6_p1_realism.py tests/unit/test_emitters.py -q --no-cov`
- `uv run eforge validate-config`
- `uv run ruff check .`
- `uv run ruff format --check .`
- Regenerated `/private/tmp/eforge-windows-auth-baseline-output/data`; 4768 distribution was `PreAuthType=2: 397`, `PreAuthType=0: 4`, `PreAuthType=15: 9`, with `0` certificate coherence errors.
- Blind realism eval after regeneration reported the previous Kerberos PreAuthType=15-with-empty-cert-fields finding fixed and scored the dataset at 60% synthetic.