### PR TITLE
fix: harden beacon destination matching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,6 +54,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 - [x] Fix RDP user coercion session/ground-truth desynchronization vulnerability and malformed fallback user crash — aligned preallocated RDP session usernames with coerced Windows credentials, records RDP ground truth from canonical session identity, and sanitizes fallback email domains.
 - [x] **P1** SCP receiver source-port correlation — fixed Linux SCP storyline receiver-side sshd/file artifacts so target syslog messages reuse the same client source port as the generated SSH network flow evidence; added focused unit coverage.
 - [x] Harden storyline command-line URL inference against malformed scenario-controlled URLs so invalid hosts/ports cannot crash generation.
+- [x] Harden evaluator beacon destination matching to parse URL hosts exactly and avoid substring false positives in proxy/HTTP beacon evidence records.
 - [x] Add dual-agent `eforge install-skills` workflow — default to Claude project installs, add explicit `--agent claude|codex`, keep Claude project/global behavior, add Codex user-level `~/.codex/skills/` installs, reject invalid Codex/global combinations, and cover installer safety/stale-cleanup behavior with tests.
 - [x] Reduce Codex skill reference duplication — bundle only the references each Codex skill needs and rely on installer stale cleanup to prune no-longer-needed reference files from prior installs.
 - [x] Import existing Claude `/eforge assess` command as a Codex skill without modifying the source skill.

--- a/src/evidenceforge/evaluation/pillars/causality.py
+++ b/src/evidenceforge/evaluation/pillars/causality.py
@@ -31,10 +31,12 @@ Sub-scores (weights sum to 1.0):
   storyline_trace_coverage (0.10): All expected format-groups have traces.
 """
 
+import ipaddress
 import logging
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.parse import urlsplit
 
 from evidenceforge.evaluation._shared import _condition_matches, _extract_hostname, _normalize_ts
 from evidenceforge.evaluation.dimensions import (
@@ -589,23 +591,75 @@ class CausalityScorer(DimensionScorer):
             or expected_lower.startswith(record_str + ".")
         )
 
-    @staticmethod
-    def _beacon_dst_matches(fields: dict, expected_dst: str) -> bool:
+    @classmethod
+    def _beacon_dst_matches(cls, fields: dict, expected_dst: str) -> bool:
         """Check whether a record references expected_dst as a beacon destination.
 
