### PR TITLE
fix: avoid fabricated eCAR process object IDs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,6 +56,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 - [x] Harden storyline command-line URL inference against malformed scenario-controlled URLs so invalid hosts/ports cannot crash generation.
 - [x] Harden evaluator beacon destination matching to parse URL hosts exactly and avoid substring false positives in proxy/HTTP beacon evidence records.
 - [x] Fix DHCP setup for storyline hosts so setup leases remain warm-up-only state and cannot emit visible out-of-window REQUEST/ACK records.
+- [x] Fix eCAR process object ID lookup so missing processes do not fabricate orphan UUID references; missing lookups now return empty IDs, and remote-thread/process-access generation skips absent targets.
 - [x] Add dual-agent `eforge install-skills` workflow — default to Claude project installs, add explicit `--agent claude|codex`, keep Claude project/global behavior, add Codex user-level `~/.codex/skills/` installs, reject invalid Codex/global combinations, and cover installer safety/stale-cleanup behavior with tests.
 - [x] Reduce Codex skill reference duplication — bundle only the references each Codex skill needs and rely on installer stale cleanup to prune no-longer-needed reference files from prior installs.
 - [x] Import existing Claude `/eforge assess` command as a Codex skill without modifying the source skill.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -7652,7 +7652,14 @@ class ActivityGenerator:
     ) -> None:
         """Generate Sysmon Event 8 (CreateRemoteThread) for process injection."""
         # Entity lifecycle: validate target PID exists
-        self.state_manager.validate_target_pid(system.hostname, target_pid)
+        if not self.state_manager.validate_target_pid(system.hostname, target_pid):
+            logger.debug(
+                "Skipping remote thread for non-running target process: %s source_pid=%s target_pid=%s",
+                system.hostname,
+                source_pid,
+                target_pid,
+            )
+            return
 
         from evidenceforge.events.contexts import ProcessContext
 
