### PR TITLE
fix: bound Linux PID block offsets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Fix unbounded Linux PID block allocation for far-future storyline timestamps by replacing materialized intermediate PID block caches with bounded direct offset computation; added a far-future regression test.
 - [x] Harden Windows spool JSON encoding and flushing against scenario-triggered denial-of-service — replaced collision-prone datetime sentinels with typed spool field wrappers and kept final spooled rendering on SQLite-backed streaming fixup passes instead of materializing all rows.
 - [x] Fix TCP DNS fallback packet overhead so TCP SERVFAIL accounting preserves TCP/IP header distributions.
 - [x] Fix unbounded Sysmon parent process-create shift loop for cyclic raw ProcessGuid relationships with cycle detection and bounded parent-ordering passes.

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -605,18 +605,22 @@ class StateManager:
         return 997 + (_stable_seed(f"linux_pid_stride:{system}:{block}") % 311)
 
     def _linux_pid_block_offset(self, system: str, block: int) -> int:
-        """Return cumulative per-host Linux PID churn before a coarse time block."""
-        offsets = self._linux_pid_block_offsets.setdefault(system, {0: 0})
-        if block in offsets:
-            return offsets[block]
+        """Return cumulative per-host Linux PID churn before a coarse time block.
 
-        last_block = max(offsets)
-        offset = offsets[last_block]
-        for current_block in range(last_block, block):
-            gap = 37 + (_stable_seed(f"linux_pid_block_gap:{system}:{current_block}") % 61)
-            offset += self._linux_pid_block_stride(system, current_block) + gap
-            offsets[current_block + 1] = offset
-        return offsets[block]
+        Storyline timestamps are scenario-controlled and may sit far outside the
+        baseline window. Compute the block offset directly instead of caching
+        every intermediate 5-minute block, so a distant timestamp cannot force
+        unbounded dictionary growth or CPU work during PID allocation.
+        """
+        if block <= 0:
+            return 0
+
+        # Keep offsets strictly increasing while avoiding visible wall-clock
+        # second deltas. The jitter range is smaller than the base stride, so
+        # offset(block + 1) is always greater than offset(block).
+        base_stride = 1_141
+        jitter = _stable_seed(f"linux_pid_cumulative_jitter:{system}:{block}") % 257
+        return (block * base_stride) + jitter
 
     @staticmethod
     def _normalize_linux_pid(pid: int) -> int:

--- a/tests/unit/test_pid_allocation_realism.py
+++ b/tests/unit/test_pid_allocation_realism.py
@@ -174,6 +174,33 @@ class TestLinuxPidAllocation:
         assert earlier_pid < later_pid
         assert abs((later_pid - earlier_pid) - 900) > 1.0
 
+    def test_linux_pid_allocation_does_not_materialize_intermediate_time_blocks(self, sm):
+        """Far-future Linux process times must not fill one cache entry per PID block."""
+        boot_time = datetime(2024, 3, 18, 8, 0, 0)
+        sm.register_boot_time("TEST-01", boot_time)
+        sm.set_current_time(boot_time)
+        init_pid = sm.create_process(
+            system="TEST-01",
+            parent_pid=0,
+            image="/usr/lib/systemd/systemd",
+            command_line="/usr/lib/systemd/systemd --system",
+            username="root",
+            integrity_level="System",
+        )
+
+        sm.set_current_time(datetime(9998, 12, 31, 23, 59, 0))
+        future_pid = sm.create_process(
+            system="TEST-01",
+            parent_pid=init_pid,
+            image="/usr/bin/bash",
+            command_line="bash /tmp/far-future.sh",
+            username="root",
+            integrity_level="System",
+        )
+
+        assert future_pid > 0
+        assert len(sm._linux_pid_block_offsets.get("TEST-01", {})) == 0
+
     def test_linux_pids_do_not_encode_elapsed_wall_clock_seconds(self, sm):
         """Adjacent Linux process PIDs should not reveal elapsed seconds."""
         boot_time = datetime(2024, 3, 18, 8, 0, 0)


### PR DESCRIPTION
### Motivation
- Prevent unbounded CPU/memory work during Linux PID allocation when storyline events include far-future absolute timestamps that produce huge elapsed-second blocks.
- Preserve realistic, deterministic Linux PID behavior while removing the attack surface where an attacker-controlled timestamp could force one cache entry per 5-minute block.

### Description
- Replace the previous incremental cache-fill implementation in `_linux_pid_block_offset()` with a bounded direct computation that returns a monotonic block offset formula plus a stable jitter, avoiding materializing intermediate blocks.
- Keep the visible properties of offsets (strictly increasing, small jitter) so allocation semantics and realism are preserved while removing O(block) work and storage.
- Add a regression unit test `test_linux_pid_allocation_does_not_materialize_intermediate_time_blocks` to `tests/unit/test_pid_allocation_realism.py` which allocates a Linux process at year 9998 and asserts the block-offset cache is not populated with intermediate entries.
- Update `TODO.md` to record the security fix as completed.

### Testing
- Ran the focused unit file: `uv run pytest --no-cov tests/unit/test_pid_allocation_realism.py -q`, which passed (`12 passed`).
- Ran the full unit suite: `uv run pytest --no-cov -q`, which passed (`3163 passed, 37 skipped`).
- Ran lint/format checks: `uv run ruff check .` and `uv run ruff format --check .`, which passed.
- All automated tests and checks related to the change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0f2d046c8325bb5f781f34e9cbd5)