### PR TITLE
fix: preserve explicit HTTP process attribution

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Remediate browser-like HTTP User-Agent process-attribution repair so explicit/storyline process ownership is preserved — scoped the browser repair to respect caller-provided live PIDs while retaining svchost/default-owner repair behavior, with a regression test for spoofed browser UA PowerShell flows.
 - [x] Harden Windows spool JSON encoding and flushing against scenario-triggered denial-of-service — replaced collision-prone datetime sentinels with typed spool field wrappers and kept final spooled rendering on SQLite-backed streaming fixup passes instead of materializing all rows.
 - [x] Fix TCP DNS fallback packet overhead so TCP SERVFAIL accounting preserves TCP/IP header distributions.
 - [x] Fix unbounded Sysmon parent process-create shift loop for cyclic raw ProcessGuid relationships with cycle detection and bounded parent-ordering passes.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3201,6 +3201,7 @@ class ActivityGenerator:
         *,
         source_system: System | None,
         time: datetime,
+        caller_provided_pid: bool = False,
     ) -> None:
         """Prevent browser-like HTTP rows from inheriting service-process ownership."""
         if (
@@ -3224,14 +3225,16 @@ class ActivityGenerator:
         current_pid = event.network.initiating_pid
         if current_pid > 0:
             current = self.state_manager.get_process(source_system.hostname, current_pid)
-            if (
+            current_is_usable = (
                 current is not None
-                and current.image.lower() == expected_image
                 and not self._foreground_process_expired_for_attribution(
                     source_system,
                     current,
                     time,
                 )
+            )
+            if current_is_usable and (
+                caller_provided_pid or current.image.lower() == expected_image
             ):
                 self._set_connection_process_context(
                     event,
@@ -6754,6 +6757,8 @@ class ActivityGenerator:
         else:
             self._remember_connection_tuple(src_ip, src_port, dst_ip, dst_port, proto, time)
 
+        caller_provided_pid = pid > 0
+
         if service == "dns" and proto in ("udp", "tcp") and dst_port == 53:
             dns_pid = self._infer_connection_pid(resolved_source_system, service, dst_port, proto)
             if dns_pid > 0:
@@ -7951,6 +7956,7 @@ class ActivityGenerator:
             event,
             source_system=resolved_source_system,
             time=time,
+            caller_provided_pid=caller_provided_pid,
         )
         pid = event.network.initiating_pid
         process_ctx = event.process

--- a/tests/unit/test_edr_flow_pid.py
+++ b/tests/unit/test_edr_flow_pid.py
@@ -244,6 +244,48 @@ class TestConnectionPidPropagation:
             tags=[],
         )
 
+    def test_browser_http_flow_preserves_explicit_non_browser_process(
+        self, activity_gen, state_manager, timestamp, win_system, mock_emitters
+    ):
+        """Explicit malware/tool HTTP ownership should survive browser UA spoofing."""
+        state_manager.set_current_time(timestamp - timedelta(seconds=5))
+        attacker_pid = state_manager.create_process(
+            win_system.hostname,
+            4,
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            r"powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\Users\Public\stage.ps1",
+            "jdoe",
+            "Medium",
+        )
+        activity_gen._ip_to_system = {win_system.ip: win_system}
+
+        activity_gen.generate_connection(
+            src_ip=win_system.ip,
+            dst_ip="10.0.20.10",
+            time=timestamp,
+            dst_port=80,
+            proto="tcp",
+            service="http",
+            duration=0.5,
+            orig_bytes=400,
+            resp_bytes=2048,
+            conn_state="SF",
+            source_system=win_system,
+            http=self._browser_http_context(),
+            pid=attacker_pid,
+        )
+
+        event = self._find_connection_event(mock_emitters)
+        assert event is not None
+        assert event.network.initiating_pid == attacker_pid
+        assert event.process is not None
+        assert event.process.image.endswith(r"\WindowsPowerShell\v1.0\powershell.exe")
+        assert event.edr is not None
+        assert event.edr.actor_id == state_manager.get_process_object_id(
+            win_system.hostname,
+            attacker_pid,
+        )
+
     def test_browser_http_flow_uses_interactive_browser_instead_of_svchost(
         self, activity_gen, state_manager, timestamp, win_system, mock_emitters
     ):


### PR DESCRIPTION
### Motivation
- The browser-like User-Agent repair path was overwriting caller-provided/storyline process ownership for HTTP connections, causing malicious or tool processes that spoof browser UAs to be attributed to a synthetic browser process.

### Description
- Carry a `caller_provided_pid` boolean through `generate_connection()` into `_repair_browser_http_process_attribution()` and use it to avoid replacing an explicit, live PID unless it is expired or otherwise unusable.
- Adjust `_repair_browser_http_process_attribution()` to preserve usable caller-supplied PIDs while keeping the existing repair behavior for inferred/default service ownership and for creating/reusing interactive browser processes when appropriate.
- Add a regression test `test_browser_http_flow_preserves_explicit_non_browser_process` in `tests/unit/test_edr_flow_pid.py` that verifies an explicit PowerShell PID with a Firefox-style UA is preserved (including `eCAR` actor_id and process image assertions).
- Update `TODO.md` to mark the remediation as completed.

### Testing
- Ran `uv run pytest --no-cov tests/unit/test_edr_flow_pid.py -q` and the suite passed (`15 passed`).
- Ran `uv run ruff check .` and `uv run ruff format --check .` with no issues reported.
- Confirmed the change is limited to `src/evidenceforge/generation/activity/generator.py`, the added unit test in `tests/unit/test_edr_flow_pid.py`, and the `TODO.md` update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0d4f3de88325bf57e7da4cd02694)