### PR TITLE
[codex] Emit syslog as RFC 5424

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -81,7 +81,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### P1 Syslog BSD Timestamp Year Inference
 
-- [ ] **P1** Syslog emitter uses BSD format (`%b %d %H:%M:%S`) with no year in the output template (`syslog.yaml` line 61). The parser substitutes `datetime.now().year` at parse time, so evaluating scenario data in a different calendar year than it was generated stamps all syslog events with the wrong year. This inflates the observed event span for the diurnal-pattern short-scenario guard and any other evaluator logic that computes spans across formats. Fix: switch the syslog emitter template to ISO 8601 (`%Y-%m-%dT%H:%M:%SZ`) and remove the BSD branch from the parser (keeping it only as a fallback for real-world log ingestion). Existing `_SYSLOG_MONTHS`, `_SYSLOG_TS_RE`, and `_syslog_sort_key` in the emitter can be removed once the template is ISO. Scenarios regenerated after this fix will parse cleanly at any future date.
+- [x] **P1** Syslog year-bearing timestamp fix — generated Linux syslog now renders RFC 5424 with full ISO/RFC3339 timestamps and PRI/version/procid fields, removing the yearless BSD output path that caused future-date eval drift. `eforge eval` keeps parser-marked BSD/RFC3164 and legacy ISO input as compatibility fallbacks for older datasets, while strict validation requires RFC 5424 for unmarked/generated syslog. Verified with config validation, focused syslog/eval tests, Ruff, and full normal pytest.
 
 ### P0 Cross-Source Timing Audit
 

--- a/commands/eforge/evaluate.md
+++ b/commands/eforge/evaluate.md
@@ -68,7 +68,7 @@ Present a clear summary of the evaluation results. The report shows two tiers fo
 For each pillar, explain what the score means in practical terms:
 
 **Pillar 1: Parseability (weight 0.30)**
-- Spec Conformance: Does every record parse cleanly under strict-mode rules? Missing required fields? Type violations? RFC5424 strict for syslog; typed columns for Zeek; schema-strict for eCAR; XML-schema for Windows EventLog.
+- Spec Conformance: Does every record parse cleanly under strict-mode rules? Missing required fields? Type violations? RFC 5424 strict for generated syslog with legacy BSD/RFC3164 eval fallback; typed columns for Zeek; schema-strict for eCAR; XML-schema for Windows EventLog.
 - Format Constraints: Do records satisfy `FormatDefinition` constraints (field ranges, enum values, structural rules)?
 
 **Pillar 2: Plausibility (weight 0.25)**

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -162,7 +162,7 @@ After reviewing output, you can suggest:
 | windows | Windows Event Logs (XML) — Security (30 event IDs) + Sysmon (Events 1, 3, 5, 7, 8, 10, 11, 12, 13, 22) | Windows systems |
 | zeek | Zeek logs (NDJSON) — conn/dns/http/ssl/files/ntp per sensor | Network connections via sensors |
 | ecar | EDR/XDR telemetry in eCAR format (NDJSON) — PROCESS, FILE, FLOW, REGISTRY, MODULE, USER_SESSION | Any OS (optional EDR layer) |
-| syslog | Linux syslog (BSD format) | Linux systems |
+| syslog | Linux syslog (RFC 5424) | Linux systems |
 | bash_history | Bash command history | Linux systems |
 | snort_alert | Snort/Suricata alerts (fast format) | Network IDS via sensors |
 | cisco_asa | Cisco ASA firewall syslog (Built/Teardown/Deny) | Firewall sensors |

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -24,7 +24,7 @@ output/
     files.json                             # Zeek files.log
     ...                                    # Other Zeek logs
   ecar.json                                # eCAR EDR/XDR telemetry (NDJSON)
-  syslog.log                               # Linux syslog (BSD format)
+  syslog.log                               # Linux syslog (RFC 5424)
   snort_alert.log                          # Snort/Suricata IDS alerts
   <fw-hostname>/                           # Per-firewall directories
     cisco_asa.log                          # Cisco ASA firewall syslog
@@ -173,9 +173,9 @@ EDR/XDR telemetry rendered in MITRE CAR-based eCAR format. Represents what an ED
 ## Linux Syslog
 
 **File:** `syslog.log`
-**Format:** BSD syslog (RFC 3164 text format)
+**Format:** RFC 5424 syslog
 
