### PR TITLE
fix(state): bound session/PID block offsets to prevent far‑future DoS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Fix unbounded session offset allocation caches for far-future scenario times — replaced minute/four-hour catch-up caches with direct deterministic offsets and covered far-future allocation cases.
 - [x] Harden Windows spool JSON encoding and flushing against scenario-triggered denial-of-service — replaced collision-prone datetime sentinels with typed spool field wrappers and kept final spooled rendering on SQLite-backed streaming fixup passes instead of materializing all rows.
 - [x] Fix TCP DNS fallback packet overhead so TCP SERVFAIL accounting preserves TCP/IP header distributions.
 - [x] Fix unbounded Sysmon parent process-create shift loop for cyclic raw ProcessGuid relationships with cycle detection and bounded parent-ordering passes.

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -150,18 +150,19 @@ class StateManager:
         return 56 + (_stable_seed(f"logon_luid_stride:{system}:{block}") % 73)
 
     def _logon_luid_block_offset(self, system: str, block: int) -> int:
-        """Return cumulative per-host LUID churn before a minute-scale block."""
-        offsets = self._logon_id_block_offsets.setdefault(system, {0: 0})
-        if block in offsets:
-            return offsets[block]
+        """Return deterministic per-host LUID churn before a minute-scale block.
 
-        last_block = max(offsets)
-        offset = offsets[last_block]
-        for current_block in range(last_block, block):
-            gap = 17 + (_stable_seed(f"logon_luid_block_gap:{system}:{current_block}") % 61)
-            offset += (60 * self._logon_luid_block_stride(system, current_block)) + gap
-            offsets[current_block + 1] = offset
-        return offsets[block]
+        Scenario event times can be far outside the visible generation window.
+        Compute the block offset directly instead of caching every elapsed
+        minute, keeping allocation CPU and memory bounded by the number of
+        emitted events rather than attacker-controlled wall-clock distance.
+        """
+        if block <= 0:
+            return 0
+
+        block_width = 8192
+        jitter = _stable_seed(f"logon_luid_block_jitter:{system}:{block}") % 512
+        return (block * block_width) + jitter
 
     def _allocate_logon_luid(self, system: str, event_time: datetime) -> int:
         """Allocate a deterministic host-local Windows LogonID.
@@ -524,26 +525,10 @@ class StateManager:
                 minute_in_quarter = (elapsed_seconds % 900) // 60
                 block = elapsed_quarters // 16
                 quarter_in_block = elapsed_quarters % 16
-                block_offsets = self._linux_logind_session_block_offsets.setdefault(
-                    system,
-                    {0: 0},
-                )
-                if block not in block_offsets:
-                    last_block = max(block_offsets)
-                    offset = block_offsets[last_block]
-                    for current_block in range(last_block, block):
-                        stride = 4 + (
-                            _stable_seed(f"logind_session_stride:{system}:{current_block}") % 3
-                        )
-                        gap = _stable_seed(f"logind_session_gap:{system}:{current_block}") % 3
-                        offset += (16 * stride) + gap
-                        block_offsets[current_block + 1] = offset
+                block_offset = self._linux_logind_session_block_offset(system, block)
                 stride = 4 + (_stable_seed(f"logind_session_stride:{system}:{block}") % 3)
                 candidate = (
-                    initial
-                    + block_offsets[block]
-                    + (quarter_in_block * stride)
-                    + (minute_in_quarter // 5)
+                    initial + block_offset + (quarter_in_block * stride) + (minute_in_quarter // 5)
                 )
                 used = self._linux_logind_session_used_ids.setdefault(system, set())
                 allocations = self._linux_logind_session_allocations.setdefault(system, [])
@@ -568,6 +553,15 @@ class StateManager:
                 self._linux_logind_session_counters[system] = rng.randint(20, 250)
             self._linux_logind_session_counters[system] += rng.randint(1, 4)
             return self._linux_logind_session_counters[system]
+
+    def _linux_logind_session_block_offset(self, system: str, block: int) -> int:
+        """Return deterministic logind session churn before a four-hour block."""
+        if block <= 0:
+            return 0
+
+        block_width = 128
+        jitter = _stable_seed(f"logind_session_block_jitter:{system}:{block}") % 16
+        return (block * block_width) + jitter
 
     @staticmethod
     def _linux_logind_matches_elapsed_delta(
@@ -605,18 +599,13 @@ class StateManager:
         return 997 + (_stable_seed(f"linux_pid_stride:{system}:{block}") % 311)
 
     def _linux_pid_block_offset(self, system: str, block: int) -> int:
-        """Return cumulative per-host Linux PID churn before a coarse time block."""
-        offsets = self._linux_pid_block_offsets.setdefault(system, {0: 0})
-        if block in offsets:
-            return offsets[block]
+        """Return deterministic per-host Linux PID churn before a coarse time block."""
+        if block <= 0:
+            return 0
 
-        last_block = max(offsets)
-        offset = offsets[last_block]
-        for current_block in range(last_block, block):
-            gap = 37 + (_stable_seed(f"linux_pid_block_gap:{system}:{current_block}") % 61)
-            offset += self._linux_pid_block_stride(system, current_block) + gap
-            offsets[current_block + 1] = offset
-        return offsets[block]
+        block_width = 2048
+        jitter = _stable_seed(f"linux_pid_block_jitter:{system}:{block}") % 128
+        return (block * block_width) + jitter
 
     @staticmethod
     def _normalize_linux_pid(pid: int) -> int:

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -159,6 +159,33 @@ class TestStateManagerInit:
         assert ids == sorted(ids)
         assert len(set(ids)) == len(ids)
 
+    def test_linux_logind_session_far_future_time_does_not_materialize_blocks(self):
+        """Far-future logind IDs should not cache every elapsed four-hour block."""
+        import random
+
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        sm.register_boot_time("linux01", start)
+        rng = random.Random(31)
+
+        session_id = sm.next_linux_logind_session_id(
+            "linux01",
+            rng,
+            start + timedelta(days=1_000_000),
+        )
+
+        assert session_id > 0
+        assert sm._linux_logind_session_block_offsets == {}
+
+    def test_linux_pid_far_future_block_offset_does_not_materialize_blocks(self):
+        """Far-future Linux PID offsets should be direct arithmetic, not catch-up caches."""
+        sm = StateManager()
+
+        offset = sm._linux_pid_block_offset("linux01", 1_000_000_000)
+
+        assert offset > 0
+        assert sm._linux_pid_block_offsets == {}
+
 
 class TestSessionManagement:
     """Tests for session lifecycle."""
@@ -305,6 +332,17 @@ class TestSessionManagement:
         )
 
         assert int(earlier, 16) < int(later, 16)
+
+    def test_allocate_logon_id_far_future_time_does_not_materialize_blocks(self):
+        """Far-future Windows LogonIDs should not cache every elapsed minute block."""
+        sm = StateManager()
+        boot = datetime(2024, 1, 15, 9, 0, 0, tzinfo=UTC)
+        sm.register_boot_time("DC-01", boot)
+
+        logon_id = sm.allocate_logon_id("DC-01", boot + timedelta(days=1_000_000))
+
+        assert int(logon_id, 16) > 0
+        assert sm._logon_id_block_offsets == {}
 
     def test_reassign_session_logon_id_rekeys_session_to_event_time(self):
         """Planned sessions can be re-keyed once final source-native logon time is known."""


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled far-future storyline times from forcing linear catch-up loops that materialize per-time-block caches and can exhaust CPU and memory during allocation of Windows LUIDs, Linux logind session IDs, and Linux PIDs.

### Description
- Replace the minute-scale Windows `_logon_luid_block_offset()` catch‑up cache with a closed-form deterministic arithmetic model using a `block_width` + seeded `jitter` to avoid per-minute dictionary population.
- Replace the four‑hour Linux `systemd-logind` catch‑up loop by delegating to a new `_linux_logind_session_block_offset()` closed‑form helper and use that during session ID allocation.
- Replace the Linux PID block offset catch‑up cache with a deterministic `_linux_pid_block_offset()` arithmetic model (bounded by block width + jitter).
- Add regression unit tests asserting that far‑future allocations do not materialize block‑offset caches and update `TODO.md` to mark this security fix complete.

### Testing
- Ran the focused unit tests: `uv run pytest tests/unit/test_state_manager.py -q --no-cov`, which passed (58 passed). 
- Ran lint/format checks: `uv run ruff check .` and `uv run ruff format --check .`, which passed. 
- Ran the complete test suite without coverage: `uv run pytest -q --no-cov`, which completed successfully (2984 passed, 37 skipped). 
- Note: a prior run with coverage (`uv run pytest -q` / coverage) failed due to global coverage thresholds unrelated to these functional changes, so the change was validated with the focused unit tests and full test run without coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0557047fa08325a537ef892921f5c5)