### PR TITLE
fix: preserve exact web_scan counts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,8 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Skill Installer Agent Support
 
+- [x] Fix count-based `web_scan` generation so random skip/pause realism does not consume count-limited ticks before emitting requests.
+
 - [x] Add dual-agent `eforge install-skills` workflow — default to Claude project installs, add explicit `--agent claude|codex`, keep Claude project/global behavior, add Codex user-level `~/.codex/skills/` installs, reject invalid Codex/global combinations, and cover installer safety/stale-cleanup behavior with tests.
 - [x] Reduce Codex skill reference duplication — bundle only the references each Codex skill needs and rely on installer stale cleanup to prune no-longer-needed reference files from prior installs.
 - [x] Import existing Claude `/eforge assess` command as a Codex skill without modifying the source skill.

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1992,13 +1992,14 @@ class StorylineMixin:
             for tick_time in _iter_periodic_ticks(
                 start, interval_sec, duration_sec, count, spec.jitter, rng
             ):
-                if pause_until is not None and tick_time < pause_until:
-                    continue
-                if request_count > 0 and rng.random() < 0.025:
-                    continue
-                if request_count > 0 and rng.random() < 0.008:
-                    pause_until = tick_time + timedelta(seconds=rng.uniform(3.0, 45.0))
-                    continue
+                if count is None:
+                    if pause_until is not None and tick_time < pause_until:
+                        continue
+                    if request_count > 0 and rng.random() < 0.025:
+                        continue
+                    if request_count > 0 and rng.random() < 0.008:
+                        pause_until = tick_time + timedelta(seconds=rng.uniform(3.0, 45.0))
+                        continue
 
                 self.state_manager.set_current_time(tick_time)
                 path_entry = scan_paths[path_idx % len(scan_paths)]

--- a/tests/unit/test_bulk_events.py
+++ b/tests/unit/test_bulk_events.py
@@ -5,11 +5,14 @@
 
 import random
 from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
 
 import pytest
 from pydantic import ValidationError
 
+import evidenceforge.generation.engine.storyline as storyline_module
 from evidenceforge.generation.engine.storyline import (
+    StorylineMixin,
     _effective_rate_interval,
     _iter_dns_tunnel_ticks,
     _iter_periodic_ticks,
@@ -23,11 +26,36 @@ from evidenceforge.models.scenario import (
     DnsQueryEventSpec,
     DnsTunnelEventSpec,
     ExplicitCredentialsEventSpec,
+    System,
+    User,
     WebScanEventSpec,
     WorkstationLockEventSpec,
     WorkstationUnlockEventSpec,
     _PeriodicEventBase,
 )
+
+
+class _AlwaysSkipWebScanRng:
+    """RNG that triggers web-scan skip branches while keeping other values realistic."""
+
+    def __init__(self) -> None:
+        self._base = random.Random(7)
+
+    def random(self) -> float:
+        return 0.0
+
+    def uniform(self, a: float, b: float) -> float:
+        return self._base.uniform(a, b)
+
+    def randint(self, a: int, b: int) -> int:
+        return self._base.randint(a, b)
+
+    def choice(self, seq):
+        return self._base.choice(seq)
+
+    def choices(self, population, weights=None, *, cum_weights=None, k=1):
+        return self._base.choices(population, weights=weights, cum_weights=cum_weights, k=k)
+
 
 # ── _PeriodicEventBase validation ─────────────────────────────────────────
 
@@ -399,6 +427,45 @@ class TestWebScanEventSpec:
                 duration="1h",
                 preset="nikto",
             )
+
+
+class TestWebScanGeneration:
+    def test_count_based_web_scan_emits_exact_request_count(self, monkeypatch):
+        """Count-based web scans should not lose requests to realism skip/pause branches."""
+        engine = type("FakeEngine", (StorylineMixin,), {}).__new__(
+            type("FakeEngine", (StorylineMixin,), {})
+        )
+        engine.state_manager = Mock()
+        engine.dispatcher = Mock(visibility_engine=None)
+        engine.activity_generator = Mock()
+        engine.activity_generator._ip_to_system = {}
+        engine._last_storyline_process_by_system = {}
+
+        monkeypatch.setattr(storyline_module, "_get_rng", lambda: _AlwaysSkipWebScanRng())
+
+        actor = User(username="scanner", full_name="Scanner", email="scanner@example.com")
+        system = System(hostname="SCAN-01", ip="10.0.0.10", os="Linux", type="workstation")
+        spec = WebScanEventSpec(
+            dst_ip="10.0.0.5",
+            source_ip="10.0.0.10",
+            rate=50.0,
+            count=25,
+            jitter=0.0,
+            preset="nikto",
+        )
+
+        result = engine._execute_typed_event(
+            spec=spec,
+            actor=actor,
+            system=system,
+            time=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+            activity="scan web server",
+            explicit_types={"web_scan"},
+        )
+
+        assert engine.activity_generator.generate_connection.call_count == spec.count
+        assert result is not None
+        assert result["request_count"] == spec.count
 
 
 # ── CredentialSprayEventSpec ──────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- The `web_scan` periodic generator used `_iter_periodic_ticks` (which counts yielded ticks) while per-tick realism logic (random skips and pauses) could `continue` before a request was emitted, causing count-based scans to emit fewer requests than the scenario `count` and producing inconsistent `request_count` in ground truth.

### Description
- Apply skip/pause randomness only for duration/end-time scans by guarding the skip/pause branch with `if count is None:` in `src/evidenceforge/generation/engine/storyline.py` so `count`-based scans remain exact.
- Add a regression test `TestWebScanGeneration::test_count_based_web_scan_emits_exact_request_count` in `tests/unit/test_bulk_events.py` which injects an RNG that would have forced the skip path and verifies both the number of `generate_connection` calls and the returned `request_count` equal the requested `count`.
- Mark the corresponding TODO entry complete in `TODO.md` and run lint/format fixes to keep imports and formatting consistent.

### Testing
- Ran the new unit test: `uv run pytest tests/unit/test_bulk_events.py::TestWebScanGeneration::test_count_based_web_scan_emits_exact_request_count` and it passed.
- Ran the full `tests/unit/test_bulk_events.py` test file and observed `95 passed` across the file.
- Ran project style checks: `uv run ruff check .` and `uv run ruff format --check .`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f2b2b6448325aec743aab0a94bbe)