-Authentication and system logs from Linux hosts. All syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent.
+Authentication and system logs from Linux hosts. Generated syslog uses RFC 5424 with year-bearing ISO/RFC3339 timestamps. `eforge eval` still accepts older BSD/RFC3164-style syslog as a legacy ingest fallback. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent.
 
 | Program | Description | Notes |
 |---------|-------------|-------|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,7 +251,7 @@ LogEmitter (ABC)
 │   ├── ZeekSslEmitter               # ssl.log
 │   └── ... (10 more Zeek types)
 ├── EcarEmitter                      # eCAR NDJSON (MITRE CAR model, objectID/actorID graph via EdrContext)
-├── SyslogEmitter                    # Linux syslog (BSD format)
+├── SyslogEmitter                    # Linux syslog (RFC 5424)
 ├── BashHistoryEmitter               # Per-user bash history
 ├── SnortEmitter                     # Snort IDS alerts
 ├── CiscoAsaEmitter                  # Cisco ASA firewall syslog (Built/Teardown/Deny)

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -24,7 +24,7 @@ output/
     files.json                             # Zeek files.log
     ...                                    # Other Zeek logs
   ecar.json                                # eCAR EDR/XDR telemetry (NDJSON)
-  syslog.log                               # Linux syslog (BSD format)
+  syslog.log                               # Linux syslog (RFC 5424)
   snort_alert.log                          # Snort/Suricata IDS alerts
   <fw-hostname>/                           # Per-firewall directories
     cisco_asa.log                          # Cisco ASA firewall syslog
@@ -173,9 +173,9 @@ EDR/XDR telemetry rendered in MITRE CAR-based eCAR format. Represents what an ED
 ## Linux Syslog
 
 **File:** `syslog.log`
-**Format:** BSD syslog (RFC 3164 text format)
+**Format:** RFC 5424 syslog
 
-Authentication and system logs from Linux hosts. All syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent.
+Authentication and system logs from Linux hosts. Generated syslog uses RFC 5424 with year-bearing ISO/RFC3339 timestamps. `eforge eval` still accepts older BSD/RFC3164-style syslog as a legacy ingest fallback. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent.
 
 | Program | Description | Notes |
 |---------|-------------|-------|

--- a/src/evidenceforge/config/formats/syslog.yaml
+++ b/src/evidenceforge/config/formats/syslog.yaml
@@ -25,7 +25,7 @@ fields:
   - name: facility
     type: integer
     required: false
-    description: "Syslog facility (1=user, 4=auth, 3=daemon, 10=authpriv). Not present in BSD format text."
+    description: "Syslog facility (1=user, 4=auth, 3=daemon, 10=authpriv). Rendered into RFC 5424 PRI."
     constraints:
       min_value: 0
       max_value: 23
@@ -33,7 +33,7 @@ fields:
   - name: severity
     type: integer
     required: false
-    description: "Syslog severity (6=info, 5=notice, 4=warning). Not present in BSD format text."
+    description: "Syslog severity (6=info, 5=notice, 4=warning). Rendered into RFC 5424 PRI."
     constraints:
       min_value: 0
       max_value: 7
@@ -43,10 +43,47 @@ fields:
     required: true
     description: "Application/process name (sshd, su, sudo, systemd, etc.)"
 
+  - name: pri
+    type: integer
+    required: false
+    description: "RFC 5424 PRI value derived from facility * 8 + severity"
+    constraints:
+      min_value: 0
+      max_value: 191
+
+  - name: version
+    type: integer
+    required: false
+    description: "RFC 5424 protocol version. EvidenceForge emits version 1."
+    constraints:
+      allowed_values: [1]
+
   - name: pid
     type: integer
     required: false
     description: "Process ID"
+
+  - name: procid
+    type: string
+    required: false
+    description: "RFC 5424 PROCID token, usually the process ID or '-'"
+
+  - name: msgid
+    type: string
+    required: false
+    description: "RFC 5424 MSGID token. EvidenceForge currently emits '-'."
+
+  - name: structured_data
+    type: string
+    required: false
+    description: "RFC 5424 structured-data field. EvidenceForge currently emits '-'."
+
+  - name: syslog_protocol
+    type: string
+    required: false
+    description: "Parser metadata identifying RFC 5424 output or legacy RFC 3164/BSD eval input."
+    constraints:
+      allowed_values: [rfc5424, rfc3164_legacy, iso_legacy]
 
   - name: message
     type: string
@@ -58,4 +95,4 @@ output:
   file_extension: ".log"
   encoding: utf-8
   template: |
