### PR TITLE
fix: suppress duplicate Windows lock/unlock transitions without Type 7 4624

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
+- [x] Remediate Windows lock/unlock duplicate suppression regression — moved in-memory duplicate deletion outside the Type 7 unlock-logon loop, added no-Type-7 regression coverage, and verified focused Windows emitter tests plus Ruff checks.
 - [x] Move coverage to the release lane — default/local and feature-PR tests now run without coverage, final `dev` → `main` readiness keeps explicit coverage and slow comprehensive gates, CI/docs/agent guidance are updated, workflow YAML parses, Ruff checks pass, and `uv run pytest --no-cov` passed in 34.74s.
 - [x] Refresh the v0.7.0 `dev` -> `main` release PR after PR #162 merged into `dev` — confirmed the release PR head includes merge commit `87ac753`, kept the version at `0.7.0`, and updated the changelog with the calibration-cleanup work from PR #162.
 - [x] Split slow comprehensive tests from coverage instrumentation in CI and update contributor/agent testing guidance — normal coverage gate passed at 79.38% with slow tests skipped; slow comprehensive suite passed separately with `--no-cov` in 2m36s; Ruff checks passed.

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -1870,12 +1870,12 @@ class WindowsEventEmitter(LogEmitter):
                     dropped_indexes.add(index)
                     break
 
-            if dropped_indexes:
-                self._event_dicts = [
-                    event
-                    for index, event in enumerate(self._event_dicts)
-                    if index not in dropped_indexes
-                ]
+        if dropped_indexes:
+            self._event_dicts = [
+                event
+                for index, event in enumerate(self._event_dicts)
+                if index not in dropped_indexes
+            ]
 
     def _shift_process_creates_after_logons(self) -> None:
         """Prevent visible Security 4688 rows from preceding same-session 4624 rows."""

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -2025,6 +2025,52 @@ class TestWindowsEventEmitter:
             (4801, base + timedelta(minutes=20)),
         ]
 
+    def test_duplicate_lock_unlock_transitions_are_suppressed_without_type7_logon(
+        self, format_def, temp_output
+    ):
+        """Duplicate Security 4800/4801 rows should be removed without Type 7 logons."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=10)
+        host = "WKS-01.corp.local"
+        base = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        emitter._event_dicts = [
+            {
+                "EventID": 4800,
+                "TimeCreated": base,
+                "Computer": host,
+                "TargetLogonId": "0x4f2a1b",
+                "SessionId": 2,
+            },
+            {
+                "EventID": 4800,
+                "TimeCreated": base + timedelta(minutes=5),
+                "Computer": host,
+                "TargetLogonId": "0x4f2a1b",
+                "SessionId": 2,
+            },
+            {
+                "EventID": 4801,
+                "TimeCreated": base + timedelta(minutes=20),
+                "Computer": host,
+                "TargetLogonId": "0x4f2a1b",
+                "SessionId": 2,
+            },
+            {
+                "EventID": 4801,
+                "TimeCreated": base + timedelta(minutes=25),
+                "Computer": host,
+                "TargetLogonId": "0x4f2a1b",
+                "SessionId": 2,
+            },
+        ]
+
+        emitter._suppress_duplicate_lock_unlock_transitions()
+
+        remaining = [(event["EventID"], event["TimeCreated"]) for event in emitter._event_dicts]
+        assert remaining == [
+            (4800, base),
+            (4801, base + timedelta(minutes=20)),
+        ]
+
     def test_spooled_duplicate_lock_unlock_state_transitions_are_suppressed(
         self, format_def, temp_output
     ):


### PR DESCRIPTION
### Motivation
- A recent change indented the in-memory deletion of marked duplicate Windows lock/unlock rows inside the later 4624 LogonType 7 loop, causing marked 4800/4801 duplicates to remain when no Type 7 row was present.

### Description
- Move the `dropped_indexes` cleanup for in-memory events outside of the 4624 Type 7 scan so marked duplicate `4800`/`4801` rows are always removed (`src/evidenceforge/generation/emitters/windows.py`).
- Add a focused regression test `test_duplicate_lock_unlock_transitions_are_suppressed_without_type7_logon` that verifies duplicates are removed even when no `4624` LogonType 7 row exists (`tests/unit/test_emitters.py`).
- Update `TODO.md` to mark the remediation complete and record the change.

### Testing
- Ran the focused unit tests with `uv run pytest --no-cov tests/unit/test_emitters.py -k 'duplicate_lock_unlock'`, which executed the relevant cases and reported `3 passed`.
- Ran linters/format checks with `uv run ruff check .` and `uv run ruff format --check .`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0f2d2fd8832597136a6b09b4e3a7)