### PR TITLE
fix: bound cross-source eval joins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -215,6 +215,7 @@ Verification is complete: dedicated `tests/unit/test_world_model.py` coverage wa
 - [x] Security: bound baseline failed-logon synthetic service account selection loops to prevent scenario-controlled infinite loops/DoS.
 - [x] Security: guard persona `activity_intensity` normalization against all-zero values to prevent divide-by-zero DoS during generation (all-zero overrides now safely map to floor probability instead of crashing).
 - [x] Security: prevent nmap CIDR fallback host expansion from materializing full `network.hosts()` lists (large attacker-controlled CIDRs can trigger memory/CPU DoS).
+- [x] Security: bound cross-source field-agreement joins in evaluation to prevent attacker-controlled pivot buckets from causing quadratic CPU exhaustion (per-pivot B buckets and total pair comparisons are capped, with regression coverage).
 - [x] **Re-generation appends to existing output** — CLI now checks for existing `data/`, `GROUND_TRUTH.md`, and `ENVIRONMENT.md` before generation. Prompts user to confirm overwrite or abort. `--force` / `-f` flag skips prompt for automation/AI use.
 
 ### Tier 1: Foundational Correctness

--- a/src/evidenceforge/config/schemas.py
+++ b/src/evidenceforge/config/schemas.py
@@ -12,7 +12,7 @@ All models use extra="forbid" so misspelled fields are caught as errors.
 
 from __future__ import annotations
 
-from typing import Any, Literal, Self
+from typing import Any, ClassVar, Literal, Self
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -744,7 +744,7 @@ class WindowsFailedLogonConfig(BaseModel, extra="forbid"):
 class WindowsWorkstationLockConfig(BaseModel, extra="forbid"):
     """Windows workstation lock/unlock realism config."""
 
-    MAX_UNLOCK_GAP_SECONDS = 86_400
+    MAX_UNLOCK_GAP_SECONDS: ClassVar[int] = 86_400
 
     min_unlock_gap_seconds: int
 

--- a/src/evidenceforge/evaluation/pillars/plausibility.py
+++ b/src/evidenceforge/evaluation/pillars/plausibility.py
@@ -66,6 +66,11 @@ _OS_BOUND_FORMATS = {
     "bash_history": "linux",
 }
 
+# Cross-source agreement uses attacker-controlled eval log input. Keep pivot joins bounded so
+# a single high-cardinality collision bucket cannot force quadratic CPU work.
+_MAX_PIVOT_BUCKET_RECORDS = 256
+_MAX_FIELD_AGREEMENT_MATCHES = 100_000
+
 
 class PlausibilityScorer(DimensionScorer):
     number = 2
@@ -737,12 +742,17 @@ def _get_pivot_key_a(record: ParsedRecord, pivot: dict) -> Any:
         return raw_key
 
 
-def _build_pivot_index(records: list[ParsedRecord], pivot: dict) -> dict:
+def _build_pivot_index(
+    records: list[ParsedRecord],
+    pivot: dict,
+    max_bucket_records: int = _MAX_PIVOT_BUCKET_RECORDS,
+) -> dict:
     index: dict = defaultdict(list)
     coerce = pivot.get("coerce")
     require_hn = pivot.get("require_hostname_match", False)
 
     for rec in records:
+        key: object | None = None
         if pivot.get("b_fields"):
             parts = []
             for f in pivot["b_fields"]:
@@ -757,7 +767,7 @@ def _build_pivot_index(records: list[ParsedRecord], pivot: dict) -> dict:
                         break
                     parts.append(v)
             else:
-                index[tuple(parts)].append(rec)
+                key = tuple(parts)
         else:
             b_field = pivot.get("b_field")
             if not b_field:
@@ -771,7 +781,12 @@ def _build_pivot_index(records: list[ParsedRecord], pivot: dict) -> dict:
                 key = (hn.lower() if hn else None, raw_key)
             else:
                 key = raw_key
-            index[key].append(rec)
+
+        if key is None:
+            continue
+        bucket = index[key]
+        if len(bucket) < max_bucket_records:
+            bucket.append(rec)
     return dict(index)
 
 
@@ -837,6 +852,7 @@ def _score_pair(
     b_index: dict,
     pivot: dict,
     agree_on: list,
+    max_matches: int = _MAX_FIELD_AGREEMENT_MATCHES,
 ) -> tuple[int, int, list[str]]:
     total_matched = 0
     agreeing = 0