-        Handles proxy_access (stores destination as 'host' hostname),
-        zeek_http (id.resp_h / uri), and fallback IP fields.
+        Handles proxy_access (stores destination as 'host' hostname), zeek_http
+        (id.resp_h / host / uri), and fallback IP fields. URL/URI values are
+        parsed so only authority hostnames can satisfy the destination check.
         """
-        candidates = [
-            fields.get("id.resp_h"),
-            fields.get("dst_ip"),
-            fields.get("host"),
-        ]
-        # Also check hostname within full URL/URI
-        url = fields.get("url") or fields.get("uri")
-        if url:
-            candidates.append(url)
-        return any(expected_dst == c or (c and expected_dst in c) for c in candidates if c)
+        expected = cls._normalize_beacon_host(expected_dst)
+        if not expected:
+            return False
+
+        candidates: list[str] = []
+        for field_name in ("id.resp_h", "dst_ip", "host"):
+            candidate = cls._normalize_beacon_host(fields.get(field_name))
+            if candidate:
+                candidates.append(candidate)
+
+        for field_name in ("url", "uri"):
+            candidate = cls._extract_beacon_url_host(fields.get(field_name))
+            if candidate:
+                candidates.append(candidate)
+
+        return any(cls._beacon_host_matches(candidate, expected) for candidate in candidates)
+
+    @staticmethod
+    def _normalize_beacon_host(value: Any) -> str:
+        """Normalize a beacon destination host/IP for exact comparisons."""
+        if value is None:
+            return ""
+        host = str(value).strip().lower().strip("[]")
+        if not host:
+            return ""
+        if host.endswith("."):
+            host = host[:-1]
+        try:
+            return str(ipaddress.ip_address(host))
+        except ValueError:
+            return host
+
+    @classmethod
+    def _extract_beacon_url_host(cls, value: Any) -> str:
+        """Extract and normalize only the authority host from an absolute URL/URI."""
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if not text:
+            return ""
+        parsed = urlsplit(text)
+        if not parsed.hostname and text.startswith("//"):
+            parsed = urlsplit(f"http:{text}")
+        return cls._normalize_beacon_host(parsed.hostname)
+
+    @staticmethod
+    def _beacon_host_matches(candidate: str, expected: str) -> bool:
+        """Compare beacon hosts/IPs without unsafe substring matching."""
+        if candidate == expected:
+            return True
+        try:
+            ipaddress.ip_address(candidate)
+            return False
+        except ValueError:
+            pass
+        try:
+            ipaddress.ip_address(expected)
+            return False
+        except ValueError:
+            pass
+        return candidate.endswith(f".{expected}")
 
     # --- Sub-score 1: Causal Ordering ---
 

--- a/tests/unit/test_eval_cross_source.py
+++ b/tests/unit/test_eval_cross_source.py
@@ -604,11 +604,39 @@ class TestBeaconProxyMatcher:
         assert scorer._beacon_dst_matches(fields, "evil.example.com")
         assert not scorer._beacon_dst_matches(fields, "other.example.com")
 
-    def test_beacon_allow_proxy_matches_ip_in_url(self):
-        """_beacon_dst_matches should match IP found in url field."""
+    def test_beacon_allow_proxy_matches_ip_url_host(self):
+        """_beacon_dst_matches should match IP found in the URL authority host."""
         scorer = CrossSourceScorer()
         fields = {"url": "https://45.33.32.30/check", "status_code": 200}
         assert scorer._beacon_dst_matches(fields, "45.33.32.30")
+
+    def test_beacon_allow_proxy_rejects_ip_url_path_only(self):
+        """_beacon_dst_matches should not match an IP that appears only in a URL path."""
+        scorer = CrossSourceScorer()
+        fields = {"url": "https://attacker.example/check/45.33.32.30", "status_code": 200}
+        assert not scorer._beacon_dst_matches(fields, "45.33.32.30")
+
+    def test_beacon_allow_proxy_rejects_domain_url_path_only(self):
+        """_beacon_dst_matches should not match a domain that appears only in a URL path."""
+        scorer = CrossSourceScorer()
+        fields = {
+            "host": "attacker.tld",
+            "url": "http://attacker.tld/download/evil.example.com/pixel.gif",
+            "status_code": 200,
+        }
+        assert not scorer._beacon_dst_matches(fields, "evil.example.com")
+
+    def test_beacon_allow_proxy_rejects_larger_hostname(self):
+        """_beacon_dst_matches should not match larger hostnames by substring."""
+        scorer = CrossSourceScorer()
+        fields = {"host": "evil.example.com.attacker.net", "status_code": 200}
+        assert not scorer._beacon_dst_matches(fields, "evil.example.com")
+
+    def test_beacon_allow_proxy_matches_subdomain_boundary(self):
+        """_beacon_dst_matches should allow validated domain-boundary subdomain matches."""
+        scorer = CrossSourceScorer()
+        fields = {"host": "api.evil.example.com", "status_code": 200}
+        assert scorer._beacon_dst_matches(fields, "evil.example.com")
 
     def test_beacon_deny_proxy_403_counts_as_deny(self):
         """proxy_access record with status_code 403 should match beacon deny."""


### PR DESCRIPTION
### Motivation
- Prevent evaluator false-positives where substring containment in proxy/HTTP fields (URL paths or larger hostnames) caused crafted records to be counted as beacon evidence for an unrelated host.

### Description
- Replace unsafe substring checks in `_beacon_dst_matches` with normalized host/IP comparisons and URL/URI authority-host extraction using `ipaddress` and `urlsplit`.
- Add helpers `_normalize_beacon_host`, `_extract_beacon_url_host`, and `_beacon_host_matches` to canonicalize IPs/hosts and enforce domain-boundary subdomain matching instead of arbitrary substring matches.
- Update beacon allow/deny matching to consult parsed authority hosts and normalized candidate fields (`id.resp_h`, `dst_ip`, `host`, and URL authority) only.
- Add regression unit tests that assert exact host/IP and subdomain-boundary matches succeed while path-only IP/domain occurrences and larger-hostname substring cases are rejected, and mark the TODO entry for this hardening as done.

### Testing
- Ran `PYTHONPATH=src uv run pytest tests/unit/test_eval_cross_source.py -q --no-cov` and the suite passed (39 passed). 
- Ran targeted `PYTHONPATH=src uv run pytest tests/unit/test_eval_cross_source.py::TestBeaconProxyMatcher -q --no-cov` and it passed (all tests in the class passed).
- Ran linter/format checks with `uv run ruff check .` and `uv run ruff format --check .` and both succeeded.
- Note: invoking the same pytest run with the repository-wide coverage addopts (the default `pyproject.toml` addopts) can fail due to global coverage `fail_under` enforcement even though the modified unit tests themselves pass; the targeted tests and lint checks used above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ebb4bfd083258d0c2bc749777185)