### PR TITLE
fix: keep storyline DHCP setup in warmup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 - [x] **P1** SCP receiver source-port correlation — fixed Linux SCP storyline receiver-side sshd/file artifacts so target syslog messages reuse the same client source port as the generated SSH network flow evidence; added focused unit coverage.
 - [x] Harden storyline command-line URL inference against malformed scenario-controlled URLs so invalid hosts/ports cannot crash generation.
 - [x] Harden evaluator beacon destination matching to parse URL hosts exactly and avoid substring false positives in proxy/HTTP beacon evidence records.
+- [x] Fix DHCP setup for storyline hosts so setup leases remain warm-up-only state and cannot emit visible out-of-window REQUEST/ACK records.
 - [x] Add dual-agent `eforge install-skills` workflow — default to Claude project installs, add explicit `--agent claude|codex`, keep Claude project/global behavior, add Codex user-level `~/.codex/skills/` installs, reject invalid Codex/global combinations, and cover installer safety/stale-cleanup behavior with tests.
 - [x] Reduce Codex skill reference duplication — bundle only the references each Codex skill needs and rely on installer stale cleanup to prune no-longer-needed reference files from prior installs.
 - [x] Import existing Claude `/eforge assess` command as a Codex skill without modifying the source skill.

--- a/src/evidenceforge/generation/engine/emitter_setup.py
+++ b/src/evidenceforge/generation/engine/emitter_setup.py
@@ -288,12 +288,6 @@ class EmitterSetupMixin:
 
         # Track lease state for periodic renewals
         self._dhcp_lease_state: dict[str, dict] = {}
-        storyline_dhcp_hosts = {
-            entry.system
-            for entry in getattr(self.scenario, "storyline", [])
-            for event in getattr(entry, "events", [])
-            if getattr(event, "type", None) == "dhcp_lease"
-        }
         # Stagger across first 5 minutes using per-host deterministic offsets
         base_time = getattr(self, "warmup_start_time", self.start_time)
 
@@ -310,12 +304,7 @@ class EmitterSetupMixin:
             oui = oui_rng.choices(_oui_values, weights=_oui_weights, k=1)[0]
             mac = f"{oui}:{(ip_seed >> 16) & 0xFF:02x}:{(ip_seed >> 8) & 0xFF:02x}:{ip_seed & 0xFF:02x}"
             offset = (_stable_seed(f"dhcp_offset_{system.hostname}") % 300) + rng.uniform(0, 5)
-            if system.hostname in storyline_dhcp_hosts:
-                ts = self.start_time + timedelta(seconds=offset)
-                msg_types = ["REQUEST", "ACK"]
-            else:
-                ts = base_time + timedelta(seconds=offset)
-                msg_types = None
+            ts = base_time + timedelta(seconds=offset)
             uid = generate_zeek_uid("C")
             lease_time = float(rng.choice([3600, 7200, 14400, 86400]))
             self.state_manager.set_current_time(ts)
@@ -325,7 +314,6 @@ class EmitterSetupMixin:
                 mac=mac,
                 lease_time=lease_time,
                 uid=uid,
-                msg_types=msg_types,
             )
             # Store state for renewals
             self._dhcp_lease_state[system.hostname] = {

--- a/tests/unit/test_dhcp_setup.py
+++ b/tests/unit/test_dhcp_setup.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for DHCP lease setup behavior."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+from evidenceforge.generation.engine import GenerationEngine
+from evidenceforge.models import (
+    BaselineActivity,
+    Environment,
+    OutputSpec,
+    Scenario,
+    System,
+    TimeWindow,
+    User,
+)
+from evidenceforge.models.scenario import StorylineEvent
+
+
+def _scenario_with_storyline_dhcp() -> Scenario:
+    """Build a short scenario whose DHCP setup offset would exceed the output window."""
+    return Scenario(
+        version="1.0",
+        name="short-dhcp-storyline",
+        description="Short DHCP storyline scenario",
+        environment=Environment(
+            description="Test environment",
+            users=[
+                User(
+                    username="attacker",
+                    full_name="Attacker",
+                    email="attacker@example.com",
+                    enabled=True,
+                    primary_system="TEST-01",
+                )
+            ],
+            systems=[
+                System(hostname="TEST-01", ip="10.0.0.1", os="Windows 10", type="workstation")
+            ],
+        ),
+        time_window=TimeWindow(start="2024-01-15T10:00:00Z", duration="1m"),
+        baseline_activity=BaselineActivity(
+            description="Test baseline", intensity="low", variation="low"
+        ),
+        output=OutputSpec(logs=[{"format": "zeek_dhcp"}], destination="./output"),
+        storyline=[
+            StorylineEvent(
+                id="dhcp-storyline",
+                time="2024-01-15T10:00:30Z",
+                actor="attacker",
+                system="TEST-01",
+                activity="Rogue host obtains a DHCP lease",
+                events=[{"type": "dhcp_lease"}],
+            )
+        ],
+    )
+
+
+def test_emit_dhcp_leases_keeps_storyline_hosts_in_warmup_state(tmp_path):
+    """Storyline DHCP hosts should get setup state without visible out-of-window leases."""
+    scenario = _scenario_with_storyline_dhcp()
+    engine = GenerationEngine(scenario, tmp_path)
+    engine.start_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    engine.end_time = datetime(2024, 1, 15, 10, 1, 0, tzinfo=UTC)
+    engine.warmup_start_time = engine.start_time - timedelta(hours=8)
+    engine.emitters = {"zeek_dhcp": Mock()}
+    engine.state_manager = Mock()
+    engine.activity_generator = Mock()
+
+    engine._emit_dhcp_leases()
+
+    engine.activity_generator.generate_dhcp_lease.assert_called_once()
+    kwargs = engine.activity_generator.generate_dhcp_lease.call_args.kwargs
+    assert kwargs["system"].hostname == "TEST-01"
+    assert kwargs["time"] < engine.start_time
+    assert kwargs["time"] < engine.end_time
+    assert "msg_types" not in kwargs
+    assert engine._dhcp_lease_state["TEST-01"]["last_renewal"] == kwargs["time"].timestamp()


### PR DESCRIPTION
### Motivation
- Storyline hosts with explicit `dhcp_lease` events were receiving a visible REQUEST/ACK during emitter setup computed as `start_time + offset`, which could fall after the scenario `end_time` or be emitted before normal chronological generation. 
- This produced out-of-window visible DHCP rows and broke temporal integrity guarantees for short scenarios and warm-up suppression semantics.

### Description
- Always anchor initial DHCP setup timestamps to the warm-up `base_time` (previously `warmup_start_time`) for all hosts so setup leases establish renewal state only and remain suppressed from visible output. 
- Remove special-case detection and visible `msg_types` for storyline DHCP hosts so the setup path no longer emits REQUEST/ACK records at `start_time`. 
- Add a focused unit test `tests/unit/test_dhcp_setup.py` that builds a one-minute storyline DHCP scenario and asserts the setup lease time is before `start_time` and `end_time`, that no `msg_types` were set, and that lease state is stored for renewals. 
- Update `TODO.md` to record the completed fix for DHCP setup behavior.

### Testing
- Ran `uv run pytest tests/unit/test_dhcp_setup.py tests/unit/test_engine.py --no-cov` and both tests passed (`34 passed` total including the new DHCP test). 
- Ran formatter/linter checks `uv run ruff check .` and `uv run ruff format --check .`, which passed after formatting the new test file. 
- The new unit test verifies the regression case where setup offsets could exceed the scenario end; it passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f0fb13f48325bc67a8b9bb8e8f40)