### PR TITLE
Release 0.4.1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,8 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 
 ### Recently Resolved
 
+- [ ] **IN PROGRESS** Windows Security/authentication source review — focused baseline eval is complete; fixing high-signal Windows auth realism findings first (4672/session semantics and sparse 4800/4801 rendering), then rerunning focused generation/eval before moving deeper.
+
 - [x] TODO.md reality audit — verified high-signal open realism/code-cleanup findings against the current codebase, marked stale items, and identified the generated-output validation pass needed before deeper realism work.
   Targeted verification: `uv run pytest tests/unit/test_network_realism.py tests/unit/test_activity_helpers.py tests/unit/test_dc_kerberos_logon.py -q --no-cov` passed (25 tests).
 
@@ -127,7 +129,7 @@ Data is structurally correct but the hunt doesn't work — key attack steps are 
 - [x] **RDP lateral movement invisible + zero RDP noise** — added background IT admin RDP connections (1-3/hour) to Windows servers/DCs in baseline. Storyline RDP sessions already produce Zeek conn records via generate_rdp_session().
 - [x] **No DC Kerberos events for compromised user** — generate_logon() now emits 4768 (TGT) + 4769 (service ticket) on the DC for Kerberos-authenticated domain logons, with realistic timing offsets.
 - [x] **No LSASS access events (Sysmon 10)** — added Sysmon Event 10 (ProcessAccess) emitter, format template, and generate_process_access() method. Auto-emits alongside create_remote_thread when target is lsass.exe.
-- [x] **No 4672 (Special Privileges) on Domain Controller** — new `special_privileges` event type emits standalone 4672 on DC during Kerberos authentication for elevated users.
+- [x] **4672 (Special Privileges) target-host semantics** — elevated-session 4672 is auto-emitted alongside the target-host 4624; Kerberos causal expansion emits DC 4768/4769 only.
 - [x] **Storyline events too perfect** — /eforge scenario skill now interviews about attacker sophistication and generates fumbles (mistakes) and dead ends (abandoned paths) appropriate to the chosen level.
 - [x] **C2/exfiltration SNI values are auto-generated CDN names** — replaced `host-x-x-x-x.cdn-provider.net` fallback with 30 plausible SaaS/analytics/CDN domains.
 - [x] **Proxy log issues** — CONNECT entries now use domain names from REVERSE_DNS or plausible random hostnames instead of raw IPs.
@@ -150,6 +152,14 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] Blind HTTP/proxy/network telemetry realism evaluation of `/private/tmp/eforge-http-proxy-review-output/data` — scored highly synthetic due to concrete ASA/Zeek DNS and proxy/client-tap contradictions, with ASA connection-ID artifacts and DNS consistency issues as supporting tells.
 - [x] Fresh blind HTTP/proxy/network telemetry realism evaluation of regenerated `/private/tmp/eforge-http-proxy-review-output/data` — TLS-intercept proxy pattern accepted; remaining high-signal findings were plain HTTP proxy/client status contradiction, OCSP responder/issuer mismatch, and generated-looking Zeek certificate FUID artifact.
 - [x] Fresh blind HTTP/proxy/network telemetry realism evaluation after latest fixes for `/private/tmp/eforge-http-proxy-review-output/data` — prior critical proxy/client and OCSP/public-responder issues were fixed; remaining evidence is medium/high realism polish around Zeek HTTP body length semantics, Let's Encrypt OCSP responder choice, and ASA connection-ID spacing artifacts.
+- [x] Fresh blind Windows authentication/security telemetry realism evaluation of `/private/tmp/eforge-windows-auth-baseline-output/data` completed; assessed high synthetic likelihood from impossible 4672 logon semantics, documentation IP usage, and malformed sparse Windows events.
+- [x] Fresh blind Windows authentication/security telemetry realism evaluation of regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; TEST-NET artifact no longer present, with remaining synthetic evidence centered on 4672 logon semantics and empty EventData for 1102/4800/4801.
+- [x] Windows 4672 session semantics — removed duplicate DC-side standalone 4672 from Kerberos causal expansion; elevated 4672 now stays tied to the target-host 4624 logon session, and non-service audit fallback logon IDs no longer use SYSTEM's `0x3e7`.
+- [x] Windows 4800/4801 rendering — populated workstation lock/unlock EventData fields in the Windows Security XML template.
+- [x] Blind Windows authentication/security realism evaluation of current `/private/tmp/eforge-windows-auth-baseline-output/data` completed; prior 4672 issues are fixed, 4800/4801 fields are populated, with remaining synthetic indicators in DC 4625/4776 status contradictions and lock/unlock SessionId mismatches.
+- [x] Windows failed-auth DC consistency — failed NTLM validation 4776 now carries the matching failure status instead of success.
+- [x] Windows lock/unlock session consistency — 4800/4801 derive a stable SessionId from TargetLogonId so lock/unlock pairs do not change terminal sessions.
+- [x] Blind Windows authentication/security realism evaluation of latest regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; prior 4672, 4625/4776, and 4800/4801 findings are fixed, with remaining realism concerns around Kerberos 4768 PreAuthType distribution and missing Zeek visibility for external failed-auth source.
 
 **Snort/IDS:**
 - [x] ✓ Snort protocol field randomly assigned (no binding to SID/rule) — restructured `_FP_SIGS` to protocol-keyed dict with per-signature port and direction
@@ -263,7 +273,7 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] Only 2 unique TicketOptions values; zero 4771 pre-auth failures — randomized TicketOptions per event type; boosted stale 4771 probability to 15%; added active-user typo 4771 at 2%/hour
 - [x] File server has no domain user logon events — type 3 logon+logoff pairs for SMB access in baseline traffic profiles and storyline causal expansion
 - [x] NETWORK SERVICE TargetDomainName shows domain instead of "NT AUTHORITY" — _subject_domain() helper in windows.py returns "NT AUTHORITY" for SYSTEM/NETWORK SERVICE/LOCAL SERVICE
-- [x] Event 4672 LogonId 0x3e7 for domain users — stale audit finding: DC-side special privileges now use `_get_user_logon_id(user.username, dc_hostname)` and targeted Kerberos/DC tests pass.
+- [x] Event 4672 LogonId 0x3e7 for domain users — target-host 4672 now shares the 4624 LogonID, and Kerberos causal expansion no longer emits duplicate standalone DC 4672 records.
 
 **Process Trees:**
 - [x] ✓³ explorer.exe parent for everything — spawn_rules.yaml now defines valid parent-child relationships; _resolve_parent() auto-creates intermediate chains (shells for CLI tools, services.exe for system processes, sshd→bash for Linux)

--- a/TODO.md
+++ b/TODO.md
@@ -160,6 +160,8 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 - [x] Windows failed-auth DC consistency — failed NTLM validation 4776 now carries the matching failure status instead of success.
 - [x] Windows lock/unlock session consistency — 4800/4801 derive a stable SessionId from TargetLogonId so lock/unlock pairs do not change terminal sessions.
 - [x] Blind Windows authentication/security realism evaluation of latest regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; prior 4672, 4625/4776, and 4800/4801 findings are fixed, with remaining realism concerns around Kerberos 4768 PreAuthType distribution and missing Zeek visibility for external failed-auth source.
+- [x] Windows Kerberos 4768 pre-auth realism — moved TGT PreAuthType/ticket/encryption distributions into `kerberos_realism.yaml`, added overlay-aware loader and `eforge validate-config` schema/coherence checks, and verified generation now produces mostly encrypted timestamp pre-auth with rare populated PKINIT certificate fields.
+- [x] Blind Windows authentication/security realism evaluation of latest regenerated `/private/tmp/eforge-windows-auth-baseline-output/data` completed; Kerberos PreAuthType=15 empty-cert issue is fixed, with remaining lower-confidence tells in one repeated 4672 on unlock and absent Zeek visibility for external failed auth.
 
 **Snort/IDS:**
 - [x] ✓ Snort protocol field randomly assigned (no binding to SID/rule) — restructured `_FP_SIGS` to protocol-keyed dict with per-signature port and direction

--- a/commands/eforge/references/config-dependency-graph.md
+++ b/commands/eforge/references/config-dependency-graph.md
@@ -49,6 +49,13 @@ Each row is a file; columns show what it depends on and what depends on it.
 | depends on | nothing | Standalone rate table |
 | **depended on by** | Engine (runtime) | Drives all baseline traffic rate calculations (user activity, web, DNS, SMB, Kerberos, LDAP, persona connections) |
 
