### PR TITLE
fix: scope log clear token inheritance by actor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 - [x] Remediate Windows singleton PID path traversal telemetry suppression — canonicalize Windows singleton paths with ntpath before seeded PID reuse and cover traversal variants with a unit test.
 - [x] Fix DNS tunnel label payload accounting so sequence metadata does not truncate counted exfiltration bytes.
+- [x] Fix actor-scoped LogonID inheritance for typed `log_cleared` storyline events.
 
 **Goal:** Fix all expert-identified issues that would cause an analyst to reject the data. Consolidated from 6 blind expert panel improvement loops (Threat Hunter, DFIR, Network Eng, Detection Eng) plus infrastructure issues. Work top to bottom.
 

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -495,12 +495,13 @@ class StorylineMixin:
 
     def _recent_storyline_process_logon_id(
         self,
+        actor: User,
         system: System,
         time: datetime,
         *,
         executable: str | None = None,
     ) -> str | None:
-        """Return the LogonID from a recent storyline process on the same host."""
+        """Return a recent storyline process LogonID for this actor and host."""
         pid, image = self._last_storyline_process_for_system(system)
         if pid <= 0 or not image:
             return None
@@ -509,9 +510,18 @@ class StorylineMixin:
             if image_name != executable.lower():
                 return None
         proc = self.state_manager.get_process(system.hostname, pid)
-        if proc is None or not proc.logon_id or proc.start_time is None:
+        if proc is None or proc.username != actor.username or not proc.logon_id:
             return None
-        if proc.start_time > time or time - proc.start_time > timedelta(minutes=5):
+        session = self.state_manager.get_session(proc.logon_id)
+        if (
+            session is None
+            or session.username != actor.username
+            or session.system != system.hostname
+        ):
+            return None
+        if proc.start_time is None or proc.start_time > time:
+            return None
+        if time - proc.start_time > timedelta(minutes=5):
             return None
         return proc.logon_id
 
@@ -1454,6 +1464,7 @@ class StorylineMixin:
 
         elif spec.type == "log_cleared":
             subject_logon_id = self._recent_storyline_process_logon_id(
+                actor,
                 system,
                 time,
                 executable="wevtutil.exe",

--- a/tests/unit/test_logonid_scoping.py
+++ b/tests/unit/test_logonid_scoping.py
@@ -530,3 +530,60 @@ def test_log_cleared_storyline_event_inherits_recent_wevtutil_logon_id(
     )
 
     assert captured["subject_logon_id"] == logon_id
+
+
+def test_log_cleared_storyline_event_rejects_different_actor_wevtutil_logon_id(
+    state_manager, mock_emitters, system_a, attacker, monkeypatch
+):
+    """Typed log_cleared events must not inherit another actor's process token."""
+    other = User(
+        username="other",
+        full_name="Other User",
+        email="other@example.com",
+        enabled=True,
+    )
+    ag = ActivityGenerator(state_manager, mock_emitters)
+    engine = type("FakeEngine", (StorylineMixin,), {}).__new__(
+        type("FakeEngine", (StorylineMixin,), {})
+    )
+    engine.state_manager = state_manager
+    engine.activity_generator = ag
+    engine.dispatcher = ag.dispatcher
+    engine.malicious_events = []
+
+    process_time = datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC)
+    state_manager.set_current_time(process_time)
+    other_logon_id = state_manager.create_session(
+        username=other.username,
+        system=system_a.hostname,
+        logon_type=2,
+        source_ip=system_a.ip,
+    )
+    pid = state_manager.create_process(
+        system_a.hostname,
+        4,
+        r"C:\Windows\System32\wevtutil.exe",
+        "wevtutil cl Security",
+        other.username,
+        "High",
+        logon_id=other_logon_id,
+    )
+    engine._record_last_storyline_process(system_a, pid, r"C:\Windows\System32\wevtutil.exe")
+
+    captured: dict[str, str | None] = {}
+
+    def fake_generate_log_cleared(*args, **kwargs):
+        captured["subject_logon_id"] = kwargs["subject_logon_id"]
+
+    monkeypatch.setattr(ag, "generate_log_cleared", fake_generate_log_cleared)
+
+    engine._execute_typed_event(
+        spec=Mock(type="log_cleared"),
+        actor=attacker,
+        system=system_a,
+        time=process_time + timedelta(seconds=2),
+        activity="clear security log",
+        explicit_types=set(),
+    )
+
+    assert captured["subject_logon_id"] is None


### PR DESCRIPTION
### Motivation
- Typed `log_cleared` storyline events could inherit a recent `wevtutil.exe` process LogonID tracked only by host, which allowed a different actor on the same host to be misattributed the clearing process token and corrupt Windows 1102 subject fields.

### Description
- Require actor-scoped validation when inheriting a recent storyline process LogonID by adding an `actor: User` parameter to `_recent_storyline_process_logon_id` and verifying the recent process `username` matches `actor.username` and that the corresponding `ActiveSession` belongs to the same actor and host before returning the LogonID.
- Preserve existing checks for executable basename, process start time, and the five-minute recency window; adjust the call site to pass `actor` into `_recent_storyline_process_logon_id` when handling `log_cleared` event specs.
- Add a regression test `test_log_cleared_storyline_event_rejects_different_actor_wevtutil_logon_id` to ensure a later actor does not inherit another actor’s `wevtutil.exe` LogonID.
- Mark the fix complete in `TODO.md`.

### Testing
- Ran the targeted unit test file with coverage disabled using `uv run pytest tests/unit/test_logonid_scoping.py -q --no-cov`, which passed (`9 passed`).
- Running `uv run pytest tests/unit/test_logonid_scoping.py -q` with the repo-wide coverage plugin exercised the global coverage gate and reported a coverage fail unrelated to this change (tests themselves executed successfully). 
- Ran formatting and lint checks with `uv run ruff format` and `uv run ruff check .`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb445508325a554c9432707a855)