### PR TITLE
fix: reserve DNS tunnel label capacity for metadata and correct bytes_exfiltrated accounting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
 - [x] Remediate Windows singleton PID path traversal telemetry suppression — canonicalize Windows singleton paths with ntpath before seeded PID reuse and cover traversal variants with a unit test.
+- [x] Fix DNS tunnel label payload accounting so sequence metadata does not truncate counted exfiltration bytes.
 
 **Goal:** Fix all expert-identified issues that would cause an analyst to reject the data. Consolidated from 6 blind expert panel improvement loops (Threat Hunter, DFIR, Network Eng, Detection Eng) plus infrastructure issues. Work top to bottom.
 

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -2358,7 +2358,7 @@ class StorylineMixin:
             else:
                 payload_bytes = rng.randbytes(spec.payload_size)
 
-            # Calculate bytes per label based on encoding
+            # Calculate raw bytes that can fit in the visible label for each encoding.
             if spec.encoding == "hex":
                 bytes_per_label = spec.label_length // 2
             elif spec.encoding == "base32":
@@ -2367,10 +2367,23 @@ class StorylineMixin:
                 bytes_per_label = (spec.label_length * 3) // 4
             bytes_per_label = max(1, bytes_per_label)
 
-            # Chunk payload
-            chunks = []
-            for i in range(0, len(payload_bytes), bytes_per_label):
-                chunks.append(payload_bytes[i : i + bytes_per_label])
+            # Reserve visible label capacity for tunnel metadata before chunking the payload.
+            # Otherwise full-sized chunks would be encoded with metadata and truncated, causing
+            # GROUND_TRUTH.md to count bytes that never appeared in the emitted DNS label.
+            visible_nonce_len = 2
+            sequence_len = 4
+            payload_bytes_per_label = max(0, bytes_per_label - visible_nonce_len - sequence_len)
+
+            # Chunk only the bytes that can actually be emitted in the label. Very small labels
+            # still generate DNS traffic but carry no visible payload, so ground truth reports 0.
+            chunks: list[bytes]
+            if payload_bytes_per_label > 0:
+                chunks = [
+                    payload_bytes[i : i + payload_bytes_per_label]
+                    for i in range(0, len(payload_bytes), payload_bytes_per_label)
+                ]
+            else:
+                chunks = [b""]
 
             qtype_num = _QTYPE_MAP.get(spec.qtype, 16)
             min_rtt, max_rtt = dns_tunnel_rtt_range()
@@ -2393,9 +2406,8 @@ class StorylineMixin:
                     )
                 ).getrandbits(32)
                 sequence = (query_count ^ sequence_mask).to_bytes(4, "big", signed=False)
