### PR TITLE
fix: harden syslog system_types validation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Harden validate-config syslog system_types validation against null or malformed overlay values — guarded the custom system_types loop so null is treated as absent and scalar malformed values fall through to schema validation; added regression coverage for null and scalar overlay entries.
 - [x] Harden Windows spool JSON encoding and flushing against scenario-triggered denial-of-service — replaced collision-prone datetime sentinels with typed spool field wrappers and kept final spooled rendering on SQLite-backed streaming fixup passes instead of materializing all rows.
 - [x] Fix TCP DNS fallback packet overhead so TCP SERVFAIL accounting preserves TCP/IP header distributions.
 - [x] Fix unbounded Sysmon parent process-create shift loop for cyclic raw ProcessGuid relationships with cycle detection and bounded parent-ordering passes.

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -1937,7 +1937,10 @@ def validate_config() -> ValidationResult:
                 continue
             app = str(entry.get("app") or "<unknown>")
             _VALID_SYSLOG_SYSTEM_TYPES = {"workstation", "server", "domain_controller"}
-            for system_type in entry.get("system_types", []):
+            system_types = entry.get("system_types") or []
+            if not isinstance(system_types, list):
+                continue
+            for system_type in system_types:
                 if system_type not in _VALID_SYSLOG_SYSTEM_TYPES:
                     result.issues.append(
                         Issue(

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -1057,6 +1057,58 @@ class TestValidateConfig:
             for issue in result.issues
         )
 
+    def test_validate_config_accepts_null_extra_syslog_system_types(self, monkeypatch):
+        from evidenceforge.generation.activity import extra_syslog
+
+        def load_extra_syslog_messages_with_null_system_types():
+            return [
+                {
+                    "app": "packagekitd",
+                    "system_types": None,
+                    "messages": ["search-names transaction /12345"],
+                }
+            ]
+
+        monkeypatch.setattr(
+            extra_syslog,
+            "load_extra_syslog_messages",
+            load_extra_syslog_messages_with_null_system_types,
+        )
+
+        result = validate_config()
+
+        assert not any(
+            issue.file == "extra_syslog_messages.yaml" and "system_types" in issue.message
+            for issue in result.issues
+        )
+
+    def test_validate_config_rejects_scalar_extra_syslog_system_types(self, monkeypatch):
+        from evidenceforge.generation.activity import extra_syslog
+
+        def load_extra_syslog_messages_with_scalar_system_types():
+            return [
+                {
+                    "app": "packagekitd",
+                    "system_types": 7,
+                    "messages": ["search-names transaction /12345"],
+                }
+            ]
+
+        monkeypatch.setattr(
+            extra_syslog,
+            "load_extra_syslog_messages",
+            load_extra_syslog_messages_with_scalar_system_types,
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "extra_syslog_messages.yaml"
+            and "system_types" in issue.message
+            for issue in result.issues
+        )
+
     def test_validate_config_rejects_networkmanager_same_state_transition(self, monkeypatch):
         from evidenceforge.generation.activity import extra_syslog
 


### PR DESCRIPTION
### Motivation
- The custom allow-list loop in `eforge validate-config` iterated `entry.get("system_types", [])` directly, which raises `TypeError` when an overlay YAML explicitly sets `system_types: null` before Pydantic schema validation runs. 
- The intent is to let the schema validator report malformed `system_types` values while preventing a pre-validation crash caused by `null` or other non-iterable overlay values.

### Description
- Guarded the syslog check in `src/evidenceforge/cli/validate_config.py` by treating an explicit `null` as absent and skipping the custom iteration when `system_types` is not a `list` (added `system_types = entry.get("system_types") or []` and `if not isinstance(system_types, list): continue`).
- Added two regression tests to `tests/unit/test_validate_config.py` to cover `system_types: null` and scalar `system_types` overlays so the code accepts `null` without crashing and rejects non-list scalars via schema validation.
- Recorded the completed security fix in `TODO.md` to track the change in the implementation plan.

### Testing
- Ran the targeted tests with `uv run pytest --no-cov tests/unit/test_validate_config.py -k 'extra_syslog_system_types or invalid_extra_syslog_system_type'` and the three selected tests passed.
- Ran the full `validate_config` unit suite with `uv run pytest --no-cov tests/unit/test_validate_config.py` and all tests passed (`41 passed`).
- Verified code style with `uv run ruff check .` and `uv run ruff format --check .`, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0f2e407083259ef304c7b02813f4)