-    {% if app_name == 'kernel' %}{{ timestamp.strftime('%b %d %H:%M:%S') }} {{ hostname }} kernel: {{ message }}{% else %}{{ timestamp.strftime('%b %d %H:%M:%S') }} {{ hostname }} {{ app_name }}[{{ pid }}]: {{ message }}{% endif %}
+    <{{ pri }}>1 {{ timestamp }} {{ hostname }} {{ app_name }} {{ procid }} {{ msgid }} {{ structured_data }} {{ message }}

--- a/src/evidenceforge/evaluation/parsers/syslog.py
+++ b/src/evidenceforge/evaluation/parsers/syslog.py
@@ -20,7 +20,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Parser for syslog (RFC 5424 / BSD) text files."""
+"""Parser for generated RFC 5424 syslog plus legacy BSD eval input."""
 
 import re
 from collections.abc import Iterator
@@ -29,17 +29,28 @@ from pathlib import Path
 
 from . import LogParser, ParsedRecord, register_parser
 
-# BSD syslog format: "Mon DD HH:MM:SS hostname app[pid]: message"
-# Also handles "Mon DD HH:MM:SS hostname app: message" (no PID, e.g., kernel)
-SYSLOG_PATTERN = re.compile(
+RFC5424_PATTERN = re.compile(
+    r"^<(?P<pri>\d{1,3})>(?P<version>\d+)\s+"
+    r"(?P<timestamp>\S+)\s+"
+    r"(?P<hostname>\S+)\s+"
+    r"(?P<app_name>\S+)\s+"
+    r"(?P<procid>\S+)\s+"
+    r"(?P<msgid>\S+)\s+"
+    r"(?P<structured_data>-|(?:\[[^\]]*\])+)"
+    r"(?:\s(?P<message>.*))?$"
+)
+
+# Legacy BSD/RFC3164 syslog format: "Mon DD HH:MM:SS hostname app[pid]: message".
+# Kept only so `eforge eval` can ingest older generated datasets.
+LEGACY_BSD_SYSLOG_PATTERN = re.compile(
     r"^(\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2})\s+"  # timestamp (BSD)
     r"(\S+)\s+"  # hostname
     r"(\S+?)(?:\[([^\]]*)\])?:\s+"  # app_name[pid]: or app_name:
     r"(.*)$"  # message
 )
 
-# ISO 8601 variant: "2026-03-15T10:15:00Z hostname app[pid]: message"
-SYSLOG_ISO_PATTERN = re.compile(
+# Legacy ISO variant: "2026-03-15T10:15:00Z hostname app[pid]: message".
+LEGACY_ISO_SYSLOG_PATTERN = re.compile(
     r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\S*)\s+"  # ISO timestamp
     r"(\S+)\s+"  # hostname
     r"(\S+?)(?:\[([^\]]*)\])?:\s+"  # app_name[pid]: or app_name:
@@ -138,36 +149,62 @@ class SyslogParser(LogParser):
         if seed_year is None:
             seed_year = datetime.now(UTC).year
 
-        # Try ISO format first, then BSD
-        match = SYSLOG_ISO_PATTERN.match(raw)
+        match = RFC5424_PATTERN.match(raw)
         if match:
-            ts_str, hostname, app_name, pid_str, message = match.groups()
+            groups = match.groupdict()
+            ts_str = groups["timestamp"]
             try:
                 timestamp = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
             except ValueError:
-                errors.append(f"Invalid ISO timestamp: {ts_str}")
+                errors.append(f"Invalid RFC 5424 timestamp: {ts_str}")
+            pri = int(groups["pri"])
+            fields["pri"] = pri
+            fields["version"] = int(groups["version"])
+            fields["hostname"] = groups["hostname"]
+            fields["app_name"] = groups["app_name"]
+            fields["procid"] = groups["procid"]
+            fields["msgid"] = groups["msgid"]
+            fields["structured_data"] = groups["structured_data"]
+            fields["message"] = groups["message"] or ""
+            fields["facility"] = pri // 8
+            fields["severity"] = pri % 8
+            fields["syslog_protocol"] = "rfc5424"
+            pid_str = groups["procid"]
         else:
-            match = SYSLOG_PATTERN.match(raw)
+            match = LEGACY_ISO_SYSLOG_PATTERN.match(raw)
             if match:
                 ts_str, hostname, app_name, pid_str, message = match.groups()
-                timestamp = _resolve_bsd_year(ts_str, seed_year, last_ts)
-                if timestamp is None:
-                    errors.append(f"Invalid BSD timestamp: {ts_str}")
+                try:
+                    timestamp = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                except ValueError:
+                    errors.append(f"Invalid legacy ISO timestamp: {ts_str}")
+                fields["hostname"] = hostname
+                fields["app_name"] = app_name
+                fields["message"] = message
+                fields["syslog_protocol"] = "iso_legacy"
             else:
-                errors.append("Line does not match syslog format")
-                return ParsedRecord(
-                    source_format=self.format_name,
-                    raw=raw,
-                    fields={},
-                    timestamp=None,
-                    parse_errors=errors,
-                    line_number=line_num,
-                )
+                match = LEGACY_BSD_SYSLOG_PATTERN.match(raw)
+                if match:
+                    ts_str, hostname, app_name, pid_str, message = match.groups()
+                    timestamp = _resolve_bsd_year(ts_str, seed_year, last_ts)
+                    if timestamp is None:
+                        errors.append(f"Invalid legacy BSD timestamp: {ts_str}")
+                    fields["hostname"] = hostname
+                    fields["app_name"] = app_name
+                    fields["message"] = message
+                    fields["syslog_protocol"] = "rfc3164_legacy"
+                else:
+                    errors.append("Line does not match RFC 5424 or legacy syslog format")
+                    return ParsedRecord(
+                        source_format=self.format_name,
+                        raw=raw,
+                        fields={},
+                        timestamp=None,
+                        parse_errors=errors,
+                        line_number=line_num,
+                    )
 
         fields["timestamp"] = str(timestamp) if timestamp else ts_str
-        fields["hostname"] = hostname
-        fields["app_name"] = app_name
-        fields["message"] = message
 
         if pid_str is not None and pid_str != "-":
             try:

--- a/src/evidenceforge/evaluation/pillars/parseability.py
+++ b/src/evidenceforge/evaluation/pillars/parseability.py
@@ -117,7 +117,8 @@ class ParseabilityScorer(DimensionScorer):
         """Spec conformance: parse errors + strict-mode validation failures.
 
         Counts records where the parser returned errors OR the strict validator
