### PR TITLE
fix: recompute UDP packet/IP-byte accounting after fallback DNS SERVFAIL rewrite

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 - [x] Fix Cisco ASA connection ID normalization to avoid repeated full-file rewrites during emitter barrier flushes by deferring whole-file normalization to final close.
 - [x] Fix causal-ordering scoring so diagnostic sample caps do not hide additional violations — diagnostic failure samples remain capped at 10, but every non-allow_missing_prior inversion now contributes to causal-ordering totals; covered by a regression test with 20 inversions plus 5 valid pairs.
 - [x] Fix stale storyline source PID handling so skipped create_remote_thread/process_access evidence is reflected in ground truth instead of silently claiming generated evidence.
+- [x] Fix fallback DNS SERVFAIL Zeek packet accounting so rewritten UDP history, packet counts, and IP-byte totals remain consistent.
 
 ### Skill Installer Agent Support
 

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -4526,6 +4526,7 @@ class ActivityGenerator:
                 event.network.history = "Dd"
                 event.network.duration = rng.uniform(0.001, 0.03)
                 event.network.resp_bytes = rng.randint(80, 220)
+                overhead = rng.choices(_UDP_OVERHEAD_VALUES, weights=_UDP_OVERHEAD_WEIGHTS, k=1)[0]
                 if proto == "udp":
                     event.network.orig_pkts = event.network.history.count("D")
                     event.network.resp_pkts = event.network.history.count("d")

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -4526,13 +4526,27 @@ class ActivityGenerator:
                 event.network.history = "Dd"
                 event.network.duration = rng.uniform(0.001, 0.03)
                 event.network.resp_bytes = rng.randint(80, 220)
-                event.network.resp_pkts = max(event.network.resp_pkts or 0, 1)
-                overhead = rng.choices(
-                    _UDP_OVERHEAD_VALUES,
-                    weights=_UDP_OVERHEAD_WEIGHTS,
-                    k=1,
-                )[0]
-                event.network.resp_ip_bytes = event.network.resp_bytes + overhead
+                if proto == "udp":
+                    event.network.orig_pkts = event.network.history.count("D")
+                    event.network.resp_pkts = event.network.history.count("d")
+                    event.network.orig_bytes = max(
+                        event.network.orig_bytes or 0,
+                        event.network.orig_pkts * 28,
+                    )
+                    event.network.orig_ip_bytes = (
+                        event.network.orig_bytes + event.network.orig_pkts * overhead
+                    )
+                    event.network.resp_ip_bytes = (
+                        event.network.resp_bytes + event.network.resp_pkts * overhead
+                    )
+                else:
+                    event.network.resp_pkts = max(event.network.resp_pkts or 0, 1)
+                    event.network.resp_ip_bytes = event.network.resp_bytes + overhead
+                self.state_manager.update_connection_bytes(
+                    event.network.conn_id,
+                    event.network.orig_bytes or 0,
+                    event.network.resp_bytes or 0,
+                )
             if event.dns.rtt is not None:
                 event.network.duration = event.dns.rtt
 

--- a/tests/unit/test_dns_realism.py
+++ b/tests/unit/test_dns_realism.py
@@ -566,10 +566,14 @@ class TestWeirdProtocolConstraint:
         assert event.network.resp_bytes > 0
 
     def test_inferred_servfail_dns_row_keeps_responder_accounting(
-        self, activity_gen, timestamp, state_manager, mock_emitters
+        self, activity_gen, timestamp, state_manager, mock_emitters, monkeypatch
     ):
-        """Fallback DNS synthesis should not pair SERVFAIL with a one-way conn row."""
+        """Fallback DNS synthesis should not pair SERVFAIL with stale packet accounting."""
+        from evidenceforge.generation.activity import generator as generator_module
+
         state_manager.set_current_time(timestamp)
+        monkeypatch.setattr(generator_module, "_UDP_CONN_ENTRIES", [("S0", 1, "DD")])
+        monkeypatch.setattr(generator_module, "_UDP_CONN_WEIGHTS", [1])
 
         activity_gen.generate_connection(
             src_ip="10.0.1.50",
@@ -587,8 +591,12 @@ class TestWeirdProtocolConstraint:
         assert event.dns.rcode == "SERVFAIL"
         assert event.network.conn_state == "SF"
         assert event.network.history == "Dd"
-        assert event.network.resp_pkts > 0
+        assert event.network.orig_pkts == event.network.history.count("D")
+        assert event.network.resp_pkts == event.network.history.count("d")
         assert event.network.resp_bytes > 0
+        assert event.network.orig_ip_bytes - event.network.orig_bytes == (
+            event.network.resp_ip_bytes - event.network.resp_bytes
+        )
 
     def test_dns_conn_duration_is_not_shorter_than_explicit_rtt(
         self, activity_gen, timestamp, state_manager, mock_emitters


### PR DESCRIPTION
### Motivation

- A late fallback path synthesized a DNS `SERVFAIL` and rewrote the Zeek `conn` `history` to `"Dd"` but did not recompute dependent UDP packet counters and IP-byte totals, causing inconsistent conn rows (history vs stale `orig_pkts`/`orig_ip_bytes`).

### Description

- Recompute UDP packet counts and IP-byte totals after the fallback DNS `SERVFAIL` synthesis in `ActivityGenerator.generate_connection()` so the rewritten `history` (`"Dd"`) and derived fields remain consistent (`orig_pkts`, `resp_pkts`, `orig_bytes`, `orig_ip_bytes`, `resp_ip_bytes`). (modified `src/evidenceforge/generation/activity/generator.py`)
- Update the `StateManager` connection byte accounting via `update_connection_bytes()` after synthesizing responder bytes so state and emitted records remain aligned. (modified `src/evidenceforge/generation/activity/generator.py`)
- Strengthen the DNS realism regression test to force a stale multi-datagram UDP history and assert the synthesized SERVFAIL event has matching packet counts and IP-byte arithmetic. (modified `tests/unit/test_dns_realism.py`)
- Mark the fix complete in the persistent tracker `TODO.md`.

### Testing

- Ran `uv sync --extra dev` to install dev deps successfully. (succeeded)
- Ran the focused test with coverage disabled: `uv run pytest tests/unit/test_dns_realism.py::TestWeirdProtocolConstraint::test_inferred_servfail_dns_row_keeps_responder_accounting -q --no-cov` and the test passed. (succeeded)
- Ran the full DNS realism unit test file: `uv run pytest tests/unit/test_dns_realism.py -q --no-cov` and all `38` tests passed. (succeeded)
- Ran linter/format checks: `uv run ruff check . && uv run ruff format --check .` and formatting/lint checks passed. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb4482c8325840a5aa04274e136)