### PR TITLE
fix: avoid duplicate RDP connection emission and preserve source-port correlation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -118,6 +118,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] Security: cap `dns_tunnel` payload/payload_size to 1 MiB to prevent memory exhaustion from untrusted scenarios
 - [x] Security: guard web_scan preset overlay merge against non-dict `presets` payloads to prevent malformed overlay crash/DoS
 - [x] Fix `_find_user_session` mixed tz-aware/naive `start_time` comparison crash (Aardvark finding)
+- [x] Fix RDP remote-logon network evidence duplication/coherence (avoid duplicate type-10 helper connection; preserve shared source-port correlation)
 - [x] Baseline inbound profile traffic no longer depends on outbound role traffic for business-hour gating (fixed UnboundLocalError when outbound profile is empty).
 - [x] Security: validate blocked_c2 interval/duration are > 0 to prevent zero-interval infinite loop DoS
 - [x] Harden temporal evaluator `exclude_ports` parsing against malformed `zeek_conn.id.resp_p` values (prevent eval crash on non-numeric ports)

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -1834,6 +1834,7 @@ class ActivityGenerator:
         source_ip: str | None = None,
         source_port: int | None = None,
         emit_transport_syslog: bool = True,
+        emit_network_evidence: bool = True,
         logon_id: str | None = None,
     ) -> str:
         """Generate logon event across all applicable log formats.
@@ -1999,14 +2000,15 @@ class ActivityGenerator:
             os_category=_get_os_category(system.os),
         )
 
-        self._maybe_emit_remote_logon_network_connection(
-            system=system,
-            time=time,
-            logon_type=logon_type,
-            source_ip=source_ip,
-            source_port=source_port or 0,
-            auth_package=auth_package_name,
-        )
+        if emit_network_evidence:
+            self._maybe_emit_remote_logon_network_connection(
+                system=system,
+                time=time,
+                logon_type=logon_type,
+                source_ip=source_ip,
+                source_port=source_port or 0,
+                auth_package=auth_package_name,
+            )
 
         # Phase 3: Dispatch to matching emitters
         self.dispatcher.dispatch(event)
@@ -6186,6 +6188,7 @@ class ActivityGenerator:
             logon_type=10,
             source_ip=source_ip,
             source_port=src_port,
+            emit_network_evidence=False,
             logon_id=logon_id,
         )
 

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -382,7 +382,7 @@ class TestActivityGenerator:
     def test_generate_rdp_session_reuses_source_port_across_network_and_logon(
         self, activity_gen, test_user, test_system, state_manager, mock_emitters
     ):
-        """RDP network evidence and destination 4624 should share one source port."""
+        """RDP session should emit one connection and share source port with 4624."""
         timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         state_manager.set_current_time(timestamp)
 
@@ -390,14 +390,16 @@ class TestActivityGenerator:
             user=test_user,
             target_system=test_system,
             time=timestamp,
-            source_ip="10.0.99.50",
+            source_ip="45.83.221.45",
         )
 
-        network_event = next(
+        rdp_connections = [
             call[0][0]
             for call in mock_emitters["zeek_conn"].emit.call_args_list
             if call[0][0].event_type == "connection" and call[0][0].network.dst_port == 3389
-        )
+        ]
+        assert len(rdp_connections) == 1
+        network_event = rdp_connections[0]
         logon_event = next(
             call[0][0]
             for call in mock_emitters["windows_event_security"].emit.call_args_list


### PR DESCRIPTION
### Motivation
- Remote logons (type 3/10) gained automatic network evidence but this duplicated or desynced RDP network records when `generate_rdp_session()` already emitted the canonical connection.
- The duplication produced inconsistent source-port/UID correlation between Zeek connections and Windows 4624 events, breaking dataset integrity for RDP scenarios.

### Description
- Added a new `emit_network_evidence: bool = True` parameter to `ActivityGenerator.generate_logon()` to let callers opt out of the helper network-emit path when they have already emitted canonical network evidence.
- Updated `generate_rdp_session()` to call `generate_logon(..., emit_network_evidence=False)` while still passing the RDP `src_port` so the 4624 `source_port` remains coherent with the pre-existing connection.
- Adjusted unit test `test_generate_rdp_session_reuses_source_port_across_network_and_logon` to assert exactly one RDP connection is emitted and that the `4624` `source_port` matches that connection's `src_port`. 
- Recorded the fix in `TODO.md` per repository workflow.

### Testing
- Modified unit coverage in `tests/unit/test_activity.py` to validate single RDP connection emission and source-port reuse (test updated but not fully executed in this environment).
- Attempted to run the targeted test with `uv run pytest tests/unit/test_activity.py -k "rdp_session_reuses_source_port" -q --no-cov` but the test run failed in this environment due to import/runtime setup issues (`ModuleNotFoundError: No module named 'evidenceforge'`), and a second run with `PYTHONPATH=src` failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`), so automated test execution could not be completed here.
- The code changes are minimal and scoped to `src/evidenceforge/generation/activity/generator.py` and the related unit test in `tests/unit/test_activity.py` to preserve existing behaviors except for preventing duplicate RDP helper connections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35b071cd48325ba093edc75805db5)