### PR TITLE
fix: harden storyline URL parsing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 - [x] Fix Codex skill installer symlink clobber vulnerability by validating/writing nested destination files safely.
 - [x] Fix RDP user coercion session/ground-truth desynchronization vulnerability and malformed fallback user crash — aligned preallocated RDP session usernames with coerced Windows credentials, records RDP ground truth from canonical session identity, and sanitizes fallback email domains.
 - [x] **P1** SCP receiver source-port correlation — fixed Linux SCP storyline receiver-side sshd/file artifacts so target syslog messages reuse the same client source port as the generated SSH network flow evidence; added focused unit coverage.
+- [x] Harden storyline command-line URL inference against malformed scenario-controlled URLs so invalid hosts/ports cannot crash generation.
 - [x] Add dual-agent `eforge install-skills` workflow — default to Claude project installs, add explicit `--agent claude|codex`, keep Claude project/global behavior, add Codex user-level `~/.codex/skills/` installs, reject invalid Codex/global combinations, and cover installer safety/stale-cleanup behavior with tests.
 - [x] Reduce Codex skill reference duplication — bundle only the references each Codex skill needs and rely on installer stale cleanup to prune no-longer-needed reference files from prior installs.
 - [x] Import existing Claude `/eforge assess` command as a Codex skill without modifying the source skill.

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1002,17 +1002,14 @@ class StorylineMixin:
 
             http_url = self._extract_http_url(command_line)
             if http_url is not None:
-                from urllib.parse import urlparse
-
-                parsed_url = urlparse(http_url)
-                if parsed_url.hostname:
-                    hostname = parsed_url.hostname
+                parsed_target = self._parse_http_url_target(http_url)
+                if parsed_target is not None:
+                    hostname, dst_port = parsed_target
                     dst_ip = self._resolve_storyline_network_target(hostname)
                     if dst_ip is None:
                         from evidenceforge.generation.activity.dns_registry import resolve_domain_ip
 
                         dst_ip = resolve_domain_ip(hostname, src_host=system.hostname)
-                    dst_port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
                     service = "ssl" if dst_port == 443 else "http"
                     self.activity_generator.generate_connection(
                         src_ip=system.ip,
@@ -2749,6 +2746,24 @@ class StorylineMixin:
         if not match:
             return None
         return match.group(0).rstrip(".")
+
+    @staticmethod
+    def _parse_http_url_target(http_url: str) -> tuple[str, int] | None:
+        """Parse a storyline command URL into a safe hostname and destination port."""
+        from urllib.parse import urlparse
+
+        try:
+            parsed_url = urlparse(http_url)
+            hostname = parsed_url.hostname
+            port = parsed_url.port
+        except ValueError:
+            logger.debug("Ignoring malformed HTTP URL from storyline command: %s", http_url)
+            return None
+
+        if not hostname:
+            return None
+
+        return hostname, port or (443 if parsed_url.scheme.lower() == "https" else 80)
 
     def _resolve_storyline_network_target(self, target: str) -> str | None:
         """Resolve a storyline command target host/IP to an environment IP when possible."""

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -20,6 +20,21 @@ class TestStorylineCommandNetworks:
 
         assert url == "https://cdn.example.test/stage.ps1"
 
+    def test_parse_http_url_target_accepts_valid_url(self):
+        target = StorylineMixin._parse_http_url_target("https://cdn.example.test:8443/stage.ps1")
+
+        assert target == ("cdn.example.test", 8443)
+
+    def test_parse_http_url_target_rejects_non_numeric_port(self):
+        target = StorylineMixin._parse_http_url_target("http://example.com:bad/path")
+
+        assert target is None
+
+    def test_parse_http_url_target_rejects_malformed_bracketed_host(self):
+        target = StorylineMixin._parse_http_url_target("http://[not-a-valid-host/path")
+
+        assert target is None
+
     def test_extract_scp_target_from_remote_destination(self):
         target = StorylineMixin._extract_scp_target(
             "scp /tmp/patient_claims.sql.gz root@10.10.2.30:/var/tmp/",


### PR DESCRIPTION
### Motivation
- Storyline process command lines can contain attacker-controlled HTTP(S) substrings that, when parsed, could raise `ValueError` (malformed bracketed hosts or non-numeric/out-of-range ports) and crash `eforge generate`; this is a local availability issue.  

### Description
- Add a safe helper `StorylineMixin._parse_http_url_target()` that wraps `urllib.parse.urlparse()` in a `try/except ValueError` and returns `None` for malformed URLs; it returns `(hostname, port)` using explicit or default ports (443 for https, 80 otherwise).  
- Replace the previous inline `urlparse()` usage in storyline command handling with the new helper and only generate inferred connections when the helper returns a valid `(hostname, port)`.  
- Add unit tests covering valid URL parsing, rejection of non-numeric ports, and rejection of malformed bracketed hosts, and mark the hardening item complete in `TODO.md`.  
- Files changed: `src/evidenceforge/generation/engine/storyline.py`, `tests/unit/test_storyline_command_networks.py`, `TODO.md`.  

### Testing
- Ran the focused unit tests `uv run pytest tests/unit/test_storyline_command_networks.py -q --no-cov`, which passed (`6 passed`).  
- Ran lint/format checks with `uv run ruff check .` and `uv run ruff format --check .`, which passed.  
- Running the full test suite with coverage (`uv run pytest`) previously fails the repo-wide coverage threshold (existing condition), but the targeted unit tests and linters used to validate this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb57ef08325ad8596f08593c7ec)