-        (RFC5424 syslog, Zeek typed columns, eCAR schema, Windows XML) rejected
+        (RFC 5424 syslog with legacy fallback, Zeek typed columns, eCAR schema, Windows XML)
+        rejected
         the record. These failures indicate a downstream parser would reject the
         record entirely.
         """

--- a/src/evidenceforge/formats/validator.py
+++ b/src/evidenceforge/formats/validator.py
@@ -249,10 +249,20 @@ def validate_field(field_def: FieldDefinition, field_value: Any) -> ValidationRe
 # Strict-mode validators — format-specific raw-content checks
 # ---------------------------------------------------------------------------
 
-# RFC 5424 syslog header: <PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID
-# BSD syslog: <PRI>MONTH DD HH:MM:SS HOSTNAME
-_RFC5424_RE = re.compile(r"^<(\d{1,3})>(?:(\d+) [\w:+\-Z.]+|[A-Z][a-z]{2}\s+\d+\s+[\d:]+)\s+\S")
+# RFC 5424 syslog header: <PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID STRUCTURED-DATA
+_RFC5424_RE = re.compile(
+    r"^<(?P<pri>\d{1,3})>(?P<version>\d+)\s+"
+    r"(?P<timestamp>\S+)\s+"
+    r"(?P<hostname>\S+)\s+"
+    r"(?P<app_name>\S+)\s+"
+    r"(?P<procid>\S+)\s+"
+    r"(?P<msgid>\S+)\s+"
+    r"(?P<structured_data>-|(?:\[[^\]]*\])+)"
+    r"(?:\s(?P<message>.*))?$"
+)
 _RFC5424_PRIORITY_MAX = 191  # 23 facilities × 8 severities - 1
+_LEGACY_BSD_SYSLOG_RE = re.compile(r"^[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s+\S+")
+_LEGACY_ISO_SYSLOG_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\S*\s+\S+\s+\S+")
 
 # eCAR valid object/action combos
 _ECAR_VALID_OBJECTS = frozenset(
@@ -322,7 +332,7 @@ def validate_strict(format_name: str, raw: str, fields: dict[str, Any]) -> Valid
     result = ValidationResult()
 
     if format_name == "syslog":
-        _validate_strict_syslog(raw, result)
+        _validate_strict_syslog(raw, fields, result)
     elif format_name.startswith("zeek_"):
         _validate_strict_zeek_json(raw, result)
     elif format_name in ("windows_event_security", "windows_event_sysmon"):
@@ -333,33 +343,41 @@ def validate_strict(format_name: str, raw: str, fields: dict[str, Any]) -> Valid
     return result
 
 
-_BSD_SYSLOG_RE = re.compile(r"^[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S")
+def _validate_strict_syslog(raw: str, fields: dict[str, Any], result: ValidationResult) -> None:
+    """Require RFC 5424 for generated syslog, allowing parser-marked legacy eval input."""
+    if not raw.strip():
+        return
 
+    protocol = fields.get("syslog_protocol")
+    if protocol == "rfc3164_legacy":
+        if not _LEGACY_BSD_SYSLOG_RE.match(raw):
+            result.add_error("syslog", "Legacy syslog marker does not match BSD/RFC3164 input")
+        return
+    if protocol == "iso_legacy":
+        if not _LEGACY_ISO_SYSLOG_RE.match(raw):
+            result.add_error("syslog", "Legacy syslog marker does not match ISO-style input")
+        return
 
-def _validate_strict_syslog(raw: str, result: ValidationResult) -> None:
-    """RFC 5424 / BSD syslog structural checks.
+    match = _RFC5424_RE.match(raw)
+    if match is None:
+        result.add_error("syslog", "Syslog line does not match RFC 5424")
+        return
 
