### PR TITLE
fix: correlate scp receiver source ports

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,6 +51,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 - [x] Fix Codex skill installer symlink clobber vulnerability by validating/writing nested destination files safely.
 - [x] Fix RDP user coercion session/ground-truth desynchronization vulnerability and malformed fallback user crash — aligned preallocated RDP session usernames with coerced Windows credentials, records RDP ground truth from canonical session identity, and sanitizes fallback email domains.
+- [x] **P1** SCP receiver source-port correlation — fixed Linux SCP storyline receiver-side sshd/file artifacts so target syslog messages reuse the same client source port as the generated SSH network flow evidence; added focused unit coverage.
 - [x] Add dual-agent `eforge install-skills` workflow — default to Claude project installs, add explicit `--agent claude|codex`, keep Claude project/global behavior, add Codex user-level `~/.codex/skills/` installs, reject invalid Codex/global combinations, and cover installer safety/stale-cleanup behavior with tests.
 - [x] Reduce Codex skill reference duplication — bundle only the references each Codex skill needs and rely on installer stale cleanup to prune no-longer-needed reference files from prior installs.
 - [x] Import existing Claude `/eforge assess` command as a Codex skill without modifying the source skill.

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1029,6 +1029,13 @@ class StorylineMixin:
                 dst_ip = self._resolve_storyline_network_target(scp_target)
                 if dst_ip:
                     transfer_time = time + timedelta(milliseconds=rng.randint(250, 900))
+                    source_port = self.activity_generator.reserve_ssh_source_port(
+                        system.ip,
+                        dst_ip,
+                        None,
+                        rng,
+                        _get_os_category(system.os),
+                    )
                     self.activity_generator.generate_connection(
                         src_ip=system.ip,
                         dst_ip=dst_ip,
@@ -1044,6 +1051,7 @@ class StorylineMixin:
                         source_system=system,
                         pid=pid,
                         process_image=process_name,
+                        src_port=source_port,
                     )
                     target_system = self._system_for_ip(dst_ip)
                     if (
@@ -1061,6 +1069,7 @@ class StorylineMixin:
                             target_user=scp_destination[2] or actor.username,
                             target_path=scp_destination[1],
                             transfer_time=transfer_time,
+                            source_port=source_port,
                             rng=rng,
                         )
 
@@ -2644,6 +2653,7 @@ class StorylineMixin:
         target_user: str,
         target_path: str,
         transfer_time: datetime,
+        source_port: int,
         rng: random.Random,
     ) -> None:
         """Emit target-side SSH and file evidence for a storyline scp transfer."""
@@ -2655,13 +2665,6 @@ class StorylineMixin:
             ProcessContext,
         )
 
