### PR TITLE
fix: mark stale storyline process evidence skipped

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,6 +44,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 - [x] Fix Cisco ASA connection ID normalization to avoid repeated full-file rewrites during emitter barrier flushes by deferring whole-file normalization to final close.
 - [x] Fix causal-ordering scoring so diagnostic sample caps do not hide additional violations — diagnostic failure samples remain capped at 10, but every non-allow_missing_prior inversion now contributes to causal-ordering totals; covered by a regression test with 20 inversions plus 5 valid pairs.
+- [x] Fix stale storyline source PID handling so skipped create_remote_thread/process_access evidence is reflected in ground truth instead of silently claiming generated evidence.
 
 ### Skill Installer Agent Support
 

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -471,7 +471,7 @@ class StorylineMixin:
         return logon_id
 
     def _last_storyline_process_for_system(self, system: System | None) -> tuple[int, str | None]:
-        """Return last storyline process only when it belongs to the same source host."""
+        """Return the last live storyline process for the same source host."""
         if system is None:
             return -1, None
         processes = getattr(self, "_last_storyline_process_by_system", {})
@@ -483,6 +483,13 @@ class StorylineMixin:
         if os_category == "windows" and image.startswith("/"):
             return -1, None
         if os_category == "linux" and re.match(r"^[A-Za-z]:\\", image):
+            return -1, None
+        if self.state_manager.get_process(system.hostname, pid) is None:
+            processes.pop(system.hostname, None)
+            if getattr(self, "_last_storyline_system", None) == system.hostname:
+                self._last_storyline_pid = -1
+                self._last_storyline_image = ""
+                self._last_storyline_system = ""
             return -1, None
         return pid, image
 
@@ -1459,9 +1466,6 @@ class StorylineMixin:
 
         elif spec.type == "create_remote_thread":
             source_pid, source_image = self._last_storyline_process_for_system(system)
-            if source_pid <= 0:
-                source_pid = 0
-                source_image = "unknown"
             # Use a realistic target PID — look up the process name from
             # system PIDs or use a plausible default (not 4 = System kernel)
             target_image = _normalize_storyline_process_image(
@@ -1470,50 +1474,57 @@ class StorylineMixin:
                 username=actor.username,
             )
             target_name = target_image.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