@@ -7754,7 +7761,14 @@ class ActivityGenerator:
             granted_access: Access mask (0x1010=VM_READ, 0x1FFFFF=ALL_ACCESS)
         """
         # Entity lifecycle: validate target PID exists
-        self.state_manager.validate_target_pid(system.hostname, target_pid)
+        if not self.state_manager.validate_target_pid(system.hostname, target_pid):
+            logger.debug(
+                "Skipping process access for non-running target process: %s source_pid=%s target_pid=%s",
+                system.hostname,
+                source_pid,
+                target_pid,
+            )
+            return
 
         time = self._clamp_time_after_process_start(system, source_pid, time)
         source_proc = self.state_manager.get_process(system.hostname, source_pid)

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -492,9 +492,7 @@ class StateManager:
             proc = self.state.running_processes.get(key)
             if proc:
                 return proc.ecar_object_id
-            if key not in self._process_object_ids:
-                self._process_object_ids[key] = str(uuid.uuid4())
-            return self._process_object_ids[key]
+            return self._process_object_ids.get(key, "")
 
     def update_process_activity_time(self, system: str, pid: int, activity_time: datetime) -> bool:
         """Record the latest dependent activity timestamp for a running process."""

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -44,15 +44,15 @@ from evidenceforge.models import System, User
 
 
 class TestStateObjectIds:
-    def test_missing_process_object_id_is_allocated_once(self):
-        """Unseen process IDs should still get stable eCAR object IDs."""
+    def test_missing_process_object_id_returns_empty(self):
+        """Unseen process IDs should not fabricate eCAR object IDs."""
         state = StateManager()
 
         first = state.get_process_object_id("WS-01", 4444)
         second = state.get_process_object_id("WS-01", 4444)
 
-        assert first
-        assert second == first
+        assert first == ""
+        assert second == ""
 
 
 class TestNetworkValidation:
@@ -1558,6 +1558,39 @@ class TestActivityGenerator:
         assert event.edr.actor_id == source_obj_id
         assert event.remote_thread.start_address > 0
         assert event.remote_thread.start_module
+
+    def test_create_remote_thread_skips_missing_target_pid(
+        self, activity_gen, test_user, test_system, state_manager, mock_emitters
+    ):
+        """Remote-thread generation should not reference missing target process objects."""
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        state_manager.set_current_time(timestamp)
+        source_pid = state_manager.create_process(
+            system=test_system.hostname,
+            parent_pid=4,
+            image=r"C:\Temp\inject.exe",
+            command_line=r"C:\Temp\inject.exe",
+            username=test_user.username,
+            integrity_level="High",
+            logon_id="0xabc",
+        )
+
+        activity_gen.generate_create_remote_thread(
+            test_user,
+            test_system,
+            timestamp,
+            source_pid=source_pid,
+            source_image=r"C:\Temp\inject.exe",
+            target_pid=99999,
+            target_image=r"C:\Windows\System32\lsass.exe",
+        )
+
+        assert not [
+            call[0][0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call[0][0].event_type == "create_remote_thread"
+        ]
+        assert state_manager.get_process_object_id(test_system.hostname, 99999) == ""
 
     def test_module_load_uses_process_aware_dll_profile(
         self, activity_gen, test_user, test_system, state_manager, mock_emitters

--- a/tests/unit/test_edr_object_graph.py
+++ b/tests/unit/test_edr_object_graph.py
@@ -127,13 +127,12 @@ class TestStateManagerObjectIds:
     def test_missing_session_returns_empty(self, state_manager):
         assert state_manager.get_session_object_id("nonexistent") == ""
 
-    def test_missing_process_allocates_stable_id(self, state_manager):
+    def test_missing_process_returns_empty_id(self, state_manager):
         first = state_manager.get_process_object_id("WKS-01", 99999)
         second = state_manager.get_process_object_id("WKS-01", 99999)
 
-        assert first == second
-        assert first != ""
-        uuid.UUID(first)
+        assert first == ""
+        assert second == ""
 
 
 # ---- Lifecycle Persistence ----

--- a/tests/unit/test_sysmon_process_access.py
+++ b/tests/unit/test_sysmon_process_access.py
@@ -132,6 +132,34 @@ class TestSysmonProcessAccess:
         assert event.process_access.target_image == r"C:\Windows\System32\lsass.exe"
         assert event.process_access.granted_access == "0x1010"
 
+    def test_process_access_skips_missing_target_pid(
+        self, state_manager, activity_gen, mock_emitters, windows_system, test_user
+    ):
+        """ProcessAccess should not emit orphan object references for missing targets."""
+        ts = datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC)
+        source_image = r"C:\Users\compromised.user\AppData\Local\Temp\mimikatz.exe"
+        source_pid = state_manager.create_process(
+            windows_system.hostname,
+            parent_pid=4,
+            image=source_image,
+            command_line=source_image,
+            username=test_user.username,
+            integrity_level="High",
+        )
+
+        activity_gen.generate_process_access(
+            user=test_user,
+            system=windows_system,
+            time=ts,
+            source_pid=source_pid,
+            source_image=source_image,
+            target_pid=99999,
+        )
+
+        assert mock_emitters["windows_event_sysmon"].emit.call_count == 0
+        assert mock_emitters["ecar"].emit.call_count == 0
+        assert state_manager.get_process_object_id(windows_system.hostname, 99999) == ""
+
     def test_process_access_default_target_is_lsass(
         self, state_manager, activity_gen, mock_emitters, windows_system, test_user
     ):


### PR DESCRIPTION
### Motivation
- `StateManager.get_process_object_id()` previously allocated and cached UUIDs for unknown `(system, pid)` pairs, fabricating stable objectIDs for processes that were never tracked and producing orphan references in eCAR output.  
- Callers (process parenting, remote-thread, process-access) rely on that lookup and could emit non-existent actor/target references that corrupt the eCAR object graph.  
- The generator should signal absence (empty ID) and skip emitting cross-process evidence that would reference missing runtime objects.

### Description
- Stop allocating UUIDs for unknown processes: `get_process_object_id()` now returns `""` when the `(system, pid)` is not running and not previously recorded, preserving the invariant that only real/historically-tracked processes have eCAR objectIDs. (`src/evidenceforge/generation/state_manager.py`)  
- Add target-PID existence guards so remote-thread and process-access generation abort early when the target PID is absent, with debug logs to aid diagnostics; this prevents emitting orphan `target_process_uuid` / `objectID` references. (`src/evidenceforge/generation/activity/generator.py`)  
- Update and add unit tests that assert the new behavior: missing process lookups return empty IDs and generation of remote-thread/process-access is skipped for absent targets. Also updated `TODO.md` to reflect the remediation. (tests in `tests/unit/test_activity.py`, `tests/unit/test_edr_object_graph.py`, `tests/unit/test_sysmon_process_access.py`)  

### Testing
- Ran focused unit tests: `uv run pytest --no-cov tests/unit/test_edr_object_graph.py tests/unit/test_sysmon_process_access.py tests/unit/test_activity.py -q` and the selected test permutations used during development; all tests passed (129 passed across the invoked suites).  
- Ran linter/format checks: `uv run ruff check .` and `uv run ruff format --check .`, both succeeded.  
- Verified the smaller focused test runs used during development (examples in the changelist) also passed; no regressions were observed in the covered unit suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f10317fc832586fcfc05ef106550)