-        source_port = 32768 + (
-            _stable_seed(
-                f"scp_receiver_port:{source_system.ip}:{target_system.ip}:"
-                f"{source_pid}:{transfer_time.isoformat()}"
-            )
-            % 28232
-        )
         self.state_manager.set_current_time(transfer_time + timedelta(milliseconds=40))
         parent_pid = self.activity_generator._get_system_pid(target_system.hostname, "sshd", 0)
         sshd_pid = self.state_manager.create_process(

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -3,10 +3,12 @@
 
 """Tests for network evidence inferred from storyline commands."""
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 
 from evidenceforge.generation.engine.storyline import StorylineMixin
-from evidenceforge.models.scenario import System
+from evidenceforge.models.scenario import System, User
 
 
 class TestStorylineCommandNetworks:
@@ -45,3 +47,89 @@ class TestStorylineCommandNetworks:
         assert engine._resolve_storyline_network_target("APP-INT-01.meridianhcs.local") == (
             "10.10.2.30"
         )
+
+
+class _FakeActivityGenerator:
+    def __init__(self) -> None:
+        self.reserved_ports: list[int] = []
+        self.connections: list[dict] = []
+
+    def generate_bash_command(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def _resolve_parent(self, *args: Any, **kwargs: Any) -> int:
+        return 1
+
+    def generate_process(self, *args: Any, **kwargs: Any) -> int:
+        return 4242
+
+    def _record_user_process(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def reserve_ssh_source_port(self, *args: Any, **kwargs: Any) -> int:
+        self.reserved_ports.append(45678)
+        return 45678
+
+    def generate_connection(self, **kwargs: Any) -> str:
+        self.connections.append(kwargs)
+        return "Cscptransfer00001"
+
+
+class _FakeStateManager:
+    def get_sessions_for_user(self, username: str) -> list[SimpleNamespace]:
+        return [SimpleNamespace(system="SRC", logon_id="0xabc")]
+
+    def mark_story_process(self, hostname: str, pid: int) -> None:
+        return None
+
+
+class TestStorylineScpCorrelation:
+    def test_scp_receiver_artifacts_reuse_network_source_port(self):
+        source = System(
+            hostname="SRC",
+            ip="10.10.0.10",
+            os="Ubuntu 22.04",
+            type="workstation",
+        )
+        target = System(
+            hostname="DST",
+            ip="10.10.0.20",
+            os="Ubuntu 22.04",
+            type="server",
+        )
+        actor = User(
+            username="alice",
+            full_name="Alice Example",
+            email="alice@example.com",
+        )
+        engine = object.__new__(StorylineMixin)
+        engine.scenario = SimpleNamespace(
+            environment=SimpleNamespace(systems=[source, target], service_accounts=[])
+        )
+        engine.state_manager = _FakeStateManager()
+        engine.activity_generator = _FakeActivityGenerator()
+        engine.dispatcher = SimpleNamespace(visibility_engine=None)
+        receiver_ports: list[int] = []
+
+        def capture_receiver_artifacts(**kwargs) -> None:
+            receiver_ports.append(kwargs["source_port"])
+
+        engine._emit_scp_receiver_artifacts = capture_receiver_artifacts
+        spec = SimpleNamespace(
+            type="process",
+            process_name="scp",
+            command_line="scp /tmp/archive.tar.gz root@DST:/var/tmp/archive.tar.gz",
+        )
+
+        engine._execute_typed_event(
+            spec=spec,
+            actor=actor,
+            system=source,
+            time=datetime(2026, 5, 11, 12, 0, tzinfo=UTC),
+            activity="copy archive to staging host",
+            explicit_types={"process"},
+        )
+
+        assert engine.activity_generator.reserved_ports == [45678]
+        assert engine.activity_generator.connections[0]["src_port"] == 45678
+        assert receiver_ports == [45678]


### PR DESCRIPTION
### Motivation
- Storyline SCP transfers generated an SSH connection without supplying a `src_port`, while receiver-side sshd/syslog artifacts computed a separate deterministic port, producing contradictory 5-tuples across Zeek/eCAR and syslog evidence and breaking cross-source correlation.
- The change ensures the same client source port is used everywhere for a single SCP transfer so downstream analysis and evaluation can reliably join records by network tuple.

### Description
- Reserve a single SSH source port via `activity_generator.reserve_ssh_source_port(...)` before emitting the SCP connection and pass it into `generate_connection()` via `src_port` so the network flow uses the canonical port.
- Thread the same `source_port` into `_emit_scp_receiver_artifacts(...)` (added `source_port` parameter) so target-side `sshd` syslog messages use the identical client port instead of computing an independent port.
- Remove the prior deterministic port computation inside `_emit_scp_receiver_artifacts` and update the SCP call sites to pass the reserved port through the flow.
- Add a focused unit test `tests/unit/test_storyline_command_networks.py::TestStorylineScpCorrelation::test_scp_receiver_artifacts_reuse_network_source_port` and mark the fix in `TODO.md`.

### Testing
- Ran the focused unit tests with `PYTHONPATH=src uv run pytest tests/unit/test_storyline_command_networks.py -q --no-cov` and all tests passed (4 passed).
- Ran the repository-wide coverage-enabled test run `PYTHONPATH=src uv run pytest tests/unit/test_storyline_command_networks.py -q` which showed the focused tests passed but the global coverage gate failed due to the narrow test scope (coverage failure unrelated to this focused change).
- Ran static checks `PYTHONPATH=src uv run ruff check .` and `PYTHONPATH=src uv run ruff format --check .` which passed against the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb5c648832598e5fd2a4d6fbf1b)