-    Accepts:
-      - RFC 5424: <PRI>VERSION TIMESTAMP HOSTNAME ...
-      - BSD syslog with PRI: <PRI>Mon DD HH:MM:SS HOSTNAME ...
-      - BSD syslog without PRI: Mon DD HH:MM:SS HOSTNAME ... (common generator output)
-    """
-    if raw.startswith("<"):
-        # PRI-prefixed: validate PRI value
-        m = re.match(r"^<(\d{1,3})>", raw)
-        if not m:
-            result.add_error("syslog_pri", "Malformed PRI field")
-            return
-        pri = int(m.group(1))
-        if pri > _RFC5424_PRIORITY_MAX:
-            result.add_error("syslog_pri", f"PRI {pri} exceeds maximum {_RFC5424_PRIORITY_MAX}")
-    else:
-        # BSD syslog without PRI — must match MMM DD HH:MM:SS pattern
-        if not _BSD_SYSLOG_RE.match(raw):
-            result.add_error(
-                "syslog",
-                "Syslog line does not match BSD (Mon DD HH:MM:SS) or RFC 5424 pattern",
-            )
+    pri = int(match.group("pri"))
+    if pri > _RFC5424_PRIORITY_MAX:
+        result.add_error("syslog_pri", f"PRI {pri} exceeds maximum {_RFC5424_PRIORITY_MAX}")
+
+    if match.group("version") != "1":
+        result.add_error("syslog_version", "RFC 5424 VERSION must be 1")
+
+    timestamp = match.group("timestamp")
+    if timestamp == "-":
+        result.add_error("syslog_timestamp", "Generated syslog requires a timestamp")
+        return
+    try:
+        datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        result.add_error("syslog_timestamp", f"Invalid RFC 5424 timestamp: {timestamp}")
 
 
 def _validate_strict_zeek_json(raw: str, result: ValidationResult) -> None:

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -28,6 +28,7 @@ just formats the context fields into the syslog template.
 """
 
 import re
+from datetime import UTC, datetime
 from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
@@ -35,34 +36,20 @@ from evidenceforge.events.contexts import HostContext
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
 from evidenceforge.utils.rng import _stable_seed
 
-_SYSLOG_MONTHS = {
-    "Jan": 1,
-    "Feb": 2,
-    "Mar": 3,
-    "Apr": 4,
-    "May": 5,
-    "Jun": 6,
-    "Jul": 7,
-    "Aug": 8,
-    "Sep": 9,
-    "Oct": 10,
-    "Nov": 11,
-    "Dec": 12,
-}
-_SYSLOG_TS_RE = re.compile(r"^(?P<mon>[A-Z][a-z]{2})\s+(?P<day>\d{1,2})\s+(?P<hms>\d\d:\d\d:\d\d)")
+_RFC5424_TS_RE = re.compile(r"^<\d{1,3}>1\s+(?P<timestamp>\S+)")
 _LOGIND_NEW_SESSION_RE = re.compile(
-    r"(?P<prefix>\bsystemd-logind\[(?P<pid>\d+)\]: New session )"
+    r"(?P<prefix>\bsystemd-logind\s+(?P<pid>\d+)\s+\S+\s+\S+\s+New session )"
     r"(?P<session>\d+)(?P<suffix> of user .*)"
 )
 _LOGIND_REMOVED_SESSION_RE = re.compile(
-    r"(?P<prefix>\bsystemd-logind\[(?P<pid>\d+)\]: Removed session )"
+    r"(?P<prefix>\bsystemd-logind\s+(?P<pid>\d+)\s+\S+\s+\S+\s+Removed session )"
     r"(?P<session>\d+)(?P<suffix>\.)"
 )
 
 
 def _ssh_lifecycle_priority(line: str) -> int:
     """Order same-second SSH lifecycle messages after timestamp precision is lost."""