-            target_pid = self.activity_generator._get_system_pid(
-                system.hostname,
-                target_name.replace(".exe", ""),
-                0x27C,  # 636 default
-            )
-            self.activity_generator.generate_create_remote_thread(
-                user=actor,
-                system=system,
-                time=time,
-                source_pid=source_pid,
-                source_image=source_image,
-                target_pid=target_pid,
-                target_image=target_image,
-            )
-            # Emit ProcessAccess via causal expansion engine (or legacy fallback)
-            # when targeting lsass.exe — primary credential-dumping detection signal
-            if "lsass" in target_name:
-                self.activity_generator._expand_and_emit(
-                    "create_remote_thread",
-                    time,
-                    actor=actor,
-                    target_system=system,
+            if source_pid <= 0:
+                # Without a live source process, there is no realistic Sysmon
+                # Event 8 relationship to render. Keep the storyline record,
+                # but mark it skipped instead of claiming generated evidence.
+                malicious_event["target_process"] = target_image
+                malicious_event["skipped_reason"] = "no_live_source_process"
+            else:
+                target_pid = self.activity_generator._get_system_pid(
+                    system.hostname,
+                    target_name.replace(".exe", ""),
+                    0x27C,  # 636 default
+                )
+                self.activity_generator.generate_create_remote_thread(
+                    user=actor,
+                    system=system,
+                    time=time,
                     source_pid=source_pid,
                     source_image=source_image,
                     target_pid=target_pid,
                     target_image=target_image,
                 )
-            malicious_event["target_process"] = target_image
+                # Emit ProcessAccess via causal expansion engine (or legacy fallback)
+                # when targeting lsass.exe — primary credential-dumping detection signal
+                if "lsass" in target_name:
+                    self.activity_generator._expand_and_emit(
+                        "create_remote_thread",
+                        time,
+                        actor=actor,
+                        target_system=system,
+                        source_pid=source_pid,
+                        source_image=source_image,
+                        target_pid=target_pid,
+                        target_image=target_image,
+                    )
+                malicious_event["target_process"] = target_image
 
         elif spec.type == "process_access":
             source_pid, source_image = self._last_storyline_process_for_system(system)
+            os_category = _get_os_category(system.os)
+            target_image = _normalize_storyline_process_image(
+                spec.target_process,
+                os_category,
+                username=actor.username,
+            )
             if source_pid <= 0:
-                # Without a source process, there is no realistic Sysmon Event
-                # 10 relationship to render. Keep the storyline record, but do
-                # not fabricate an unowned process-access event.
-                malicious_event["target_process"] = spec.target_process
-                malicious_event["skipped_reason"] = "no_source_process"
+                # Without a live source process, there is no realistic Sysmon
+                # Event 10 relationship to render. Keep the storyline record,
+                # but mark it skipped instead of claiming generated evidence.
+                malicious_event["target_process"] = target_image
+                malicious_event["skipped_reason"] = "no_live_source_process"
             else:
-                os_category = _get_os_category(system.os)
-                target_image = _normalize_storyline_process_image(
-                    spec.target_process,
-                    os_category,
-                    username=actor.username,
-                )
                 target_name = target_image.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
                 target_pid = self.activity_generator._get_system_pid(
                     system.hostname,

--- a/src/evidenceforge/generation/ground_truth.py
+++ b/src/evidenceforge/generation/ground_truth.py
@@ -170,6 +170,13 @@ class GroundTruthGenerator:
             Formatted details string
         """
         event_type = event["type"]
+        skipped_reason = event.get("skipped_reason")
+        if skipped_reason:
+            reason = str(skipped_reason).replace("_", " ")
+            target = event.get("target_process")
+            if target:
+                return f"Skipped ({reason}); no evidence emitted for target {target}"
+            return f"Skipped ({reason}); no evidence emitted"
 
         if event_type == "logon":
             source_ip = event.get("source_ip", "N/A")
@@ -312,6 +319,9 @@ class GroundTruthGenerator:
         }
 
         for event in self.malicious_events:
+            if event.get("skipped_reason"):
+                continue
+
             # Extract actor (user)
             iocs["users"].add(event["actor"])
 

--- a/tests/unit/test_ground_truth.py
+++ b/tests/unit/test_ground_truth.py
@@ -641,6 +641,22 @@ class TestGroundTruthGenerator:
         iocs = generator._extract_iocs()
         assert "Injection Target: C:\\Windows\\System32\\lsass.exe" in iocs["processes"]
 
+    def test_extract_iocs_skips_unemitted_events(self, minimal_scenario):
+        """_extract_iocs() should not list indicators for skipped evidence."""
+        events = [
+            {
+                "actor": "attacker",
+                "type": "create_remote_thread",
+                "target_process": "C:\\Windows\\System32\\lsass.exe",
+                "skipped_reason": "no_live_source_process",
+            }
+        ]
+        generator = GroundTruthGenerator(minimal_scenario, events)
+        iocs = generator._extract_iocs()
+        assert "Injection Target: C:\\Windows\\System32\\lsass.exe" not in iocs.get(
+            "processes", set()
+        )
+
     def test_extract_iocs_account_created(self, minimal_scenario):
         """_extract_iocs() should extract target username from account_created."""
         events = [
@@ -712,6 +728,20 @@ class TestGroundTruthGenerator:
         generator = GroundTruthGenerator(minimal_scenario, malicious_events)
         details = generator._format_event_details(event)
         assert "Remote thread injection into C:\\Windows\\System32\\lsass.exe" in details
+
+    def test_format_event_details_skipped_event(self, minimal_scenario, malicious_events):
+        """_format_event_details() should identify skipped evidence without claiming success."""
+        event = {
+            "type": "create_remote_thread",
+            "target_process": "C:\\Windows\\System32\\lsass.exe",
+            "skipped_reason": "no_live_source_process",
+        }
+        generator = GroundTruthGenerator(minimal_scenario, malicious_events)
+        details = generator._format_event_details(event)
+        assert details == (
+            "Skipped (no live source process); "
+            "no evidence emitted for target C:\\Windows\\System32\\lsass.exe"
+        )
 
     def test_format_event_details_account_created(self, minimal_scenario, malicious_events):
         """_format_event_details() should format account_created events."""

--- a/tests/unit/test_logonid_scoping.py
+++ b/tests/unit/test_logonid_scoping.py
@@ -218,9 +218,19 @@ class TestLogonIdSystemScoping:
     ):
         """Typed process_access should emit Sysmon Event 10 from the prior process."""
         engine = self._build_engine(state_manager, mock_emitters, [system_a], [attacker])
+        state_manager.set_current_time(datetime(2024, 3, 15, 10, 29, 0, tzinfo=UTC))
+        pid = state_manager.create_process(
+            "WKS-A",
+            4,
+            r"C:\Windows\Temp\procdump64.exe",
+            r"C:\Windows\Temp\procdump64.exe -ma lsass.exe",
+            attacker.username,
+            "High",
+            logon_id="0x12345",
+        )
         engine._record_last_storyline_process(
             system_a,
-            4242,
+            pid,
             r"C:\Windows\Temp\procdump64.exe",
         )
         engine.activity_generator.generate_process_access = Mock()
@@ -241,7 +251,7 @@ class TestLogonIdSystemScoping:
 
         engine.activity_generator.generate_process_access.assert_called_once()
         kwargs = engine.activity_generator.generate_process_access.call_args.kwargs
-        assert kwargs["source_pid"] == 4242
+        assert kwargs["source_pid"] == pid
         assert kwargs["source_image"] == r"C:\Windows\Temp\procdump64.exe"
         assert kwargs["target_image"] == r"C:\Windows\System32\lsass.exe"
         assert kwargs["granted_access"] == "0x1010"
@@ -251,9 +261,19 @@ class TestLogonIdSystemScoping:
     ):
         """Typed create_remote_thread should share full target image paths across sources."""
         engine = self._build_engine(state_manager, mock_emitters, [system_a], [attacker])
+        state_manager.set_current_time(datetime(2024, 3, 15, 10, 29, 0, tzinfo=UTC))
+        pid = state_manager.create_process(
+            "WKS-A",
+            4,
+            r"C:\Windows\Temp\procdump64.exe",
+            r"C:\Windows\Temp\procdump64.exe -ma lsass.exe",
+            attacker.username,
+            "High",
+            logon_id="0x12345",
+        )
         engine._record_last_storyline_process(
             system_a,
-            4242,
+            pid,
             r"C:\Windows\Temp\procdump64.exe",
         )
         engine.activity_generator.generate_create_remote_thread = Mock()
@@ -278,6 +298,67 @@ class TestLogonIdSystemScoping:
         assert kwargs["target_image"] == r"C:\Windows\System32\lsass.exe"
         expand_kwargs = engine.activity_generator._expand_and_emit.call_args.kwargs
         assert expand_kwargs["target_image"] == r"C:\Windows\System32\lsass.exe"
+
+    def test_storyline_process_access_with_stale_source_is_marked_skipped(
+        self, state_manager, mock_emitters, system_a, attacker
+    ):
+        """Typed process_access should not claim evidence when remembered PID is stale."""
+        engine = self._build_engine(state_manager, mock_emitters, [system_a], [attacker])
+        engine._record_last_storyline_process(
+            system_a,
+            4242,
+            r"C:\Windows\Temp\procdump64.exe",
+        )
+        engine.activity_generator.generate_process_access = Mock()
+
+        spec = Mock()
+        spec.type = "process_access"
+        spec.target_process = "lsass.exe"
+        spec.access_mask = "0x1010"
+
+        malicious_event = engine._execute_typed_event(
+            spec=spec,
+            actor=attacker,
+            system=system_a,
+            time=datetime(2024, 3, 15, 10, 30, 0, tzinfo=UTC),
+            activity="Dump credentials",
+            explicit_types={"process_access"},
+        )
+
+        engine.activity_generator.generate_process_access.assert_not_called()
+        assert malicious_event["target_process"] == r"C:\Windows\System32\lsass.exe"
+        assert malicious_event["skipped_reason"] == "no_live_source_process"
+
+    def test_storyline_create_remote_thread_with_stale_source_is_marked_skipped(
+        self, state_manager, mock_emitters, system_a, attacker
+    ):
+        """Typed create_remote_thread should not claim evidence when remembered PID is stale."""
+        engine = self._build_engine(state_manager, mock_emitters, [system_a], [attacker])
+        engine._record_last_storyline_process(
+            system_a,
+            4242,
+            r"C:\Windows\Temp\injector.exe",
+        )
+        engine.activity_generator.generate_create_remote_thread = Mock()
+        engine.activity_generator._expand_and_emit = Mock()
+
+        spec = Mock()
+        spec.type = "create_remote_thread"
+        spec.target_process = "lsass.exe"
+
+        malicious_event = engine._execute_typed_event(
+            spec=spec,
+            actor=attacker,
+            system=system_a,
+            time=datetime(2024, 3, 15, 10, 30, 0, tzinfo=UTC),
+            activity="Inject into lsass",
+            explicit_types={"create_remote_thread"},
+        )
+
+        engine.activity_generator.generate_create_remote_thread.assert_not_called()
+        engine.activity_generator._expand_and_emit.assert_not_called()
+        assert malicious_event["target_process"] == r"C:\Windows\System32\lsass.exe"
+        assert malicious_event["skipped_reason"] == "no_live_source_process"
 
     def test_storyline_process_termination_is_deferred_until_step_end(
         self, state_manager, mock_emitters, system_a, attacker


### PR DESCRIPTION
### Motivation

- Storyline cached the last process PID/image per host but did not verify the PID was still running, creating contradictions when generators silently skipped emission for non-running source PIDs while `GROUND_TRUTH.md` still recorded the attack.
- The intent is to ensure ground-truth reflects actual emitted evidence and avoid answer-key/Ioc contradictions when a remembered PID is stale.

### Description

- Verify remembered PIDs are live in `StateManager` in `_last_storyline_process_for_system()` and clear stale cached state when the process is gone (`src/evidenceforge/generation/engine/storyline.py`).
- For `create_remote_thread` and `process_access` storyline handlers, mark the storyline event as skipped (`skipped_reason = "no_live_source_process"`) and avoid invoking the activity generators when no live source process exists, instead of relying on generator-side early returns (`src/evidenceforge/generation/engine/storyline.py`).
- Update ground-truth rendering so skipped events produce an explicit skipped/no-evidence message and skipped events are omitted from IOC extraction (`src/evidenceforge/generation/ground_truth.py`).
- Add unit tests covering live-source reuse and stale-source skip handling and skipped-ground-truth formatting/IOC suppression (`tests/unit/test_logonid_scoping.py`, `tests/unit/test_ground_truth.py`).
- Record the fix as completed in `TODO.md`.

### Testing

- Ran targeted unit tests: `tests/unit/test_logonid_scoping.py` and `tests/unit/test_ground_truth.py`, and the updated test suite passed (57 tests passed locally).
- Ran dependency sync (`uv sync --extra dev`) and style checks: `uv run ruff check .` and `uv run ruff format --check .`, which succeeded.
- Confirmed the new tests assert that generators are not called for stale remembered PIDs and that ground-truth/IOC output excludes skipped (unemitted) evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb587148325ada96f8c57ed5450)