-                visible_nonce = rng.randbytes(2)
-                visible_payload_len = max(1, bytes_per_label - len(visible_nonce))
-                visible_payload = chunk[:visible_payload_len]
+                visible_nonce = rng.randbytes(visible_nonce_len)
+                visible_payload = chunk[:payload_bytes_per_label]
                 pad_len = max(
                     0,
                     bytes_per_label - len(visible_nonce) - len(visible_payload) - len(sequence),

--- a/tests/unit/test_bulk_events.py
+++ b/tests/unit/test_bulk_events.py
@@ -5,17 +5,20 @@
 
 import random
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
 from evidenceforge.generation.engine.storyline import (
+    StorylineMixin,
     _effective_rate_interval,
     _iter_dns_tunnel_ticks,
     _iter_periodic_ticks,
     _web_scan_connection_profile,
     _web_scan_path_allows_referrer,
 )
+from evidenceforge.models import System, User
 from evidenceforge.models.scenario import (
     BeaconEventSpec,
     CredentialSprayEventSpec,
@@ -735,6 +738,77 @@ class TestDnsTunnelEventSpec:
                 count=10,
                 payload="a" * ((1024 * 1024) + 1),
             )
+
+    def test_hex_labels_reserve_metadata_before_accounting_payload(self):
+        engine = object.__new__(StorylineMixin)
+        captured_dns = []
+
+        def capture_connection(**kwargs):
+            captured_dns.append(kwargs["dns"])
+
+        engine.state_manager = SimpleNamespace(set_current_time=lambda _time: None)
+        engine.activity_generator = SimpleNamespace(
+            _dns_server_ips=["10.0.0.53"],
+            generate_connection=capture_connection,
+        )
+        spec = DnsTunnelEventSpec(
+            base_domain="tunnel.example.test",
+            encoding="hex",
+            label_length=14,
+            payload="ABCD",
+            interval="1s",
+            count=2,
+        )
+
+        event = engine._execute_typed_event(
+            spec=spec,
+            actor=User(username="attacker", full_name="Attacker", email="a@example.com"),
+            system=System(hostname="WS-01", ip="10.0.0.10", os="Windows 10", type="workstation"),
+            time=datetime(2024, 1, 15, 10, 0, tzinfo=UTC),
+            activity="DNS exfiltration",
+            explicit_types={"dns_tunnel"},
+        )
+
+        visible_payload = b""
+        for dns_ctx in captured_dns:
+            raw_label = bytes.fromhex(dns_ctx.query.split(".", 1)[0])
+            visible_payload += raw_label[2:-4]
+        assert visible_payload == b"AB"
+        assert event["bytes_exfiltrated"] == len(visible_payload)
+
+    def test_tiny_hex_labels_do_not_report_truncated_payload_as_exfiltrated(self):
+        engine = object.__new__(StorylineMixin)
+        captured_dns = []
+
+        def capture_connection(**kwargs):
+            captured_dns.append(kwargs["dns"])
+
+        engine.state_manager = SimpleNamespace(set_current_time=lambda _time: None)
+        engine.activity_generator = SimpleNamespace(
+            _dns_server_ips=["10.0.0.53"],
+            generate_connection=capture_connection,
+        )
+        spec = DnsTunnelEventSpec(
+            base_domain="tunnel.example.test",
+            encoding="hex",
+            label_length=8,
+            payload="ABCD",
+            interval="1s",
+            count=1,
+        )
+
+        event = engine._execute_typed_event(
+            spec=spec,
+            actor=User(username="attacker", full_name="Attacker", email="a@example.com"),
+            system=System(hostname="WS-01", ip="10.0.0.10", os="Windows 10", type="workstation"),
+            time=datetime(2024, 1, 15, 10, 0, tzinfo=UTC),
+            activity="DNS exfiltration",
+            explicit_types={"dns_tunnel"},
+        )
+
+        raw_label = bytes.fromhex(captured_dns[0].query.split(".", 1)[0])
+        assert b"ABCD" not in raw_label
+        assert event["bytes_exfiltrated"] == 0
 
 
 # ── ExplicitCredentialsEventSpec ──────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- The dns_tunnel generator prepended a 4-byte sequence and other metadata after chunking payload at the full label capacity, then truncated the encoded label, which removed payload bytes while `bytes_exfiltrated` still counted the original chunk size, causing ground-truth/data contradictions.

### Description
- Reserve visible label capacity for the nonce and 4-byte sequence before chunking payload by computing `payload_bytes_per_label` and chunking only that many payload bytes per DNS label in `src/evidenceforge/generation/engine/storyline.py`.
- Build emitted label data from `visible_nonce + visible_payload + pad + sequence` so truncation no longer drops payload that was counted, and keep `total_bytes` accounting tied to the actual chunk bytes that can appear in labels.
- Add two regression tests in `tests/unit/test_bulk_events.py` that verify normal hex-label behavior and the tiny-label case that must not report truncated payload as exfiltrated, and mark the TODO item complete in `TODO.md`.

### Testing
- Ran lint/format checks with `uv run ruff check .` and `uv run ruff format --check .` which passed.
- Ran the targeted unit tests `PYTHONPATH=src uv run pytest tests/unit/test_bulk_events.py::TestDnsTunnelEventSpec -q --no-cov` which passed.
- Ran the full unit + integration test suite `PYTHONPATH=src uv run pytest -q --no-cov`, which completed successfully (all tests passed / skipped as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb5b29483259faf7896c81f4130)