### PR TITLE
fix: align preallocated RDP session identity with coerced Windows user & sanitize AD fallback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,6 +48,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 ### Skill Installer Agent Support
 
 - [x] Fix Codex skill installer symlink clobber vulnerability by validating/writing nested destination files safely.
+- [x] Fix RDP user coercion session/ground-truth desynchronization vulnerability and malformed fallback user crash — aligned preallocated RDP session usernames with coerced Windows credentials, records RDP ground truth from canonical session identity, and sanitizes fallback email domains.
 - [x] Add dual-agent `eforge install-skills` workflow — default to Claude project installs, add explicit `--agent claude|codex`, keep Claude project/global behavior, add Codex user-level `~/.codex/skills/` installs, reject invalid Codex/global combinations, and cover installer safety/stale-cleanup behavior with tests.
 - [x] Reduce Codex skill reference duplication — bundle only the references each Codex skill needs and rely on installer stale cleanup to prune no-longer-needed reference files from prior installs.
 - [x] Import existing Claude `/eforge assess` command as a Codex skill without modifying the source skill.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -7078,6 +7078,7 @@ class ActivityGenerator:
         if logon_id is not None:
             self.state_manager.update_session_metadata(
                 logon_id,
+                username=user.username,
                 start_time=logon_time,
                 source_port=src_port,
                 session_kind="rdp",
@@ -7119,12 +7120,30 @@ class ActivityGenerator:
         known_users = getattr(self, "_users_by_username", {})
         if selected.username in known_users:
             return known_users[selected.username]
-        ad_domain = getattr(self, "_ad_domain", "corp.local")
+        ad_domain = self._valid_fallback_email_domain()
         return User(
             username=selected.username,
             full_name=selected.username,
             email=f"{selected.username}@{ad_domain}",
         )
+
+    def _valid_fallback_email_domain(self) -> str:
+        """Return a safe domain for synthetic fallback users."""
+        ad_domain = str(getattr(self, "_ad_domain", "corp.local")).strip().lower()
+        allowed = set("abcdefghijklmnopqrstuvwxyz0123456789.-")
+        labels = ad_domain.split(".")
+        if (
+            len(labels) >= 2
+            and all(labels)
+            and all(
+                set(label) <= allowed and not label.startswith("-") and not label.endswith("-")
+                for label in labels
+            )
+            and labels[-1].isalpha()
+            and len(labels[-1]) >= 2
+        ):
+            return ad_domain
+        return "corp.local"
 
     def generate_service_logon(
         self,

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1315,6 +1315,8 @@ class StorylineMixin:
                     source_ip=source_ip,
                 )
                 result = SimpleNamespace(network_uid=uid)
+            if getattr(result, "session", None) is not None:
+                malicious_event["actor"] = result.session.username
             malicious_event["dst_ip"] = system.ip
             malicious_event["dst_port"] = 3389
             result_source_ip = (

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -236,6 +236,7 @@ class StateManager:
         self,
         logon_id: str,
         *,
+        username: str | None = None,
         start_time: datetime | None = None,
         source_port: int | None = None,
         session_kind: str | None = None,
@@ -247,6 +248,8 @@ class StateManager:
             session = self.state.active_sessions.get(logon_id)
             if session is None:
                 return False
+            if username is not None:
+                session.username = username
             if start_time is not None:
                 session.start_time = ensure_utc(start_time)
             if source_port is not None:

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -591,6 +591,88 @@ class TestActivityGenerator:
         )
         assert logon_event.auth.username == "aisha.johnson"
 
+    def test_generate_rdp_session_updates_preallocated_session_identity(
+        self, activity_gen, test_system, state_manager, mock_emitters
+    ):
+        """RDP user coercion must keep preallocated session identity aligned."""
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        source_ip = "10.0.99.50"
+        state_manager.set_current_time(timestamp)
+        domain_user = User(
+            username="aisha.johnson",
+            full_name="Aisha Johnson",
+            email="aisha.johnson@example.local",
+        )
+        root_user = User(username="root", full_name="root", email="root@example.local")
+        activity_gen.generate_logon(
+            domain_user,
+            test_system,
+            timestamp - timedelta(seconds=10),
+            logon_type=3,
+            source_ip=source_ip,
+        )
+        preallocated_logon_id = state_manager.create_session(
+            username=root_user.username,
+            system=test_system.hostname,
+            logon_type=10,
+            source_ip=source_ip,
+            session_kind="rdp",
+        )
+        mock_emitters["windows_event_security"].reset_mock()
+
+        activity_gen.generate_rdp_session(
+            user=root_user,
+            target_system=test_system,
+            time=timestamp,
+            source_ip=source_ip,
+            logon_id=preallocated_logon_id,
+        )
+
+        logon_event = next(
+            call.args[0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call.args[0].event_type == "logon" and call.args[0].auth.logon_type == 10
+        )
+        session = state_manager.get_session(preallocated_logon_id)
+
+        assert logon_event.auth.username == "aisha.johnson"
+        assert logon_event.auth.logon_id == preallocated_logon_id
+        assert session is not None
+        assert session.username == logon_event.auth.username
+
+    def test_generate_rdp_session_fallback_user_tolerates_malformed_ad_domain(
+        self, activity_gen, test_system, state_manager, mock_emitters
+    ):
+        """Fallback RDP users should not crash when scenario AD domain is malformed."""
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        source_ip = "10.0.99.50"
+        root_user = User(username="root", full_name="root", email="root@example.local")
+        activity_gen._ad_domain = "bad"
+        state_manager.set_current_time(timestamp)
+        state_manager.register_session(
+            logon_id="0xabc123",
+            username="orphan",
+            system=test_system.hostname,
+            logon_type=3,
+            source_ip=source_ip,
+            start_time=timestamp - timedelta(seconds=10),
+            session_kind="network",
+        )
+
+        activity_gen.generate_rdp_session(
+            user=root_user,
+            target_system=test_system,
+            time=timestamp,
+            source_ip=source_ip,
+        )
+
+        logon_event = next(
+            call.args[0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call.args[0].event_type == "logon" and call.args[0].auth.logon_type == 10
+        )
+        assert logon_event.auth.username == "orphan"
+
     def test_nmap_process_emits_matching_network_scan_evidence(
         self, activity_gen, test_user, state_manager, mock_emitters
     ):


### PR DESCRIPTION
### Motivation
- Prevent desynchronization between a preallocated RDP `LogonID` and the username later chosen by RDP user-coercion, which caused emitted Windows/eCAR evidence to attribute the logon to a different user than StateManager/storyline ground truth.
- Avoid a crash when constructing a synthetic fallback `User` from a malformed AD domain found in scenario data.

### Description
- Allow session metadata updates to also update the session username by adding an optional `username` parameter to `StateManager.update_session_metadata` and applying it when present (`src/evidenceforge/generation/state_manager.py`).
- When `ActivityGenerator.generate_rdp_session()` is given a preallocated `logon_id`, update the session `username` along with timing/port metadata before emitting the RDP logon (`src/evidenceforge/generation/activity/generator.py`).
- Harden the fallback synthetic-user construction by validating the AD domain and falling back to `corp.local` if the configured `_ad_domain` is malformed; implemented `_valid_fallback_email_domain()` and use it when creating fallback `User` objects (`src/evidenceforge/generation/activity/generator.py`).
- Align storyline ground-truth for RDP events to the canonical session identity when available by recording the actor from the resolved session into the malicious-event record (`src/evidenceforge/generation/engine/storyline.py`).
- Add two regression tests covering (1) preallocated RDP session identity alignment and (2) tolerant fallback behavior for malformed AD domains (`tests/unit/test_activity.py`).
- Mark the fix as completed in `TODO.md`.

### Testing
- Ran targeted unit tests for RDP scenarios: `uv run pytest tests/unit/test_activity.py -k 'rdp_session' --no-cov -q` and `uv run pytest tests/unit/test_activity.py --no-cov -q`, both passed (selected and full file respectively).
- Ran broader unit and integration test suites: `uv run pytest --no-cov -q` completed successfully (all unit tests passed with many integration tests exercised; overall test run shown as `2658 passed, 37 skipped`).
- Performed static checks: `uv run ruff check .` and `uv run ruff format --check .` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e92f21788325b77de314c3673a8d)