@@ -844,6 +860,9 @@ def _score_pair(
     time_window = pivot.get("time_window_seconds")
 
     for rec_a in filtered_a:
+        if total_matched >= max_matches:
+            break
+
         key_a = _get_pivot_key_a(rec_a, pivot)
         if key_a is None:
             continue
@@ -870,6 +889,8 @@ def _score_pair(
                 continue
 
         for rec_b in matching_b:
+            if total_matched >= max_matches:
+                break
             total_matched += 1
             all_agree = True
             for agree_spec in agree_on:

--- a/tests/unit/test_eval_cross_source_pairs.py
+++ b/tests/unit/test_eval_cross_source_pairs.py
@@ -319,6 +319,16 @@ class TestScorePair:
 
         assert len(b_index[("ws-01", 1234)]) == 2
 
+    def test_pivot_index_caps_colliding_buckets_b_fields(self):
+        """b_fields composite-key path is also subject to the bucket cap."""
+        pivot = {
+            "b_fields": ["pid", "hostname"],
+            "require_hostname_match": False,
+        }
+        ecar_recs = [self._make_ecar(1234, f"proc-{i}.exe", "WS-01") for i in range(5)]
+        b_index = _build_pivot_index(ecar_recs, pivot, max_bucket_records=2)
+        assert len(b_index[(1234, "WS-01")]) == 2
+
     def test_score_pair_stops_at_global_match_cap(self):
         """Colliding pivot keys cannot force exhaustive A×B comparisons."""
         windows_recs = [

--- a/tests/unit/test_eval_cross_source_pairs.py
+++ b/tests/unit/test_eval_cross_source_pairs.py
@@ -311,6 +311,35 @@ class TestScorePair:
         assert matched == 3
         assert agreeing == 3
 
+    def test_pivot_index_caps_colliding_buckets(self):
+        """High-collision B-side buckets retain only a bounded number of records."""
+        ecar_recs = [self._make_ecar(1234, f"proc-{i}.exe", "WS-01") for i in range(5)]
+
+        b_index = _build_pivot_index(ecar_recs, self._PIVOT, max_bucket_records=2)
+
+        assert len(b_index[("ws-01", 1234)]) == 2
+
+    def test_score_pair_stops_at_global_match_cap(self):
+        """Colliding pivot keys cannot force exhaustive A×B comparisons."""
+        windows_recs = [
+            self._make_win(1234, r"C:\Windows\System32\cmd.exe", "WS-01") for _ in range(5)
+        ]
+        ecar_recs = [self._make_ecar(1234, "cmd.exe", "WS-01") for _ in range(5)]
+        b_index = _build_pivot_index(ecar_recs, self._PIVOT)
+
+        matched, agreeing, failures = _score_pair(
+            "4688↔eCAR",
+            windows_recs,
+            b_index,
+            self._PIVOT,
+            self._AGREE_ON,
+            max_matches=7,
+        )
+
+        assert matched == 7
+        assert agreeing == 7
+        assert failures == []
+
 
 # ---------------------------------------------------------------------------
 # CrossSourceScorer._score_field_agreement — empty records


### PR DESCRIPTION
### Motivation
- The cross-source field-agreement scorer performed exhaustive A×B joins for each pivot key, allowing an attacker-controlled eval input to create a high-cardinality pivot bucket and force quadratic CPU work. 
- The change prevents eval-time CPU exhaustion while preserving the intended agreement logic and diagnosable failure reporting.

### Description
- Add configuration-backed caps: `_MAX_PIVOT_BUCKET_RECORDS` limits B-side records retained per pivot key and `_MAX_FIELD_AGREEMENT_MATCHES` limits total pair comparisons per configured pair. 
- Truncate B-side buckets in `_build_pivot_index(...)` to at most `max_bucket_records` and skip indexing beyond the cap. 
- Stop pairwise comparisons early in `_score_pair(...)` once the `max_matches` limit is reached to bound A×B work. 
- Add regression tests in `tests/unit/test_eval_cross_source_pairs.py` that verify pivot-bucket truncation and the global match cap behavior, and mark the TODO tracking entry as resolved in `TODO.md`.

### Testing
- Ran the focused unit tests with `uv run pytest --no-cov tests/unit/test_eval_cross_source_pairs.py` and all tests passed. 
- Executed `uv run ruff check .` and `uv run ruff format --check .` and both checks passed. 
- Running the targeted pytest file with coverage produced a repository-wide coverage failure when the full coverage threshold was enforced because only the one test file was executed, but the behavioral tests added here succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb4662483258b91de2962618002)