### PR TITLE
fix(ecar): bound parent-order normalization to avoid infinite timestamp shifts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Fix cyclic eCAR process parent normalization denial-of-service — added cycle detection and bounded parent-ordering passes, with self-parent and mutual-parent raw eCAR regression coverage.
 - [x] Harden Windows spool JSON encoding and flushing against scenario-triggered denial-of-service — replaced collision-prone datetime sentinels with typed spool field wrappers and kept final spooled rendering on SQLite-backed streaming fixup passes instead of materializing all rows.
 - [x] Fix TCP DNS fallback packet overhead so TCP SERVFAIL accounting preserves TCP/IP header distributions.
 - [x] Fix unbounded Sysmon parent process-create shift loop for cyclic raw ProcessGuid relationships with cycle detection and bounded parent-ordering passes.

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -706,58 +706,87 @@ class EcarEmitter(HostMultiplexEmitter):
 
     @classmethod
     def _normalize_process_parent_order(cls, lines: list[str]) -> list[str]:
-        """Move PROCESS/CREATE rows after visible parent PROCESS/CREATE rows."""
+        """Move PROCESS/CREATE rows after visible parent PROCESS/CREATE rows.
+
+        Raw eCAR records can contain arbitrary ``objectID``/``actorID`` or PID
+        relationships, including self-parenting and cycles.  Cyclic parentage is
+        unsatisfiable, so those edges are treated as unshiftable instead of
+        repeatedly advancing timestamps forever during final flush.
+        """
         records: list[dict[str, Any] | None] = []
-        for line in lines:
+        process_create_records: dict[str, dict[str, Any]] = {}
+        pid_keys: dict[int, str] = {}
+        for index, line in enumerate(lines):
             try:
-                records.append(json.loads(line))
+                record = json.loads(line)
             except json.JSONDecodeError:
                 records.append(None)
+                continue
+            records.append(record)
+            if record.get("object") != "PROCESS" or record.get("action") != "CREATE":
+                continue
+            key = str(record.get("objectID") or f"__process_create_{index}")
+            process_create_records[key] = record
+            try:
+                pid = int(record.get("pid", -1))
+            except (TypeError, ValueError):
+                pid = -1
+            if pid > 0:
+                pid_keys[pid] = key
 
-        changed = True
-        while changed:
+        if not process_create_records:
+            return lines
+
+        parent_keys: dict[str, str] = {}
+        for key, record in process_create_records.items():
+            parent_id = record.get("actorID")
+            if parent_id is not None and str(parent_id) in process_create_records:
+                parent_keys[key] = str(parent_id)
+                continue
+            try:
+                parent_pid = int(record.get("ppid", -1))
+            except (TypeError, ValueError):
+                parent_pid = -1
+            parent_key = pid_keys.get(parent_pid)
+            if parent_key is not None:
+                parent_keys[key] = parent_key
+
+        cyclic_keys: set[str] = set()
+        for key in process_create_records:
+            path: list[str] = []
+            seen: set[str] = set()
+            current: str | None = key
+            while current is not None:
+                if current in seen:
+                    cyclic_keys.update(path[path.index(current) :])
+                    break
+                if current in cyclic_keys:
+                    break
+                seen.add(current)
+                path.append(current)
+                parent_key = parent_keys.get(current)
+                current = parent_key if parent_key in process_create_records else None
+
+        max_passes = len(process_create_records)
+        for _ in range(max_passes):
             changed = False
             create_times: dict[str, int] = {}
-            create_times_by_pid: dict[int, int] = {}
-            for record in records:
-                if (
-                    record is None
-                    or record.get("object") != "PROCESS"
-                    or record.get("action") != "CREATE"
-                ):
-                    continue
-                object_id = record.get("objectID")
-                if object_id:
-                    create_times[str(object_id)] = int(record.get("timestamp_ms", 0))
-                try:
-                    pid = int(record.get("pid", -1))
-                except (TypeError, ValueError):
-                    pid = -1
-                if pid > 0:
-                    create_times_by_pid[pid] = max(
-                        create_times_by_pid.get(pid, 0),
-                        int(record.get("timestamp_ms", 0)),
-                    )
+            for key, record in process_create_records.items():
+                create_times[key] = int(record.get("timestamp_ms", 0))
 
-            for record in records:
-                if (
-                    record is None
-                    or record.get("object") != "PROCESS"
-                    or record.get("action") != "CREATE"
-                ):
+            for key, record in process_create_records.items():
+                if key in cyclic_keys:
                     continue
-                parent_id = record.get("actorID")
-                parent_ms = create_times.get(str(parent_id)) if parent_id else None
-                if parent_ms is None:
-                    try:
-                        parent_pid = int(record.get("ppid", -1))
-                    except (TypeError, ValueError):
-                        parent_pid = -1
-                    parent_ms = create_times_by_pid.get(parent_pid)
+                parent_key = parent_keys.get(key)
+                if parent_key is None or parent_key in cyclic_keys:
+                    continue
+                parent_ms = create_times.get(parent_key)
                 timestamp_ms = int(record.get("timestamp_ms", 0))
                 if parent_ms is not None and timestamp_ms <= parent_ms:
                     record["timestamp_ms"] = parent_ms + 1
                     changed = True
