### PR TITLE
fix: ignore malformed process command URLs to prevent ValueError crash

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Harden process command URL parsing so malformed command-line ports cannot crash connection generation — skipped invalid command-line URL authorities/ports during HTTP context inference and covered both direct helper parsing and attributed connection generation.
 - [x] Harden Windows spool JSON encoding and flushing against scenario-triggered denial-of-service — replaced collision-prone datetime sentinels with typed spool field wrappers and kept final spooled rendering on SQLite-backed streaming fixup passes instead of materializing all rows.
 - [x] Fix TCP DNS fallback packet overhead so TCP SERVFAIL accounting preserves TCP/IP header distributions.
 - [x] Fix unbounded Sysmon parent process-create shift loop for cyclic raw ProcessGuid relationships with cycle detection and bounded parent-ordering passes.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -315,8 +315,12 @@ def _extract_http_url_from_command(command_line: str) -> str | None:
     """Return the first HTTP(S) URL embedded in a process command line."""
     for match in re.finditer(r"https?://[^\s'\"<>]+", command_line):
         candidate = match.group(0).rstrip(").,;]")
-        parsed = urlsplit(candidate)
-        if parsed.scheme in {"http", "https"} and parsed.hostname:
+        try:
+            parsed = urlsplit(candidate)
+            hostname = parsed.hostname
+        except ValueError:
+            continue
+        if parsed.scheme in {"http", "https"} and hostname:
             return candidate
     return None
 
@@ -375,11 +379,14 @@ def _http_context_from_process_command(
     if not http_url:
         return None
     parsed = urlsplit(http_url)
-    host = parsed.hostname or ""
+    try:
+        host = parsed.hostname or ""
+        service = "ssl" if parsed.scheme == "https" else "http"
+        port = parsed.port or (443 if service == "ssl" else 80)
+    except ValueError:
+        return None
     if not host:
         return None
-    service = "ssl" if parsed.scheme == "https" else "http"
-    port = parsed.port or (443 if service == "ssl" else 80)
     path = parsed.path or "/"
     if parsed.query:
         path = f"{path}?{parsed.query}"

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -124,6 +124,24 @@ class TestProcessHttpCommandCorrelation:
         assert second_http.response_body_len == expected_size
         assert first_http.resp_mime_types == ["image/x-icon"]
 
+    @pytest.mark.parametrize(
+        "command_line",
+        [
+            "curl -s http://example.com:99999/payload",
+            "wget http://example.com:abc/payload",
+            "curl -s http://[not-a-valid-host/payload",
+        ],
+    )
+    def test_http_context_from_command_rejects_malformed_url_port(self, command_line):
+        """Malformed command-line URL ports should not abort HTTP context inference."""
+        result = _http_context_from_process_command(
+            "/usr/bin/curl",
+            command_line,
+            response_body_len=1234,
+        )
+
+        assert result is None
+
     def test_proxy_context_preserves_cli_http_user_agent(self):
         """Proxy logs should not replace a caller-provided CLI User-Agent."""
         generator = ActivityGenerator(StateManager(), {})
@@ -249,6 +267,51 @@ class TestProcessHttpCommandCorrelation:
         assert isinstance(http, HttpContext)
         assert http.user_agent == "curl/7.88.1"
         assert http.uri == "/methods/api.test"
+
+    def test_generate_connection_ignores_malformed_process_http_command(self):
+        """Attributed TCP connections should not crash on a malformed stored command URL."""
+        state = StateManager()
+        generator = ActivityGenerator(
+            state,
+            {},
+            dispatcher=EventDispatcher(state_manager=state, emitters={}),
+        )
+        source = System(
+            hostname="APP-INT-01",
+            ip="10.10.2.30",
+            os="Ubuntu 24.04",
+            type="server",
+        )
+        generator._ip_to_system = {source.ip: source}
+
+        timestamp = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+        state.set_current_time(timestamp)
+        pid = state.create_process(
+            system=source.hostname,
+            parent_pid=4,
+            image="/usr/bin/curl",
+            command_line="curl -s http://example.com:99999/payload",
+            username="sarah.martinez",
+            integrity_level="Medium",
+            logon_id="0x1234",
+        )
+
+        uid = generator.generate_connection(
+            src_ip=source.ip,
+            dst_ip="203.0.113.20",
+            time=timestamp + timedelta(seconds=1),
+            dst_port=443,
+            proto="tcp",
+            service="ssl",
+            duration=2.0,
+            orig_bytes=400,
+            resp_bytes=1200,
+            emit_dns=False,
+            pid=pid,
+            source_system=source,
+        )
+
+        assert uid.startswith("C")
 
 
 class TestNetworkValidation:


### PR DESCRIPTION
### Motivation
- A stored process `command_line` containing a malformed or out-of-range HTTP URL (e.g., `:99999`, non-numeric port, or invalid bracketed authority) could be reparsed during connection attribution and cause `urllib.parse.urlsplit` to raise `ValueError`, aborting generation.
- The new process→connection inference path called the unsafe helper without guarding against `ValueError`, introducing a denial-of-service crash for crafted scenario inputs.

### Description
- Hardened `_extract_http_url_from_command()` to skip URL candidates that cause `urlsplit()` to raise `ValueError` instead of propagating the exception.
- Hardened `_http_context_from_process_command()` to catch `ValueError` when accessing parsed attributes (hostname/port) and return `None` for malformed command-line URLs so connection generation will not infer HTTP context from invalid data.
- Added regression tests that cover malformed/out-of-range/non-numeric/bracketed authorities in process command URLs and an attributed-connection test that verifies `generate_connection()` no longer crashes when a stored `curl` command contains a bad port.
- Updated `TODO.md` to record the security fix as completed.
- Files changed: `src/evidenceforge/generation/activity/generator.py`, `tests/unit/test_activity.py`, `TODO.md`.

### Testing
- Ran the focused unit tests `tests/unit/test_activity.py::TestProcessHttpCommandCorrelation` and observed all tests pass (`10 passed`).
- Ran repository linters and format checks: `uv run ruff check .` and `uv run ruff format --check .` passed with no issues.
- The regression verifies that malformed command-line URLs are ignored for HTTP context inference and that an attributed TCP connection generation path no longer raises `ValueError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b13befc3c8325b97157b934b27582)