-    if " sshd[" not in line:
+    if " sshd " not in line and " sshd[" not in line:
         return 50
     if "Connection from " in line:
         return 10
@@ -75,45 +62,54 @@ def _ssh_lifecycle_priority(line: str) -> int:
 
 def _systemd_lifecycle_priority(line: str) -> int:
     """Order same-second systemd unit lifecycle messages after second-precision render."""
-    if " systemd[" not in line or ".service" not in line:
+    if (" systemd " not in line and " systemd[" not in line) or ".service" not in line:
         return 50
-    if ": Starting " in line:
+    if " Starting " in line:
         return 10
-    if ": Started " in line:
+    if " Started " in line:
         return 20
-    if ": Stopping " in line:
+    if " Stopping " in line:
         return 30
-    if ": Stopped " in line or ": Finished " in line:
+    if " Stopped " in line or " Finished " in line:
         return 40
     return 50
 
 
 def _dhclient_lifecycle_priority(line: str) -> int:
     """Order same-second DHCP client messages after timestamp precision is lost."""
-    if " dhclient[" not in line:
+    if " dhclient " not in line and " dhclient[" not in line:
         return 50
-    if ": DHCPDISCOVER " in line:
+    if " DHCPDISCOVER " in line:
         return 10
-    if ": DHCPOFFER " in line:
+    if " DHCPOFFER " in line:
         return 20
-    if ": DHCPREQUEST " in line:
+    if " DHCPREQUEST " in line:
         return 30
-    if ": DHCPACK " in line:
+    if " DHCPACK " in line:
         return 40
-    if ": bound to " in line:
+    if " bound to " in line:
         return 50
     return 60
 
 
