### PR TITLE
fix: count all causal ordering failures

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,6 +41,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 ### Security Fixes
 
 - [x] Fix Cisco ASA connection ID normalization to avoid repeated full-file rewrites during emitter barrier flushes by deferring whole-file normalization to final close.
+- [x] Fix causal-ordering scoring so diagnostic sample caps do not hide additional violations — diagnostic failure samples remain capped at 10, but every non-allow_missing_prior inversion now contributes to causal-ordering totals; covered by a regression test with 20 inversions plus 5 valid pairs.
 
 ### Skill Installer Agent Support
 

--- a/src/evidenceforge/evaluation/pillars/causality.py
+++ b/src/evidenceforge/evaluation/pillars/causality.py
@@ -740,12 +740,13 @@ class CausalityScorer(DimensionScorer):
                         # after-record is inverted; it can be a continuing pre-window session,
                         # DNS cache hit, hosts-file lookup, or static infrastructure flow.
                         continue
-                    elif len(failures) < 10:
+                    else:
                         rule_total += 1
-                        failures.append(
-                            f"Rule '{rule['name']}': after event at line "
-                            f"{rec.line_number} precedes all matching before events"
-                        )
+                        if len(failures) < 10:
+                            failures.append(
+                                f"Rule '{rule['name']}': after event at line "
+                                f"{rec.line_number} precedes all matching before events"
+                            )
 
             if rule_total > 0 and tolerance > 0:
                 failure_rate = 1.0 - (rule_correct / rule_total)

--- a/tests/unit/test_eval_temporal.py
+++ b/tests/unit/test_eval_temporal.py
@@ -366,6 +366,53 @@ class TestCausalOrdering:
         result = scorer._score_causal_ordering(records, scenario)
         assert result.score == 100.0
 
+    def test_causal_ordering_counts_failures_after_sample_cap(self):
+        """Failures beyond the diagnostic sample cap still count against the score."""
+        base = T0 + self._AFTER_GRACE
+        windows_records = []
+        for idx in range(20):
+            logon_id = f"0xbad{idx:x}"
+            windows_records.extend(
+                [
+                    _record(
+                        "windows_event_security",
+                        {"EventID": 4634, "TargetLogonId": logon_id},
+                        ts=base + timedelta(minutes=idx),
+                    ),
+                    _record(
+                        "windows_event_security",
+                        {"EventID": 4624, "TargetLogonId": logon_id},
+                        ts=base + timedelta(minutes=idx, seconds=30),
+                    ),
+                ]
+            )
+        for idx in range(5):
+            logon_id = f"0xgood{idx:x}"
+            windows_records.extend(
+                [
+                    _record(
+                        "windows_event_security",
+                        {"EventID": 4624, "TargetLogonId": logon_id},
+                        ts=base + timedelta(hours=1, minutes=idx),
+                    ),
+                    _record(
+                        "windows_event_security",
+                        {"EventID": 4634, "TargetLogonId": logon_id},
+                        ts=base + timedelta(hours=1, minutes=idx, seconds=30),
+                    ),
+                ]
+            )
+        records = {"windows_event_security": windows_records}
+        scenario = _make_scenario()
+        scorer = CausalityScorer()
+
+        result = scorer._score_causal_ordering(records, scenario)
+
+        assert result.score == 20.0
+        assert result.details == "5/25 causal pairs correctly ordered"
+        assert result.sample_failures is not None
+        assert len(result.sample_failures) == 10
+
     def test_non_string_principal_does_not_raise(self):
         """Malformed principal values should not crash exclusion checks."""
         base = T0 + self._AFTER_GRACE


### PR DESCRIPTION
### Motivation
- The causal-ordering scorer accidentally stopped counting rule failures once the diagnostic sample list reached its 10-entry cap, which let additional causal inversions be ignored and inflated the causality score.
- The intent is to keep the diagnostic sample storage capped while ensuring every non-`allow_missing_prior` inversion contributes to the `rule_total` denominator so scores remain integrity-preserving.

### Description
- Adjusted `CausalityScorer._score_causal_ordering()` in `src/evidenceforge/evaluation/pillars/causality.py` so `rule_total` is incremented for every failed pair and the diagnostic `failures` list remains capped at 10 entries (sample messages only).
- Kept the `allow_missing_prior` behavior unchanged so weak-key rules still skip counting when intended.
- Added a regression test `test_causal_ordering_counts_failures_after_sample_cap` to `tests/unit/test_eval_temporal.py` that creates 20 inverted pairs + 5 valid pairs and asserts the scorer reports `5/25` correctly and that the `sample_failures` list length is 10.
- Marked the related item complete in `TODO.md` to reflect the security fix.

### Testing
- Ran the targeted unit tests for the causal ordering group with `pytest` and the `TestCausalOrdering` suite (`tests/unit/test_eval_temporal.py::TestCausalOrdering`) which passed (8 tests passed).
- Executed the new regression test alone and as part of the suite; the test passed and confirms the score and diagnostic sample behavior are correct.
- Ran lint/format checks with `ruff` (`uv run ruff check . && uv run ruff format --check .`) which passed.
- Note: a coverage-enabled run that included only the focused test showed the repository-wide coverage enforcement failed as expected for a targeted invocation, but this does not affect the regression verification for the causal-ordering fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb4d0048325953dfff596af3946)