+            if not changed:
+                break
 
         normalized: list[str] = []
         for line, record in zip(lines, records, strict=True):

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -703,6 +703,86 @@ class TestChronologicalOutput:
         child_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "child-process")
         assert child_ms > parent_ms
 
+    def test_process_create_self_parent_cycle_is_not_shifted_forever(self, tmp_path, ts):
+        """Self-parented raw eCAR process creates should not hang final close."""
+        fmt = Mock()
+        fmt.output.template = "{}"
+        fmt.output.header_template = None
+        fmt.output.footer_template = None
+        fmt.output.encoding = "utf-8"
+        emitter = EcarEmitter(fmt, tmp_path, threaded=False)
+
+        emitter.emit_event(
+            {
+                "timestamp": ts,
+                "hostname": "ws01",
+                "object": "PROCESS",
+                "action": "CREATE",
+                "objectID": "self-parent-process",
+                "actorID": "self-parent-process",
+                "pid": 5000,
+                "ppid": 5000,
+                "_host_fqdn": "ws01.example.org",
+            }
+        )
+
+        emitter.close()
+
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
+        ]
+        assert rows[0]["objectID"] == "self-parent-process"
+        assert rows[0]["timestamp_ms"] == int(ts.timestamp() * 1000)
+
+    def test_process_create_mutual_parent_cycle_is_not_shifted_forever(self, tmp_path, ts):
+        """Mutually cyclic raw eCAR process creates should not hang final close."""
+        fmt = Mock()
+        fmt.output.template = "{}"
+        fmt.output.header_template = None
+        fmt.output.footer_template = None
+        fmt.output.encoding = "utf-8"
+        emitter = EcarEmitter(fmt, tmp_path, threaded=False)
+
+        emitter.emit_event(
+            {
+                "timestamp": ts,
+                "hostname": "ws01",
+                "object": "PROCESS",
+                "action": "CREATE",
+                "objectID": "first-process",
+                "actorID": "second-process",
+                "pid": 5001,
+                "ppid": 5002,
+                "_host_fqdn": "ws01.example.org",
+            }
+        )
+        emitter.emit_event(
+            {
+                "timestamp": ts.replace(second=1),
+                "hostname": "ws01",
+                "object": "PROCESS",
+                "action": "CREATE",
+                "objectID": "second-process",
+                "actorID": "first-process",
+                "pid": 5002,
+                "ppid": 5001,
+                "_host_fqdn": "ws01.example.org",
+            }
+        )
+
+        emitter.close()
+
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
+        ]
+        timestamps = {row["objectID"]: row["timestamp_ms"] for row in rows}
+        assert timestamps == {
+            "first-process": int(ts.timestamp() * 1000),
+            "second-process": int(ts.replace(second=1).timestamp() * 1000),
+        }
+
 
 class TestTidAlwaysPresent:
     def test_tid_present_default(self, emitter, ts):


### PR DESCRIPTION
### Motivation
- Prevent an infinite loop in eCAR finalization where untrusted/raw `PROCESS/CREATE` records that self-reference or form cycles force repeated timestamp increments and hang generation.  
- Ensure emitter-level normalization is resilient to arbitrary `objectID`/`actorID`/`ppid` values supplied by raw storyline events without changing higher-level semantics.  

### Description
- Hardened `_normalize_process_parent_order()` in `src/evidenceforge/generation/emitters/ecar.py` to build an explicit graph of visible `PROCESS/CREATE` records, detect cycles, and treat cyclic edges as unshiftable instead of iterating forever.  
- Bounded the number of parent-ordering passes to at most the number of visible `PROCESS/CREATE` records and skip adjustments for keys flagged as part of a cycle.  
- Added regression tests in `tests/unit/test_ecar_spec_compliance.py` that cover self-parent and mutual-parent cycles to verify `EcarEmitter.close()` completes and preserves original timestamps for cyclic records.  
- Updated `TODO.md` to mark the security fix as completed.  

### Testing
- Ran the eCAR spec unit file with `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py` and all tests in that file passed (`33 passed`).  
- Ran the targeted subset with `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py -k 'parent_process_create or parent_cycle'` and those tests passed.  
- Noted that running the same targeted tests under the repository-wide coverage gate (`pytest` with coverage enabled) fails the global coverage threshold (not the tests themselves); the fix was validated with `--no-cov` to avoid the global coverage fail-under blocking focused verification.  
- Ran lint/format checks with `uv run ruff check .` and `uv run ruff format --check .`, which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0398e0d7348325bec2c6b6cb800c00)