-def _syslog_sort_key(line: str) -> tuple[int, int, str, int, str]:
-    """Sort traditional syslog lines by their rendered month/day/time prefix."""
-    match = _SYSLOG_TS_RE.match(line)
+def _parse_rfc5424_timestamp(value: str) -> datetime:
+    """Parse an RFC 5424 timestamp into UTC, returning datetime.max on failure."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.max.replace(tzinfo=UTC)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _syslog_sort_key(line: str) -> tuple[datetime, int, str]:
+    """Sort RFC 5424 syslog lines by timestamp plus same-time lifecycle order."""
+    match = _RFC5424_TS_RE.match(line)
     if match is None:
-        return (13, 32, "99:99:99", 99, line)
+        return (datetime.max.replace(tzinfo=UTC), 99, line)
     return (
-        _SYSLOG_MONTHS.get(match.group("mon"), 13),
-        int(match.group("day")),
-        match.group("hms"),
+        _parse_rfc5424_timestamp(match.group("timestamp")),
         min(
             _ssh_lifecycle_priority(line),
             _systemd_lifecycle_priority(line),
@@ -191,17 +187,49 @@ class SyslogEmitter(HostMultiplexEmitter):
             from evidenceforge.utils.time import parse_iso8601
 
             ts = parse_iso8601(ts)
+        if not isinstance(ts, datetime):
+            raise ValueError("Syslog events require a datetime timestamp")
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        ts = ts.astimezone(UTC)
+
+        facility = self._bounded_int(event_data.get("facility"), default=3, minimum=0, maximum=23)
+        severity = self._bounded_int(event_data.get("severity"), default=6, minimum=0, maximum=7)
+        pid = event_data.get("pid")
         context = {
-            "timestamp": ts,
+            "pri": facility * 8 + severity,
+            "timestamp": ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "hostname": event_data.get("hostname") or "",
             "facility": event_data.get("facility"),
             "severity": event_data.get("severity"),
-            "app_name": event_data.get("app_name"),
-            "pid": event_data.get("pid"),
+            "app_name": self._rfc5424_token(event_data.get("app_name"), default="-"),
+            "pid": pid,
+            "procid": str(pid) if pid not in (None, "") else "-",
+            "msgid": self._rfc5424_token(event_data.get("msgid"), default="-"),
+            "structured_data": event_data.get("structured_data") or "-",
             "message": event_data.get("message"),
         }
         rendered = self._template.render(**context)
         return rendered.strip()
+
+    @staticmethod
+    def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+        """Return value as an int clamped to the RFC-supported range."""
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return max(minimum, min(maximum, parsed))
+
+    @staticmethod
+    def _rfc5424_token(value: Any, *, default: str) -> str:
+        """Render an RFC 5424 header token, replacing whitespace with underscores."""
+        if value is None:
+            return default
+        token = str(value).strip()
+        if not token:
+            return default
+        return re.sub(r"\s+", "_", token)
 
     def close(self) -> None:
         """Close emitter after normalizing source-native logind session order."""

--- a/tests/fixtures/eval/good/syslog.log
+++ b/tests/fixtures/eval/good/syslog.log
@@ -1,3 +1,3 @@
-Mar 15 10:15:00 SRV-WEB-01 sshd[12345]: Accepted publickey for admin from 10.0.10.50 port 54321 ssh2
-Mar 15 10:20:00 SRV-WEB-01 sudo[12346]: admin : TTY=pts/0 ; PWD=/home/admin ; USER=root ; COMMAND=/bin/systemctl restart nginx
-Mar 15 10:25:00 SRV-WEB-01 sshd[12345]: Disconnected from user admin 10.0.10.50 port 54321
+<86>1 2026-03-15T10:15:00.000000Z SRV-WEB-01 sshd 12345 - - Accepted publickey for admin from 10.0.10.50 port 54321 ssh2
+<86>1 2026-03-15T10:20:00.000000Z SRV-WEB-01 sudo 12346 - - admin : TTY=pts/0 ; PWD=/home/admin ; USER=root ; COMMAND=/bin/systemctl restart nginx
+<86>1 2026-03-15T10:25:00.000000Z SRV-WEB-01 sshd 12345 - - Disconnected from user admin 10.0.10.50 port 54321

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -468,8 +468,8 @@ class TestCanHandleDefault:
         emitter.close()
 
         lines = output_path.read_text(encoding="utf-8").splitlines()
-        assert "19:00:53" in lines[0]
-        assert "20:01:25" in lines[1]
+        assert lines[0].startswith("<86>1 2024-10-14T19:00:53.000000Z")
+        assert lines[1].startswith("<86>1 2024-10-14T20:01:25.000000Z")
 
     def test_syslog_normalizes_logind_session_ids_in_rendered_order(self, tmp_path):
         """Rendered New-session IDs should not move backward after final syslog sort."""

--- a/tests/unit/test_eval_cross_source.py
+++ b/tests/unit/test_eval_cross_source.py
@@ -748,7 +748,7 @@ class TestPortScanSourceIp:
 
 
 class TestSyslogYearInference:
-    """Syslog BSD parser must infer year from file mtime, not datetime.now()."""
+    """Legacy BSD syslog eval fallback must infer year from file metadata."""
 
     def test_bsd_timestamp_uses_file_mtime_year(self, tmp_path):
         """SyslogParser should infer year from file modification time."""

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -198,6 +198,9 @@ class TestSyslogParser:
         assert first.fields["hostname"] == "SRV-WEB-01"
         assert first.fields["app_name"] == "sshd"
         assert first.fields["pid"] == 12345
+        assert first.fields["facility"] == 10
+        assert first.fields["severity"] == 6
+        assert first.fields["syslog_protocol"] == "rfc5424"
         assert "Accepted publickey" in first.fields["message"]
 
     def test_extracts_timestamps(self):
@@ -236,6 +239,7 @@ class TestSyslogParser:
         assert len(records) == 1
         assert records[0].timestamp is not None
         assert records[0].timestamp.year == 2024
+        assert records[0].fields["syslog_protocol"] == "rfc3164_legacy"
 
     def test_mtime_fallback_when_no_scenario(self, tmp_path):
         """Without a scenario, year falls back to mtime."""

--- a/tests/unit/test_eval_strict_parsers.py
+++ b/tests/unit/test_eval_strict_parsers.py
@@ -30,43 +30,57 @@ from evidenceforge.formats.validator import STRICT_FORMATS, validate_strict
 
 
 class TestStrictSyslog:
-    def test_valid_bsd_no_pri(self):
-        """BSD syslog without PRI: Mon DD HH:MM:SS host msg — valid."""
+    def test_bsd_without_legacy_marker_is_invalid(self):
+        """Generated syslog strict mode requires RFC 5424."""
         raw = "Mar 18 12:00:00 PROXY-01 sudo[50424]: root : TTY=pts/1"
         result = validate_strict("syslog", raw, {})
+        assert not result.valid
+        assert any("rfc 5424" in e.lower() for e in result.errors)
+
+    def test_legacy_bsd_parser_records_are_valid(self):
+        """Legacy BSD remains acceptable when the parser marks it as eval fallback input."""
+        raw = "Mar 18 12:00:00 PROXY-01 sudo[50424]: root : TTY=pts/1"
+        result = validate_strict("syslog", raw, {"syslog_protocol": "rfc3164_legacy"})
         assert result.valid, result.errors
 
     def test_valid_rfc5424_with_pri(self):
-        """RFC 5424 / BSD with PRI < 192 — valid."""
-        raw = "<166>Mar 18 12:00:00 PROXY-01 sudo: message"
+        """RFC 5424 with PRI < 192 — valid."""
+        raw = "<86>1 2026-03-18T12:00:00.000000Z PROXY-01 sudo 50424 - - message"
         result = validate_strict("syslog", raw, {})
         assert result.valid, result.errors
 
     def test_valid_pri_boundary_191(self):
         """PRI == 191 is the maximum valid priority."""
-        raw = "<191>Mar 18 12:00:00 host app: msg"
+        raw = "<191>1 2026-03-18T12:00:00Z host app 123 - - msg"
         result = validate_strict("syslog", raw, {})
         assert result.valid, result.errors
 
     def test_invalid_bsd_no_pri_wrong_format(self):
-        """Plain text that matches neither BSD nor RFC pattern — fails."""
+        """Plain text that is not RFC 5424 — fails."""
         raw = "not a syslog line"
         result = validate_strict("syslog", raw, {})
         assert not result.valid
-        assert any("syslog" in e.lower() or "bsd" in e.lower() for e in result.errors)
+        assert any("rfc 5424" in e.lower() for e in result.errors)
 
     def test_invalid_pri_exceeds_191(self):
         """PRI > 191 — fails."""
-        raw = "<200>Mar 18 12:00:00 host app: msg"
+        raw = "<200>1 2026-03-18T12:00:00Z host app 123 - - msg"
         result = validate_strict("syslog", raw, {})
         assert not result.valid
         assert any("192" in e or "200" in e or "191" in e for e in result.errors)
 
     def test_invalid_malformed_pri_bracket(self):
         """Opening angle bracket without digits — fails."""
-        raw = "<>Mar 18 12:00:00 host app: msg"
+        raw = "<>1 2026-03-18T12:00:00Z host app 123 - - msg"
         result = validate_strict("syslog", raw, {})
         assert not result.valid
+
+    def test_invalid_rfc5424_version(self):
+        """RFC 5424 VERSION must be 1."""
+        raw = "<86>2 2026-03-18T12:00:00Z host app 123 - - msg"
+        result = validate_strict("syslog", raw, {})
+        assert not result.valid
+        assert any("version" in e.lower() for e in result.errors)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_systemd_ecar_correlation.py
+++ b/tests/unit/test_systemd_ecar_correlation.py
@@ -218,8 +218,8 @@ class TestSystemdProcessLifecycle:
 def test_syslog_sort_orders_same_second_systemd_start_before_finish():
     """Second-precision syslog sorting should preserve systemd unit lifecycle order."""
     lines = [
-        "Mar 18 12:04:02 WEB-EXT-01 systemd[1]: Finished phpsessionclean.service - Clean PHP session files.",
-        "Mar 18 12:04:02 WEB-EXT-01 systemd[1]: Starting phpsessionclean.service - Clean PHP session files.",
+        "<30>1 2024-03-18T12:04:02.000000Z WEB-EXT-01 systemd 1 - - Finished phpsessionclean.service - Clean PHP session files.",
+        "<30>1 2024-03-18T12:04:02.000000Z WEB-EXT-01 systemd 1 - - Starting phpsessionclean.service - Clean PHP session files.",
     ]
 
     assert sorted(lines, key=_syslog_sort_key)[0].endswith(


### PR DESCRIPTION
## Summary
- Switch generated Linux syslog output to RFC 5424 with year-bearing ISO/RFC3339 timestamps, PRI/version/procid fields, and RFC 5424 sorting semantics.
- Keep `eforge eval` compatible with older BSD/RFC3164 and legacy ISO-style syslog through parser-marked legacy fallback paths.
- Tighten strict syslog validation so generated/unmarked syslog must be RFC 5424, and update docs, skill references, fixtures, tests, and TODO status.

## Why
BSD/RFC3164 syslog omits the year. The evaluator previously had to infer that year, which could stamp older generated datasets with the wrong calendar year when evaluated later and distort span-based scoring.

## Validation
- `uv run eforge validate-config`
- focused syslog/eval tests
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` -> `3014 passed, 15 skipped`