+### kerberos_realism.yaml
+| Direction | File | Relationship |
+|-----------|------|-------------|
+| depends on | nothing | Standalone Kerberos field-distribution profile |
+| **depended on by** | Engine (runtime) | Drives Windows 4768 TGT PreAuthType, TicketOptions, TicketEncryptionType, and PKINIT certificate fields |
+| validated by | `eforge validate-config` | Enforces coherent combinations: PKINIT requires a certificate profile, non-PKINIT must not emit certificate fields, and no-preauth/PKINIT/RC4 weights stay bounded |
+
 ### proxy_uri_templates.yaml
 | Direction | File | Relationship |
 |-----------|------|-------------|

--- a/commands/eforge/references/config-host-activity.md
+++ b/commands/eforge/references/config-host-activity.md
@@ -11,7 +11,8 @@ Schema documentation for host-level activity config files. User customizations g
 1. [bash_commands.yaml](#bash_commandsyaml)
 2. [systemd_schedules.yaml](#systemd_schedulesyaml)
 3. [extra_syslog_messages.yaml](#extra_syslog_messagesyaml)
-4. [Domain Controller Baseline Activity](#domain-controller-baseline-activity)
+4. [kerberos_realism.yaml](#kerberos_realismyaml)
+5. [Domain Controller Baseline Activity](#domain-controller-baseline-activity)
 
 ---
 
@@ -160,6 +161,55 @@ programs:
 | `distro` | string | no | Restrict to `ubuntu` (excluded on RHEL-like) |
 | `roles` | list[string] | no | Required host roles (any match includes the entry) |
 | `transient` | bool | no | If `true`, uses random PID per invocation |
+
+---
+
+## kerberos_realism.yaml
+
+Data-driven Kerberos field distributions for Windows Security authentication events. The generator uses this file for successful 4768 TGT requests.
+
+### Structure
+
+```yaml
+tgt_success:
+  pre_auth_types:
+    encrypted_timestamp:
+      value: 2
+      weight: 96
+      certificate_required: false
+    pkinit:
+      value: 15
+      weight: 3
+      certificate_required: true
+      certificate_profile: enterprise_user
+    none_or_legacy:
+      value: 0
+      weight: 1
+      certificate_required: false
+  ticket_options:
+    forwardable_renewable_canonicalize:
+      value: "0x40810010"
+      weight: 60
+  encryption_types:
+    aes256:
+      value: "0x12"
+      weight: 70
+
+certificate_profiles:
+  enterprise_user:
+    issuer_names:
+      - "CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"
+    serial_hex_bytes: 16
+    thumbprint_hex_chars: 40
+```
+
+### Conventions
+
+- `PreAuthType: 2` is the normal encrypted timestamp case and should dominate default profiles.
+- `PreAuthType: 15` models PKINIT/certificate pre-auth and must reference a certificate profile so 4768 cert fields are populated.
+- `PreAuthType: 0` is rare legacy/no-preauth behavior.
+- Supported encryption types are `0x12` (AES-256), `0x11` (AES-128), and `0x17` (RC4-HMAC).
+- Run `eforge validate-config` after changes; it rejects invalid PKINIT/certificate combinations and excessively high no-preauth, PKINIT, or RC4 weights.
 
 ---
 

--- a/commands/eforge/references/config-validation.md
+++ b/commands/eforge/references/config-validation.md
@@ -78,6 +78,7 @@ Run `eforge info <field>` to get specific values (e.g., `eforge info paths.activ
 | 33 | process_access_patterns.yaml structure | ERROR | Baseline pair missing source/target PID keys, image paths, or positive weighted hex access masks |
 | 34 | create_remote_thread_patterns.yaml structure | ERROR | Baseline pair missing source/target PID keys, image paths, or positive weight |
 | 35 | smb_file_transfers.yaml structure | ERROR | Missing SMB file-analysis thresholds/probabilities, invalid probability ranges, empty MIME/analyzer lists, invalid filename templates, or non-positive weights |
+| 36 | kerberos_realism.yaml structure | ERROR | Invalid Kerberos 4768 pre-auth/ticket/encryption distribution, unsupported hex values, PKINIT without certificate profile, non-PKINIT with certificate fields, excessive no-preauth/PKINIT/RC4 weights, or malformed certificate profile fields |
 
 ## Scenario Validation: traffic_rates
 

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -62,7 +62,7 @@ output/
 | 4738 | User Account Changed | Account Management | Has unique leading `Dummy` field (always "-"). Full account property fields. |
 | 4756 | Member Added to Universal Group | Privilege Escalation | e.g., Enterprise Admins. |
 | 4757 | Member Removed from Universal Group | Privilege Escalation | No sample data verification (identical structure to 4756). |
-| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. CertIssuerName/CertSerialNumber/CertThumbprint always empty. |
+| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. Successful TGTs use data-driven PreAuthType/TicketOptions/encryption distributions; PKINIT (`PreAuthType=15`) populates CertIssuerName/CertSerialNumber/CertThumbprint. |
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -43,7 +43,7 @@ output/
 | 4625 | Failed Logon | Authentication | Version 0. Keywords=0x8010 (Audit Failure). Includes Status/SubStatus failure codes. |
 | 4634 | Logoff | Authentication | Paired with 4624 via matching TargetLogonId. |
 | 4648 | Explicit Credentials | Lateral Movement | Fires when RunAs, PsExec, WMIC, or scheduled tasks use alternate credentials. Emitted on the source system. |
-| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
+| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside the target-host 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
 | 4688 | Process Created | Execution | Version 2. Includes CommandLine, ParentProcessName, MandatoryLabel. TokenElevationType indicates UAC status. |
 | 4689 | Process Exited | Execution | Paired with 4688. Status always 0x0. |
 | 4697 | Service Installed | Persistence | ServiceFileName can contain full command lines. ServiceType 0x10=Own Process. |
@@ -66,7 +66,7 @@ output/
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |
-| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). |
+| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). Status reflects validation success or failure. |
 | 5156 | WFP Connection Permitted | Network | Application path uses device format (`\device\harddiskvolume1\...`). Direction: %%14592=Inbound, %%14593=Outbound. |
 
 **Known Limitations:**

--- a/commands/eforge/references/scenario-reference.md
+++ b/commands/eforge/references/scenario-reference.md
@@ -312,7 +312,7 @@ Each event in the `events` list has a `type` field that selects a validated sche
 | Type | Generates | Required Fields | Optional Fields |
 |------|-----------|-----------------|-----------------|
 | `process` | 4688, Sysmon 1, eCAR PROCESS | `process_name` | `command_line`, `supplementary` (auto/none) |
-| `logon` | 4624, 4672, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
+| `logon` | 4624, target-host 4672 for elevated sessions, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
 | `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent` |

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -514,7 +514,7 @@ events:
 **Causal expansion — auto-generated prerequisite events:** The generation engine automatically emits prerequisite and consequent events with realistic timing offsets. You do NOT need to manually specify these as prerequisites:
 
 - **DNS before connections** — TCP connections auto-generate a DNS lookup (5-80ms before) with caching, SERVFAIL probability, and NXDOMAIN companions. Baseline web/SaaS connections use domain-first selection for consistent DNS/SNI/proxy hostnames. Storyline connections with `hostname` set always emit DNS; connections without `hostname` skip DNS (correct for raw-IP C2)
-- **Kerberos before logons** — Kerberos-authenticated Windows domain logons auto-generate TGT (4768) and TGS (4769) on the DC, plus 4672 for elevated users
+- **Kerberos before logons** — Kerberos-authenticated Windows domain logons auto-generate TGT (4768) and TGS (4769) on the DC; elevated-session 4672 is emitted on the host where the 4624 logon session is created
 - **ProcessAccess after lsass injection** — `create_remote_thread` targeting lsass.exe auto-generates Sysmon Event 10 (1-50ms after)
 - **Audit events from commands** — Process events with admin commands (`net user /add`, `sc create`, `schtasks /create`, `wevtutil cl`) auto-generate the corresponding Windows audit events (4720, 4726, 4728, 4697, 4698, 1102)
 - **DNS for RDP/SSH** — `rdp_session` and `ssh_session` auto-generate DNS + connection events

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,7 +402,7 @@ ActivityGenerator.generate_connection()
 | Rule | Trigger | Emits | Timing |
 |------|---------|-------|--------|
 | `DnsBeforeConnection` | TCP connection (not port 53) | DNS query (UDP/53) | 5-80ms before |
-| `KerberosBeforeLogon` | Kerberos-auth Windows logon (not on DC) | TGT (4768) + TGS (4769) + optional 4672 | TGT 50-200ms before, TGS 20-100ms after TGT |
+| `KerberosBeforeLogon` | Kerberos-auth Windows logon (not on DC) | TGT (4768) + TGS (4769) | TGT 50-200ms before, TGS 20-100ms after TGT; elevated-session 4672 remains tied to the target-host 4624 |
 | `ProcessAccessAfterRemoteThread` | CreateRemoteThread targeting lsass | ProcessAccess (Sysmon 10) | 1-50ms after |
 | `SupplementaryAuditEvents` | Process creation with admin commands | 4720/4726/4728/4697/4698/1102 | 100-500ms after |
 

--- a/docs/reference/CUSTOMIZING_CONFIG.md
+++ b/docs/reference/CUSTOMIZING_CONFIG.md
@@ -156,6 +156,7 @@ Configuration files are interconnected. When you add an entry to one file, other
 | A new domain | `proxy_uri_templates.yaml` (URI paths), `site_maps.yaml` (browsing depth) |
 | New proxy User-Agent behavior | `proxy_user_agents.yaml` (workstation/server UA pools, package-manager host bindings, domain-specific update/cert/telemetry overrides) |
 | New TLS OCSP responder behavior | `tls_realism.yaml` (`ocsp.responders`) plus `dns_registry.yaml` for each responder hostname |
+| Kerberos TGT pre-auth realism | `kerberos_realism.yaml` (`tgt_success.pre_auth_types`, ticket options, encryption types, and PKINIT certificate profiles). Run `eforge validate-config`; PKINIT (`PreAuthType: 15`) requires populated certificate profile support. |
 | Public NTP fallback servers | `network_params.yaml` (`public_ntp_servers`; scenario-defined internal/domain NTP servers still take precedence) |
 | A new application | `spawn_rules.yaml` (process tree), `process_network_map.yaml` (if it generates traffic) |
 | A DLL load profile | Add `loaded_modules` to the app in `application_catalog.yaml`, or to the process entry in `system_processes.yaml`. Overlay entries extend the DLL pool (deep merge adds new modules alongside defaults). |

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -68,7 +68,7 @@ output/
 | 4738 | User Account Changed | Account Management | Has unique leading `Dummy` field (always "-"). Full account property fields. |
 | 4756 | Member Added to Universal Group | Privilege Escalation | e.g., Enterprise Admins. |
 | 4757 | Member Removed from Universal Group | Privilege Escalation | No sample data verification (identical structure to 4756). |
-| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. CertIssuerName/CertSerialNumber/CertThumbprint always empty. |
+| 4768 | Kerberos TGT Request | Authentication | Keywords reflect success/failure based on Status field. Successful TGTs use data-driven PreAuthType/TicketOptions/encryption distributions; PKINIT (`PreAuthType=15`) populates CertIssuerName/CertSerialNumber/CertThumbprint. |
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -49,7 +49,7 @@ output/
 | 4625 | Failed Logon | Authentication | Version 0. Keywords=0x8010 (Audit Failure). Includes Status/SubStatus failure codes. |
 | 4634 | Logoff | Authentication | Paired with 4624 via matching TargetLogonId. Generated for interactive sessions (type 2/10) at work-day end and for type 3 network logons (including machine account logons on DCs) after short delays. |
 | 4648 | Explicit Credentials | Lateral Movement | Fires when RunAs, PsExec, WMIC, or scheduled tasks use alternate credentials. Emitted on the source system. |
-| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
+| 4672 | Special Privileges Assigned | Privilege Use | Auto-emitted alongside the target-host 4624 for elevated accounts. Admin accounts get full privilege set; regular users get limited set. |
 | 4688 | Process Created | Execution | Version 2. Includes CommandLine, ParentProcessName, MandatoryLabel. TokenElevationType indicates UAC status. |
 | 4689 | Process Exited | Execution | Paired with 4688. Status always 0x0. |
 | 4697 | Service Installed | Persistence | ServiceFileName can contain full command lines. ServiceType 0x10=Own Process. |
@@ -72,7 +72,7 @@ output/
 | 4769 | Kerberos Service Ticket | Authentication | TargetUserName includes @DOMAIN suffix. Keywords reflect success/failure. |
 | 4770 | Kerberos TGT Renewal | Authentication | Always success. |
 | 4771 | Kerberos Pre-Auth Failed | Credential Access | Keywords always 0x8010 (Audit Failure). Key indicator for password spraying. |
-| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). |
+| 4776 | NTLM Credential Validation | Authentication | Field names: TargetUserName (not LogonAccount), Workstation (not SourceWorkstation). Status reflects validation success or failure. |
 | 5156 | WFP Connection Permitted | Network | Application path uses device format (`\device\harddiskvolume1\...`). Direction: %%14592=Inbound, %%14593=Outbound. |
 
 **Known Limitations:**

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -420,7 +420,7 @@ Each event in the `events` list has a `type` field that selects a validated sche
 | Type | Generates | Required Fields | Optional Fields |
 |------|-----------|-----------------|-----------------|
 | `process` | 4688, Sysmon 1, eCAR PROCESS | `process_name` | `command_line`, `supplementary` (auto/none) |
-| `logon` | 4624, 4672, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
+| `logon` | 4624, target-host 4672 for elevated sessions, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
 | `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent` |
@@ -487,7 +487,7 @@ The generation engine automatically emits prerequisite events for certain event 
 | Trigger Event | Auto-Generated Prerequisites | Timing |
 |---|---|---|
 | `connection` (TCP, not port 53) | DNS query (UDP/53) for destination hostname | 5-80ms before |
-| `logon` (Kerberos auth, Windows, not on DC) | Kerberos TGT (4768) + TGS (4769) on DC, optional 4672 for elevated users | TGT 50-200ms before, TGS 20-100ms after TGT |
+| `logon` (Kerberos auth, Windows, not on DC) | Kerberos TGT (4768) + TGS (4769) on DC | TGT 50-200ms before, TGS 20-100ms after TGT. Elevated-session 4672 is emitted with the target-host 4624. |
 | `rdp_session` | DNS query + connection (port 3389) + logon (type 10) | Connection at event time, logon 50-200ms after |
 | `ssh_session` | DNS query + connection (port 22) + syslog auth | Connection at event time |
 | `process` (with admin commands) | Supplementary audit events (4720, 4726, 4728, 4697, 4698, 1102) inferred from command-line patterns | 100-500ms after |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "evidence-forge"
-version = "0.4.0"
+version = "0.4.1"
 description = "Generate realistic synthetic security logs for cybersecurity threat hunting training and research"
 readme = "README.md"
 authors = [

--- a/src/evidenceforge/__init__.py
+++ b/src/evidenceforge/__init__.py
@@ -27,5 +27,5 @@ for cybersecurity threat hunting training and research. It uses a two-phase
 architecture combining LLM-driven scenario creation with deterministic log generation.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __all__ = []  # Will be expanded as modules are implemented

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -1018,6 +1018,7 @@ def validate_config() -> ValidationResult:
         ConnectionEntry,
         CreateRemoteThreadPatternEntry,
         DnsEntry,
+        KerberosRealismConfig,
         OuiEntry,
         PersonaEntry,
         ProcessAccessPatternEntry,
@@ -1125,6 +1126,15 @@ def validate_config() -> ValidationResult:
     tls_realism_data = load_tls_realism()
     if tls_realism_data:
         _SCHEMA_CHECKS.append(([tls_realism_data], TlsRealismConfig, "tls_realism.yaml"))
+
+    # kerberos_realism.yaml
+    from evidenceforge.generation.activity.kerberos_realism import load_kerberos_realism
+
+    kerberos_realism_data = load_kerberos_realism()
+    if kerberos_realism_data:
+        _SCHEMA_CHECKS.append(
+            ([kerberos_realism_data], KerberosRealismConfig, "kerberos_realism.yaml")
+        )
 
     # smb_file_transfers.yaml
     from evidenceforge.generation.activity.smb_file_transfers import load_smb_file_transfers

--- a/src/evidenceforge/config/activity/README.md
+++ b/src/evidenceforge/config/activity/README.md
@@ -19,6 +19,7 @@ caches data after first load. Two files (`network_params.yaml`,
 | `system_processes.yaml` | `system_processes.py` | Baseline Windows scheduled tasks and system services (svchost, MpCmdRun, etc.). |
 | `tls_issuers.yaml` | `tls_issuers.py` | Certificate issuer configs (Let's Encrypt, DigiCert, etc.) with validity periods and key types. |
 | `tls_realism.yaml` | `tls_realism.py` | TLS SAN, OCSP, certificate-chain, and destination-profile settings with overlay support. |
+| `kerberos_realism.yaml` | `kerberos_realism.py` | Kerberos 4768 TGT PreAuthType, TicketOptions, encryption, and PKINIT certificate field distributions with overlay support. |
 | `proxy_uri_templates.yaml` | `proxy_uri.py` | Per-domain URI path templates for proxy logs (Windows Update, CRL, OCSP, Azure AD, etc.). |
 | `network_params.yaml` | `engine/emitter_setup.py` | MAC address OUI prefixes (Dell, HP, VMware, etc.) for realistic MAC generation. |
 | `systemd_schedules.yaml` | `engine/baseline.py` | Systemd timer and cron job schedules (logrotate, fstrim, apt-daily, etc.). |

--- a/src/evidenceforge/config/activity/kerberos_realism.yaml
+++ b/src/evidenceforge/config/activity/kerberos_realism.yaml
@@ -1,0 +1,62 @@
+# Kerberos realism knobs for Windows Security authentication events.
+#
+# User customizations go in:
+#   .eforge/config/activity/kerberos_realism.yaml
+#
+# Overlay behavior: nested dicts merge and lists extend. Prefer overriding
+# weights by profile key instead of adding duplicate profile values.
+
+tgt_success:
+  pre_auth_types:
+    encrypted_timestamp:
+      value: 2
+      weight: 96
+      certificate_required: false
+      description: "Encrypted timestamp pre-auth; common for password and machine TGT requests."
+    pkinit:
+      value: 15
+      weight: 3
+      certificate_required: true
+      certificate_profile: enterprise_user
+      description: "PKINIT/smart-card or certificate-based pre-auth."
+    none_or_legacy:
+      value: 0
+      weight: 1
+      certificate_required: false
+      description: "No pre-auth/legacy edge cases; intentionally rare."
+
+  ticket_options:
+    forwardable_renewable_canonicalize:
+      value: "0x40810010"
+      weight: 60
+    forwardable_renewable:
+      value: "0x40810000"
+      weight: 20
+    renewable_canonicalize:
+      value: "0x40000010"
+      weight: 10
+    renewable_ok_as_delegate:
+      value: "0x50800000"
+      weight: 5
+    canonicalize_only:
+      value: "0x10"
+      weight: 5
+
+  encryption_types:
+    aes256:
+      value: "0x12"
+      weight: 70
+    aes128:
+      value: "0x11"
+      weight: 20
+    rc4_hmac:
+      value: "0x17"
+      weight: 10
+
+certificate_profiles:
+  enterprise_user:
+    issuer_names:
+      - "CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"
+      - "CN=Acme Enterprise Smartcard CA, O=Acme Corp, C=US"
+    serial_hex_bytes: 16
+    thumbprint_hex_chars: 40

--- a/src/evidenceforge/config/formats/windows_event_security.yaml
+++ b/src/evidenceforge/config/formats/windows_event_security.yaml
@@ -1400,6 +1400,12 @@ output:
         {% if EventID in [4723, 4726] %}
         <Data Name="PrivilegeList">{{ PrivilegeList | default('-') }}</Data>
         {% endif %}
+        {% elif EventID in [4800, 4801] %}
+        <Data Name="TargetUserSid">{{ TargetUserSid }}</Data>
+        <Data Name="TargetUserName">{{ TargetUserName }}</Data>
+        <Data Name="TargetDomainName">{{ TargetDomainName }}</Data>
+        <Data Name="TargetLogonId">{{ TargetLogonId }}</Data>
+        <Data Name="SessionId">{{ SessionId }}</Data>
         {% elif EventID == 5156 %}
         <Data Name="ProcessID">{{ ProcessID }}</Data>
         <Data Name="Application">{{ Application }}</Data>

--- a/src/evidenceforge/config/formats/windows_event_security.yaml
+++ b/src/evidenceforge/config/formats/windows_event_security.yaml
@@ -1286,7 +1286,7 @@ output:
         <Data Name="TicketOptions">{{ TicketOptions }}</Data>
         <Data Name="Status">{{ Status }}</Data>
         <Data Name="TicketEncryptionType">{{ TicketEncryptionType }}</Data>
-        <Data Name="PreAuthType">{{ PreAuthType | default(15) }}</Data>
+        <Data Name="PreAuthType">{{ PreAuthType | default(2) }}</Data>
         <Data Name="IpAddress">{{ IpAddress }}</Data>
         <Data Name="IpPort">{{ IpPort | default(0) }}</Data>
         <Data Name="CertIssuerName">{{ CertIssuerName | default('') }}</Data>

--- a/src/evidenceforge/config/schemas.py
+++ b/src/evidenceforge/config/schemas.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # --- DNS Registry ---
 
@@ -319,6 +319,183 @@ class TlsRealismConfig(BaseModel, extra="forbid"):
     ocsp: TlsOcspConfig
     certificate_chains: TlsCertificateChainConfig
     destinations: TlsDestinationsConfig
+
+
+# --- Kerberos Realism ---
+
+
+class KerberosWeightedHexValue(BaseModel, extra="forbid"):
+    """Weighted hex value used by kerberos_realism.yaml."""
+
+    value: str
+    weight: int
+
+    @field_validator("value")
+    @classmethod
+    def value_hex(cls, v: str) -> str:
+        if not v.startswith("0x"):
+            raise ValueError("value must be a hex string beginning with 0x")
+        int(v, 16)
+        return v
+
+    @field_validator("weight")
+    @classmethod
+    def weight_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("weight must be positive")
+        return v
+
+
+class KerberosPreAuthTypeEntry(BaseModel, extra="forbid"):
+    """Weighted Kerberos pre-auth type profile."""
+
+    value: int
+    weight: int
+    certificate_required: bool
+    certificate_profile: str | None = None
+    description: str = ""
+
+    @field_validator("value")
+    @classmethod
+    def allowed_pre_auth_type(cls, v: int) -> int:
+        if v not in {0, 2, 15}:
+            raise ValueError("pre-auth value must be one of 0, 2, or 15")
+        return v
+
+    @field_validator("weight")
+    @classmethod
+    def weight_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("weight must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def coherent_certificate_flags(self) -> KerberosPreAuthTypeEntry:
+        if self.value == 15 and not self.certificate_required:
+            raise ValueError("PreAuthType 15 must set certificate_required=true")
+        if self.certificate_required and self.value != 15:
+            raise ValueError("certificate_required=true is only valid for PreAuthType 15")
+        if self.value == 15 and not self.certificate_profile:
+            raise ValueError("PreAuthType 15 must reference a certificate_profile")
+        if self.value != 15 and self.certificate_profile:
+            raise ValueError("certificate_profile is only valid for PreAuthType 15")
+        return self
+
+
+class KerberosTgtSuccessConfig(BaseModel, extra="forbid"):
+    """Successful 4768 field distributions."""
+
+    pre_auth_types: dict[str, KerberosPreAuthTypeEntry]
+    ticket_options: dict[str, KerberosWeightedHexValue]
+    encryption_types: dict[str, KerberosWeightedHexValue]
+
+    @field_validator("pre_auth_types", "ticket_options", "encryption_types")
+    @classmethod
+    def weighted_profiles_non_empty(cls, v: dict) -> dict:
+        if not v:
+            raise ValueError("weighted profile dict must not be empty")
+        if sum(entry.weight for entry in v.values()) <= 0:
+            raise ValueError("weighted profile dict must have a positive total weight")
+        return v
+
+    @field_validator("ticket_options")
+    @classmethod
+    def allowed_ticket_options(
+        cls, v: dict[str, KerberosWeightedHexValue]
+    ) -> dict[str, KerberosWeightedHexValue]:
+        allowed = {"0x40810010", "0x40810000", "0x40000010", "0x50800000", "0x10"}
+        invalid = sorted({entry.value for entry in v.values()} - allowed)
+        if invalid:
+            raise ValueError(f"ticket_options contains unsupported values: {invalid}")
+        return v
+
+    @field_validator("encryption_types")
+    @classmethod
+    def allowed_encryption_types(
+        cls, v: dict[str, KerberosWeightedHexValue]
+    ) -> dict[str, KerberosWeightedHexValue]:
+        allowed = {"0x12", "0x11", "0x17"}
+        invalid = sorted({entry.value for entry in v.values()} - allowed)
+        if invalid:
+            raise ValueError(f"encryption_types contains unsupported values: {invalid}")
+        return v
+
+    @model_validator(mode="after")
+    def realistic_weights(self) -> KerberosTgtSuccessConfig:
+        pre_auth_weight_by_value: dict[int, int] = {}
+        for entry in self.pre_auth_types.values():
+            pre_auth_weight_by_value[entry.value] = (
+                pre_auth_weight_by_value.get(entry.value, 0) + entry.weight
+            )
+        total_pre_auth = sum(pre_auth_weight_by_value.values())
+        if pre_auth_weight_by_value.get(2, 0) == 0:
+            raise ValueError("PreAuthType 2 must be present for normal encrypted timestamp TGTs")
+        if pre_auth_weight_by_value.get(15, 0) / total_pre_auth > 0.20:
+            raise ValueError("PreAuthType 15 PKINIT weight must not exceed 20% by default")
+        if pre_auth_weight_by_value.get(0, 0) / total_pre_auth > 0.05:
+            raise ValueError("PreAuthType 0/no-preauth weight must not exceed 5%")
+
+        encryption_weight_by_value: dict[str, int] = {}
+        for entry in self.encryption_types.values():
+            encryption_weight_by_value[entry.value] = (
+                encryption_weight_by_value.get(entry.value, 0) + entry.weight
+            )
+        total_encryption = sum(encryption_weight_by_value.values())
+        if encryption_weight_by_value.get("0x17", 0) / total_encryption > 0.30:
+            raise ValueError("RC4 encryption type 0x17 weight must not exceed 30%")
+        return self
+
+
+class KerberosCertificateProfile(BaseModel, extra="forbid"):
+    """Certificate field generation profile for Kerberos PKINIT events."""
+
+    issuer_names: list[str]
+    serial_hex_bytes: int = 16
+    thumbprint_hex_chars: int = 40
+
+    @field_validator("issuer_names")
+    @classmethod
+    def issuer_names_non_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("issuer_names must not be empty")
+        if any(not issuer for issuer in v):
+            raise ValueError("issuer_names entries must be non-empty")
+        return v
+
+    @field_validator("serial_hex_bytes")
+    @classmethod
+    def serial_bytes_range(cls, v: int) -> int:
+        if not 8 <= v <= 20:
+            raise ValueError("serial_hex_bytes must be between 8 and 20")
+        return v
+
+    @field_validator("thumbprint_hex_chars")
+    @classmethod
+    def thumbprint_length_valid(cls, v: int) -> int:
+        if v not in {40, 64}:
+            raise ValueError("thumbprint_hex_chars must be 40 (SHA-1) or 64 (SHA-256)")
+        return v
+
+
+class KerberosRealismConfig(BaseModel, extra="forbid"):
+    """Root schema for kerberos_realism.yaml."""
+
+    tgt_success: KerberosTgtSuccessConfig
+    certificate_profiles: dict[str, KerberosCertificateProfile] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def referenced_certificate_profiles_exist(self) -> KerberosRealismConfig:
+        profile_names = set(self.certificate_profiles)
+        missing = sorted(
+            {
+                entry.certificate_profile
+                for entry in self.tgt_success.pre_auth_types.values()
+                if entry.certificate_profile and entry.certificate_profile not in profile_names
+            }
+        )
+        if missing:
+            raise ValueError(f"unknown certificate_profile references: {missing}")
+        return self
 
 
 # --- SMB File Transfers ---

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -230,6 +230,9 @@ class KerberosContext:
     ticket_status: str = "0x0"
     encryption_type: str = ""  # e.g., "0x12" (AES-256)
     pre_auth_type: int = 0  # 4768 only
+    cert_issuer_name: str = ""  # 4768 PKINIT only
+    cert_serial_number: str = ""  # 4768 PKINIT only
+    cert_thumbprint: str = ""  # 4768 PKINIT only
     source_ip: str = ""  # IPv6-mapped: "::ffff:x.x.x.x"
     source_port: int = 0
     reporting_pid: int = 0  # PID of lsass.exe that wrote this event

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -5154,6 +5154,9 @@ class ActivityGenerator:
         # Kerberos realm is always the DNS FQDN in uppercase, never NetBIOS short name
         domain = domain or getattr(self, "_ad_domain", "corp.local").upper()
         rng = _get_rng()
+        from evidenceforge.generation.activity.kerberos_realism import pick_tgt_success_fields
+
+        tgt_fields = pick_tgt_success_fields(rng)
 
         event = SecurityEvent(
             timestamp=time,
@@ -5165,13 +5168,12 @@ class ActivityGenerator:
                 target_sid=self._get_sid(username),
                 service_name="krbtgt",
                 service_sid=self._get_sid("krbtgt"),
-                ticket_options=rng.choices(
-                    ["0x40810010", "0x40810000", "0x40000010", "0x50800000", "0x10"],
-                    weights=[60, 20, 10, 5, 5],
-                    k=1,
-                )[0],
-                encryption_type=rng.choices(["0x12", "0x11", "0x17"], weights=[70, 15, 15], k=1)[0],
-                pre_auth_type=15,
+                ticket_options=tgt_fields["ticket_options"],
+                encryption_type=tgt_fields["encryption_type"],
+                pre_auth_type=tgt_fields["pre_auth_type"],
+                cert_issuer_name=tgt_fields["cert_issuer_name"],
+                cert_serial_number=tgt_fields["cert_serial_number"],
+                cert_thumbprint=tgt_fields["cert_thumbprint"],
                 source_ip=f"::ffff:{source_ip}",
                 source_port=_ephemeral_port(rng, self._os_for_ip(source_ip)),
             ),

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -1824,8 +1824,9 @@ class ActivityGenerator:
             )
 
         # Emit DC-side Kerberos events for domain logons via causal expansion.
-        # The KerberosBeforeLogon rule handles TGT (4768), TGS (4769), and
-        # optional 4672 for elevated users.
+        # The target-host 4624 renderer owns 4672 for elevated sessions because
+        # that privilege assignment belongs to the host where the logon session
+        # is created, not to the DC ticket request itself.
         auth_package_name = auth_pkg.get("AuthenticationPackageName", "Negotiate")
         self._expand_and_emit(
             "logon",
@@ -1979,22 +1980,6 @@ class ActivityGenerator:
             time=tgs_time,
         )
 
-        # 4672 Special Privileges on DC for elevated users (domain admins)
-        if self._should_elevate(user):
-            priv_time = tgt_time + timedelta(milliseconds=rng.randint(1, 10))
-            priv_event = SecurityEvent(
-                timestamp=priv_time,
-                event_type="special_privileges",
-                dst_host=self._build_dc_host_context(dc_hostname),
-                auth=AuthContext(
-                    username=user.username,
-                    user_sid=self._get_sid(user.username),
-                    logon_id=self._get_user_logon_id(user.username, dc_hostname),
-                    reporting_pid=self._get_system_pid(dc_hostname, "lsass", 0x2E0),
-                ),
-            )
-            self.dispatcher.dispatch(priv_event)
-
     def generate_failed_logon(
         self,
         user: User,
@@ -2118,6 +2103,7 @@ class ActivityGenerator:
                 workstation=system.hostname,
                 dc_hostname=dc_system.hostname,
                 time=time,
+                status=substatus,
             )
 
             # 4771 Kerberos pre-authentication failure on DC
@@ -5271,6 +5257,7 @@ class ActivityGenerator:
         workstation: str,
         dc_hostname: str,
         time: datetime,
+        status: str = "0x0",
     ) -> None:
         """Generate NTLM credential validation event (4776) on the DC."""
         event = SecurityEvent(
@@ -5280,6 +5267,7 @@ class ActivityGenerator:
             auth=AuthContext(
                 username=username,
                 source_ip=workstation,  # SourceWorkstation stored in source_ip
+                failure_status=status,
             ),
         )
 
@@ -5563,14 +5551,24 @@ class ActivityGenerator:
     def _get_user_logon_id(self, username: str, hostname: str) -> str:
         """Look up the user's active session LogonID on the given host.
 
-        Returns the session LogonID if found, or '0x3e7' (SYSTEM) as fallback.
+        Returns the session LogonID if found. Well-known service identities use
+        their canonical logon IDs. Human/domain accounts without an active
+        session fall back to 0x0 rather than SYSTEM's 0x3e7.
         """
+        canonical_logon_ids = {
+            "SYSTEM": "0x3e7",
+            "LOCAL SERVICE": "0x3e5",
+            "NETWORK SERVICE": "0x3e4",
+        }
+        if username in canonical_logon_ids:
+            return canonical_logon_ids[username]
+
         sessions = self.state_manager.get_sessions_for_user(username)
         if sessions:
             active = next((s for s in sessions if s.system == hostname), None)
             if active:
                 return active.logon_id
-        return "0x3e7"
+        return "0x0"
 
     def generate_log_cleared(
         self,

--- a/src/evidenceforge/generation/activity/kerberos_realism.py
+++ b/src/evidenceforge/generation/activity/kerberos_realism.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Kerberos realism configuration loader and pickers."""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from evidenceforge.config import get_activity_directory
+from evidenceforge.config.overlay import deep_merge_dict, load_with_overlay
+
+_CONFIG_PATH = get_activity_directory() / "kerberos_realism.yaml"
+_CACHED_DATA: dict[str, Any] | None = None
+
+
+def _merge_kerberos_realism(default: dict, overlay: dict) -> dict:
+    """Merge Kerberos realism overlay with package defaults."""
+    return deep_merge_dict(default, overlay)
+
+
+def load_kerberos_realism() -> dict[str, Any]:
+    """Load Kerberos realism config from YAML, merged with overlay."""
+    global _CACHED_DATA
+    if _CACHED_DATA is not None:
+        return _CACHED_DATA
+
+    _CACHED_DATA = load_with_overlay(
+        _CONFIG_PATH,
+        "activity/kerberos_realism.yaml",
+        _merge_kerberos_realism,
+    )
+    return _CACHED_DATA
+
+
+def reset_kerberos_realism_cache() -> None:
+    """Clear cached Kerberos realism config. Intended for tests."""
+    global _CACHED_DATA
+    _CACHED_DATA = None
+
+
+def pick_tgt_success_fields(rng: random.Random) -> dict[str, Any]:
+    """Pick coherent 4768 success fields from Kerberos realism config."""
+    cfg = load_kerberos_realism()
+    tgt_success = cfg.get("tgt_success", {})
+    pre_auth = _pick_weighted_profile(tgt_success.get("pre_auth_types", {}), rng)
+    certificate_fields = _certificate_fields(pre_auth, rng)
+    return {
+        "ticket_options": _pick_weighted_value(tgt_success.get("ticket_options", {}), rng),
+        "encryption_type": _pick_weighted_value(tgt_success.get("encryption_types", {}), rng),
+        "pre_auth_type": int(pre_auth.get("value", 2)),
+        **certificate_fields,
+    }
+
+
+def _pick_weighted_value(profiles: dict[str, dict[str, Any]], rng: random.Random) -> str:
+    """Pick a configured weighted profile and return its value."""
+    profile = _pick_weighted_profile(profiles, rng)
+    return str(profile.get("value", ""))
+
+
+def _pick_weighted_profile(
+    profiles: dict[str, dict[str, Any]], rng: random.Random
+) -> dict[str, Any]:
+    """Pick one profile from a keyed weighted profile dict."""
+    valid_profiles = [
+        profile
+        for profile in profiles.values()
+        if isinstance(profile, dict) and int(profile.get("weight", 0)) > 0
+    ]
+    if not valid_profiles:
+        return {}
+    weights = [int(profile.get("weight", 1)) for profile in valid_profiles]
+    return rng.choices(valid_profiles, weights=weights, k=1)[0]
+
+
+def _certificate_fields(pre_auth: dict[str, Any], rng: random.Random) -> dict[str, str]:
+    """Return 4768 certificate fields for certificate-based pre-auth."""
+    if not pre_auth.get("certificate_required", False):
+        return {
+            "cert_issuer_name": "",
+            "cert_serial_number": "",
+            "cert_thumbprint": "",
+        }
+
+    cfg = load_kerberos_realism()
+    profile_name = str(pre_auth.get("certificate_profile", ""))
+    profile = cfg.get("certificate_profiles", {}).get(profile_name, {})
+    issuer_names = profile.get("issuer_names", [])
+    issuer_name = rng.choice(issuer_names) if issuer_names else ""
+    serial_hex_bytes = int(profile.get("serial_hex_bytes", 16))
+    thumbprint_hex_chars = int(profile.get("thumbprint_hex_chars", 40))
+    serial = "".join(f"{rng.randrange(256):02X}" for _ in range(serial_hex_bytes))
+    thumbprint = "".join(rng.choice("0123456789ABCDEF") for _ in range(thumbprint_hex_chars))
+    return {
+        "cert_issuer_name": issuer_name,
+        "cert_serial_number": serial,
+        "cert_thumbprint": thumbprint,
+    }

--- a/src/evidenceforge/generation/causal/rules.py
+++ b/src/evidenceforge/generation/causal/rules.py
@@ -64,8 +64,9 @@ class KerberosBeforeLogon(ExpansionRule):
 
     Reproduces the logic from ActivityGenerator._emit_dc_kerberos_for_logon().
     Fires when auth_package is "Kerberos", target is Windows, and the target
-    system is not a DC. Delegates to the existing method which handles TGT,
-    TGS, and optional 4672 Special Privileges emission.
+    system is not a DC. Delegates to the existing method which handles TGT
+    and TGS emission. Elevated-session 4672 events are emitted with the
+    target-host 4624, where the logon session is created.
     """
 
     name: str = field(default="kerberos_before_logon")

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -623,6 +623,9 @@ class WindowsEventEmitter(LogEmitter):
             "PreAuthType": krb.pre_auth_type,
             "IpAddress": krb.source_ip,
             "IpPort": krb.source_port,
+            "CertIssuerName": krb.cert_issuer_name,
+            "CertSerialNumber": krb.cert_serial_number,
+            "CertThumbprint": krb.cert_thumbprint,
         }
         self.emit_event(event_data)
 

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -41,6 +41,7 @@ from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 from evidenceforge.generation.emitters.host_base import _SingleHostWriter
 from evidenceforge.utils.paths import sanitize_path_component
+from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import ensure_utc
 
 win_logger = logging.getLogger(__name__)
@@ -290,8 +291,9 @@ class WindowsEventEmitter(LogEmitter):
     def _render_special_privileges(self, event: SecurityEvent) -> None:
         """Render standalone Windows 4672 (Special Privileges Assigned).
 
-        Used for DC-side privilege assignment during Kerberos authentication,
-        where the DC logs 4672 independently of the target host's logon event.
+        Used for explicit standalone 4672 events. Normal elevated logons render
+        4672 from _render_logon() so the privilege event shares the target
+        host and LogonID with its 4624.
         """
         rng = random.Random()
         auth = event.auth
@@ -341,6 +343,7 @@ class WindowsEventEmitter(LogEmitter):
         rng = random.Random()
         auth = event.auth
         host = self._get_host(event)
+        session_id = self._session_id_for_logon(auth.logon_id)
         event_data = {
             "EventID": 4800,
             "TimeCreated": event.timestamp,
@@ -353,7 +356,7 @@ class WindowsEventEmitter(LogEmitter):
             "TargetUserName": auth.username,
             "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
             "TargetLogonId": auth.logon_id or "0x0",
-            "SessionId": rng.randint(1, 5),
+            "SessionId": session_id,
         }
         self.emit_event(event_data)
 
@@ -362,6 +365,7 @@ class WindowsEventEmitter(LogEmitter):
         rng = random.Random()
         auth = event.auth
         host = self._get_host(event)
+        session_id = self._session_id_for_logon(auth.logon_id)
         event_data = {
             "EventID": 4801,
             "TimeCreated": event.timestamp,
@@ -374,7 +378,7 @@ class WindowsEventEmitter(LogEmitter):
             "TargetUserName": auth.username,
             "TargetDomainName": _subject_domain(auth.username, host.netbios_domain),
             "TargetLogonId": auth.logon_id or "0x0",
-            "SessionId": rng.randint(1, 5),
+            "SessionId": session_id,
         }
         self.emit_event(event_data)
 
@@ -695,7 +699,7 @@ class WindowsEventEmitter(LogEmitter):
             "PackageName": "MICROSOFT_AUTHENTICATION_PACKAGE_V1_0",
             "TargetUserName": auth.username,
             "Workstation": auth.source_ip,  # workstation stored in source_ip
-            "Status": "0x0",
+            "Status": auth.failure_status or "0x0",
         }
         self.emit_event(event_data)
 
@@ -770,6 +774,11 @@ class WindowsEventEmitter(LogEmitter):
         if path and len(path) > 2 and path[1] == ":":
             return f"\\device\\harddiskvolume1\\{path[3:]}".lower()
         return path.lower()
+
+    @staticmethod
+    def _session_id_for_logon(logon_id: str) -> int:
+        """Return a stable Terminal Services session ID for a LogonID."""
+        return 1 + (_stable_seed(f"windows_session_id_{logon_id or '0x0'}") % 5)
 
     # --- Phase 1: Kerberos Pre-Auth Failed (4771) ---
 

--- a/tests/unit/test_dc_kerberos_logon.py
+++ b/tests/unit/test_dc_kerberos_logon.py
@@ -242,8 +242,10 @@ class TestDCKerberosOnLogon:
         assert "kerberos_tgt" not in event_types
         assert "kerberos_service" not in event_types
 
-    def test_dc_4672_for_elevated_user(self, activity_gen, mock_emitters, windows_system):
-        """Elevated users should get 4672 (Special Privileges) on the DC during Kerberos auth."""
+    def test_elevated_user_4672_stays_on_logon_target(
+        self, activity_gen, mock_emitters, windows_system
+    ):
+        """Elevated users get 4672 on the host where the logon session is created."""
         # Use a sysadmin persona which has ~80% elevation rate
         from evidenceforge.models.scenario import User
 
@@ -254,7 +256,7 @@ class TestDCKerberosOnLogon:
             persona="sysadmin",
         )
 
-        special_priv_count = 0
+        elevated_logon_count = 0
         total_kerberos_count = 0
 
         for i in range(30):
@@ -275,22 +277,26 @@ class TestDCKerberosOnLogon:
 
             if "kerberos_tgt" in event_types:
                 total_kerberos_count += 1
-                if "special_privileges" in event_types:
-                    special_priv_count += 1
-                    # Verify 4672 is on the DC
-                    priv_event = next(e for e in events if e.event_type == "special_privileges")
-                    assert priv_event.dst_host.hostname == "DC-01"
-                    assert priv_event.auth.username == "admin.user"
+                logon_event = next(e for e in events if e.event_type == "logon")
+                if logon_event.auth.elevated:
+                    elevated_logon_count += 1
+                    assert logon_event.dst_host.hostname == "WKS-01"
+                    assert logon_event.auth.username == "admin.user"
+                    assert logon_event.auth.logon_id not in {"", "0x0", "0x3e7"}
+                assert not any(
+                    e.event_type == "special_privileges" and e.dst_host.hostname == "DC-01"
+                    for e in events
+                )
 
-        # Should have at least some Kerberos logons with 4672
+        # Should have at least some Kerberos logons with elevated target-host sessions.
         assert total_kerberos_count > 0, "No Kerberos logons in 30 attempts"
-        assert special_priv_count > 0, "No DC 4672 events for admin in Kerberos logons"
+        assert elevated_logon_count > 0, "No elevated target-host logons for admin"
 
     def test_no_dc_4672_for_regular_user(
         self, activity_gen, mock_emitters, windows_system, test_user
     ):
-        """Regular users should rarely get 4672 on DC (only ~5% elevation rate)."""
-        special_priv_count = 0
+        """Regular users should rarely get 4672 (only ~5% elevation rate)."""
+        elevated_logon_count = 0
 
         for i in range(30):
             mock_emitters["windows_event_security"].emit.reset_mock()
@@ -306,14 +312,50 @@ class TestDCKerberosOnLogon:
             events = [
                 call[0][0] for call in mock_emitters["windows_event_security"].emit.call_args_list
             ]
-            if any(e.event_type == "special_privileges" for e in events):
-                special_priv_count += 1
+            logon_event = next(e for e in events if e.event_type == "logon")
+            if logon_event.auth.elevated:
+                elevated_logon_count += 1
+            assert not any(e.event_type == "special_privileges" for e in events)
 
         # Regular users have ~5% elevation rate, so most runs should have very few
         # With 30 attempts * 70% Kerberos * 5% elevation = ~1 expected
-        assert special_priv_count < 15, (
-            f"Too many DC 4672 events for regular user: {special_priv_count}"
+        assert elevated_logon_count < 15, (
+            f"Too many elevated logons for regular user: {elevated_logon_count}"
         )
+
+    def test_dc_kerberos_expansion_does_not_emit_standalone_4672(
+        self, activity_gen, mock_emitters, windows_system
+    ):
+        """DC Kerberos expansion emits 4768/4769 but not a separate DC-side 4672."""
+        admin_user = User(
+            username="admin.user",
+            full_name="Admin User",
+            email="admin.user@corp.com",
+            persona="sysadmin",
+        )
+
+        for i in range(30):
+            mock_emitters["windows_event_security"].emit.reset_mock()
+            ts = datetime(2024, 3, 15, 11, i, 0, tzinfo=UTC)
+            activity_gen.state_manager.set_current_time(ts)
+            activity_gen.generate_logon(
+                user=admin_user,
+                system=windows_system,
+                time=ts,
+                logon_type=3,
+                source_ip="10.10.10.50",
+            )
+            events = [
+                call[0][0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+            ]
+            if any(e.event_type == "kerberos_tgt" for e in events):
+                assert not any(
+                    e.event_type == "special_privileges" and e.dst_host.hostname == "DC-01"
+                    for e in events
+                )
+                return
+
+        pytest.fail("No Kerberos logons generated in 30 attempts")
 
     def test_no_dc_kerberos_when_no_dc_configured(
         self, state_manager, mock_emitters, windows_system, test_user

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -549,6 +549,95 @@ class TestWindowsEventEmitter:
         assert "UserData" in content
         assert "EventData" not in content or content.count("EventData") == 0
 
+    def test_emit_workstation_lock_contains_event_data(self, format_def, temp_output):
+        """Test emitting 4800 (workstation locked) with populated EventData fields."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)
+        event_data = {
+            "EventID": 4800,
+            "TimeCreated": datetime(2024, 1, 15, 10, 30, 0, 0, tzinfo=UTC),
+            "Computer": "WKS-01.corp.local",
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 540,
+            "ExecutionThreadID": 112,
+            "TargetUserSid": "S-1-5-21-123-456-789-1001",
+            "TargetUserName": "jsmith",
+            "TargetDomainName": "CORP",
+            "TargetLogonId": "0x4f2a1b",
+            "SessionId": 2,
+        }
+        emitter.emit_event(event_data)
+        emitter.close()
+        content = temp_output.read_text()
+        assert "<EventID>4800</EventID>" in content
+        assert '<Data Name="TargetUserName">jsmith</Data>' in content
+        assert '<Data Name="TargetLogonId">0x4f2a1b</Data>' in content
+        assert '<Data Name="SessionId">2</Data>' in content
+
+    def test_emit_workstation_unlock_contains_event_data(self, format_def, temp_output):
+        """Test emitting 4801 (workstation unlocked) with populated EventData fields."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)
+        event_data = {
+            "EventID": 4801,
+            "TimeCreated": datetime(2024, 1, 15, 10, 35, 0, 0, tzinfo=UTC),
+            "Computer": "WKS-01.corp.local",
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 541,
+            "ExecutionThreadID": 113,
+            "TargetUserSid": "S-1-5-21-123-456-789-1001",
+            "TargetUserName": "jsmith",
+            "TargetDomainName": "CORP",
+            "TargetLogonId": "0x4f2a1b",
+            "SessionId": 2,
+        }
+        emitter.emit_event(event_data)
+        emitter.close()
+        content = temp_output.read_text()
+        assert "<EventID>4801</EventID>" in content
+        assert '<Data Name="TargetUserName">jsmith</Data>' in content
+        assert '<Data Name="TargetLogonId">0x4f2a1b</Data>' in content
+        assert '<Data Name="SessionId">2</Data>' in content
+
+    def test_lock_unlock_share_stable_session_id(self, format_def, temp_output):
+        """4800 and 4801 for the same LogonID should share the same SessionId."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)
+        host = HostContext(
+            hostname="WKS-01",
+            fqdn="WKS-01.corp.local",
+            ip="10.0.0.50",
+            os="Windows 11",
+            os_category="windows",
+            system_type="workstation",
+            netbios_domain="CORP",
+        )
+        auth = AuthContext(
+            username="jsmith",
+            user_sid="S-1-5-21-123-456-789-1001",
+            logon_id="0x4f2a1b",
+        )
+        emitter.emit(
+            SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 30, 0, 0, tzinfo=UTC),
+                event_type="workstation_locked",
+                dst_host=host,
+                auth=auth,
+            )
+        )
+        emitter.emit(
+            SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 35, 0, 0, tzinfo=UTC),
+                event_type="workstation_unlocked",
+                dst_host=host,
+                auth=auth,
+            )
+        )
+        emitter.close()
+        content = temp_output.read_text()
+        session_lines = [line for line in content.splitlines() if 'Data Name="SessionId"' in line]
+        assert len(session_lines) == 2
+        assert session_lines[0] == session_lines[1]
+
     def test_emit_service_installed(self, format_def, temp_output):
         """Test emitting 4697 (service installed)."""
         emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)

--- a/tests/unit/test_kerberos_realism.py
+++ b/tests/unit/test_kerberos_realism.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Tests for data-driven Kerberos realism profiles."""
+
+import random
+
+from evidenceforge.generation.activity import kerberos_realism
+
+
+def test_default_tgt_success_profile_mostly_uses_encrypted_timestamp():
+    rng = random.Random(7)
+
+    counts: dict[int, int] = {}
+    for _ in range(1000):
+        fields = kerberos_realism.pick_tgt_success_fields(rng)
+        counts[fields["pre_auth_type"]] = counts.get(fields["pre_auth_type"], 0) + 1
+
+    assert counts[2] > 900
+    assert counts.get(15, 0) < 60
+
+
+def test_pkinit_profile_populates_certificate_fields(monkeypatch):
+    def load_pkinit_only_config():
+        return {
+            "tgt_success": {
+                "pre_auth_types": {
+                    "pkinit": {
+                        "value": 15,
+                        "weight": 1,
+                        "certificate_required": True,
+                        "certificate_profile": "enterprise_user",
+                    }
+                },
+                "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+            },
+            "certificate_profiles": {
+                "enterprise_user": {
+                    "issuer_names": ["CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"],
+                    "serial_hex_bytes": 16,
+                    "thumbprint_hex_chars": 40,
+                }
+            },
+        }
+
+    monkeypatch.setattr(kerberos_realism, "load_kerberos_realism", load_pkinit_only_config)
+
+    fields = kerberos_realism.pick_tgt_success_fields(random.Random(3))
+
+    assert fields["pre_auth_type"] == 15
+    assert fields["cert_issuer_name"] == "CN=Acme Enterprise Issuing CA, O=Acme Corp, C=US"
+    assert len(fields["cert_serial_number"]) == 32
+    assert len(fields["cert_thumbprint"]) == 40
+
+
+def test_non_pkinit_profile_leaves_certificate_fields_empty(monkeypatch):
+    def load_encrypted_timestamp_only_config():
+        return {
+            "tgt_success": {
+                "pre_auth_types": {
+                    "encrypted_timestamp": {
+                        "value": 2,
+                        "weight": 1,
+                        "certificate_required": False,
+                    }
+                },
+                "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+            },
+            "certificate_profiles": {},
+        }
+
+    monkeypatch.setattr(
+        kerberos_realism, "load_kerberos_realism", load_encrypted_timestamp_only_config
+    )
+
+    fields = kerberos_realism.pick_tgt_success_fields(random.Random(3))
+
+    assert fields["pre_auth_type"] == 2
+    assert fields["cert_issuer_name"] == ""
+    assert fields["cert_serial_number"] == ""
+    assert fields["cert_thumbprint"] == ""
+
+
+def test_kerberos_realism_overlay_overrides_nested_weight(tmp_path, monkeypatch):
+    overlay_dir = tmp_path / ".eforge" / "config" / "activity"
+    overlay_dir.mkdir(parents=True)
+    (overlay_dir / "kerberos_realism.yaml").write_text(
+        "tgt_success:\n  pre_auth_types:\n    encrypted_timestamp:\n      weight: 1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    kerberos_realism.reset_kerberos_realism_cache()
+
+    data = kerberos_realism.load_kerberos_realism()
+
+    assert data["tgt_success"]["pre_auth_types"]["encrypted_timestamp"]["value"] == 2
+    assert data["tgt_success"]["pre_auth_types"]["encrypted_timestamp"]["weight"] == 1
+    kerberos_realism.reset_kerberos_realism_cache()

--- a/tests/unit/test_phase5_failed_logon.py
+++ b/tests/unit/test_phase5_failed_logon.py
@@ -254,7 +254,7 @@ class TestFailedLogonDC:
         assert "DC-01" in hosts, "Missing 4625/4776 on DC"
 
     def test_failed_logon_dc_gets_4776(self, state_manager, mock_emitters, timestamp):
-        """DC should receive an NTLM validation (4776) event."""
+        """DC should receive a failed NTLM validation (4776) event."""
         ag = ActivityGenerator(state_manager, mock_emitters)
         state_manager.set_current_time(timestamp)
 
@@ -277,6 +277,8 @@ class TestFailedLogonDC:
         ]
         event_types = {e.event_type for e in dc_events}
         assert "ntlm_validation" in event_types, "Missing 4776 on DC"
+        ntlm_event = next(e for e in dc_events if e.event_type == "ntlm_validation")
+        assert ntlm_event.auth.failure_status != "0x0"
 
     def test_no_dc_no_extra_events(self, state_manager, mock_emitters, timestamp):
         """Without dc_system, only workstation events are emitted."""

--- a/tests/unit/test_phase6_p1_realism.py
+++ b/tests/unit/test_phase6_p1_realism.py
@@ -318,6 +318,20 @@ class TestKerberosEvents:
         assert event.event_type == "ntlm_validation"
         assert event.auth.username == "WKS-01$"
         assert event.auth.source_ip == "WKS-01"  # workstation stored in source_ip
+        assert event.auth.failure_status == "0x0"
+
+    def test_failed_ntlm_validation_carries_status(self, activity_gen, mock_emitters):
+        ts = datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC)
+        activity_gen.generate_ntlm_validation(
+            username="jsmith",
+            workstation="WKS-01",
+            dc_hostname="DC-01",
+            time=ts,
+            status="0xc000006a",
+        )
+        event = mock_emitters["windows_event_security"].emit.call_args_list[0][0][0]
+        assert event.event_type == "ntlm_validation"
+        assert event.auth.failure_status == "0xc000006a"
 
 
 class TestInfrastructureDetection:

--- a/tests/unit/test_phase6_p1_realism.py
+++ b/tests/unit/test_phase6_p1_realism.py
@@ -291,6 +291,15 @@ class TestKerberosEvents:
         event = mock_emitters["windows_event_security"].emit.call_args_list[0][0][0]
         assert event.event_type == "kerberos_tgt"
         assert event.kerberos.service_name == "krbtgt"
+        assert event.kerberos.pre_auth_type in {0, 2, 15}
+        if event.kerberos.pre_auth_type == 15:
+            assert event.kerberos.cert_issuer_name
+            assert event.kerberos.cert_serial_number
+            assert event.kerberos.cert_thumbprint
+        else:
+            assert event.kerberos.cert_issuer_name == ""
+            assert event.kerberos.cert_serial_number == ""
+            assert event.kerberos.cert_thumbprint == ""
         assert event.dst_host.fqdn.startswith("DC-01.")
 
     def test_service_ticket_emits_4769(self, activity_gen, mock_emitters):

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -50,3 +50,72 @@ class TestValidateConfig:
             in issue.message
             for issue in result.issues
         )
+
+    def test_validate_config_rejects_pkinit_without_certificate_profile(self, monkeypatch):
+        from evidenceforge.generation.activity import kerberos_realism
+
+        def load_invalid_kerberos_realism():
+            return {
+                "tgt_success": {
+                    "pre_auth_types": {
+                        "pkinit": {
+                            "value": 15,
+                            "weight": 1,
+                            "certificate_required": True,
+                        }
+                    },
+                    "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                    "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+                },
+                "certificate_profiles": {},
+            }
+
+        monkeypatch.setattr(
+            kerberos_realism, "load_kerberos_realism", load_invalid_kerberos_realism
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "kerberos_realism.yaml"
+            and "PreAuthType 15 must reference a certificate_profile" in issue.message
+            for issue in result.issues
+        )
+
+    def test_validate_config_rejects_improbable_preauth_distribution(self, monkeypatch):
+        from evidenceforge.generation.activity import kerberos_realism
+
+        def load_invalid_kerberos_realism():
+            return {
+                "tgt_success": {
+                    "pre_auth_types": {
+                        "encrypted_timestamp": {
+                            "value": 2,
+                            "weight": 1,
+                            "certificate_required": False,
+                        },
+                        "none_or_legacy": {
+                            "value": 0,
+                            "weight": 1,
+                            "certificate_required": False,
+                        },
+                    },
+                    "ticket_options": {"default": {"value": "0x40810010", "weight": 1}},
+                    "encryption_types": {"aes256": {"value": "0x12", "weight": 1}},
+                },
+                "certificate_profiles": {},
+            }
+
+        monkeypatch.setattr(
+            kerberos_realism, "load_kerberos_realism", load_invalid_kerberos_realism
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "kerberos_realism.yaml"
+            and "PreAuthType 0/no-preauth weight must not exceed 5%" in issue.message
+            for issue in result.issues
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "evidence-forge"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Release Windows authentication realism improvements from `dev` to `main`.
- Fix Windows 4672/session semantics, 4800/4801 rendering/session consistency, and failed 4776 status handling.
- Add data-driven Kerberos 4768 pre-auth realism with `kerberos_realism.yaml`, overlay support, and `eforge validate-config` coherence checks.
- Bump package version from `0.4.0` to `0.4.1`.

## Validation

- `uv run pytest tests/unit/test_dc_kerberos_logon.py tests/unit/test_emitters.py tests/unit/test_phase5_failed_logon.py tests/unit/test_phase6_p1_realism.py -q --no-cov`
- `uv run pytest tests/unit/test_kerberos_realism.py tests/unit/test_validate_config.py tests/unit/test_phase6_p1_realism.py tests/unit/test_emitters.py -q --no-cov`
- `uv run eforge validate-config`
- `uv run ruff check .`
- `uv run ruff format --check .`

## Notes

Blind realism review of the regenerated Windows-auth dataset improved from 84% synthetic baseline to 60% synthetic after the Windows auth and Kerberos fixes.