### PR TITLE
[codex] Add target-aware output rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ For scripted or non-interactive use:
 | `eforge install-skills [--agent claude\|codex] [--global]` | Install agent skills (`--global` is Claude-only) |
 | `eforge version` | Show version |
 
-Common flags: `--verbose` / `--debug` for logging, `--output` / `-o` for output directory, `--force` / `-f` to overwrite existing output without prompting.
+Common flags: `--verbose` / `--debug` for logging, `--output` / `-o` for output
+directory, `--force` / `-f` to overwrite existing output without prompting,
+and `--target default|sof-elk` to choose the generated file layout. The
+`default` target is SIEM-neutral; `sof-elk` emits target-specific variants such
+as Snare Windows events and year-partitioned RFC3164 syslog for parser
+validation.
 
 ## Customizing Configuration
 
@@ -220,16 +225,20 @@ ActivityGenerator (builds SecurityEvents with composable contexts)
     v
 EventDispatcher (routes to StateManager + matching emitters)
     |
-    +---> WindowsEventEmitter ---> Security XML + Snare/RFC3164 sidecar
-    +---> SysmonEmitter ---------> Sysmon XML + Snare/RFC3164 sidecar
+    +---> WindowsEventEmitter ---> default XML / sof-elk Snare syslog
+    +---> SysmonEmitter ---------> default XML / sof-elk Snare syslog
     +---> ZeekEmitter(s) --------> conn/dns/http/ssl/... (NDJSON)
     +---> EcarEmitter -----------> ecar.json (NDJSON)
-    +---> SyslogEmitter ---------> <host>/<year>/syslog.log
+    +---> SyslogEmitter ---------> default RFC5424 / sof-elk RFC3164 year layout
     +---> BashHistoryEmitter ----> per-user bash history
     +---> SnortEmitter ----------> snort_alert.log
+    +---> CiscoAsaEmitter -------> default flat / sof-elk year layout
     +---> WebEmitter ------------> web_access.log
     +---> ProxyEmitter ----------> proxy_access.log
 ```
+
+Generation records the selected output target in `OUTPUT_TARGET.txt` and
+emitters apply it only where file shape differs.
 
 `WorldModel` compiles authoritative host and user capabilities from scenario fields like `primary_system`, `roles`, `services`, and workstation assignments. `WorldPlanner` then chooses realistic interactive, network, SSH, and RDP session paths before `ActivityGenerator` emits the correlated evidence.
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ ActivityGenerator (builds SecurityEvents with composable contexts)
     v
 EventDispatcher (routes to StateManager + matching emitters)
     |
-    +---> WindowsEventEmitter ---> Security.evtx (XML)
-    +---> SysmonEmitter ---------> Sysmon.evtx (XML)
+    +---> WindowsEventEmitter ---> Security XML + Snare/RFC3164 sidecar
+    +---> SysmonEmitter ---------> Sysmon XML + Snare/RFC3164 sidecar
     +---> ZeekEmitter(s) --------> conn/dns/http/ssl/... (NDJSON)
     +---> EcarEmitter -----------> ecar.json (NDJSON)
     +---> SyslogEmitter ---------> <host>/<year>/syslog.log

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ EventDispatcher (routes to StateManager + matching emitters)
     +---> SysmonEmitter ---------> Sysmon.evtx (XML)
     +---> ZeekEmitter(s) --------> conn/dns/http/ssl/... (NDJSON)
     +---> EcarEmitter -----------> ecar.json (NDJSON)
-    +---> SyslogEmitter ---------> syslog.log
+    +---> SyslogEmitter ---------> <host>/<year>/syslog.log
     +---> BashHistoryEmitter ----> per-user bash history
     +---> SnortEmitter ----------> snort_alert.log
     +---> WebEmitter ------------> web_access.log

--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
+- [ ] **IN PROGRESS** Extract license-neutral output target rendering and evaluation support from the SOF-ELK external parser branch while leaving parser pipeline code/docs/tests out of dev.
 - [x] Prepare `dev` → `main` PR for final PR-review integration batch — inspected `main..dev`, applied the required v0.7.2 patch version/changelog bump, ran release checks, pushed `dev`, and opened the PR into `main`.
 - [x] Run slow comprehensive pytest suite after final PR integration — `uv run pytest -v --include-slow --no-cov` passed on current `dev` with `3265 passed, 24 skipped`; no regressions or follow-up fixes were needed.
 - [x] Move coverage to the release lane — default/local and feature-PR tests now run without coverage, final `dev` → `main` readiness keeps explicit coverage and slow comprehensive gates, CI/docs/agent guidance are updated, workflow YAML parses, Ruff checks pass, and `uv run pytest --no-cov` passed in 34.74s.

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
 - [x] Extract license-neutral output target rendering and evaluation support from the SOF-ELK external parser branch while leaving parser pipeline code/docs/tests out of dev.
+- [x] Run the full slow-enabled pytest suite on the output-target extraction branch — `uv run pytest --include-slow --no-cov` passed with `3296 passed, 24 skipped`; no regressions or fixes were needed.
 - [ ] **P1** Reduce syslog memory pressure in long scenarios by allowing barrier flushes to write year-partitioned syslog files, while preserving final sort/logind normalization at close.
 - [ ] **P2** Revisit proxy access log realism and parser compatibility; consider switching `proxy_access.log` from W3C Extended format to Apache/Nginx combined-style output with absolute URLs and CONNECT targets.
 - [x] Prepare `dev` → `main` PR for final PR-review integration batch — inspected `main..dev`, applied the required v0.7.2 patch version/changelog bump, ran release checks, pushed `dev`, and opened the PR into `main`.

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 **Status:** Phase 8.5 (Dual src/dst HostContext) COMPLETE; Pre-MVP quality fixes ongoing
 **Started:** 2026-03-11
-**Last Updated:** 2026-05-16
+**Last Updated:** 2026-05-17
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed development history of completed phases.
 
@@ -38,6 +38,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 - [ ] **IN PROGRESS** Extract license-neutral output target rendering and evaluation support from the SOF-ELK external parser branch while leaving parser pipeline code/docs/tests out of dev.
 - [ ] **P1** Reduce syslog memory pressure in long scenarios by allowing barrier flushes to write year-partitioned syslog files, while preserving final sort/logind normalization at close.
+- [ ] **P2** Revisit proxy access log realism and parser compatibility; consider switching `proxy_access.log` from W3C Extended format to Apache/Nginx combined-style output with absolute URLs and CONNECT targets.
 - [x] Prepare `dev` → `main` PR for final PR-review integration batch — inspected `main..dev`, applied the required v0.7.2 patch version/changelog bump, ran release checks, pushed `dev`, and opened the PR into `main`.
 - [x] Run slow comprehensive pytest suite after final PR integration — `uv run pytest -v --include-slow --no-cov` passed on current `dev` with `3265 passed, 24 skipped`; no regressions or follow-up fixes were needed.
 - [x] Move coverage to the release lane — default/local and feature-PR tests now run without coverage, final `dev` → `main` readiness keeps explicit coverage and slow comprehensive gates, CI/docs/agent guidance are updated, workflow YAML parses, Ruff checks pass, and `uv run pytest --no-cov` passed in 34.74s.

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
 - [ ] **IN PROGRESS** Extract license-neutral output target rendering and evaluation support from the SOF-ELK external parser branch while leaving parser pipeline code/docs/tests out of dev.
+- [ ] **P1** Reduce syslog memory pressure in long scenarios by allowing barrier flushes to write year-partitioned syslog files, while preserving final sort/logind normalization at close.
 - [x] Prepare `dev` → `main` PR for final PR-review integration batch — inspected `main..dev`, applied the required v0.7.2 patch version/changelog bump, ran release checks, pushed `dev`, and opened the PR into `main`.
 - [x] Run slow comprehensive pytest suite after final PR integration — `uv run pytest -v --include-slow --no-cov` passed on current `dev` with `3265 passed, 24 skipped`; no regressions or follow-up fixes were needed.
 - [x] Move coverage to the release lane — default/local and feature-PR tests now run without coverage, final `dev` → `main` readiness keeps explicit coverage and slow comprehensive gates, CI/docs/agent guidance are updated, workflow YAML parses, Ruff checks pass, and `uv run pytest --no-cov` passed in 34.74s.

--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
-- [ ] **IN PROGRESS** Extract license-neutral output target rendering and evaluation support from the SOF-ELK external parser branch while leaving parser pipeline code/docs/tests out of dev.
+- [x] Extract license-neutral output target rendering and evaluation support from the SOF-ELK external parser branch while leaving parser pipeline code/docs/tests out of dev.
 - [ ] **P1** Reduce syslog memory pressure in long scenarios by allowing barrier flushes to write year-partitioned syslog files, while preserving final sort/logind normalization at close.
 - [ ] **P2** Revisit proxy access log realism and parser compatibility; consider switching `proxy_access.log` from W3C Extended format to Apache/Nginx combined-style output with absolute URLs and CONNECT targets.
 - [x] Prepare `dev` → `main` PR for final PR-review integration batch — inspected `main..dev`, applied the required v0.7.2 patch version/changelog bump, ran release checks, pushed `dev`, and opened the PR into `main`.

--- a/commands/eforge/evaluate.md
+++ b/commands/eforge/evaluate.md
@@ -75,7 +75,7 @@ source-native field mismatches, and evidence marked `visible` or `delayed` remai
 For each pillar, explain what the score means in practical terms:
 
 **Pillar 1: Parseability (weight 0.30)**
-- Spec Conformance: Does every record parse cleanly under strict-mode rules? Missing required fields? Type violations? RFC3164 strict for generated syslog with legacy RFC5424 and flat BSD/RFC3164 eval fallback; typed columns for Zeek; schema-strict for eCAR; XML-schema for Windows EventLog.
+- Spec Conformance: Does every record parse cleanly under strict-mode rules? Missing required fields? Type violations? `eforge eval` reads `OUTPUT_TARGET.txt` to choose target-specific variants, treating a missing marker as legacy/default. Windows/Sysmon XML and SOF-ELK Snare syslog both map to the canonical Windows buckets; default RFC5424 syslog and SOF-ELK RFC3164/year syslog both map to `syslog`; typed columns for Zeek; schema-strict for eCAR.
 - Format Constraints: Do records satisfy `FormatDefinition` constraints (field ranges, enum values, structural rules)?
 
 **Pillar 2: Plausibility (weight 0.25)**

--- a/commands/eforge/evaluate.md
+++ b/commands/eforge/evaluate.md
@@ -75,7 +75,7 @@ source-native field mismatches, and evidence marked `visible` or `delayed` remai
 For each pillar, explain what the score means in practical terms:
 
 **Pillar 1: Parseability (weight 0.30)**
-- Spec Conformance: Does every record parse cleanly under strict-mode rules? Missing required fields? Type violations? RFC 5424 strict for generated syslog with legacy BSD/RFC3164 eval fallback; typed columns for Zeek; schema-strict for eCAR; XML-schema for Windows EventLog.
+- Spec Conformance: Does every record parse cleanly under strict-mode rules? Missing required fields? Type violations? RFC3164 strict for generated syslog with legacy RFC5424 and flat BSD/RFC3164 eval fallback; typed columns for Zeek; schema-strict for eCAR; XML-schema for Windows EventLog.
 - Format Constraints: Do records satisfy `FormatDefinition` constraints (field ranges, enum values, structural rules)?
 
 **Pillar 2: Plausibility (weight 0.25)**

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -163,12 +163,12 @@ After reviewing output, you can suggest:
 | windows | Windows Event Logs (XML) — Security (30 event IDs) + Sysmon (Events 1, 3, 5, 7, 8, 10, 11, 12, 13, 22) | Windows systems |
 | zeek | Zeek logs (NDJSON) — conn/dns/http/ssl/files/ntp per sensor | Network connections via sensors |
 | ecar | EDR/XDR telemetry in eCAR format (NDJSON) — PROCESS, FILE, FLOW, REGISTRY, MODULE, USER_SESSION | Any OS (optional EDR layer) |
-| syslog | Linux syslog (RFC 5424) | Linux systems |
+| syslog | Linux syslog (RFC3164/BSD, per-host/year) | Linux systems |
 | bash_history | Bash command history | Linux systems |
 | snort_alert | Snort/Suricata alerts (fast format) | Network IDS via sensors |
 | cisco_asa | Cisco ASA firewall syslog (Built/Teardown/Deny) | Firewall sensors |
 
-When `nat_rules` are configured on the firewall sensor, cisco_asa.log also includes 305011/305012 NAT translation records alongside the normal Built/Teardown connection records.
+When `nat_rules` are configured on the firewall sensor, `<firewall>/<year>/cisco_asa.log` also includes 305011/305012 NAT translation records alongside the normal Built/Teardown connection records.
 
 | web_access | Apache/Nginx combined access logs | Web servers |
 

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -54,6 +54,8 @@ Options:
                          `eforge info format_groups` to see available groups. Example:
                          `eforge generate scenario.yaml --formats zeek_conn,zeek_dns` to
                          generate only Zeek connection and DNS logs.
+  --target <name>        Output target: default or sof-elk. The default target is SIEM-neutral.
+                         Use sof-elk when generating SOF-ELK-compatible file layouts.
   --force, -f            Overwrite existing output without prompting
   --verbose, -v          INFO-level logging
   --debug, -d            DEBUG-level logging
@@ -95,10 +97,16 @@ scenarios/<scenario-name>/
   ENVIRONMENT.md         ← created by /eforge scenario
   GROUND_TRUTH.md        ← generated answer key (empty for benign baseline-only runs)
   OBSERVATION_MANIFEST.json ← generated source-observation sidecar
+  OUTPUT_TARGET.txt      ← "default" or "sof-elk"
   data/                  ← generated log files
-    windows/
-      security.xml
-      sysmon.xml
+    <host>/
+      windows_event_security.xml      ← default target Windows Security
+      windows_event_sysmon.xml        ← default target Sysmon
+      syslog.log                      ← default target Linux syslog
+      <year>/
+        windows_event_security_snare.log ← sof-elk target Windows Security
+        windows_event_sysmon_snare.log   ← sof-elk target Sysmon
+        syslog.log                       ← sof-elk target Linux syslog
     zeek/
       conn.json
       dns.json
@@ -160,15 +168,17 @@ After reviewing output, you can suggest:
 
 | Format | Description | Generated For |
 |--------|-------------|---------------|
-| windows | Windows Event Logs (XML) — Security (30 event IDs) + Sysmon (Events 1, 3, 5, 7, 8, 10, 11, 12, 13, 22) | Windows systems |
+| windows | Windows Event Logs — default target XML, SOF-ELK target Snare syslog. Security (30 event IDs) + Sysmon (Events 1, 3, 5, 7, 8, 10, 11, 12, 13, 22) | Windows systems |
 | zeek | Zeek logs (NDJSON) — conn/dns/http/ssl/files/ntp per sensor | Network connections via sensors |
 | ecar | EDR/XDR telemetry in eCAR format (NDJSON) — PROCESS, FILE, FLOW, REGISTRY, MODULE, USER_SESSION | Any OS (optional EDR layer) |
-| syslog | Linux syslog (RFC3164/BSD, per-host/year) | Linux systems |
+| syslog | Linux syslog — default target RFC5424 flat per-host, SOF-ELK target RFC3164/BSD per-host/year | Linux systems |
 | bash_history | Bash command history | Linux systems |
 | snort_alert | Snort/Suricata alerts (fast format) | Network IDS via sensors |
-| cisco_asa | Cisco ASA firewall syslog (Built/Teardown/Deny) | Firewall sensors |
+| cisco_asa | Cisco ASA firewall syslog — default target flat per-sensor, SOF-ELK target per-sensor/year | Firewall sensors |
 
-When `nat_rules` are configured on the firewall sensor, `<firewall>/<year>/cisco_asa.log` also includes 305011/305012 NAT translation records alongside the normal Built/Teardown connection records.
+When `nat_rules` are configured on the firewall sensor, `cisco_asa.log`
+also includes 305011/305012 NAT translation records alongside the normal
+Built/Teardown connection records.
 
 | web_access | Apache/Nginx combined access logs | Web servers |
 

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -8,16 +8,24 @@ This document lists every evidence type EvidenceForge can generate, where to fin
 
 ## Output Directory Structure
 
+One generation run emits one output target. The tree below shows both default
+and SOF-ELK target-specific files where they differ; they are not emitted
+together.
+
 ```
 output/
   GROUND_TRUTH.md                          # Ground truth sidecar; empty for baseline-only runs
   OBSERVATION_MANIFEST.json                # Source-observation sidecar for eval
+  OUTPUT_TARGET.txt                        # "default" or "sof-elk"; missing legacy marker means default
   ENVIRONMENT.md                           # Student-facing environment description (created by /eforge scenario skill)
   <hostname.domain>/                       # Per-host directories (FQDN)
     windows_event_security.xml             # Windows Security channel events
     windows_event_sysmon.xml               # Sysmon operational channel events
-    <year>/syslog.log                      # Linux syslog (RFC3164; Linux only)
+    syslog.log                             # Linux syslog (default target; RFC5424)
     bash_history/<username>.bash_history    # Per-user bash history (Linux only)
+    <year>/windows_event_security_snare.log # Windows Security Snare/RFC3164 (sof-elk target)
+    <year>/windows_event_sysmon_snare.log   # Sysmon Snare/RFC3164 (sof-elk target)
+    <year>/syslog.log                      # Linux syslog (sof-elk target; RFC3164)
   <sensor-name>/                           # Per-sensor directories (network)
     conn.json                              # Zeek conn.log (NDJSON)
     dns.json                               # Zeek dns.log
@@ -28,20 +36,46 @@ output/
   ecar.json                                # eCAR EDR/XDR telemetry (NDJSON)
   snort_alert.log                          # Snort/Suricata IDS alerts
   <fw-hostname>/                           # Per-firewall directories
-    <year>/cisco_asa.log                   # Cisco ASA firewall syslog
+    cisco_asa.log                          # Cisco ASA firewall syslog (default target)
+    <year>/cisco_asa.log                   # Cisco ASA firewall syslog (sof-elk target)
   web_access.log                           # Apache/Nginx access log
   <proxy-hostname.domain>/                 # Per-proxy-host directories
     proxy_access.log                       # HTTP forward proxy access log (W3C Extended)
 ```
 
+## Output Targets
+
+`eforge generate --target default|sof-elk` selects the on-disk rendering and
+layout for tools that expect different formats. Scenario YAML and `--formats`
+remain canonical: request `windows_event_security`, `windows_event_sysmon`,
+`syslog`, `cisco_asa`, and so on, then choose the target at generation time.
+When `OUTPUT_TARGET.txt` is missing, `eforge eval` treats the dataset as
+legacy/default output.
+
+Target-specific behavior in V1:
+
+| Canonical format | `default` target | `sof-elk` target |
+| --- | --- | --- |
+| `windows_event_security` | `<host>/windows_event_security.xml` | `<host>/<year>/windows_event_security_snare.log` |
+| `windows_event_sysmon` | `<host>/windows_event_sysmon.xml` | `<host>/<year>/windows_event_sysmon_snare.log` |
+| `syslog` | `<host>/syslog.log` as RFC5424 | `<host>/<year>/syslog.log` as RFC3164/BSD |
+| `cisco_asa` | `<firewall>/cisco_asa.log` | `<firewall>/<year>/cisco_asa.log` |
+| Zeek, proxy, web access, IDS, eCAR, bash history | Unchanged | Unchanged |
+
 ---
 
 ## Windows Security Events
 
-**File:** `<hostname.domain>/windows_event_security.xml`
-**Format:** XML (`<Events><Event>...</Event></Events>`)
+**Default target file:** `<hostname.domain>/windows_event_security.xml`
+**Default target format:** XML (`<Events><Event>...</Event></Events>`)
+**SOF-ELK target file:** `<hostname.domain>/<year>/windows_event_security_snare.log`
+**SOF-ELK target format:** Snare-style Windows Event Log fields inside an RFC3164 syslog envelope
 **Provider:** Microsoft-Windows-Security-Auditing (except 1102)
 **Channel:** Security
+
+The `default` target emits XML only. The `sof-elk` target emits Snare syslog
+only so SOF-ELK and other syslog/Snare-aware tools can parse the same canonical
+Windows Security events without requiring binary EVTX files.
 
 | Event ID | Name | Category | Notes |
 |----------|------|----------|-------|
@@ -89,10 +123,16 @@ output/
 
 ## Windows Sysmon Events
 
-**File:** `<hostname.domain>/windows_event_sysmon.xml`
-**Format:** XML (`<Events><Event>...</Event></Events>`)
+**Default target file:** `<hostname.domain>/windows_event_sysmon.xml`
+**Default target format:** XML (`<Events><Event>...</Event></Events>`)
+**SOF-ELK target file:** `<hostname.domain>/<year>/windows_event_sysmon_snare.log`
+**SOF-ELK target format:** Snare-style Windows Event Log fields inside an RFC3164 syslog envelope
 **Provider:** Microsoft-Windows-Sysmon
 **Channel:** Microsoft-Windows-Sysmon/Operational
+
+The `default` target emits XML only. The `sof-elk` target emits Snare syslog
+only and `eforge eval` maps both variants back to the canonical
+`windows_event_sysmon` format bucket.
 
 | Event ID | Name | Category | Notes |
 |----------|------|----------|-------|
@@ -173,10 +213,22 @@ EDR/XDR telemetry rendered in MITRE CAR-based eCAR format. Represents what an ED
 
 ## Linux Syslog
 
-**File:** `<hostname.domain>/<year>/syslog.log`
-**Format:** RFC3164/BSD syslog with PRI
+**Default target file:** `<hostname.domain>/syslog.log`
+**Default target format:** RFC5424 syslog with full timestamp year
+**SOF-ELK target file:** `<hostname.domain>/<year>/syslog.log`
+**SOF-ELK target format:** RFC3164/BSD syslog with PRI
 
-Authentication and system logs from Linux hosts. Generated syslog uses a BSD/RFC3164-style envelope (`<PRI>MMM DD HH:MM:SS HOST APP[PID]: MESSAGE`) and partitions files by event year so yearless syslog timestamps remain unambiguous. `eforge eval` still accepts older RFC5424 and flat BSD/RFC3164 syslog as legacy ingest fallbacks. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows reuse the same source port as the companion Zeek SSH connection tuple.
+Authentication and system logs from Linux hosts. The `default` target emits
+flat per-host RFC5424 syslog for SIEM-neutral output. The `sof-elk` target emits
+a BSD/RFC3164 envelope (`<PRI>MMM DD HH:MM:SS HOST APP[PID]: MESSAGE`) and
+partitions files by event year so SOF-ELK can recover the timestamp year from
+the archive path. `eforge eval` accepts both current target variants plus older
+legacy RFC5424 and flat BSD/RFC3164 files. All generated syslog entries are
+rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive
+messages from other contexts. This enables correlated dispatch: a logon event
+carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd
+accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows
+reuse the same source port as the companion Zeek SSH connection tuple.
 
 | Program | Description | Notes |
 |---------|-------------|-------|
@@ -232,7 +284,8 @@ Alert format: `[gid:sid:rev]` where `gid` defaults to 1, `sid` identifies the ru
 
 ## Cisco ASA Firewall Syslog
 
-**File:** `<fw-hostname>/<year>/cisco_asa.log`
+**Default target file:** `<fw-hostname>/cisco_asa.log`
+**SOF-ELK target file:** `<fw-hostname>/<year>/cisco_asa.log`
 **Format:** Cisco ASA syslog (RFC 3164 BSD syslog with ASA message IDs)
 
 Cisco ASA firewall logs for permitted and denied connections. Produced by firewall-type network sensors with `cisco_asa` in their `log_formats`. Each permitted connection generates a Built + Teardown pair; denied connections generate a single Deny record.

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -16,6 +16,7 @@ output/
   <hostname.domain>/                       # Per-host directories (FQDN)
     windows_event_security.xml             # Windows Security channel events
     windows_event_sysmon.xml               # Sysmon operational channel events
+    <year>/syslog.log                      # Linux syslog (RFC3164; Linux only)
     bash_history/<username>.bash_history    # Per-user bash history (Linux only)
   <sensor-name>/                           # Per-sensor directories (network)
     conn.json                              # Zeek conn.log (NDJSON)
@@ -25,10 +26,9 @@ output/
     files.json                             # Zeek files.log
     ...                                    # Other Zeek logs
   ecar.json                                # eCAR EDR/XDR telemetry (NDJSON)
-  syslog.log                               # Linux syslog (RFC 5424)
   snort_alert.log                          # Snort/Suricata IDS alerts
   <fw-hostname>/                           # Per-firewall directories
-    cisco_asa.log                          # Cisco ASA firewall syslog
+    <year>/cisco_asa.log                   # Cisco ASA firewall syslog
   web_access.log                           # Apache/Nginx access log
   <proxy-hostname.domain>/                 # Per-proxy-host directories
     proxy_access.log                       # HTTP forward proxy access log (W3C Extended)
@@ -173,10 +173,10 @@ EDR/XDR telemetry rendered in MITRE CAR-based eCAR format. Represents what an ED
 
 ## Linux Syslog
 
-**File:** `syslog.log`
-**Format:** RFC 5424 syslog
+**File:** `<hostname.domain>/<year>/syslog.log`
+**Format:** RFC3164/BSD syslog with PRI
 
-Authentication and system logs from Linux hosts. Generated syslog uses RFC 5424 with year-bearing ISO/RFC3339 timestamps. `eforge eval` still accepts older BSD/RFC3164-style syslog as a legacy ingest fallback. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows reuse the same source port as the companion Zeek SSH connection tuple.
+Authentication and system logs from Linux hosts. Generated syslog uses a BSD/RFC3164-style envelope (`<PRI>MMM DD HH:MM:SS HOST APP[PID]: MESSAGE`) and partitions files by event year so yearless syslog timestamps remain unambiguous. `eforge eval` still accepts older RFC5424 and flat BSD/RFC3164 syslog as legacy ingest fallbacks. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows reuse the same source port as the companion Zeek SSH connection tuple.
 
 | Program | Description | Notes |
 |---------|-------------|-------|
@@ -232,7 +232,7 @@ Alert format: `[gid:sid:rev]` where `gid` defaults to 1, `sid` identifies the ru
 
 ## Cisco ASA Firewall Syslog
 
-**File:** `<fw-hostname>/cisco_asa.log`
+**File:** `<fw-hostname>/<year>/cisco_asa.log`
 **Format:** Cisco ASA syslog (RFC 3164 BSD syslog with ASA message IDs)
 
 Cisco ASA firewall logs for permitted and denied connections. Produced by firewall-type network sensors with `cisco_asa` in their `log_formats`. Each permitted connection generates a Built + Teardown pair; denied connections generate a single Deny record.

--- a/commands/eforge/references/scenario-reference.md
+++ b/commands/eforge/references/scenario-reference.md
@@ -958,6 +958,11 @@ output:
 
 Supported formats: `windows`, `zeek`, `ecar`, `syslog`, `bash_history`, `snort_alert`, `cisco_asa`, `web_access`, `proxy_access`.
 
+Output formats here are canonical and target-neutral. Choose target-specific
+file shapes, such as SOF-ELK Snare Windows events or year-partitioned RFC3164
+syslog, with `eforge generate --target default|sof-elk`; do not encode a parser
+target in scenario YAML.
+
 `proxy_access` requires at least one system with `roles: [forward_proxy]`. If it is requested without a forward proxy system, validation warns because no proxy access log file will be generated. When proxy logs are requested, add `environment.proxy.mode` to make transparent vs explicit proxy semantics clear. Current proxy behavior assumes TLS interception, so HTTPS can include CONNECT plus inspected request rows; non-intercepting tunnel-only proxy behavior is deferred.
 
 #### Format Filtering

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -18,6 +18,11 @@ The goal is a scenario that produces data useful for threat hunting training —
 
 The engine now supports up to 9 log formats including Cisco ASA firewall logs (`cisco_asa`) with explicit firewall policy rules for allow/deny decisions.
 
+Scenario YAML should name canonical log formats only. Target-specific renderings
+such as SOF-ELK Snare Windows events or year-partitioned RFC3164 syslog are
+selected at generation time with `eforge generate --target default|sof-elk`, not
+encoded in the scenario.
+
 ## How This Works
 
 EvidenceForge uses a two-phase approach:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,7 +251,7 @@ LogEmitter (ABC)
 │   ├── ZeekSslEmitter               # ssl.log
 │   └── ... (10 more Zeek types)
 ├── EcarEmitter                      # eCAR NDJSON (MITRE CAR model, objectID/actorID graph via EdrContext)
-├── SyslogEmitter                    # Linux syslog (RFC 5424)
+├── SyslogEmitter                    # Linux syslog (RFC3164, per-host/year)
 ├── BashHistoryEmitter               # Per-user bash history
 ├── SnortEmitter                     # Snort IDS alerts
 ├── CiscoAsaEmitter                  # Cisco ASA firewall syslog (Built/Teardown/Deny)
@@ -259,7 +259,7 @@ LogEmitter (ABC)
 └── ProxyEmitter                     # HTTP forward proxy access logs (W3C Extended)
 ```
 
-**Sensor multiplexing:** Network emitters (Zeek family, Snort, Cisco ASA) use `SensorMultiplexEmitter` to route output to per-sensor directories. A single emitter instance manages output for multiple sensors, each writing to `<sensor_hostname>/<log_file>`. The CiscoAsaEmitter also generates deny baseline traffic from the firewall sensor's policy rules.
+**Sensor multiplexing:** Network emitters (Zeek family, Snort, Cisco ASA) use `SensorMultiplexEmitter` to route output to per-sensor directories. A single emitter instance manages output for multiple sensors. Zeek/Snort write to `<sensor_hostname>/<log_file>`; Cisco ASA is syslog-family output and writes to `<sensor_hostname>/<year>/cisco_asa.log`. The CiscoAsaEmitter also generates deny baseline traffic from the firewall sensor's policy rules.
 
 **Proxy path modeling:** `environment.proxy.mode` controls whether proxy-routed HTTP/HTTPS keeps transparent client→origin network evidence or is split into explicit client→proxy and proxy→origin legs. Explicit mode dispatches each concrete leg through the normal sensor visibility engine so Zeek/IDS/firewall sources only contain the side of the proxy they can observe; the original logical client→origin request is not emitted as network evidence. Denied proxy requests emit only the client→proxy/proxy access evidence and do not create downstream origin-side transactions.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,8 +243,8 @@ LogEmitter (ABC)
 ├── _buffer: list                    # 10K event buffer before flush
 └── _flush()                         # Write buffer to file
 │
-├── WindowsEventEmitter              # Security.evtx XML, 30 event IDs
-├── SysmonEventEmitter               # Sysmon.evtx XML
+├── WindowsEventEmitter              # Security XML plus Snare/RFC3164 sidecar
+├── SysmonEventEmitter               # Sysmon XML plus Snare/RFC3164 sidecar
 ├── ZeekEmitter                      # conn.log (base for 13 Zeek types)
 │   ├── ZeekDnsEmitter               # dns.log
 │   ├── ZeekHttpEmitter              # http.log

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,15 +243,15 @@ LogEmitter (ABC)
 ├── _buffer: list                    # 10K event buffer before flush
 └── _flush()                         # Write buffer to file
 │
-├── WindowsEventEmitter              # Security XML plus Snare/RFC3164 sidecar
-├── SysmonEventEmitter               # Sysmon XML plus Snare/RFC3164 sidecar
+├── WindowsEventEmitter              # Security XML (default) or Snare syslog (sof-elk)
+├── SysmonEventEmitter               # Sysmon XML (default) or Snare syslog (sof-elk)
 ├── ZeekEmitter                      # conn.log (base for 13 Zeek types)
 │   ├── ZeekDnsEmitter               # dns.log
 │   ├── ZeekHttpEmitter              # http.log
 │   ├── ZeekSslEmitter               # ssl.log
 │   └── ... (10 more Zeek types)
 ├── EcarEmitter                      # eCAR NDJSON (MITRE CAR model, objectID/actorID graph via EdrContext)
-├── SyslogEmitter                    # Linux syslog (RFC3164, per-host/year)
+├── SyslogEmitter                    # Linux syslog (default RFC5424 or sof-elk RFC3164/year)
 ├── BashHistoryEmitter               # Per-user bash history
 ├── SnortEmitter                     # Snort IDS alerts
 ├── CiscoAsaEmitter                  # Cisco ASA firewall syslog (Built/Teardown/Deny)
@@ -259,7 +259,13 @@ LogEmitter (ABC)
 └── ProxyEmitter                     # HTTP forward proxy access logs (W3C Extended)
 ```
 
-**Sensor multiplexing:** Network emitters (Zeek family, Snort, Cisco ASA) use `SensorMultiplexEmitter` to route output to per-sensor directories. A single emitter instance manages output for multiple sensors. Zeek/Snort write to `<sensor_hostname>/<log_file>`; Cisco ASA is syslog-family output and writes to `<sensor_hostname>/<year>/cisco_asa.log`. The CiscoAsaEmitter also generates deny baseline traffic from the firewall sensor's policy rules.
+**Output target policy:** `eforge generate --target default|sof-elk` selects
+target-specific rendering only where a consuming tool needs a different shape.
+Scenario YAML and `--formats` stay canonical. `OUTPUT_TARGET.txt` records the
+selected target beside `GROUND_TRUTH.md`; missing markers are treated as
+legacy/default during evaluation.
+
+**Sensor multiplexing:** Network emitters (Zeek family, Snort, Cisco ASA) use `SensorMultiplexEmitter` to route output to per-sensor directories. A single emitter instance manages output for multiple sensors. Zeek/Snort write to `<sensor_hostname>/<log_file>`; Cisco ASA is syslog-family output and writes to `<sensor_hostname>/cisco_asa.log` for the default target or `<sensor_hostname>/<year>/cisco_asa.log` for the SOF-ELK target. The CiscoAsaEmitter also generates deny baseline traffic from the firewall sensor's policy rules.
 
 **Proxy path modeling:** `environment.proxy.mode` controls whether proxy-routed HTTP/HTTPS keeps transparent client→origin network evidence or is split into explicit client→proxy and proxy→origin legs. Explicit mode dispatches each concrete leg through the normal sensor visibility engine so Zeek/IDS/firewall sources only contain the side of the proxy they can observe; the original logical client→origin request is not emitted as network evidence. Denied proxy requests emit only the client→proxy/proxy access evidence and do not create downstream origin-side transactions.
 

--- a/docs/design/PRD.md
+++ b/docs/design/PRD.md
@@ -432,13 +432,14 @@ output/
     generation.log              # Detailed generation log
     GROUND_TRUTH.md            # Ground truth sidecar (empty for baseline-only scenarios)
     OBSERVATION_MANIFEST.json  # Source-observation sidecar
+    OUTPUT_TARGET.txt          # default or sof-elk output target
     windows_events.xml         # Windows Event Logs
     zeek_conn.log              # Zeek connection logs
     ecar.json                  # ECAR events
-    <linux-host>/<year>/syslog.log        # Linux syslogs
+    <linux-host>/syslog.log               # Linux syslogs (default target)
     bash_history.log           # Bash history entries
     snort_alerts.log           # Snort/Suricata alerts
-    <firewall>/<year>/cisco_asa.log       # Cisco ASA firewall syslogs
+    <firewall>/cisco_asa.log              # Cisco ASA firewall syslogs (default target)
     web_access.log             # Web/proxy logs
 ```
 

--- a/docs/design/PRD.md
+++ b/docs/design/PRD.md
@@ -435,9 +435,10 @@ output/
     windows_events.xml         # Windows Event Logs
     zeek_conn.log              # Zeek connection logs
     ecar.json                  # ECAR events
-    syslog.log                 # Linux syslogs
+    <linux-host>/<year>/syslog.log        # Linux syslogs
     bash_history.log           # Bash history entries
     snort_alerts.log           # Snort/Suricata alerts
+    <firewall>/<year>/cisco_asa.log       # Cisco ASA firewall syslogs
     web_access.log             # Web/proxy logs
 ```
 

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -16,6 +16,7 @@ output/
   <hostname.domain>/                       # Per-host directories (FQDN)
     windows_event_security.xml             # Windows Security channel events
     windows_event_sysmon.xml               # Sysmon operational channel events
+    <year>/syslog.log                      # Linux syslog (RFC3164; Linux only)
     bash_history/<username>.bash_history    # Per-user bash history (Linux only)
   <sensor-name>/                           # Per-sensor directories (network)
     conn.json                              # Zeek conn.log (NDJSON)
@@ -25,10 +26,9 @@ output/
     files.json                             # Zeek files.log
     ...                                    # Other Zeek logs
   ecar.json                                # eCAR EDR/XDR telemetry (NDJSON)
-  syslog.log                               # Linux syslog (RFC 5424)
   snort_alert.log                          # Snort/Suricata IDS alerts
   <fw-hostname>/                           # Per-firewall directories
-    cisco_asa.log                          # Cisco ASA firewall syslog
+    <year>/cisco_asa.log                   # Cisco ASA firewall syslog
   web_access.log                           # Apache/Nginx access log
   <proxy-hostname.domain>/                 # Per-proxy-host directories
     proxy_access.log                       # HTTP forward proxy access log (W3C Extended)
@@ -173,10 +173,10 @@ EDR/XDR telemetry rendered in MITRE CAR-based eCAR format. Represents what an ED
 
 ## Linux Syslog
 
-**File:** `syslog.log`
-**Format:** RFC 5424 syslog
+**File:** `<hostname.domain>/<year>/syslog.log`
+**Format:** RFC3164/BSD syslog with PRI
 
-Authentication and system logs from Linux hosts. Generated syslog uses RFC 5424 with year-bearing ISO/RFC3339 timestamps. `eforge eval` still accepts older BSD/RFC3164-style syslog as a legacy ingest fallback. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows reuse the same source port as the companion Zeek SSH connection tuple.
+Authentication and system logs from Linux hosts. Generated syslog uses a BSD/RFC3164-style envelope (`<PRI>MMM DD HH:MM:SS HOST APP[PID]: MESSAGE`) and partitions files by event year so yearless syslog timestamps remain unambiguous. `eforge eval` still accepts older RFC5424 and flat BSD/RFC3164 syslog as legacy ingest fallbacks. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows reuse the same source port as the companion Zeek SSH connection tuple.
 
 | Program | Description | Notes |
 |---------|-------------|-------|
@@ -232,7 +232,7 @@ Alert format: `[gid:sid:rev]` where `gid` defaults to 1, `sid` identifies the ru
 
 ## Cisco ASA Firewall Syslog
 
-**File:** `<fw-hostname>/cisco_asa.log`
+**File:** `<fw-hostname>/<year>/cisco_asa.log`
 **Format:** Cisco ASA syslog (RFC 3164 BSD syslog with ASA message IDs)
 
 Cisco ASA firewall logs for permitted and denied connections. Produced by firewall-type network sensors with `cisco_asa` in their `log_formats`. Each permitted connection generates a Built + Teardown pair; denied connections generate a single Deny record.

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -16,6 +16,8 @@ output/
   <hostname.domain>/                       # Per-host directories (FQDN)
     windows_event_security.xml             # Windows Security channel events
     windows_event_sysmon.xml               # Sysmon operational channel events
+    <year>/windows_event_security_snare.log # Windows Security Snare/RFC3164 sidecar
+    <year>/windows_event_sysmon_snare.log   # Sysmon Snare/RFC3164 sidecar
     <year>/syslog.log                      # Linux syslog (RFC3164; Linux only)
     bash_history/<username>.bash_history    # Per-user bash history (Linux only)
   <sensor-name>/                           # Per-sensor directories (network)
@@ -42,6 +44,12 @@ output/
 **Format:** XML (`<Events><Event>...</Event></Events>`)
 **Provider:** Microsoft-Windows-Security-Auditing (except 1102)
 **Channel:** Security
+
+**Parser-validation sidecar:** `<hostname.domain>/<year>/windows_event_security_snare.log`
+uses Snare-style Windows Event Log fields inside an RFC3164 syslog envelope.
+The XML file remains the canonical EvidenceForge Windows Security output while
+the Snare sidecar provides a standards-shaped path for third-party parser
+validation.
 
 | Event ID | Name | Category | Notes |
 |----------|------|----------|-------|
@@ -93,6 +101,11 @@ output/
 **Format:** XML (`<Events><Event>...</Event></Events>`)
 **Provider:** Microsoft-Windows-Sysmon
 **Channel:** Microsoft-Windows-Sysmon/Operational
+
+**Parser-validation sidecar:** `<hostname.domain>/<year>/windows_event_sysmon_snare.log`
+uses the same Snare-over-RFC3164 family as Windows Security. This sidecar is
+generated in parallel with XML so SOF-ELK and other syslog/Snare-aware tools can
+validate the events without requiring binary EVTX files.
 
 | Event ID | Name | Category | Notes |
 |----------|------|----------|-------|

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -8,18 +8,24 @@ This document lists every evidence type EvidenceForge can generate, where to fin
 
 ## Output Directory Structure
 
+One generation run emits one output target. The tree below shows both default
+and SOF-ELK target-specific files where they differ; they are not emitted
+together.
+
 ```
 output/
   GROUND_TRUTH.md                          # Ground truth sidecar; empty for baseline-only runs
   OBSERVATION_MANIFEST.json                # Source-observation sidecar for eval
+  OUTPUT_TARGET.txt                        # "default" or "sof-elk"; missing legacy marker means default
   ENVIRONMENT.md                           # Student-facing environment description (created by /eforge scenario skill)
   <hostname.domain>/                       # Per-host directories (FQDN)
     windows_event_security.xml             # Windows Security channel events
     windows_event_sysmon.xml               # Sysmon operational channel events
-    <year>/windows_event_security_snare.log # Windows Security Snare/RFC3164 sidecar
-    <year>/windows_event_sysmon_snare.log   # Sysmon Snare/RFC3164 sidecar
-    <year>/syslog.log                      # Linux syslog (RFC3164; Linux only)
+    syslog.log                             # Linux syslog (default target; RFC5424)
     bash_history/<username>.bash_history    # Per-user bash history (Linux only)
+    <year>/windows_event_security_snare.log # Windows Security Snare/RFC3164 (sof-elk target)
+    <year>/windows_event_sysmon_snare.log   # Sysmon Snare/RFC3164 (sof-elk target)
+    <year>/syslog.log                      # Linux syslog (sof-elk target; RFC3164)
   <sensor-name>/                           # Per-sensor directories (network)
     conn.json                              # Zeek conn.log (NDJSON)
     dns.json                               # Zeek dns.log
@@ -30,26 +36,46 @@ output/
   ecar.json                                # eCAR EDR/XDR telemetry (NDJSON)
   snort_alert.log                          # Snort/Suricata IDS alerts
   <fw-hostname>/                           # Per-firewall directories
-    <year>/cisco_asa.log                   # Cisco ASA firewall syslog
+    cisco_asa.log                          # Cisco ASA firewall syslog (default target)
+    <year>/cisco_asa.log                   # Cisco ASA firewall syslog (sof-elk target)
   web_access.log                           # Apache/Nginx access log
   <proxy-hostname.domain>/                 # Per-proxy-host directories
     proxy_access.log                       # HTTP forward proxy access log (W3C Extended)
 ```
 
+## Output Targets
+
+`eforge generate --target default|sof-elk` selects the on-disk rendering and
+layout for tools that expect different formats. Scenario YAML and `--formats`
+remain canonical: request `windows_event_security`, `windows_event_sysmon`,
+`syslog`, `cisco_asa`, and so on, then choose the target at generation time.
+When `OUTPUT_TARGET.txt` is missing, `eforge eval` treats the dataset as
+legacy/default output.
+
+Target-specific behavior in V1:
+
+| Canonical format | `default` target | `sof-elk` target |
+| --- | --- | --- |
+| `windows_event_security` | `<host>/windows_event_security.xml` | `<host>/<year>/windows_event_security_snare.log` |
+| `windows_event_sysmon` | `<host>/windows_event_sysmon.xml` | `<host>/<year>/windows_event_sysmon_snare.log` |
+| `syslog` | `<host>/syslog.log` as RFC5424 | `<host>/<year>/syslog.log` as RFC3164/BSD |
+| `cisco_asa` | `<firewall>/cisco_asa.log` | `<firewall>/<year>/cisco_asa.log` |
+| Zeek, proxy, web access, IDS, eCAR, bash history | Unchanged | Unchanged |
+
 ---
 
 ## Windows Security Events
 
-**File:** `<hostname.domain>/windows_event_security.xml`
-**Format:** XML (`<Events><Event>...</Event></Events>`)
+**Default target file:** `<hostname.domain>/windows_event_security.xml`
+**Default target format:** XML (`<Events><Event>...</Event></Events>`)
+**SOF-ELK target file:** `<hostname.domain>/<year>/windows_event_security_snare.log`
+**SOF-ELK target format:** Snare-style Windows Event Log fields inside an RFC3164 syslog envelope
 **Provider:** Microsoft-Windows-Security-Auditing (except 1102)
 **Channel:** Security
 
-**Parser-validation sidecar:** `<hostname.domain>/<year>/windows_event_security_snare.log`
-uses Snare-style Windows Event Log fields inside an RFC3164 syslog envelope.
-The XML file remains the canonical EvidenceForge Windows Security output while
-the Snare sidecar provides a standards-shaped path for third-party parser
-validation.
+The `default` target emits XML only. The `sof-elk` target emits Snare syslog
+only so SOF-ELK and other syslog/Snare-aware tools can parse the same canonical
+Windows Security events without requiring binary EVTX files.
 
 | Event ID | Name | Category | Notes |
 |----------|------|----------|-------|
@@ -97,15 +123,16 @@ validation.
 
 ## Windows Sysmon Events
 
-**File:** `<hostname.domain>/windows_event_sysmon.xml`
-**Format:** XML (`<Events><Event>...</Event></Events>`)
+**Default target file:** `<hostname.domain>/windows_event_sysmon.xml`
+**Default target format:** XML (`<Events><Event>...</Event></Events>`)
+**SOF-ELK target file:** `<hostname.domain>/<year>/windows_event_sysmon_snare.log`
+**SOF-ELK target format:** Snare-style Windows Event Log fields inside an RFC3164 syslog envelope
 **Provider:** Microsoft-Windows-Sysmon
 **Channel:** Microsoft-Windows-Sysmon/Operational
 
-**Parser-validation sidecar:** `<hostname.domain>/<year>/windows_event_sysmon_snare.log`
-uses the same Snare-over-RFC3164 family as Windows Security. This sidecar is
-generated in parallel with XML so SOF-ELK and other syslog/Snare-aware tools can
-validate the events without requiring binary EVTX files.
+The `default` target emits XML only. The `sof-elk` target emits Snare syslog
+only and `eforge eval` maps both variants back to the canonical
+`windows_event_sysmon` format bucket.
 
 | Event ID | Name | Category | Notes |
 |----------|------|----------|-------|
@@ -186,10 +213,22 @@ EDR/XDR telemetry rendered in MITRE CAR-based eCAR format. Represents what an ED
 
 ## Linux Syslog
 
-**File:** `<hostname.domain>/<year>/syslog.log`
-**Format:** RFC3164/BSD syslog with PRI
+**Default target file:** `<hostname.domain>/syslog.log`
+**Default target format:** RFC5424 syslog with full timestamp year
+**SOF-ELK target file:** `<hostname.domain>/<year>/syslog.log`
+**SOF-ELK target format:** RFC3164/BSD syslog with PRI
 
-Authentication and system logs from Linux hosts. Generated syslog uses a BSD/RFC3164-style envelope (`<PRI>MMM DD HH:MM:SS HOST APP[PID]: MESSAGE`) and partitions files by event year so yearless syslog timestamps remain unambiguous. `eforge eval` still accepts older RFC5424 and flat BSD/RFC3164 syslog as legacy ingest fallbacks. All generated syslog entries are rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive messages from other contexts. This enables correlated dispatch: a logon event carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows reuse the same source port as the companion Zeek SSH connection tuple.
+Authentication and system logs from Linux hosts. The `default` target emits
+flat per-host RFC5424 syslog for SIEM-neutral output. The `sof-elk` target emits
+a BSD/RFC3164 envelope (`<PRI>MMM DD HH:MM:SS HOST APP[PID]: MESSAGE`) and
+partitions files by event year so SOF-ELK can recover the timestamp year from
+the archive path. `eforge eval` accepts both current target variants plus older
+legacy RFC5424 and flat BSD/RFC3164 files. All generated syslog entries are
+rendered from `SyslogContext` on `SecurityEvent` — the emitter doesn't derive
+messages from other contexts. This enables correlated dispatch: a logon event
+carries both `AuthContext` (for Windows 4624) and `SyslogContext` (for sshd
+accepted) on the same SecurityEvent. Remote Linux `sshd` failed-password rows
+reuse the same source port as the companion Zeek SSH connection tuple.
 
 | Program | Description | Notes |
 |---------|-------------|-------|
@@ -245,7 +284,8 @@ Alert format: `[gid:sid:rev]` where `gid` defaults to 1, `sid` identifies the ru
 
 ## Cisco ASA Firewall Syslog
 
-**File:** `<fw-hostname>/<year>/cisco_asa.log`
+**Default target file:** `<fw-hostname>/cisco_asa.log`
+**SOF-ELK target file:** `<fw-hostname>/<year>/cisco_asa.log`
 **Format:** Cisco ASA syslog (RFC 3164 BSD syslog with ASA message IDs)
 
 Cisco ASA firewall logs for permitted and denied connections. Produced by firewall-type network sensors with `cisco_asa` in their `log_formats`. Each permitted connection generates a Built + Teardown pair; denied connections generate a single Deny record.

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -958,6 +958,11 @@ output:
 
 Supported formats: `windows`, `zeek`, `ecar`, `syslog`, `bash_history`, `snort_alert`, `cisco_asa`, `web_access`, `proxy_access`.
 
+Output formats here are canonical and target-neutral. Choose target-specific
+file shapes, such as SOF-ELK Snare Windows events or year-partitioned RFC3164
+syslog, with `eforge generate --target default|sof-elk`; do not encode a parser
+target in scenario YAML.
+
 `proxy_access` requires at least one system with `roles: [forward_proxy]`. If it is requested without a forward proxy system, validation warns because no proxy access log file will be generated. When proxy logs are requested, add `environment.proxy.mode` to make transparent vs explicit proxy semantics clear. Current proxy behavior assumes TLS interception, so HTTPS can include CONNECT plus inspected request rows; non-intercepting tunnel-only proxy behavior is deferred.
 
 #### Format Filtering

--- a/src/evidenceforge/cli/commands.py
+++ b/src/evidenceforge/cli/commands.py
@@ -50,6 +50,11 @@ from rich.progress import (
 from evidenceforge import __version__
 from evidenceforge.generation import GenerationEngine
 from evidenceforge.models.scenario import Scenario
+from evidenceforge.output_targets import (
+    OUTPUT_TARGET_FILENAME,
+    normalize_output_target,
+    write_output_target_marker,
+)
 from evidenceforge.utils import load_yaml
 
 
@@ -162,6 +167,11 @@ def generate(
         "Only generates formats present in both this list and the scenario. "
         "Supports group names (zeek, windows). See 'eforge info format_groups'.",
     ),
+    target: str = typer.Option(
+        "default",
+        "--target",
+        help="Output rendering target: default or sof-elk",
+    ),
 ) -> None:
     """Generate synthetic security logs from a scenario file.
 
@@ -177,9 +187,15 @@ def generate(
     """
     setup_logging(verbose, debug)
     logger = logging.getLogger(__name__)
+    try:
+        output_target = normalize_output_target(target)
+    except ValueError as exc:
+        console.print(f"[bold red]Error:[/bold red] {exc}", style="red")
+        raise typer.Exit(EXIT_INPUT_ERROR) from exc
 
     console.print("[bold blue]EvidenceForge Log Generator[/bold blue]")
     console.print(f"Scenario: {scenario_file}")
+    console.print(f"Output target: {output_target.value}")
 
     # Load and validate scenario
     try:
@@ -310,6 +326,9 @@ def generate(
         existing.append(f"  GROUND_TRUTH.md ({gt_path})")
     if _path_exists_or_symlink(manifest_path):
         existing.append(f"  {OBSERVATION_MANIFEST_FILENAME} ({manifest_path})")
+    target_path = ground_truth_dir / OUTPUT_TARGET_FILENAME
+    if _path_exists_or_symlink(target_path):
+        existing.append(f"  {OUTPUT_TARGET_FILENAME} ({target_path})")
 
     has_existing = bool(existing)
     if has_existing:
@@ -403,8 +422,10 @@ def generate(
                 output_dir=gen_data_dir,
                 progress_callback=progress_callback,
                 ground_truth_dir=gen_gt_dir,
+                output_target=output_target,
             )
             engine.generate()
+            write_output_target_marker(gen_gt_dir, output_target)
 
         # Transactional swap: backup old → install new → cleanup backup.
         # If any step fails (including KeyboardInterrupt), old output is
@@ -413,6 +434,7 @@ def generate(
         if staging_dir:
             staged_gt = gen_gt_dir / "GROUND_TRUTH.md"
             staged_manifest = gen_gt_dir / OBSERVATION_MANIFEST_FILENAME
+            staged_target = gen_gt_dir / OUTPUT_TARGET_FILENAME
             if not gen_data_dir.exists():
                 raise RuntimeError("Staged data/ directory missing after generation")
             if not staged_gt.exists():
@@ -421,6 +443,8 @@ def generate(
                 raise RuntimeError(
                     f"Staged {OBSERVATION_MANIFEST_FILENAME} missing after generation"
                 )
+            if not staged_target.exists():
+                raise RuntimeError(f"Staged {OUTPUT_TARGET_FILENAME} missing after generation")
 
             # Clean up stale rollback dirs from prior killed runs
             for stale in ground_truth_dir.glob(".eforge_rollback_*"):
@@ -437,12 +461,16 @@ def generate(
                     gt_path.rename(rollback_dir / "GROUND_TRUTH.md")
                 if manifest_path.exists():
                     manifest_path.rename(rollback_dir / OBSERVATION_MANIFEST_FILENAME)
+                if _path_exists_or_symlink(target_path):
+                    target_path.rename(rollback_dir / OUTPUT_TARGET_FILENAME)
 
                 # Step 2: Install new output
                 gen_data_dir.rename(data_dir)
                 staged_gt.rename(gt_path)
                 if staged_manifest.exists():
                     staged_manifest.rename(manifest_path)
+                if staged_target.exists():
+                    staged_target.rename(target_path)
                 swap_succeeded = True
 
             except BaseException:
@@ -454,6 +482,8 @@ def generate(
                         gt_path.unlink()
                     if manifest_path.exists():
                         manifest_path.unlink()
+                    if _path_exists_or_symlink(target_path):
+                        target_path.unlink()
                     if (rollback_dir / "data").exists():
                         (rollback_dir / "data").rename(data_dir)
                     if (rollback_dir / "GROUND_TRUTH.md").exists():
@@ -461,6 +491,9 @@ def generate(
                     rollback_manifest = rollback_dir / OBSERVATION_MANIFEST_FILENAME
                     if rollback_manifest.exists():
                         rollback_manifest.rename(manifest_path)
+                    rollback_target = rollback_dir / OUTPUT_TARGET_FILENAME
+                    if rollback_target.exists():
+                        rollback_target.rename(target_path)
                 except Exception:
                     logger.error("Rollback failed — old output may be in: %s", rollback_dir)
                 raise
@@ -481,6 +514,7 @@ def generate(
                 if file.is_file() and file.name in {
                     "GROUND_TRUTH.md",
                     OBSERVATION_MANIFEST_FILENAME,
+                    OUTPUT_TARGET_FILENAME,
                 }:
                     size = file.stat().st_size
                     size_str = f"{size:,} bytes" if size < 1024 else f"{size / 1024:.1f} KB"

--- a/src/evidenceforge/config/formats/syslog.yaml
+++ b/src/evidenceforge/config/formats/syslog.yaml
@@ -54,7 +54,7 @@ fields:
   - name: version
     type: integer
     required: false
-    description: "Legacy RFC 5424 protocol version field. EvidenceForge now emits RFC3164."
+    description: "RFC 5424 protocol version field used by the default output target."
     constraints:
       allowed_values: [1]
 
@@ -71,19 +71,19 @@ fields:
   - name: msgid
     type: string
     required: false
-    description: "Legacy RFC 5424 MSGID token. EvidenceForge currently emits RFC3164."
+    description: "RFC 5424 MSGID token used by the default output target."
 
   - name: structured_data
     type: string
     required: false
-    description: "Legacy RFC 5424 structured-data field. EvidenceForge currently emits RFC3164."
+    description: "RFC 5424 structured-data field used by the default output target."
 
   - name: syslog_protocol
     type: string
     required: false
-    description: "Parser metadata identifying generated RFC3164 output or legacy RFC5424 input."
+    description: "Parser metadata identifying generated or legacy syslog protocol variants."
     constraints:
-      allowed_values: [rfc3164, rfc5424_legacy, rfc3164_legacy, iso_legacy]
+      allowed_values: [rfc5424, rfc3164, rfc5424_legacy, rfc3164_legacy, iso_legacy]
 
   - name: message
     type: string
@@ -95,4 +95,4 @@ output:
   file_extension: ".log"
   encoding: utf-8
   template: |
-    <{{ pri }}>{{ timestamp.strftime('%b') }} {{ "%2d"|format(timestamp.day) }} {{ timestamp.strftime('%H:%M:%S') }} {{ hostname }} {{ app_name }}{% if pid %}[{{ pid }}]{% endif %}: {{ message }}
+    <{{ pri }}>1 {{ timestamp.isoformat().replace('+00:00', 'Z') }} {{ hostname }} {{ app_name }} {{ pid | default('-', true) }} {{ msgid | default('-', true) }} {{ structured_data | default('-', true) }} {{ message }}

--- a/src/evidenceforge/config/formats/syslog.yaml
+++ b/src/evidenceforge/config/formats/syslog.yaml
@@ -25,7 +25,7 @@ fields:
   - name: facility
     type: integer
     required: false
-    description: "Syslog facility (1=user, 4=auth, 3=daemon, 10=authpriv). Rendered into RFC 5424 PRI."
+    description: "Syslog facility (1=user, 4=auth, 3=daemon, 10=authpriv). Rendered into PRI."
     constraints:
       min_value: 0
       max_value: 23
@@ -33,7 +33,7 @@ fields:
   - name: severity
     type: integer
     required: false
-    description: "Syslog severity (6=info, 5=notice, 4=warning). Rendered into RFC 5424 PRI."
+    description: "Syslog severity (6=info, 5=notice, 4=warning). Rendered into PRI."
     constraints:
       min_value: 0
       max_value: 7
@@ -46,7 +46,7 @@ fields:
   - name: pri
     type: integer
     required: false
-    description: "RFC 5424 PRI value derived from facility * 8 + severity"
+    description: "Syslog PRI value derived from facility * 8 + severity"
     constraints:
       min_value: 0
       max_value: 191
@@ -54,7 +54,7 @@ fields:
   - name: version
     type: integer
     required: false
-    description: "RFC 5424 protocol version. EvidenceForge emits version 1."
+    description: "Legacy RFC 5424 protocol version field. EvidenceForge now emits RFC3164."
     constraints:
       allowed_values: [1]
 
@@ -66,24 +66,24 @@ fields:
   - name: procid
     type: string
     required: false
-    description: "RFC 5424 PROCID token, usually the process ID or '-'"
+    description: "Legacy RFC 5424 PROCID token, usually the process ID or '-'"
 
   - name: msgid
     type: string
     required: false
-    description: "RFC 5424 MSGID token. EvidenceForge currently emits '-'."
+    description: "Legacy RFC 5424 MSGID token. EvidenceForge currently emits RFC3164."
 
   - name: structured_data
     type: string
     required: false
-    description: "RFC 5424 structured-data field. EvidenceForge currently emits '-'."
+    description: "Legacy RFC 5424 structured-data field. EvidenceForge currently emits RFC3164."
 
   - name: syslog_protocol
     type: string
     required: false
-    description: "Parser metadata identifying RFC 5424 output or legacy RFC 3164/BSD eval input."
+    description: "Parser metadata identifying generated RFC3164 output or legacy RFC5424 input."
     constraints:
-      allowed_values: [rfc5424, rfc3164_legacy, iso_legacy]
+      allowed_values: [rfc3164, rfc5424_legacy, rfc3164_legacy, iso_legacy]
 
   - name: message
     type: string
@@ -95,4 +95,4 @@ output:
   file_extension: ".log"
   encoding: utf-8
   template: |
-    <{{ pri }}>1 {{ timestamp }} {{ hostname }} {{ app_name }} {{ procid }} {{ msgid }} {{ structured_data }} {{ message }}
+    <{{ pri }}>{{ timestamp.strftime('%b') }} {{ "%2d"|format(timestamp.day) }} {{ timestamp.strftime('%H:%M:%S') }} {{ hostname }} {{ app_name }}{% if pid %}[{{ pid }}]{% endif %}: {{ message }}

--- a/src/evidenceforge/evaluation/engine.py
+++ b/src/evidenceforge/evaluation/engine.py
@@ -47,6 +47,7 @@ from evidenceforge.evaluation.pillars import (
 from evidenceforge.evaluation.thresholds import EvalThresholds, load_thresholds
 from evidenceforge.events.observation_manifest import load_observation_manifest
 from evidenceforge.models.scenario import Scenario
+from evidenceforge.output_targets import read_output_target_marker
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,7 @@ class EvaluationEngine:
         self.verbose = verbose
         self._progress = progress_callback
         self._thresholds = load_thresholds()
+        self.output_target = read_output_target_marker(output_dir)
 
     def run(self) -> QualityReport:
         """Execute the full evaluation pipeline."""
@@ -232,6 +234,7 @@ class EvaluationEngine:
 
         # 7. Merge pillar-level supplementary data into report supplementary
         supplementary: dict = {}
+        supplementary["output_target"] = self.output_target.value
         for pillar in pillars:
             supplementary.update(pillar.supplementary)
         if observation_manifest is not None:
@@ -266,7 +269,7 @@ class EvaluationEngine:
 
     def _parse_all_logs(self) -> tuple[dict[str, list[ParsedRecord]], dict[str, int]]:
         """Discover and parse all log files in the output directory."""
-        file_map = discover_log_files(self.output_dir)
+        file_map = discover_log_files(self.output_dir, output_target=self.output_target)
         records: dict[str, list[ParsedRecord]] = {}
         source_counts: dict[str, int] = {}
 
@@ -282,6 +285,7 @@ class EvaluationEngine:
             )
             parser = get_parser(format_name)
             parser.scenario = self.scenario
+            parser.output_target = self.output_target
             format_records: list[ParsedRecord] = []
             for path in paths:
                 logger.info(f"Parsing {format_name}: {path.name}")

--- a/src/evidenceforge/evaluation/parsers/__init__.py
+++ b/src/evidenceforge/evaluation/parsers/__init__.py
@@ -56,6 +56,7 @@ class LogParser(ABC):
     # Optional: set by the evaluation engine before parse_file is called so
     # parsers that need scenario metadata (e.g. time_window year) can read it.
     scenario: Any = None
+    output_target: Any = None
 
     @abstractmethod
     def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
@@ -99,7 +100,7 @@ def _is_safe_path(path: Path, root: Path) -> bool:
     return True
 
 
-def discover_log_files(output_dir: Path) -> dict[str, list[Path]]:
+def discover_log_files(output_dir: Path, output_target: Any = None) -> dict[str, list[Path]]:
     """Discover log files in an output directory and map to format parsers.
 
     Scans both top-level files and per-sensor subdirectories (e.g., zeek-fw01/).
@@ -155,6 +156,7 @@ def discover_log_files(output_dir: Path) -> dict[str, list[Path]]:
         if format_name == "bash_history":
             continue  # Already handled above
         parser = parser_cls()
+        parser.output_target = output_target
         for candidate in candidates:
             if parser.can_parse(candidate):
                 result.setdefault(format_name, []).append(candidate)
@@ -170,7 +172,10 @@ from evidenceforge.evaluation.parsers.proxy import ProxyAccessParser  # noqa: E4
 from evidenceforge.evaluation.parsers.snort import SnortAlertParser  # noqa: E402,F401
 from evidenceforge.evaluation.parsers.syslog import SyslogParser  # noqa: E402,F401
 from evidenceforge.evaluation.parsers.web import WebAccessParser  # noqa: E402,F401
-from evidenceforge.evaluation.parsers.windows import WindowsEventParser  # noqa: E402,F401
+from evidenceforge.evaluation.parsers.windows import (  # noqa: E402
+    SysmonEventParser,  # noqa: F401
+    WindowsEventParser,  # noqa: F401
+)
 from evidenceforge.evaluation.parsers.zeek import ZeekConnParser  # noqa: E402,F401
 from evidenceforge.evaluation.parsers.zeek_dhcp import ZeekDhcpParser  # noqa: E402,F401
 from evidenceforge.evaluation.parsers.zeek_dns import ZeekDnsParser  # noqa: E402,F401

--- a/src/evidenceforge/evaluation/parsers/cisco_asa.py
+++ b/src/evidenceforge/evaluation/parsers/cisco_asa.py
@@ -24,7 +24,7 @@
 
 import re
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from . import LogParser, ParsedRecord, register_parser
@@ -109,14 +109,15 @@ class CiscoAsaParser(LogParser):
         return path.name == "cisco_asa.log"
 
     def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
+        seed_year = _infer_seed_year(path, self.scenario)
         with path.open(encoding="utf-8") as f:
             for line_num, line in enumerate(f, 1):
                 line = line.rstrip("\n")
                 if not line:
                     continue
-                yield self._parse_line(line, line_num)
+                yield self._parse_line(line, line_num, seed_year)
 
-    def _parse_line(self, raw: str, line_num: int) -> ParsedRecord:
+    def _parse_line(self, raw: str, line_num: int, seed_year: int) -> ParsedRecord:
         fields: dict = {}
         errors: list[str] = []
         timestamp = None
@@ -135,9 +136,9 @@ class CiscoAsaParser(LogParser):
 
         pri_str, ts_str, hostname, severity_str, msg_id_str, message = header.groups()
 
-        # Parse timestamp (no year — use current year, same as syslog/snort)
+        # Parse timestamp (no year — generated output stores the year in the parent dir).
         try:
-            ts_with_year = f"{datetime.now().year} {ts_str}"
+            ts_with_year = f"{seed_year} {ts_str}"
             timestamp = datetime.strptime(ts_with_year, "%Y %b %d %H:%M:%S")
         except ValueError:
             errors.append(f"Invalid timestamp: {ts_str}")
@@ -252,3 +253,24 @@ class CiscoAsaParser(LogParser):
                 fields["avg_rate"] = int(match.group(5))
                 fields["avg_max"] = int(match.group(6))
                 fields["cumulative_count"] = int(match.group(7))
+
+
+def _infer_seed_year(path: Path, scenario: object | None) -> int:
+    parent_year = _path_year(path)
+    if parent_year is not None:
+        return parent_year
+    time_window = getattr(scenario, "time_window", None)
+    start = getattr(time_window, "start", None)
+    if isinstance(start, datetime):
+        return start.year
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).year
+    except OSError:
+        return datetime.now(UTC).year
+
+
+def _path_year(path: Path) -> int | None:
+    parent = path.parent.name
+    if len(parent) == 4 and parent.isdigit():
+        return int(parent)
+    return None

--- a/src/evidenceforge/evaluation/parsers/syslog.py
+++ b/src/evidenceforge/evaluation/parsers/syslog.py
@@ -27,6 +27,8 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
+from evidenceforge.output_targets import OutputTarget
+
 from . import LogParser, ParsedRecord, register_parser
 
 RFC5424_PATTERN = re.compile(
@@ -186,7 +188,9 @@ class SyslogParser(LogParser):
             fields["message"] = groups["message"] or ""
             fields["facility"] = pri // 8
             fields["severity"] = pri % 8
-            fields["syslog_protocol"] = "rfc5424_legacy"
+            fields["syslog_protocol"] = (
+                "rfc5424" if self.output_target == OutputTarget.DEFAULT else "rfc5424_legacy"
+            )
             pid_str = groups["procid"]
         else:
             match = LEGACY_ISO_SYSLOG_PATTERN.match(raw)

--- a/src/evidenceforge/evaluation/parsers/syslog.py
+++ b/src/evidenceforge/evaluation/parsers/syslog.py
@@ -20,7 +20,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Parser for generated RFC 5424 syslog plus legacy BSD eval input."""
+"""Parser for generated RFC3164 syslog plus legacy syslog eval input."""
 
 import re
 from collections.abc import Iterator
@@ -40,10 +40,10 @@ RFC5424_PATTERN = re.compile(
     r"(?:\s(?P<message>.*))?$"
 )
 
-# Legacy BSD/RFC3164 syslog format: "Mon DD HH:MM:SS hostname app[pid]: message".
-# Kept only so `eforge eval` can ingest older generated datasets.
-LEGACY_BSD_SYSLOG_PATTERN = re.compile(
-    r"^(\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2})\s+"  # timestamp (BSD)
+# BSD/RFC3164 syslog format: "Mon DD HH:MM:SS hostname app[pid]: message".
+RFC3164_SYSLOG_PATTERN = re.compile(
+    r"^(?:<(?P<pri>\d{1,3})>)?"
+    r"(?P<timestamp>\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2})\s+"  # timestamp (BSD)
     r"(\S+)\s+"  # hostname
     r"(\S+?)(?:\[([^\]]*)\])?:\s+"  # app_name[pid]: or app_name:
     r"(.*)$"  # message
@@ -62,14 +62,24 @@ LEGACY_ISO_SYSLOG_PATTERN = re.compile(
 _WRAP_THRESHOLD_SECONDS = 180 * 24 * 3600  # ~6 months
 
 
+def _path_year(path: Path) -> int | None:
+    """Return the immediate parent year from a year-partitioned syslog path."""
+    if re.fullmatch(r"\d{4}", path.parent.name):
+        return int(path.parent.name)
+    return None
+
+
 def _infer_seed_year(path: Path, scenario: object | None = None) -> int:
     """Return the best-guess year for BSD syslog records in *path*.
 
     Preference order:
-    1. scenario.time_window.start year — the canonical date the scenario targets.
-    2. File modification time — fallback for use outside the evaluation engine.
-    3. Current year — last resort.
+    1. Parent YYYY directory — generated syslog-family layout.
+    2. scenario.time_window.start year — fallback for old flat datasets.
+    3. File modification time — fallback for use outside the evaluation engine.
+    4. Current year — last resort.
     """
+    if (year := _path_year(path)) is not None:
+        return year
     if scenario is not None:
         try:
             tw = getattr(scenario, "time_window", None)
@@ -123,6 +133,7 @@ class SyslogParser(LogParser):
 
     def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
         seed_year = _infer_seed_year(path, getattr(self, "scenario", None))
+        generated_rfc3164 = _path_year(path) is not None
         last_ts: datetime | None = None
 
         with path.open(encoding="utf-8") as f:
@@ -130,7 +141,13 @@ class SyslogParser(LogParser):
                 line = line.rstrip("\n")
                 if not line:
                     continue
-                record = self._parse_line(line, line_num, seed_year=seed_year, last_ts=last_ts)
+                record = self._parse_line(
+                    line,
+                    line_num,
+                    seed_year=seed_year,
+                    last_ts=last_ts,
+                    generated_rfc3164=generated_rfc3164,
+                )
                 if record.timestamp is not None:
                     last_ts = record.timestamp
                 yield record
@@ -141,6 +158,7 @@ class SyslogParser(LogParser):
         line_num: int,
         seed_year: int | None = None,
         last_ts: datetime | None = None,
+        generated_rfc3164: bool = False,
     ) -> ParsedRecord:
         fields: dict = {}
         errors: list[str] = []
@@ -168,7 +186,7 @@ class SyslogParser(LogParser):
             fields["message"] = groups["message"] or ""
             fields["facility"] = pri // 8
             fields["severity"] = pri % 8
-            fields["syslog_protocol"] = "rfc5424"
+            fields["syslog_protocol"] = "rfc5424_legacy"
             pid_str = groups["procid"]
         else:
             match = LEGACY_ISO_SYSLOG_PATTERN.match(raw)
@@ -183,16 +201,23 @@ class SyslogParser(LogParser):
                 fields["message"] = message
                 fields["syslog_protocol"] = "iso_legacy"
             else:
-                match = LEGACY_BSD_SYSLOG_PATTERN.match(raw)
+                match = RFC3164_SYSLOG_PATTERN.match(raw)
                 if match:
-                    ts_str, hostname, app_name, pid_str, message = match.groups()
+                    groups = match.groupdict()
+                    ts_str = groups["timestamp"]
+                    hostname, app_name, pid_str, message = match.groups()[2:]
                     timestamp = _resolve_bsd_year(ts_str, seed_year, last_ts)
                     if timestamp is None:
                         errors.append(f"Invalid legacy BSD timestamp: {ts_str}")
+                    if groups.get("pri"):
+                        pri = int(groups["pri"])
+                        fields["pri"] = pri
+                        fields["facility"] = pri // 8
+                        fields["severity"] = pri % 8
                     fields["hostname"] = hostname
                     fields["app_name"] = app_name
                     fields["message"] = message
-                    fields["syslog_protocol"] = "rfc3164_legacy"
+                    fields["syslog_protocol"] = "rfc3164" if generated_rfc3164 else "rfc3164_legacy"
                 else:
                     errors.append("Line does not match RFC 5424 or legacy syslog format")
                     return ParsedRecord(

--- a/src/evidenceforge/evaluation/parsers/windows.py
+++ b/src/evidenceforge/evaluation/parsers/windows.py
@@ -25,10 +25,16 @@
 import re
 import xml.etree.ElementTree as ET
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
+from evidenceforge.generation.emitters.windows_snare import (
+    WINDOWS_SECURITY_SNARE_FILENAME,
+    WINDOWS_SYSMON_SNARE_FILENAME,
+)
+
 from . import LogParser, ParsedRecord, register_parser
+from .syslog import _infer_seed_year, _resolve_bsd_year
 
 # Namespace used in Windows Event XML
 NS = "http://schemas.microsoft.com/win/2004/08/events/event"
@@ -36,14 +42,22 @@ NS = "http://schemas.microsoft.com/win/2004/08/events/event"
 # Regex boundaries used for streaming extraction of individual <Event> blocks
 EVENT_START_PATTERN = re.compile(r"<Event(?:\s|>)")
 EVENT_END_PATTERN = re.compile(r"</Event>")
+SNARE_SYSLOG_PATTERN = re.compile(
+    r"^<(?P<pri>\d{1,3})>"
+    r"(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+"
+    r"(?P<hostname>\S+)\s+"
+    r"(?P<payload>.*)$"
+)
+EXPANDED_FIELD_PATTERN = re.compile(r"(?P<name>[^:]+):\s+(?P<value>.*?)(?=\s{2}[^:]+:\s+|\s*$)")
 
 
-@register_parser
-class WindowsEventParser(LogParser):
-    format_name = "windows_event_security"
+class _WindowsXmlParser(LogParser):
+    """Shared streaming parser for Windows Event XML files."""
+
+    xml_filename = ""
 
     def can_parse(self, path: Path) -> bool:
-        return path.name == "windows_event_security.xml"
+        return path.name == self.xml_filename
 
     def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
         event_index = 0
@@ -174,3 +188,164 @@ class WindowsEventParser(LogParser):
             parse_errors=errors,
             line_number=index,
         )
+
+
+class _WindowsSnareParser(_WindowsXmlParser):
+    """Shared parser for Snare-over-RFC3164 Windows event files."""
+
+    snare_filename = ""
+    xml_filename = ""
+
+    def can_parse(self, path: Path) -> bool:
+        return path.name in {self.xml_filename, self.snare_filename}
+
+    def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
+        if path.name == self.snare_filename:
+            yield from self._parse_snare_file(path)
+            return
+        yield from super().parse_file(path)
+
+    def _parse_snare_file(self, path: Path) -> Iterator[ParsedRecord]:
+        seed_year = _infer_seed_year(path, getattr(self, "scenario", None))
+        last_ts: datetime | None = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line_num, line in enumerate(handle, 1):
+                raw = line.rstrip("\n")
+                if not raw:
+                    continue
+                record = self._parse_snare_line(raw, line_num, seed_year, last_ts)
+                if record.timestamp is not None:
+                    last_ts = record.timestamp
+                yield record
+
+    def _parse_snare_line(
+        self,
+        raw: str,
+        line_num: int,
+        seed_year: int,
+        last_ts: datetime | None,
+    ) -> ParsedRecord:
+        fields: dict = {}
+        errors: list[str] = []
+        timestamp = None
+        source_host = None
+
+        match = SNARE_SYSLOG_PATTERN.match(raw)
+        if match is None:
+            errors.append("Line does not match Snare RFC3164 syslog format")
+            return ParsedRecord(
+                source_format=self.format_name,
+                raw=raw,
+                fields=fields,
+                timestamp=None,
+                parse_errors=errors,
+                line_number=line_num,
+            )
+
+        groups = match.groupdict()
+        source_host = groups["hostname"]
+        timestamp = _resolve_bsd_year(groups["timestamp"], seed_year, last_ts)
+        if timestamp is None:
+            errors.append(f"Invalid Snare syslog timestamp: {groups['timestamp']}")
+        else:
+            timestamp = timestamp.replace(tzinfo=UTC)
+
+        fields["pri"] = int(groups["pri"])
+        fields["Computer"] = source_host
+        fields["TimeCreated"] = timestamp.isoformat() if timestamp else groups["timestamp"]
+
+        columns = groups["payload"].split("\t")
+        if len(columns) < 14:
+            errors.append(f"Snare payload has {len(columns)} columns; expected at least 14")
+        else:
+            (
+                computer,
+                marker,
+                criticality,
+                channel,
+                event_record_id,
+                snare_time,
+                event_id,
+                provider,
+                username,
+                _sid,
+                logtype,
+                _computer_repeat,
+                category,
+                full_data,
+                *_extra,
+            ) = columns
+            if marker != "MSWinEventLog":
+                errors.append(f"Unexpected Snare marker: {marker}")
+            fields.update(
+                {
+                    "Computer": computer or source_host,
+                    "Channel": channel,
+                    "Provider": provider,
+                    "User": username,
+                    "LogType": logtype,
+                    "Category": category,
+                    "Message": full_data,
+                    "SnareTimeCreated": snare_time,
+                }
+            )
+            for key, value, converter in (
+                ("EventRecordID", event_record_id, int),
+                ("EventID", event_id, int),
+                ("Criticality", criticality, int),
+            ):
+                try:
+                    fields[key] = converter(value)
+                except ValueError:
+                    fields[key] = value
+                    errors.append(f"Invalid integer field {key}: {value}")
+            fields.update(_parse_expanded_snare_fields(full_data))
+
+        return ParsedRecord(
+            source_format=self.format_name,
+            raw=raw,
+            fields=fields,
+            timestamp=timestamp,
+            parse_errors=errors,
+            line_number=line_num,
+            source_host=source_host,
+        )
+
+
+def _parse_expanded_snare_fields(full_data: str) -> dict[str, str]:
+    """Extract Snare's flattened ``Name: value`` field suffix."""
+    parsed: dict[str, str] = {}
+    tail = full_data.split(":  ", 1)[1] if ":  " in full_data else full_data
+    for match in EXPANDED_FIELD_PATTERN.finditer(tail):
+        name = _snare_field_name(match.group("name").strip())
+        value = match.group("value").strip()
+        if name and value:
+            parsed[name] = value
+    return parsed
+
+
+def _snare_field_name(name: str) -> str:
+    """Return a stable eval-friendly field name for a Snare expanded label."""
+    if not name:
+        return ""
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        return name
+    return re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_")
+
+
+@register_parser
+class WindowsEventParser(_WindowsSnareParser):
+    """Parser for Windows Security XML or SOF-ELK Snare target files."""
+
+    format_name = "windows_event_security"
+    xml_filename = "windows_event_security.xml"
+    snare_filename = WINDOWS_SECURITY_SNARE_FILENAME
+
+
+@register_parser
+class SysmonEventParser(_WindowsSnareParser):
+    """Parser for Sysmon XML or SOF-ELK Snare target files."""
+
+    format_name = "windows_event_sysmon"
+    xml_filename = "windows_event_sysmon.xml"
+    snare_filename = WINDOWS_SYSMON_SNARE_FILENAME

--- a/src/evidenceforge/evaluation/pillars/parseability.py
+++ b/src/evidenceforge/evaluation/pillars/parseability.py
@@ -119,7 +119,7 @@ class ParseabilityScorer(DimensionScorer):
         """Spec conformance: parse errors + strict-mode validation failures.
 
         Counts records where the parser returned errors OR the strict validator
-        (RFC 5424 syslog with legacy fallback, Zeek typed columns, eCAR schema, Windows XML)
+        (RFC3164 syslog with legacy fallback, Zeek typed columns, eCAR schema, Windows XML)
         rejected
         the record. These failures indicate a downstream parser would reject the
         record entirely.

--- a/src/evidenceforge/formats/validator.py
+++ b/src/evidenceforge/formats/validator.py
@@ -249,6 +249,15 @@ def validate_field(field_def: FieldDefinition, field_value: Any) -> ValidationRe
 # Strict-mode validators — format-specific raw-content checks
 # ---------------------------------------------------------------------------
 
+# RFC3164 syslog header: <PRI>MMM DD HH:MM:SS HOSTNAME APP[PID]:
+_RFC3164_RE = re.compile(
+    r"^<(?P<pri>\d{1,3})>"
+    r"(?P<timestamp>[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+"
+    r"(?P<hostname>\S+)\s+"
+    r"(?P<app_name>\S+?)(?:\[[^\]]+\])?:\s+"
+    r".*$"
+)
+
 # RFC 5424 syslog header: <PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID STRUCTURED-DATA
 _RFC5424_RE = re.compile(
     r"^<(?P<pri>\d{1,3})>(?P<version>\d+)\s+"
@@ -344,11 +353,20 @@ def validate_strict(format_name: str, raw: str, fields: dict[str, Any]) -> Valid
 
 
 def _validate_strict_syslog(raw: str, fields: dict[str, Any], result: ValidationResult) -> None:
-    """Require RFC 5424 for generated syslog, allowing parser-marked legacy eval input."""
+    """Require RFC3164 for generated syslog, allowing parser-marked legacy eval input."""
     if not raw.strip():
         return
 
     protocol = fields.get("syslog_protocol")
+    if protocol in (None, "", "rfc3164"):
+        match = _RFC3164_RE.match(raw)
+        if match is None:
+            result.add_error("syslog", "Syslog line does not match BSD/RFC3164")
+            return
+        pri = int(match.group("pri"))
+        if pri > _RFC5424_PRIORITY_MAX:
+            result.add_error("syslog_pri", f"PRI {pri} exceeds maximum {_RFC5424_PRIORITY_MAX}")
+        return
     if protocol == "rfc3164_legacy":
         if not _LEGACY_BSD_SYSLOG_RE.match(raw):
             result.add_error("syslog", "Legacy syslog marker does not match BSD/RFC3164 input")
@@ -357,10 +375,13 @@ def _validate_strict_syslog(raw: str, fields: dict[str, Any], result: Validation
         if not _LEGACY_ISO_SYSLOG_RE.match(raw):
             result.add_error("syslog", "Legacy syslog marker does not match ISO-style input")
         return
+    if protocol != "rfc5424_legacy":
+        result.add_error("syslog", f"Unknown syslog protocol marker: {protocol}")
+        return
 
     match = _RFC5424_RE.match(raw)
     if match is None:
-        result.add_error("syslog", "Syslog line does not match RFC 5424")
+        result.add_error("syslog", "Legacy syslog marker does not match RFC 5424")
         return
 
     pri = int(match.group("pri"))

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -4683,7 +4683,8 @@ class ActivityGenerator:
                     severity=4,
                     message=(
                         "pam_unix(login:auth): authentication failure; "
-                        f"logname= uid=0 euid=0 tty=tty1 ruser= rhost= user={effective_username}"
+                        f"logname=LOGIN uid=0 euid=0 tty=/dev/tty1 ruser= rhost=  "
+                        f"user={effective_username}"
                     ),
                 )
 
@@ -5042,8 +5043,8 @@ class ActivityGenerator:
                 event.syslog = None
             else:
                 message = (
-                    f"Received disconnect from {session.source_ip} port {source_port}:11: "
-                    "disconnected by user"
+                    f"Received disconnect from {session.source_ip} port {source_port}:11:  "
+                    "[preauth]"
                 )
                 event.syslog = SyslogContext(
                     app_name="sshd",
@@ -8368,8 +8369,7 @@ class ActivityGenerator:
                     facility=10,
                     severity=6,
                     message=(
-                        f"Connection from {source_ip} port {src_port}"
-                        f' on {target_system.ip} port 22 rdomain ""'
+                        f"Connection from {source_ip} port {src_port} on {target_system.ip} port 22"
                     ),
                 ),
             )

--- a/src/evidenceforge/generation/emitters/base.py
+++ b/src/evidenceforge/generation/emitters/base.py
@@ -34,6 +34,7 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.formats.format_def import FormatDefinition
+from evidenceforge.output_targets import OutputTarget, normalize_output_target
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,7 @@ class LogEmitter(ABC):
         self.format_def = format_def
         self.output_path = output_path
         self.buffer_size = buffer_size
+        self.output_target = OutputTarget.DEFAULT
         self.buffer: list[str] = []
         self.event_count = 0
         # DESIGN DECISION: StrictUndefined intentionally removed (commit 5a4e7db).
@@ -101,6 +103,10 @@ class LogEmitter(ABC):
             self._thread = Thread(target=self._run, daemon=True, name=f"Emitter-{format_def.name}")
             self._thread.start()
             logger.debug(f"Started emitter thread for {format_def.name}")
+
+    def configure_output_target(self, target: str | OutputTarget | None) -> None:
+        """Configure the generated-output target for this emitter."""
+        self.output_target = normalize_output_target(target)
 
     @abstractmethod
     def emit_event(self, event_data: dict[str, Any]) -> None:

--- a/src/evidenceforge/generation/emitters/cisco_asa.py
+++ b/src/evidenceforge/generation/emitters/cisco_asa.py
@@ -26,7 +26,8 @@ Renders ASA-format syslog entries for connection events observed by firewall
 sensors. Produces Built/Teardown pairs for permitted connections and Deny
 records for blocked connections.
 
-Per-sensor directory routing: each firewall sensor gets its own cisco_asa.log.
+Per-sensor/year directory routing: each firewall sensor gets cisco_asa.log files
+partitioned by event year.
 """
 
 import hashlib
@@ -34,12 +35,22 @@ import ipaddress
 import math
 import re
 from collections import deque
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.formats.format_def import FormatDefinition
+from evidenceforge.generation.emitters.syslog_family import (
+    make_syslog_family_route_key,
+    render_rfc3164_syslog,
+    rfc3164_timestamp_sort_key,
+    sanitize_syslog_family_route_key,
+    syslog_family_writer_path,
+    syslog_route_source,
+    syslog_route_year,
+)
 from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
 
 # ASA facility: local4 (20)
@@ -49,23 +60,11 @@ _TCP_SUCCESS_TEARDOWN_REASONS = ("TCP FINs",)
 _TCP_PARTIAL_TEARDOWN_REASONS = ("Conn-timeout", "TCP Reset-O", "TCP Reset-I")
 
 
-def _asa_timestamp_sort_key(line: str) -> str:
-    """Extract timestamp from ASA syslog line for chronological sorting.
-
-    Format: <NNN>Mon DD HH:MM:SS hostname ...
-    Returns the timestamp portion so entries sort chronologically
-    regardless of message ID.
-    """
-    gt = line.find(">")
-    if gt >= 0:
-        return line[gt + 1 : gt + 16]
-    return line
-
-
 class CiscoAsaEmitter(SensorMultiplexEmitter):
     """Emitter for Cisco ASA firewall syslog format.
 
-    Per-sensor directory routing: each firewall sensor gets its own log file.
+    Per-sensor/year directory routing: each firewall sensor gets its own yearly
+    log file.
 
     Handles all connection events visible to firewall sensors. Unlike Snort
     (which requires IdsContext), the ASA emitter renders every connection it
@@ -76,7 +75,7 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
     _flat_filename = "cisco_asa.log"
     _supported_types: set[str] = {"connection"}
     _sort_before_flush = True
-    _sort_key_func = staticmethod(_asa_timestamp_sort_key)
+    _sort_key_func = staticmethod(rfc3164_timestamp_sort_key)
 
     def __init__(
         self,
@@ -109,6 +108,18 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         self._td_avg_window: int = 60  # seconds for average rate calculation
         self._td_cooldown: int = 20  # seconds between re-firings (= burst period)
 
+    def _safe_writer_key(self, sensor_hostname: str) -> str:
+        return sanitize_syslog_family_route_key(sensor_hostname)
+
+    def _writer_path_for_key(self, safe_writer_key: str) -> Path:
+        return syslog_family_writer_path(
+            base_dir=self._base_dir,
+            safe_route_key=safe_writer_key,
+            log_filename=self._log_filename,
+            direct_file_path=self._direct_file_path,
+            flat_filename=self._flat_filename,
+        )
+
     def _next_conn_id(self, sensor_hostname: str, ts: Any = None) -> int:
         """Get a deterministic temporary ASA connection ID."""
         seed = int(hashlib.md5(sensor_hostname.encode()).hexdigest()[:8], 16)
@@ -134,37 +145,92 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         """Rewrite rendered ASA connection IDs in visible chronological order."""
         with self._writers_lock:
             writers = list(self._writers.items())
-        for sensor_hostname, writer in writers:
-            self._normalize_connection_ids_in_file(writer.output_path, sensor_hostname)
+        by_sensor: dict[str, list[tuple[str, Any]]] = {}
+        for route_key, writer in writers:
+            by_sensor.setdefault(syslog_route_source(route_key), []).append((route_key, writer))
+        for sensor_hostname, route_writers in by_sensor.items():
+            mapping = self._connection_id_mapping(route_writers, sensor_hostname)
+            for _route_key, writer in route_writers:
+                self._apply_connection_id_mapping(writer.output_path, mapping)
 
     @staticmethod
     def _normalize_connection_ids_in_file(path: Path, sensor_hostname: str) -> None:
+        """Rewrite rendered ASA connection IDs in one file.
+
+        Kept for focused tests and direct-file usage. Normal generated output
+        uses _normalize_visible_connection_ids so year-partitioned files share
+        one connection-ID mapping per sensor.
+        """
         if not path.exists():
             return
         lines = path.read_text(encoding="utf-8").splitlines()
         if not lines:
             return
 
+        mapping = CiscoAsaEmitter._build_connection_id_mapping(
+            ((0, line) for line in lines),
+            sensor_hostname,
+        )
+        CiscoAsaEmitter._apply_connection_id_mapping(path, mapping)
+
+    @staticmethod
+    def _connection_id_mapping(
+        route_writers: list[tuple[str, Any]],
+        sensor_hostname: str,
+    ) -> dict[str, int]:
+        rows: list[tuple[int, tuple[int, int, int, int, int], str]] = []
+        for route_key, writer in route_writers:
+            if not writer.output_path.exists():
+                continue
+            year = int(syslog_route_year(route_key) or 0)
+            for line in writer.output_path.read_text(encoding="utf-8").splitlines():
+                rows.append((year, rfc3164_timestamp_sort_key(line), line))
+        rows.sort(key=lambda row: (row[0], row[1], row[2]))
+        return CiscoAsaEmitter._build_connection_id_mapping(
+            ((year, line) for year, _sort_key, line in rows),
+            sensor_hostname,
+        )
+
+    @staticmethod
+    def _build_connection_id_mapping(
+        lines: Iterable[tuple[int, str]],
+        sensor_hostname: str,
+    ) -> dict[str, int]:
         seed = int(hashlib.md5(sensor_hostname.encode()).hexdigest()[:8], 16)
         current = 1_000_000 + seed % 500_000
         mapping: dict[str, int] = {}
-        changed = False
-        normalized: list[str] = []
         pattern = re.compile(r"(connection )(\d+)( for)")
-        for line in lines:
+        for _year, line in lines:
             match = pattern.search(line)
             if match is None:
-                normalized.append(line)
                 continue
             old_id = match.group(2)
             if int(old_id) < 1_000_000:
-                normalized.append(line)
                 continue
             if old_id not in mapping:
                 gap_seed = f"{sensor_hostname}:{current}:{len(mapping)}"
                 gap = 1 + int(hashlib.md5(gap_seed.encode()).hexdigest()[:2], 16) % 5
                 current += gap
                 mapping[old_id] = current
+        return mapping
+
+    @staticmethod
+    def _apply_connection_id_mapping(path: Path, mapping: dict[str, int]) -> None:
+        if not path.exists() or not mapping:
+            return
+        lines = path.read_text(encoding="utf-8").splitlines()
+        pattern = re.compile(r"(connection )(\d+)( for)")
+        changed = False
+        normalized: list[str] = []
+        for line in lines:
+            match = pattern.search(line)
+            if match is None:
+                normalized.append(line)
+                continue
+            old_id = match.group(2)
+            if old_id not in mapping:
+                normalized.append(line)
+                continue
             new_id = str(mapping[old_id])
             normalized.append(pattern.sub(rf"\g<1>{new_id}\g<3>", line, count=1))
             changed = changed or new_id != old_id
@@ -766,17 +832,26 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         rendered = self._render_event(event_data)
         if rendered is None:
             return
-        self.emit_to_sensors(rendered, sensor_hostnames)
+        targets = sensor_hostnames if sensor_hostnames else self._sensor_hostnames
+        if not targets:
+            self.emit_to_sensors(rendered, None)
+            return
+        route_targets = [
+            make_syslog_family_route_key(
+                sensor_hostname,
+                event_data["timestamp"],
+                direct_file_mode=self._direct_file_mode,
+            )
+            for sensor_hostname in targets
+        ]
+        self.emit_to_sensors(rendered, route_targets)
 
     def _render_event(self, event_data: dict[str, Any]) -> str | None:
-        """Render ASA syslog line via Jinja2 template."""
-        context = {
-            "timestamp": event_data.get("timestamp"),
-            "hostname": event_data.get("hostname"),
-            "severity": event_data.get("severity"),
-            "msg_id": event_data.get("msg_id"),
-            "message": event_data.get("message"),
-            "pri": event_data.get("pri"),
-        }
-        rendered = self._template.render(**context)
-        return rendered.strip()
+        """Render ASA syslog line via the shared RFC3164 syslog-family layer."""
+        return render_rfc3164_syslog(
+            pri=int(event_data.get("pri") or self._pri(event_data.get("severity", 6))),
+            timestamp=event_data["timestamp"],
+            hostname=str(event_data.get("hostname") or ""),
+            app_name=f"%ASA-{event_data.get('severity')}-{event_data.get('msg_id')}",
+            message=str(event_data.get("message") or ""),
+        )

--- a/src/evidenceforge/generation/emitters/cisco_asa.py
+++ b/src/evidenceforge/generation/emitters/cisco_asa.py
@@ -52,6 +52,7 @@ from evidenceforge.generation.emitters.syslog_family import (
     syslog_route_year,
 )
 from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
+from evidenceforge.output_targets import OutputTarget
 
 # ASA facility: local4 (20)
 _ASA_FACILITY = 20
@@ -63,8 +64,8 @@ _TCP_PARTIAL_TEARDOWN_REASONS = ("Conn-timeout", "TCP Reset-O", "TCP Reset-I")
 class CiscoAsaEmitter(SensorMultiplexEmitter):
     """Emitter for Cisco ASA firewall syslog format.
 
-    Per-sensor/year directory routing: each firewall sensor gets its own yearly
-    log file.
+    Default target writes flat per-sensor files. SOF-ELK target writes
+    per-sensor/year files so BSD-syslog archive consumers can infer years.
 
     Handles all connection events visible to firewall sensors. Unlike Snort
     (which requires IdsContext), the ASA emitter renders every connection it
@@ -836,14 +837,17 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
         if not targets:
             self.emit_to_sensors(rendered, None)
             return
-        route_targets = [
-            make_syslog_family_route_key(
-                sensor_hostname,
-                event_data["timestamp"],
-                direct_file_mode=self._direct_file_mode,
-            )
-            for sensor_hostname in targets
-        ]
+        if self.output_target == OutputTarget.SOF_ELK:
+            route_targets = [
+                make_syslog_family_route_key(
+                    sensor_hostname,
+                    event_data["timestamp"],
+                    direct_file_mode=self._direct_file_mode,
+                )
+                for sensor_hostname in targets
+            ]
+        else:
+            route_targets = targets
         self.emit_to_sensors(rendered, route_targets)
 
     def _render_event(self, event_data: dict[str, Any]) -> str | None:

--- a/src/evidenceforge/generation/emitters/host_base.py
+++ b/src/evidenceforge/generation/emitters/host_base.py
@@ -27,7 +27,8 @@ host's FQDN. Each host gets its own subdirectory:
 
     base_dir/<host-fqdn>/windows_event_security.xml
     base_dir/<host-fqdn>/ecar.json
-    base_dir/<host-fqdn>/<year>/syslog.log
+    base_dir/<host-fqdn>/syslog.log
+    base_dir/<host-fqdn>/<year>/syslog.log  # target-specific syslog layouts
 """
 
 import logging

--- a/src/evidenceforge/generation/emitters/host_base.py
+++ b/src/evidenceforge/generation/emitters/host_base.py
@@ -27,7 +27,7 @@ host's FQDN. Each host gets its own subdirectory:
 
     base_dir/<host-fqdn>/windows_event_security.xml
     base_dir/<host-fqdn>/ecar.json
-    base_dir/<host-fqdn>/syslog.log
+    base_dir/<host-fqdn>/<year>/syslog.log
 """
 
 import logging
@@ -148,8 +148,21 @@ class HostMultiplexEmitter(LogEmitter):
         self._buffer_size = buffer_size
         super().__init__(format_def, output_path, buffer_size, threaded)
 
+    def _safe_writer_key(self, host_fqdn: str) -> str:
+        """Return the writer key for a routed host value."""
+        return sanitize_path_component(host_fqdn)
+
+    def _writer_path_for_key(self, safe_writer_key: str) -> Path:
+        """Return the output path for a writer key."""
+        if safe_writer_key and not self._direct_file_mode:
+            return self._base_dir / safe_writer_key / self._log_filename
+        if self._direct_file_path:
+            return self._direct_file_path
+        flat_name = self._flat_filename or self._log_filename
+        return self._base_dir / flat_name
+
     def _get_writer(self, host_fqdn: str) -> _SingleHostWriter:
-        safe_host_fqdn = sanitize_path_component(host_fqdn)
+        safe_host_fqdn = self._safe_writer_key(host_fqdn)
         writer = self._writers.get(safe_host_fqdn)
         if writer is not None:
             return writer
@@ -157,13 +170,7 @@ class HostMultiplexEmitter(LogEmitter):
             writer = self._writers.get(safe_host_fqdn)
             if writer is not None:
                 return writer
-            if safe_host_fqdn and not self._direct_file_mode:
-                path = self._base_dir / safe_host_fqdn / self._log_filename
-            elif self._direct_file_path:
-                path = self._direct_file_path
-            else:
-                flat_name = self._flat_filename or self._log_filename
-                path = self._base_dir / flat_name
+            path = self._writer_path_for_key(safe_host_fqdn)
             sort = self._sort_flat_file
             writer = _SingleHostWriter(
                 path,

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -28,21 +28,34 @@ just formats the context fields into the syslog template.
 """
 
 import re
-from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
+from evidenceforge.generation.emitters.syslog_family import (
+    bounded_syslog_int,
+    coerce_syslog_datetime,
+    make_syslog_family_route_key,
+    render_rfc3164_syslog,
+    rfc3164_sort_key,
+    sanitize_syslog_family_route_key,
+    syslog_family_writer_path,
+    syslog_priority,
+    syslog_route_source,
+    syslog_route_year,
+)
 from evidenceforge.utils.rng import _stable_seed
 
-_RFC5424_TS_RE = re.compile(r"^<\d{1,3}>1\s+(?P<timestamp>\S+)")
 _LOGIND_NEW_SESSION_RE = re.compile(
-    r"(?P<prefix>\bsystemd-logind\s+(?P<pid>\d+)\s+\S+\s+\S+\s+New session )"
+    r"(?P<prefix>\bsystemd-logind(?:\[(?P<pid_bracket>\d+)\]:|"
+    r"\s+(?P<pid_token>\d+)\s+\S+\s+\S+)\s+New session )"
     r"(?P<session>\d+)(?P<suffix> of user .*)"
 )
 _LOGIND_REMOVED_SESSION_RE = re.compile(
-    r"(?P<prefix>\bsystemd-logind\s+(?P<pid>\d+)\s+\S+\s+\S+\s+Removed session )"
+    r"(?P<prefix>\bsystemd-logind(?:\[(?P<pid_bracket>\d+)\]:|"
+    r"\s+(?P<pid_token>\d+)\s+\S+\s+\S+)\s+Removed session )"
     r"(?P<session>\d+)(?P<suffix>\.)"
 )
 _MAX_LOGIND_SESSION_ID_DIGITS = 18
@@ -103,37 +116,26 @@ def _dhclient_lifecycle_priority(line: str) -> int:
     return 60
 
 
-def _parse_rfc5424_timestamp(value: str) -> datetime:
-    """Parse an RFC 5424 timestamp into UTC, returning datetime.max on failure."""
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return datetime.max.replace(tzinfo=UTC)
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
+def _logind_pid(match: re.Match[str]) -> str:
+    """Return a logind PID from either RFC3164 or legacy RFC5424-ish rendering."""
+    return match.group("pid_bracket") or match.group("pid_token")
 
 
-def _syslog_sort_key(line: str) -> tuple[datetime, int, str]:
-    """Sort RFC 5424 syslog lines by timestamp plus same-time lifecycle order."""
-    match = _RFC5424_TS_RE.match(line)
-    if match is None:
-        return (datetime.max.replace(tzinfo=UTC), 99, line)
-    return (
-        _parse_rfc5424_timestamp(match.group("timestamp")),
-        min(
-            _ssh_lifecycle_priority(line),
-            _systemd_lifecycle_priority(line),
-            _dhclient_lifecycle_priority(line),
-        ),
-        line,
+def _syslog_sort_key(line: str) -> tuple[int, int, int, int, int, int, str]:
+    """Sort RFC3164 syslog lines by timestamp plus same-time lifecycle order."""
+    lifecycle_priority = min(
+        _ssh_lifecycle_priority(line),
+        _systemd_lifecycle_priority(line),
+        _dhclient_lifecycle_priority(line),
     )
+    return rfc3164_sort_key(line, lifecycle_priority)
 
 
 class SyslogEmitter(HostMultiplexEmitter):
     """Emitter for Linux syslog format.
 
-    Per-host FQDN directory routing: each Linux host gets its own syslog.log.
+    Per-host/year directory routing: each Linux host gets syslog.log files
+    partitioned by event year.
     Renders any SecurityEvent that carries a SyslogContext on a Linux host.
     """
 
@@ -145,6 +147,18 @@ class SyslogEmitter(HostMultiplexEmitter):
 
     # Context-driven: handles any event type that carries SyslogContext
     _supported_types: set[str] = set()
+
+    def _safe_writer_key(self, host_fqdn: str) -> str:
+        return sanitize_syslog_family_route_key(host_fqdn)
+
+    def _writer_path_for_key(self, safe_writer_key: str) -> Path:
+        return syslog_family_writer_path(
+            base_dir=self._base_dir,
+            safe_route_key=safe_writer_key,
+            log_filename=self._log_filename,
+            direct_file_path=self._direct_file_path,
+            flat_filename=self._flat_filename,
+        )
 
     def can_handle(self, event: SecurityEvent) -> bool:
         """Syslog emitter handles any event with SyslogContext on a Linux host."""
@@ -190,57 +204,28 @@ class SyslogEmitter(HostMultiplexEmitter):
         """Route syslog event to per-host file."""
         rendered = self._render_event(event_data)
         host_fqdn = event_data.pop("_host_fqdn", "")
-        self.emit_to_host(rendered, host_fqdn)
+        route_key = make_syslog_family_route_key(
+            host_fqdn,
+            event_data["timestamp"],
+            direct_file_mode=self._direct_file_mode,
+        )
+        self.emit_to_host(rendered, route_key)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:
         ts = event_data.get("timestamp")
-        if isinstance(ts, str):
-            from evidenceforge.utils.time import parse_iso8601
+        ts = coerce_syslog_datetime(ts)
 
-            ts = parse_iso8601(ts)
-        if not isinstance(ts, datetime):
-            raise ValueError("Syslog events require a datetime timestamp")
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=UTC)
-        ts = ts.astimezone(UTC)
-
-        facility = self._bounded_int(event_data.get("facility"), default=3, minimum=0, maximum=23)
-        severity = self._bounded_int(event_data.get("severity"), default=6, minimum=0, maximum=7)
+        facility = bounded_syslog_int(event_data.get("facility"), default=3, minimum=0, maximum=23)
+        severity = bounded_syslog_int(event_data.get("severity"), default=6, minimum=0, maximum=7)
         pid = event_data.get("pid")
-        context = {
-            "pri": facility * 8 + severity,
-            "timestamp": ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            "hostname": event_data.get("hostname") or "",
-            "facility": event_data.get("facility"),
-            "severity": event_data.get("severity"),
-            "app_name": self._rfc5424_token(event_data.get("app_name"), default="-"),
-            "pid": pid,
-            "procid": str(pid) if pid not in (None, "") else "-",
-            "msgid": self._rfc5424_token(event_data.get("msgid"), default="-"),
-            "structured_data": event_data.get("structured_data") or "-",
-            "message": event_data.get("message"),
-        }
-        rendered = self._template.render(**context)
-        return rendered.strip()
-
-    @staticmethod
-    def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
-        """Return value as an int clamped to the RFC-supported range."""
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
-            return default
-        return max(minimum, min(maximum, parsed))
-
-    @staticmethod
-    def _rfc5424_token(value: Any, *, default: str) -> str:
-        """Render an RFC 5424 header token, replacing whitespace with underscores."""
-        if value is None:
-            return default
-        token = str(value).strip()
-        if not token:
-            return default
-        return re.sub(r"\s+", "_", token)
+        return render_rfc3164_syslog(
+            pri=syslog_priority(facility, severity),
+            timestamp=ts,
+            hostname=event_data.get("hostname") or "",
+            app_name=event_data.get("app_name") or "-",
+            pid=pid,
+            message=event_data.get("message") or "",
+        )
 
     def close(self) -> None:
         """Close emitter after normalizing source-native logind session order."""
@@ -260,15 +245,29 @@ class SyslogEmitter(HostMultiplexEmitter):
         visible in the collection window.
         """
         with self._writers_lock:
-            for host_key, writer in self._writers.items():
-                with writer._lock:
-                    if not writer.buffer:
-                        continue
-                    lines = sorted(writer.buffer, key=_syslog_sort_key)
-                    writer.buffer = self._normalize_logind_session_ids_for_lines(
-                        lines,
-                        host_key,
-                    )
+            grouped: dict[str, list[tuple[str, Any]]] = {}
+            for route_key, writer in self._writers.items():
+                grouped.setdefault(syslog_route_source(route_key), []).append((route_key, writer))
+            for host_key, route_writers in grouped.items():
+                rows: list[tuple[int, tuple[int, int, int, int, int, int, str], str, str]] = []
+                for route_key, writer in route_writers:
+                    year = int(syslog_route_year(route_key) or 0)
+                    with writer._lock:
+                        for line in writer.buffer:
+                            rows.append((year, _syslog_sort_key(line), route_key, line))
+                if not rows:
+                    continue
+                rows.sort(key=lambda row: (row[0], row[1]))
+                normalized = self._normalize_logind_session_ids_for_lines(
+                    [line for _year, _sort_key, _route_key, line in rows],
+                    host_key,
+                )
+                buffers_by_route: dict[str, list[str]] = {}
+                for row, line in zip(rows, normalized, strict=True):
+                    buffers_by_route.setdefault(row[2], []).append(line)
+                for route_key, writer in route_writers:
+                    with writer._lock:
+                        writer.buffer = buffers_by_route.get(route_key, [])
 
     @staticmethod
     def _normalize_logind_session_ids_for_lines(lines: list[str], host_key: str) -> list[str]:
@@ -278,7 +277,7 @@ class SyslogEmitter(HostMultiplexEmitter):
             match = _LOGIND_NEW_SESSION_RE.search(line)
             if match is None:
                 continue
-            pid = match.group("pid")
+            pid = _logind_pid(match)
             session = _parse_logind_session_id(match.group("session"))
             if session is None:
                 continue
@@ -290,11 +289,12 @@ class SyslogEmitter(HostMultiplexEmitter):
         next_by_pid = {pid: max(2, start) - 1 for pid, start in first_by_pid.items()}
         prewindow_next_by_pid = {pid: max(2, start) - 1 for pid, start in first_by_pid.items()}
         rewritten_by_original: dict[tuple[str, str], int] = {}
+        prewindow_removed_by_original: dict[tuple[str, str], int] = {}
         normalized: list[str] = []
         for index, line in enumerate(lines):
             new_match = _LOGIND_NEW_SESSION_RE.search(line)
             if new_match is not None:
-                pid = new_match.group("pid")
+                pid = _logind_pid(new_match)
                 original_session = new_match.group("session")
                 if _parse_logind_session_id(original_session) is None:
                     normalized.append(line)
@@ -315,23 +315,29 @@ class SyslogEmitter(HostMultiplexEmitter):
 
             removed_match = _LOGIND_REMOVED_SESSION_RE.search(line)
             if removed_match is not None:
-                key = (removed_match.group("pid"), removed_match.group("session"))
+                key = (_logind_pid(removed_match), removed_match.group("session"))
                 rewritten = rewritten_by_original.get(key)
                 if rewritten is None:
-                    pid = removed_match.group("pid")
+                    pid = _logind_pid(removed_match)
                     original_session_id = _parse_logind_session_id(removed_match.group("session"))
                     if original_session_id is None:
                         normalized.append(line)
                         continue
                     first_visible = max(2, first_by_pid.get(pid, original_session_id + 1))
-                    step_seed = _stable_seed(
-                        "syslog_logind_prewindow_session_step:"
-                        f"{host_key}:{pid}:{removed_match.group('session')}:{index}"
-                    )
-                    prewindow_next_by_pid[pid] = (
-                        prewindow_next_by_pid.get(pid, first_visible - 1) - 1 - (step_seed % 3)
-                    )
-                    rewritten = prewindow_next_by_pid[pid]
+                    if original_session_id >= first_visible:
+                        rewritten = prewindow_removed_by_original.get(key)
+                        if rewritten is None:
+                            step_seed = _stable_seed(
+                                "syslog_logind_prewindow_session_step:"
+                                f"{host_key}:{pid}:{removed_match.group('session')}:{index}"
+                            )
+                            prewindow_next_by_pid[pid] = (
+                                prewindow_next_by_pid.get(pid, first_visible - 1)
+                                - 1
+                                - (step_seed % 3)
+                            )
+                            rewritten = prewindow_next_by_pid[pid]
+                            prewindow_removed_by_original[key] = rewritten
                 if rewritten is not None:
                     line = (
                         f"{line[: removed_match.start('session')]}"

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -39,6 +39,7 @@ from evidenceforge.generation.emitters.syslog_family import (
     coerce_syslog_datetime,
     make_syslog_family_route_key,
     render_rfc3164_syslog,
+    render_rfc5424_syslog,
     rfc3164_sort_key,
     sanitize_syslog_family_route_key,
     syslog_family_writer_path,
@@ -46,6 +47,7 @@ from evidenceforge.generation.emitters.syslog_family import (
     syslog_route_source,
     syslog_route_year,
 )
+from evidenceforge.output_targets import OutputTarget
 from evidenceforge.utils.rng import _stable_seed
 
 _LOGIND_NEW_SESSION_RE = re.compile(
@@ -131,22 +133,45 @@ def _syslog_sort_key(line: str) -> tuple[int, int, int, int, int, int, str]:
     return rfc3164_sort_key(line, lifecycle_priority)
 
 
+_RFC5424_TS_RE = re.compile(r"^<\d{1,3}>1\s+(?P<timestamp>\S+)")
+
+
+def _rfc5424_syslog_sort_key(line: str) -> tuple[str, int, str]:
+    """Sort RFC5424 syslog lines by full timestamp plus lifecycle order."""
+    lifecycle_priority = min(
+        _ssh_lifecycle_priority(line),
+        _systemd_lifecycle_priority(line),
+        _dhclient_lifecycle_priority(line),
+    )
+    match = _RFC5424_TS_RE.match(line)
+    timestamp = match.group("timestamp") if match is not None else ""
+    return (timestamp, lifecycle_priority, line)
+
+
 class SyslogEmitter(HostMultiplexEmitter):
     """Emitter for Linux syslog format.
 
-    Per-host/year directory routing: each Linux host gets syslog.log files
-    partitioned by event year.
+    Default target writes flat per-host RFC5424 files. SOF-ELK target writes
+    per-host/year RFC3164 files.
     Renders any SecurityEvent that carries a SyslogContext on a Linux host.
     """
 
     _log_filename = "syslog.log"
     _flat_filename = "syslog.log"
     _sort_flat_file = True
-    _sort_key = staticmethod(_syslog_sort_key)
+    _sort_key = staticmethod(_rfc5424_syslog_sort_key)
     _defer_sorted_flush_until_close = True
 
     # Context-driven: handles any event type that carries SyslogContext
     _supported_types: set[str] = set()
+
+    def configure_output_target(self, target: str | OutputTarget | None) -> None:
+        """Configure target-specific syslog rendering and sort order."""
+        super().configure_output_target(target)
+        if self.output_target == OutputTarget.SOF_ELK:
+            self._sort_key = _syslog_sort_key
+        else:
+            self._sort_key = _rfc5424_syslog_sort_key
 
     def _safe_writer_key(self, host_fqdn: str) -> str:
         return sanitize_syslog_family_route_key(host_fqdn)
@@ -204,12 +229,15 @@ class SyslogEmitter(HostMultiplexEmitter):
         """Route syslog event to per-host file."""
         rendered = self._render_event(event_data)
         host_fqdn = event_data.pop("_host_fqdn", "")
-        route_key = make_syslog_family_route_key(
-            host_fqdn,
-            event_data["timestamp"],
-            direct_file_mode=self._direct_file_mode,
-        )
-        self.emit_to_host(rendered, route_key)
+        if self.output_target == OutputTarget.SOF_ELK:
+            route_key = make_syslog_family_route_key(
+                host_fqdn,
+                event_data["timestamp"],
+                direct_file_mode=self._direct_file_mode,
+            )
+            self.emit_to_host(rendered, route_key)
+            return
+        self.emit_to_host(rendered, host_fqdn)
 
     def _render_event(self, event_data: dict[str, Any]) -> str:
         ts = event_data.get("timestamp")
@@ -218,6 +246,15 @@ class SyslogEmitter(HostMultiplexEmitter):
         facility = bounded_syslog_int(event_data.get("facility"), default=3, minimum=0, maximum=23)
         severity = bounded_syslog_int(event_data.get("severity"), default=6, minimum=0, maximum=7)
         pid = event_data.get("pid")
+        if self.output_target != OutputTarget.SOF_ELK:
+            return render_rfc5424_syslog(
+                pri=syslog_priority(facility, severity),
+                timestamp=ts,
+                hostname=event_data.get("hostname") or "",
+                app_name=event_data.get("app_name") or "-",
+                pid=pid,
+                message=event_data.get("message") or "",
+            )
         return render_rfc3164_syslog(
             pri=syslog_priority(facility, severity),
             timestamp=ts,
@@ -249,12 +286,17 @@ class SyslogEmitter(HostMultiplexEmitter):
             for route_key, writer in self._writers.items():
                 grouped.setdefault(syslog_route_source(route_key), []).append((route_key, writer))
             for host_key, route_writers in grouped.items():
-                rows: list[tuple[int, tuple[int, int, int, int, int, int, str], str, str]] = []
+                rows: list[tuple[int, tuple[Any, ...], str, str]] = []
                 for route_key, writer in route_writers:
                     year = int(syslog_route_year(route_key) or 0)
                     with writer._lock:
                         for line in writer.buffer:
-                            rows.append((year, _syslog_sort_key(line), route_key, line))
+                            sort_key = (
+                                _syslog_sort_key(line)
+                                if self.output_target == OutputTarget.SOF_ELK
+                                else _rfc5424_syslog_sort_key(line)
+                            )
+                            rows.append((year, sort_key, route_key, line))
                 if not rows:
                     continue
                 rows.sort(key=lambda row: (row[0], row[1]))
@@ -289,7 +331,7 @@ class SyslogEmitter(HostMultiplexEmitter):
         next_by_pid = {pid: max(2, start) - 1 for pid, start in first_by_pid.items()}
         prewindow_next_by_pid = {pid: max(2, start) - 1 for pid, start in first_by_pid.items()}
         rewritten_by_original: dict[tuple[str, str], int] = {}
-        prewindow_removed_by_original: dict[tuple[str, str], int] = {}
+        prewindow_seen_by_original: set[tuple[str, str]] = set()
         normalized: list[str] = []
         for index, line in enumerate(lines):
             new_match = _LOGIND_NEW_SESSION_RE.search(line)
@@ -324,20 +366,19 @@ class SyslogEmitter(HostMultiplexEmitter):
                         normalized.append(line)
                         continue
                     first_visible = max(2, first_by_pid.get(pid, original_session_id + 1))
-                    if original_session_id >= first_visible:
-                        rewritten = prewindow_removed_by_original.get(key)
-                        if rewritten is None:
-                            step_seed = _stable_seed(
-                                "syslog_logind_prewindow_session_step:"
-                                f"{host_key}:{pid}:{removed_match.group('session')}:{index}"
-                            )
-                            prewindow_next_by_pid[pid] = (
-                                prewindow_next_by_pid.get(pid, first_visible - 1)
-                                - 1
-                                - (step_seed % 3)
-                            )
-                            rewritten = prewindow_next_by_pid[pid]
-                            prewindow_removed_by_original[key] = rewritten
+                    needs_prewindow_rewrite = (
+                        original_session_id >= first_visible or key in prewindow_seen_by_original
+                    )
+                    prewindow_seen_by_original.add(key)
+                    if needs_prewindow_rewrite:
+                        step_seed = _stable_seed(
+                            "syslog_logind_prewindow_session_step:"
+                            f"{host_key}:{pid}:{removed_match.group('session')}:{index}"
+                        )
+                        prewindow_next_by_pid[pid] = (
+                            prewindow_next_by_pid.get(pid, first_visible - 1) - 1 - (step_seed % 3)
+                        )
+                        rewritten = prewindow_next_by_pid[pid]
                 if rewritten is not None:
                     line = (
                         f"{line[: removed_match.start('session')]}"

--- a/src/evidenceforge/generation/emitters/syslog_family.py
+++ b/src/evidenceforge/generation/emitters/syslog_family.py
@@ -109,6 +109,27 @@ def render_rfc3164_syslog(
     return f"<{pri}>{format_rfc3164_timestamp(timestamp)} {host} {tag}: {message or ''}"
 
 
+def render_rfc5424_syslog(
+    *,
+    pri: int,
+    timestamp: datetime | str,
+    hostname: str,
+    app_name: str,
+    message: str,
+    pid: Any = None,
+    msgid: str = "-",
+    structured_data: str = "-",
+) -> str:
+    """Render an RFC5424 syslog line."""
+    ts = coerce_syslog_datetime(timestamp).isoformat().replace("+00:00", "Z")
+    host = _syslog_header_token(hostname, default="-")
+    app = _syslog_header_token(app_name, default="-")
+    procid = _syslog_header_token(pid, default="-")
+    msgid = _syslog_header_token(msgid, default="-")
+    structured_data = structured_data if structured_data else "-"
+    return f"<{pri}>1 {ts} {host} {app} {procid} {msgid} {structured_data} {message or ''}"
+
+
 def make_syslog_family_route_key(
     source_name: str,
     timestamp: datetime | str,

--- a/src/evidenceforge/generation/emitters/syslog_family.py
+++ b/src/evidenceforge/generation/emitters/syslog_family.py
@@ -98,10 +98,13 @@ def render_rfc3164_syslog(
     app_name: str,
     message: str,
     pid: Any = None,
+    include_app_tag: bool = True,
 ) -> str:
     """Render a BSD/RFC3164-style syslog line."""
-    app = _syslog_tag_token(app_name, default="-")
     host = _syslog_header_token(hostname, default="-")
+    if not include_app_tag:
+        return f"<{pri}>{format_rfc3164_timestamp(timestamp)} {host} {message or ''}"
+    app = _syslog_tag_token(app_name, default="-")
     tag = f"{app}[{pid}]" if pid not in (None, "") else app
     return f"<{pri}>{format_rfc3164_timestamp(timestamp)} {host} {tag}: {message or ''}"
 

--- a/src/evidenceforge/generation/emitters/syslog_family.py
+++ b/src/evidenceforge/generation/emitters/syslog_family.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Shared RFC3164 rendering and layout helpers for syslog-family emitters."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from evidenceforge.utils.paths import sanitize_path_component
+
+SYSLOG_ROUTE_SEPARATOR = "|"
+SYSLOG_FAMILY_YEAR_RE = re.compile(r"^\d{4}$")
+_RFC3164_RE = re.compile(
+    r"^<(?P<pri>\d{1,3})>"
+    r"(?P<month>[A-Z][a-z]{2})\s+"
+    r"(?P<day>\d{1,2})\s+"
+    r"(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})\s+"
+)
+_MONTHS = {
+    "Jan": 1,
+    "Feb": 2,
+    "Mar": 3,
+    "Apr": 4,
+    "May": 5,
+    "Jun": 6,
+    "Jul": 7,
+    "Aug": 8,
+    "Sep": 9,
+    "Oct": 10,
+    "Nov": 11,
+    "Dec": 12,
+}
+
+
+def coerce_syslog_datetime(value: datetime | str) -> datetime:
+    """Return a UTC datetime for a syslog-family event timestamp."""
+    if isinstance(value, str):
+        from evidenceforge.utils.time import parse_iso8601
+
+        value = parse_iso8601(value)
+    if not isinstance(value, datetime):
+        raise ValueError("syslog-family events require a datetime timestamp")
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def bounded_syslog_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    """Return value as an int clamped to a syslog-supported range."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def syslog_priority(facility: Any, severity: Any) -> int:
+    """Return the syslog PRI value for bounded facility and severity inputs."""
+    bounded_facility = bounded_syslog_int(facility, default=3, minimum=0, maximum=23)
+    bounded_severity = bounded_syslog_int(severity, default=6, minimum=0, maximum=7)
+    return bounded_facility * 8 + bounded_severity
+
+
+def format_rfc3164_timestamp(timestamp: datetime | str) -> str:
+    """Format a UTC timestamp as an RFC3164 timestamp without a year."""
+    ts = coerce_syslog_datetime(timestamp)
+    return f"{ts:%b} {ts.day:2d} {ts:%H:%M:%S}"
+
+
+def render_rfc3164_syslog(
+    *,
+    pri: int,
+    timestamp: datetime | str,
+    hostname: str,
+    app_name: str,
+    message: str,
+    pid: Any = None,
+) -> str:
+    """Render a BSD/RFC3164-style syslog line."""
+    app = _syslog_tag_token(app_name, default="-")
+    host = _syslog_header_token(hostname, default="-")
+    tag = f"{app}[{pid}]" if pid not in (None, "") else app
+    return f"<{pri}>{format_rfc3164_timestamp(timestamp)} {host} {tag}: {message or ''}"
+
+
+def make_syslog_family_route_key(
+    source_name: str,
+    timestamp: datetime | str,
+    *,
+    direct_file_mode: bool,
+) -> str:
+    """Return an internal writer key carrying source name and event year."""
+    if direct_file_mode:
+        return source_name
+    year = str(coerce_syslog_datetime(timestamp).year)
+    return f"{source_name}{SYSLOG_ROUTE_SEPARATOR}{year}"
+
+
+def sanitize_syslog_family_route_key(route_key: str) -> str:
+    """Sanitize an internal syslog-family route key."""
+    if SYSLOG_ROUTE_SEPARATOR not in route_key:
+        return sanitize_path_component(route_key)
+    source, year = route_key.rsplit(SYSLOG_ROUTE_SEPARATOR, 1)
+    safe_source = sanitize_path_component(source) or "default"
+    safe_year = year if SYSLOG_FAMILY_YEAR_RE.fullmatch(year) else ""
+    if not safe_year:
+        return safe_source
+    return f"{safe_source}{SYSLOG_ROUTE_SEPARATOR}{safe_year}"
+
+
+def syslog_route_source(route_key: str) -> str:
+    """Return the source component from a sanitized syslog-family route key."""
+    if SYSLOG_ROUTE_SEPARATOR not in route_key:
+        return route_key or "default"
+    source, _year = route_key.rsplit(SYSLOG_ROUTE_SEPARATOR, 1)
+    return source or "default"
+
+
+def syslog_route_year(route_key: str) -> str | None:
+    """Return the year component from a sanitized syslog-family route key."""
+    if SYSLOG_ROUTE_SEPARATOR not in route_key:
+        return None
+    _source, year = route_key.rsplit(SYSLOG_ROUTE_SEPARATOR, 1)
+    return year if SYSLOG_FAMILY_YEAR_RE.fullmatch(year) else None
+
+
+def syslog_family_writer_path(
+    *,
+    base_dir: Path,
+    safe_route_key: str,
+    log_filename: str,
+    direct_file_path: Path | None,
+    flat_filename: str,
+) -> Path:
+    """Return the generated output path for a syslog-family writer key."""
+    if direct_file_path is not None:
+        return direct_file_path
+    source = syslog_route_source(safe_route_key)
+    year = syslog_route_year(safe_route_key)
+    if year is not None:
+        return base_dir / source / year / log_filename
+    if source:
+        return base_dir / source / log_filename
+    return base_dir / (flat_filename or log_filename)
+
+
+def rfc3164_timestamp_sort_key(line: str) -> tuple[int, int, int, int, int]:
+    """Return a stable timestamp-only sort key for an RFC3164 syslog line."""
+    match = _RFC3164_RE.match(line)
+    if match is None:
+        return (99, 99, 99, 99, 99)
+    return (
+        _MONTHS.get(match.group("month"), 99),
+        int(match.group("day")),
+        int(match.group("hour")),
+        int(match.group("minute")),
+        int(match.group("second")),
+    )
+
+
+def rfc3164_sort_key(
+    line: str, lifecycle_priority: int = 50
+) -> tuple[int, int, int, int, int, int, str]:
+    """Return a timestamp plus lifecycle sort key for host syslog lines."""
+    return (*rfc3164_timestamp_sort_key(line), lifecycle_priority, line)
+
+
+def _syslog_header_token(value: Any, *, default: str) -> str:
+    token = "" if value is None else str(value).strip()
+    if not token:
+        return default
+    return re.sub(r"\s+", "_", token)
+
+
+def _syslog_tag_token(value: Any, *, default: str) -> str:
+    token = _syslog_header_token(value, default=default)
+    return token.rstrip(":")

--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -42,11 +42,20 @@ from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
 from evidenceforge.generation.emitters.base import LogEmitter
 from evidenceforge.generation.emitters.host_base import _SingleHostWriter
+from evidenceforge.generation.emitters.syslog_family import (
+    make_syslog_family_route_key,
+    sanitize_syslog_family_route_key,
+    syslog_family_writer_path,
+)
 from evidenceforge.generation.emitters.windows import (
     _normalize_windows_time_created,
     _subject_domain,
 )
 from evidenceforge.generation.emitters.windows_event import format_windows_system_time
+from evidenceforge.generation.emitters.windows_snare import (
+    WINDOWS_SYSMON_SNARE_FILENAME,
+    render_windows_sysmon_snare_syslog,
+)
 from evidenceforge.utils.paths import sanitize_path_component
 from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import ensure_utc
@@ -1632,6 +1641,7 @@ class SysmonEventEmitter(LogEmitter):
         self._base_dir = output_path.parent if self._direct_file_mode else output_path
         self._direct_file_path = output_path if self._direct_file_mode else None
         self._host_writers: dict[str, _SingleHostWriter] = {}
+        self._snare_writers: dict[str, _SingleHostWriter] = {}
         self._host_writers_lock = Lock()
 
         super().__init__(format_def, output_path, buffer_size, threaded)
@@ -1661,6 +1671,34 @@ class SysmonEventEmitter(LogEmitter):
             if header:
                 writer.write_header(header)
             self._host_writers[safe_host] = writer
+            return writer
+
+    def _get_snare_writer(self, host_fqdn: str, timestamp: datetime) -> _SingleHostWriter:
+        route_key = make_syslog_family_route_key(
+            host_fqdn or "default",
+            timestamp,
+            direct_file_mode=self._direct_file_mode,
+        )
+        safe_route_key = sanitize_syslog_family_route_key(route_key)
+        writer = self._snare_writers.get(safe_route_key)
+        if writer is not None:
+            return writer
+        with self._host_writers_lock:
+            writer = self._snare_writers.get(safe_route_key)
+            if writer is not None:
+                return writer
+            if self._direct_file_path is not None:
+                path = self._direct_file_path.with_name(WINDOWS_SYSMON_SNARE_FILENAME)
+            else:
+                path = syslog_family_writer_path(
+                    base_dir=self._base_dir,
+                    safe_route_key=safe_route_key,
+                    log_filename=WINDOWS_SYSMON_SNARE_FILENAME,
+                    direct_file_path=None,
+                    flat_filename=WINDOWS_SYSMON_SNARE_FILENAME,
+                )
+            writer = _SingleHostWriter(path, self.buffer_size)
+            self._snare_writers[safe_route_key] = writer
             return writer
 
     def _buffer_event(self, rendered: str) -> None:
@@ -1751,8 +1789,12 @@ class SysmonEventEmitter(LogEmitter):
             event["EventRecordID"] = self._record_id_counters[counter_key]
 
         for event in self._event_dicts:
-            rendered = self._render_event(event)
             host_fqdn = event.get("Computer", "")
+            snare_timestamp = event.get("TimeCreated")
+            if isinstance(snare_timestamp, datetime):
+                snare_rendered = render_windows_sysmon_snare_syslog(event)
+                self._get_snare_writer(host_fqdn, snare_timestamp).write(snare_rendered)
+            rendered = self._render_event(event)
             self._get_host_writer(host_fqdn).write(rendered)
 
         self._event_dicts.clear()
@@ -1880,6 +1922,8 @@ class SysmonEventEmitter(LogEmitter):
         with self._host_writers_lock:
             for writer in self._host_writers.values():
                 writer.flush()
+            for writer in self._snare_writers.values():
+                writer.flush()
 
     def close(self) -> None:
         if self.threaded:
@@ -1893,6 +1937,8 @@ class SysmonEventEmitter(LogEmitter):
             writer.flush()
             if footer and writer.event_count > 0:
                 writer.write_footer(footer)
+        for writer in self._snare_writers.values():
+            writer.flush()
 
     @property
     def event_count(self) -> int:

--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -56,6 +56,7 @@ from evidenceforge.generation.emitters.windows_snare import (
     WINDOWS_SYSMON_SNARE_FILENAME,
     render_windows_sysmon_snare_syslog,
 )
+from evidenceforge.output_targets import OutputTarget
 from evidenceforge.utils.paths import sanitize_path_component
 from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import ensure_utc
@@ -1791,11 +1792,12 @@ class SysmonEventEmitter(LogEmitter):
         for event in self._event_dicts:
             host_fqdn = event.get("Computer", "")
             snare_timestamp = event.get("TimeCreated")
-            if isinstance(snare_timestamp, datetime):
+            if self.output_target == OutputTarget.SOF_ELK and isinstance(snare_timestamp, datetime):
                 snare_rendered = render_windows_sysmon_snare_syslog(event)
                 self._get_snare_writer(host_fqdn, snare_timestamp).write(snare_rendered)
-            rendered = self._render_event(event)
-            self._get_host_writer(host_fqdn).write(rendered)
+            elif self.output_target == OutputTarget.DEFAULT:
+                rendered = self._render_event(event)
+                self._get_host_writer(host_fqdn).write(rendered)
 
         self._event_dicts.clear()
 
@@ -1942,7 +1944,9 @@ class SysmonEventEmitter(LogEmitter):
 
     @property
     def event_count(self) -> int:
-        return sum(w.event_count for w in self._host_writers.values())
+        return sum(w.event_count for w in self._host_writers.values()) + sum(
+            w.event_count for w in self._snare_writers.values()
+        )
 
     @event_count.setter
     def event_count(self, value: int) -> None:

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -49,7 +49,16 @@ from evidenceforge.generation.activity.timing_profiles import (
 )
 from evidenceforge.generation.emitters.base import LogEmitter
 from evidenceforge.generation.emitters.host_base import _SingleHostWriter
+from evidenceforge.generation.emitters.syslog_family import (
+    make_syslog_family_route_key,
+    sanitize_syslog_family_route_key,
+    syslog_family_writer_path,
+)
 from evidenceforge.generation.emitters.windows_event import format_windows_system_time
+from evidenceforge.generation.emitters.windows_snare import (
+    WINDOWS_SECURITY_SNARE_FILENAME,
+    render_windows_security_snare_syslog,
+)
 from evidenceforge.utils.paths import sanitize_path_component
 from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import ensure_utc
@@ -1353,6 +1362,7 @@ class WindowsEventEmitter(LogEmitter):
         self._base_dir = output_path.parent if self._direct_file_mode else output_path
         self._direct_file_path = output_path if self._direct_file_mode else None
         self._host_writers: dict[str, _SingleHostWriter] = {}
+        self._snare_writers: dict[str, _SingleHostWriter] = {}
         self._host_writers_lock = Lock()
 
         super().__init__(format_def, output_path, buffer_size, threaded)
@@ -1390,6 +1400,34 @@ class WindowsEventEmitter(LogEmitter):
             if header:
                 writer.write_header(header)
             self._host_writers[safe_host_fqdn] = writer
+            return writer
+
+    def _get_snare_writer(self, host_fqdn: str, timestamp: datetime) -> _SingleHostWriter:
+        route_key = make_syslog_family_route_key(
+            host_fqdn or "default",
+            timestamp,
+            direct_file_mode=self._direct_file_mode,
+        )
+        safe_route_key = sanitize_syslog_family_route_key(route_key)
+        writer = self._snare_writers.get(safe_route_key)
+        if writer is not None:
+            return writer
+        with self._host_writers_lock:
+            writer = self._snare_writers.get(safe_route_key)
+            if writer is not None:
+                return writer
+            if self._direct_file_path is not None:
+                path = self._direct_file_path.with_name(WINDOWS_SECURITY_SNARE_FILENAME)
+            else:
+                path = syslog_family_writer_path(
+                    base_dir=self._base_dir,
+                    safe_route_key=safe_route_key,
+                    log_filename=WINDOWS_SECURITY_SNARE_FILENAME,
+                    direct_file_path=None,
+                    flat_filename=WINDOWS_SECURITY_SNARE_FILENAME,
+                )
+            writer = _SingleHostWriter(path, self.buffer_size)
+            self._snare_writers[safe_route_key] = writer
             return writer
 
     def _buffer_event(self, rendered: str) -> None:
@@ -1813,8 +1851,12 @@ class WindowsEventEmitter(LogEmitter):
                     event["TimeCreated"] = current_time
                 self._last_record_time_created_by_computer[counter_key] = current_time
 
-            rendered = self._render_event(event)
             host_fqdn = event.get("Computer", "")
+            snare_timestamp = event.get("TimeCreated")
+            if isinstance(snare_timestamp, datetime):
+                snare_rendered = render_windows_security_snare_syslog(event)
+                self._get_snare_writer(host_fqdn, snare_timestamp).write(snare_rendered)
+            rendered = self._render_event(event)
             self._get_host_writer(host_fqdn).write(rendered)
 
         self._event_dicts.clear()
@@ -2057,6 +2099,8 @@ class WindowsEventEmitter(LogEmitter):
         with self._host_writers_lock:
             for writer in self._host_writers.values():
                 writer.flush()
+            for writer in self._snare_writers.values():
+                writer.flush()
 
     def close(self) -> None:
         """Close emitter — flush and write XML footers for each host file."""
@@ -2072,6 +2116,8 @@ class WindowsEventEmitter(LogEmitter):
             writer.flush()
             if footer and writer.event_count > 0:
                 writer.write_footer(footer)
+        for writer in self._snare_writers.values():
+            writer.flush()
 
     @property
     def event_count(self) -> int:

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -59,6 +59,7 @@ from evidenceforge.generation.emitters.windows_snare import (
     WINDOWS_SECURITY_SNARE_FILENAME,
     render_windows_security_snare_syslog,
 )
+from evidenceforge.output_targets import OutputTarget
 from evidenceforge.utils.paths import sanitize_path_component
 from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import ensure_utc
@@ -1853,11 +1854,12 @@ class WindowsEventEmitter(LogEmitter):
 
             host_fqdn = event.get("Computer", "")
             snare_timestamp = event.get("TimeCreated")
-            if isinstance(snare_timestamp, datetime):
+            if self.output_target == OutputTarget.SOF_ELK and isinstance(snare_timestamp, datetime):
                 snare_rendered = render_windows_security_snare_syslog(event)
                 self._get_snare_writer(host_fqdn, snare_timestamp).write(snare_rendered)
-            rendered = self._render_event(event)
-            self._get_host_writer(host_fqdn).write(rendered)
+            elif self.output_target == OutputTarget.DEFAULT:
+                rendered = self._render_event(event)
+                self._get_host_writer(host_fqdn).write(rendered)
 
         self._event_dicts.clear()
         self._cleanup_spool_unlocked()
@@ -2121,7 +2123,9 @@ class WindowsEventEmitter(LogEmitter):
 
     @property
     def event_count(self) -> int:
-        return sum(w.event_count for w in self._host_writers.values())
+        return sum(w.event_count for w in self._host_writers.values()) + sum(
+            w.event_count for w in self._snare_writers.values()
+        )
 
     @event_count.setter
     def event_count(self, value: int) -> None:

--- a/src/evidenceforge/generation/emitters/windows_snare.py
+++ b/src/evidenceforge/generation/emitters/windows_snare.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Snare-over-syslog sidecar rendering for Windows Event Log emitters."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+from evidenceforge.generation.emitters.syslog_family import (
+    render_rfc3164_syslog,
+    syslog_priority,
+)
+from evidenceforge.utils.time import ensure_utc
+
+WINDOWS_SECURITY_SNARE_FILENAME = "windows_event_security_snare.log"
+WINDOWS_SYSMON_SNARE_FILENAME = "windows_event_sysmon_snare.log"
+
+_WINDOWS_SECURITY_PROVIDER = "Microsoft-Windows-Security-Auditing"
+_WINDOWS_EVENTLOG_PROVIDER = "Microsoft-Windows-Eventlog"
+_SYSMON_PROVIDER = "Microsoft-Windows-Sysmon"
+_SNARE_MARKER = "MSWinEventLog"
+_WHITESPACE_RE = re.compile(r"[\t\r\n]+")
+_DOUBLE_PIPE_RE = re.compile(r"\|\|")
+
+_SECURITY_FAILURE_EVENTS = frozenset({4625, 4771})
+_SECURITY_SUMMARIES: dict[int, str] = {
+    1102: "The audit log was cleared.",
+    4624: "An account was successfully logged on.",
+    4625: "An account failed to log on.",
+    4634: "An account was logged off.",
+    4648: "A logon was attempted using explicit credentials.",
+    4672: "Special privileges assigned to new logon.",
+    4688: "A new process has been created.",
+    4689: "A process has exited.",
+    4697: "A service was installed in the system.",
+    4698: "A scheduled task was created.",
+    4699: "A scheduled task was deleted.",
+    4700: "A scheduled task was enabled.",
+    4701: "A scheduled task was disabled.",
+    4720: "A user account was created.",
+    4723: "An attempt was made to change an account's password.",
+    4724: "An attempt was made to reset an account's password.",
+    4726: "A user account was deleted.",
+    4728: "A member was added to a security-enabled global group.",
+    4729: "A member was removed from a security-enabled global group.",
+    4732: "A member was added to a security-enabled local group.",
+    4733: "A member was removed from a security-enabled local group.",
+    4738: "A user account was changed.",
+    4756: "A member was added to a security-enabled universal group.",
+    4757: "A member was removed from a security-enabled universal group.",
+    4768: "A Kerberos authentication ticket was requested.",
+    4769: "A Kerberos service ticket was requested.",
+    4770: "A Kerberos service ticket was renewed.",
+    4771: "Kerberos pre-authentication failed.",
+    4776: "The computer attempted to validate credentials for an account.",
+    4800: "The workstation was locked.",
+    4801: "The workstation was unlocked.",
+    5156: "The Windows Filtering Platform allowed a connection.",
+}
+_SECURITY_TASKS: dict[int, str] = {
+    4624: "Logon",
+    4625: "Logon",
+    4634: "Logoff",
+    4648: "Logon",
+    4672: "Special Logon",
+    4688: "Process Creation",
+    4689: "Process Termination",
+    4768: "Kerberos Authentication Service",
+    4769: "Kerberos Service Ticket Operations",
+    4770: "Kerberos Service Ticket Operations",
+    4771: "Kerberos Authentication Service",
+    4776: "Credential Validation",
+    4800: "Other Logon/Logoff Events",
+    4801: "Other Logon/Logoff Events",
+    5156: "Filtering Platform Connection",
+}
+_SYSMON_TASKS: dict[int, str] = {
+    1: "Process Create",
+    3: "Network connection detected",
+    5: "Process terminated",
+    7: "Image loaded",
+    8: "CreateRemoteThread detected",
+    10: "Process accessed",
+    11: "File created",
+    12: "Registry object added or deleted",
+    13: "Registry value set",
+    22: "Dns query",
+}
+
+_SECURITY_FIELD_LABELS: dict[str, str] = {
+    "SubjectUserSid": "Security ID",
+    "TargetUserSid": "Security ID",
+    "SubjectUserName": "Account Name",
+    "TargetUserName": "Account Name",
+    "SubjectDomainName": "Account Domain",
+    "TargetDomainName": "Account Domain",
+    "SubjectLogonId": "Logon ID",
+    "TargetLogonId": "Logon ID",
+    "NewProcessId": "Process ID",
+    "ProcessId": "Process ID",
+    "NewProcessName": "Process Name",
+    "ProcessName": "Process Name",
+    "Status": "Exit Status",
+    "SourcePort": "SourcePort",
+    "DestinationPort": "DestinationPort",
+    "SourceAddress": "SourceIp",
+    "DestAddress": "DestinationIp",
+}
+_INTERNAL_FIELDS = frozenset({"_storyline_origin"})
+_COMMON_SYSTEM_FIELDS = frozenset(
+    {
+        "EventID",
+        "TimeCreated",
+        "Computer",
+        "Channel",
+        "Level",
+        "EventRecordID",
+        "ExecutionProcessID",
+        "ExecutionThreadID",
+        "Provider",
+    }
+)
+
+
+def render_windows_security_snare_syslog(event_data: dict[str, Any]) -> str:
+    """Render a Windows Security event dict as an RFC3164 Snare syslog row."""
+    event_id = _event_id(event_data)
+    timestamp = _timestamp(event_data)
+    computer = _clean_field(event_data.get("Computer") or "windows-host")
+    provider = _WINDOWS_EVENTLOG_PROVIDER if event_id == 1102 else _WINDOWS_SECURITY_PROVIDER
+    payload = _snare_payload(
+        event_data=event_data,
+        computer=computer,
+        channel="Security",
+        provider=provider,
+        username=_event_username(event_data),
+        logtype=_security_logtype(event_id),
+        category=_SECURITY_TASKS.get(event_id, "Audit"),
+        summary=_SECURITY_SUMMARIES.get(event_id, f"Windows Security event {event_id}."),
+        timestamp=timestamp,
+        field_labels=_SECURITY_FIELD_LABELS,
+    )
+    severity = 5 if event_id in _SECURITY_FAILURE_EVENTS else 6
+    return render_rfc3164_syslog(
+        pri=syslog_priority(10, severity),
+        timestamp=timestamp,
+        hostname=computer,
+        app_name="",
+        message=payload,
+        include_app_tag=False,
+    )
+
+
+def render_windows_sysmon_snare_syslog(event_data: dict[str, Any]) -> str:
+    """Render a Windows Sysmon event dict as an RFC3164 Snare syslog row."""
+    event_id = _event_id(event_data)
+    timestamp = _timestamp(event_data)
+    computer = _clean_field(event_data.get("Computer") or "windows-host")
+    summary = _SYSMON_TASKS.get(event_id, f"Sysmon event {event_id}.")
+    payload = _snare_payload(
+        event_data={**event_data, "UtcTime": _sysmon_utc_time(timestamp)},
+        computer=computer,
+        channel="Microsoft-Windows-Sysmon/Operational",
+        provider=_SYSMON_PROVIDER,
+        username=_event_username(event_data),
+        logtype="Information",
+        category=summary,
+        summary=summary,
+        timestamp=timestamp,
+        field_labels={},
+    )
+    return render_rfc3164_syslog(
+        pri=syslog_priority(1, 6),
+        timestamp=timestamp,
+        hostname=computer,
+        app_name="",
+        message=payload,
+        include_app_tag=False,
+    )
+
+
+def _snare_payload(
+    *,
+    event_data: dict[str, Any],
+    computer: str,
+    channel: str,
+    provider: str,
+    username: str,
+    logtype: str,
+    category: str,
+    summary: str,
+    timestamp: datetime,
+    field_labels: dict[str, str],
+) -> str:
+    expanded = _expanded_event_data(event_data, field_labels)
+    full_data = f"{summary}:  {expanded}" if expanded else summary
+    columns = (
+        computer,
+        _SNARE_MARKER,
+        str(_criticality(logtype)),
+        channel,
+        str(event_data.get("EventRecordID") or 0),
+        _snare_datetime(timestamp),
+        str(_event_id(event_data)),
+        provider,
+        username,
+        "N/A",
+        logtype,
+        computer,
+        category,
+        full_data,
+    )
+    return "\t".join(_clean_field(value) for value in columns)
+
+
+def _expanded_event_data(event_data: dict[str, Any], field_labels: dict[str, str]) -> str:
+    pieces: list[str] = []
+    for key, value in event_data.items():
+        if key in _COMMON_SYSTEM_FIELDS or key in _INTERNAL_FIELDS or value in (None, ""):
+            continue
+        label = field_labels.get(key, key)
+        pieces.append(f"{label}: {_clean_field(value)}")
+    if not pieces:
+        return ""
+    return "  ".join(pieces) + "  "
+
+
+def _event_id(event_data: dict[str, Any]) -> int:
+    try:
+        return int(event_data.get("EventID", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _timestamp(event_data: dict[str, Any]) -> datetime:
+    value = event_data.get("TimeCreated")
+    if not isinstance(value, datetime):
+        raise ValueError("Windows Snare sidecar rendering requires datetime TimeCreated")
+    return ensure_utc(value)
+
+
+def _snare_datetime(timestamp: datetime) -> str:
+    return ensure_utc(timestamp).strftime("%a %b %d %H:%M:%S %Y")
+
+
+def _sysmon_utc_time(timestamp: datetime) -> str:
+    return ensure_utc(timestamp).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+
+def _event_username(event_data: dict[str, Any]) -> str:
+    for field in (
+        "TargetUserName",
+        "SubjectUserName",
+        "User",
+        "SourceUser",
+        "TargetUser",
+        "AccountName",
+    ):
+        value = event_data.get(field)
+        if value not in (None, ""):
+            return _clean_field(value)
+    return "N/A"
+
+
+def _security_logtype(event_id: int) -> str:
+    return "Failure Audit" if event_id in _SECURITY_FAILURE_EVENTS else "Success Audit"
+
+
+def _criticality(logtype: str) -> int:
+    if logtype in {"Error", "Failure Audit"}:
+        return 2
+    if logtype == "Warning":
+        return 1
+    return 0
+
+
+def _clean_field(value: Any) -> str:
+    text = "" if value is None else str(value)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    return _DOUBLE_PIPE_RE.sub("|", text)

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -440,8 +440,23 @@ class SensorMultiplexEmitter(LogEmitter):
         self._buffer_size = buffer_size
         super().__init__(format_def, output_path, buffer_size, threaded)
 
+    def _safe_writer_key(self, sensor_hostname: str) -> str:
+        """Return the writer key for a routed sensor value."""
+        return sanitize_path_component(sensor_hostname)
+
+    def _writer_path_for_key(self, safe_writer_key: str) -> Path:
+        """Return the output path for a writer key."""
+        if safe_writer_key:
+            return self._base_dir / safe_writer_key / self._log_filename
+        if self._direct_file_path:
+            # Direct file mode (test/simple usage): output_path was a file
+            return self._direct_file_path
+        # No sensors configured -> flat output using format name
+        flat_name = self._flat_filename or self._log_filename
+        return self._base_dir / flat_name
+
     def _get_writer(self, sensor_hostname: str) -> _SingleZeekWriter:
-        safe_sensor = sanitize_path_component(sensor_hostname)
+        safe_sensor = self._safe_writer_key(sensor_hostname)
         writer = self._writers.get(safe_sensor)
         if writer is not None:
             return writer
@@ -449,15 +464,7 @@ class SensorMultiplexEmitter(LogEmitter):
             writer = self._writers.get(safe_sensor)
             if writer is not None:
                 return writer
-            if safe_sensor:
-                path = self._base_dir / safe_sensor / self._log_filename
-            elif self._direct_file_path:
-                # Direct file mode (test/simple usage): output_path was a file
-                path = self._direct_file_path
-            else:
-                # No sensors configured → flat output using format name
-                flat_name = self._flat_filename or self._log_filename
-                path = self._base_dir / flat_name
+            path = self._writer_path_for_key(safe_sensor)
             writer = _SingleZeekWriter(
                 path,
                 self._buffer_size,

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -5589,7 +5589,7 @@ class BaselineMixin:
                         (
                             "sshd",
                             sshd_pid,
-                            f'Connection from {ip} port {port} on {system.ip} port 22 rdomain ""',
+                            f"Connection from {ip} port {port} on {system.ip} port 22",
                         ),
                         ("sshd", sshd_pid, auth_msg),
                         (

--- a/src/evidenceforge/generation/engine/core.py
+++ b/src/evidenceforge/generation/engine/core.py
@@ -43,6 +43,11 @@ from evidenceforge.generation.ground_truth import GroundTruthGenerator
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.world_model import WorldModel, WorldPlanner
 from evidenceforge.models.scenario import Scenario, System, User
+from evidenceforge.output_targets import (
+    OutputTarget,
+    normalize_output_target,
+    write_output_target_marker,
+)
 from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import parse_duration, resolve_time_window
 from evidenceforge.validation.schema import BUILTIN_ACCOUNTS
@@ -73,6 +78,7 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
         output_dir: Path,
         progress_callback: Callable[[str, dict], None] | None = None,
         ground_truth_dir: Path | None = None,
+        output_target: str | OutputTarget | None = None,
     ):
         """Initialize generation engine.
 
@@ -82,10 +88,12 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
             progress_callback: Optional callback for progress reporting.
                 Called with (event_type: str, data: dict) at key milestones.
             ground_truth_dir: Directory for GROUND_TRUTH.md. Defaults to output_dir.
+            output_target: Render/layout target for generated output.
         """
         self.scenario = scenario
         self.output_dir = output_dir
         self.ground_truth_dir = ground_truth_dir or output_dir
+        self.output_target = normalize_output_target(output_target)
         self.progress_callback = progress_callback
         self.state_manager = StateManager()
         self.emitters: dict = {}
@@ -497,6 +505,7 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
             self.scenario,
             source_evidence_status,
         )
+        write_output_target_marker(self.ground_truth_dir, self.output_target)
         logger.info(f"Ground truth documentation generated: {output_path}")
 
     def _get_next_event_record_id(self) -> int:

--- a/src/evidenceforge/generation/engine/emitter_setup.py
+++ b/src/evidenceforge/generation/engine/emitter_setup.py
@@ -204,6 +204,7 @@ class EmitterSetupMixin:
                 output_path = self.output_dir / f"{format_name}{format_def.output.file_extension}"
                 emitter = emitter_classes[format_name](format_def, output_path, threaded=True)
 
+            emitter.configure_output_target(self.output_target)
             self.emitters[format_name] = emitter
             logger.info(f"Initialized {format_name} emitter (threaded)")
 

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -3769,7 +3769,7 @@ class StorylineMixin:
             app_name="sshd",
             message=(
                 f"Connection from {source_system.ip} port {source_port} "
-                f'on {target_system.ip} port 22 rdomain ""'
+                f"on {target_system.ip} port 22"
             ),
             pid=sshd_pid,
             facility=10,

--- a/src/evidenceforge/output_targets.py
+++ b/src/evidenceforge/output_targets.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Output target policy and marker helpers.
+
+Scenario YAML names canonical EvidenceForge formats such as ``syslog`` and
+``windows_event_security``. The output target controls only the source-native
+file shape rendered on disk for those canonical formats.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+OUTPUT_TARGET_FILENAME = "OUTPUT_TARGET.txt"
+
+
+class OutputTarget(StrEnum):
+    """Supported generated-output consumers."""
+
+    DEFAULT = "default"
+    SOF_ELK = "sof-elk"
+
+
+@dataclass(frozen=True)
+class TargetFormatPolicy:
+    """Rendering policy for one canonical EvidenceForge format."""
+
+    format_name: str
+    default_variant: str
+    sof_elk_variant: str
+    notes: str = ""
+
+    @property
+    def target_dependent(self) -> bool:
+        """Return whether the on-disk file shape changes by output target."""
+        return self.default_variant != self.sof_elk_variant
+
+
+FORMAT_TARGET_POLICIES: dict[str, TargetFormatPolicy] = {
+    "windows_event_security": TargetFormatPolicy(
+        "windows_event_security",
+        default_variant="xml",
+        sof_elk_variant="snare_syslog",
+        notes="SOF-ELK consumes Windows Security through Snare-over-syslog.",
+    ),
+    "windows_event_sysmon": TargetFormatPolicy(
+        "windows_event_sysmon",
+        default_variant="xml",
+        sof_elk_variant="snare_syslog",
+        notes="SOF-ELK consumes Sysmon through the same Snare-over-syslog family.",
+    ),
+    "zeek_conn": TargetFormatPolicy("zeek_conn", "ndjson", "ndjson"),
+    "zeek_dns": TargetFormatPolicy("zeek_dns", "ndjson", "ndjson"),
+    "zeek_http": TargetFormatPolicy("zeek_http", "ndjson", "ndjson"),
+    "zeek_ssl": TargetFormatPolicy("zeek_ssl", "ndjson", "ndjson"),
+    "zeek_files": TargetFormatPolicy("zeek_files", "ndjson", "ndjson"),
+    "zeek_dhcp": TargetFormatPolicy("zeek_dhcp", "ndjson", "ndjson"),
+    "zeek_ntp": TargetFormatPolicy("zeek_ntp", "ndjson", "ndjson"),
+    "zeek_weird": TargetFormatPolicy("zeek_weird", "ndjson", "ndjson"),
+    "zeek_x509": TargetFormatPolicy("zeek_x509", "ndjson", "ndjson"),
+    "zeek_ocsp": TargetFormatPolicy("zeek_ocsp", "ndjson", "ndjson"),
+    "zeek_pe": TargetFormatPolicy("zeek_pe", "ndjson", "ndjson"),
+    "zeek_packet_filter": TargetFormatPolicy("zeek_packet_filter", "ndjson", "ndjson"),
+    "zeek_reporter": TargetFormatPolicy("zeek_reporter", "ndjson", "ndjson"),
+    "ecar": TargetFormatPolicy(
+        "ecar",
+        "json",
+        "json",
+        notes="Target-invariant EvidenceForge JSON.",
+    ),
+    "syslog": TargetFormatPolicy(
+        "syslog",
+        default_variant="rfc5424_flat",
+        sof_elk_variant="rfc3164_year_partitioned",
+    ),
+    "bash_history": TargetFormatPolicy(
+        "bash_history",
+        "bash_history",
+        "bash_history",
+        notes="Target-invariant shell history text.",
+    ),
+    "snort_alert": TargetFormatPolicy("snort_alert", "fast_alert", "fast_alert"),
+    "cisco_asa": TargetFormatPolicy(
+        "cisco_asa",
+        default_variant="flat_syslog",
+        sof_elk_variant="year_partitioned_syslog",
+    ),
+    "web_access": TargetFormatPolicy("web_access", "w3c_extended", "w3c_extended"),
+    "proxy_access": TargetFormatPolicy("proxy_access", "w3c_extended", "w3c_extended"),
+}
+
+
+def normalize_output_target(value: str | OutputTarget | None) -> OutputTarget:
+    """Return a normalized output target or raise ``ValueError``."""
+    if value is None:
+        return OutputTarget.DEFAULT
+    if isinstance(value, OutputTarget):
+        return value
+    normalized = str(value).strip().lower()
+    try:
+        return OutputTarget(normalized)
+    except ValueError as exc:
+        valid = ", ".join(target.value for target in OutputTarget)
+        raise ValueError(f"invalid output target {value!r}; expected one of: {valid}") from exc
+
+
+def write_output_target_marker(root_dir: Path, target: str | OutputTarget | None) -> Path:
+    """Write ``OUTPUT_TARGET.txt`` under a scenario/output root directory."""
+    normalized = normalize_output_target(target)
+    root_dir.mkdir(parents=True, exist_ok=True)
+    marker = root_dir / OUTPUT_TARGET_FILENAME
+    marker.write_text(f"{normalized.value}\n", encoding="utf-8")
+    return marker
+
+
+def read_output_target_marker(path: Path) -> OutputTarget:
+    """Read output target metadata for a generated dataset.
+
+    ``path`` may be either the scenario/output root or its ``data/`` directory.
+    Missing markers are treated as legacy/default output.
+    """
+    path = path.resolve()
+    candidates = [path / OUTPUT_TARGET_FILENAME]
+    if path.name == "data":
+        candidates.append(path.parent / OUTPUT_TARGET_FILENAME)
+    else:
+        candidates.append(path / "data" / OUTPUT_TARGET_FILENAME)
+
+    for marker in candidates:
+        if not marker.exists():
+            continue
+        value = marker.read_text(encoding="utf-8").strip()
+        return normalize_output_target(value or None)
+    return OutputTarget.DEFAULT
+
+
+def is_sof_elk_target(target: str | OutputTarget | None) -> bool:
+    """Return whether *target* selects SOF-ELK-compatible render variants."""
+    return normalize_output_target(target) == OutputTarget.SOF_ELK
+
+
+def target_dependent_formats() -> frozenset[str]:
+    """Return canonical formats whose generated file shape depends on target."""
+    return frozenset(
+        name for name, policy in FORMAT_TARGET_POLICIES.items() if policy.target_dependent
+    )

--- a/tests/unit/test_baseline_canonical.py
+++ b/tests/unit/test_baseline_canonical.py
@@ -642,6 +642,9 @@ class TestSyslogContext:
         event = syslog.emit.call_args[0][0]
         assert event.syslog is not None
         assert event.syslog.app_name == "login"
+        assert "logname=LOGIN" in event.syslog.message
+        assert "tty=/dev/tty1" in event.syslog.message
+        assert "rhost=  user=alice" in event.syslog.message
         assert "from -" not in event.syslog.message
         zeek_events = [call.args[0] for call in mock_emitters["zeek_conn"].emit.call_args_list]
         assert not any(
@@ -670,6 +673,9 @@ class TestSyslogContext:
         event = syslog.emit.call_args[0][0]
         assert event.syslog is not None
         assert event.syslog.app_name == "login"
+        assert "logname=LOGIN" in event.syslog.message
+        assert "tty=/dev/tty1" in event.syslog.message
+        assert "rhost=  user=alice" in event.syslog.message
         assert "from 10.0.10.2" not in event.syslog.message
 
     def test_generate_syslog_event_helper(

--- a/tests/unit/test_cisco_asa_emitter.py
+++ b/tests/unit/test_cisco_asa_emitter.py
@@ -42,6 +42,7 @@ def asa_emitter(tmp_path):
         output_path=tmp_path,
         sensor_hostnames=["fw01"],
     )
+    emitter.configure_output_target("sof-elk")
     emitter._segment_config = [
         {"name": "workstations", "cidr": "10.0.10.0/24"},
         {"name": "servers", "cidr": "10.0.20.0/24"},
@@ -343,7 +344,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         teardown = next(line for line in output.splitlines() if "%ASA-6-302014:" in line)
         assert "TCP FINs" in teardown
         assert "TCP Reset" not in teardown
@@ -932,6 +933,7 @@ class TestNatRecords:
                 output_path=sub_dir,
                 sensor_hostnames=["fw01"],
             )
+            emitter.configure_output_target("sof-elk")
             emitter._segment_config = asa_emitter._segment_config
             emitter._sensor_interfaces = asa_emitter._sensor_interfaces
 

--- a/tests/unit/test_cisco_asa_emitter.py
+++ b/tests/unit/test_cisco_asa_emitter.py
@@ -192,7 +192,7 @@ class TestConnectionIdCounter:
         asa_emitter.emit(early_event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         built_lines = [
             line for line in output.splitlines() if "Built outbound TCP connection" in line
         ]
@@ -248,7 +248,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         lines = [line for line in output.strip().split("\n") if line]
         assert len(lines) == 2
 
@@ -267,6 +267,24 @@ class TestPermitRecords:
         assert int(byte_match.group(1)) > 5120
         assert "SYN Timeout" not in lines[1]
 
+    def test_connection_crossing_year_boundary_keeps_id_pairing(self, asa_emitter, tmp_path):
+        """Built and teardown rows split by year should keep the same connection ID."""
+        event = _make_connection_event(
+            timestamp=datetime(2024, 12, 31, 23, 59, 30, tzinfo=UTC),
+            duration=90,
+        )
+        asa_emitter.emit(event)
+        asa_emitter.close()
+
+        built = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text(encoding="utf-8")
+        teardown = (tmp_path / "fw01" / "2025" / "cisco_asa.log").read_text(encoding="utf-8")
+        built_id = re.search(r"connection (\d+) for", built)
+        teardown_id = re.search(r"connection (\d+) for", teardown)
+
+        assert built_id is not None
+        assert teardown_id is not None
+        assert built_id.group(1) == teardown_id.group(1)
+
     def test_teardown_after_collection_end_is_suppressed(self, asa_emitter, tmp_path):
         """A slice ending before connection close should show a dangling Built record."""
         asa_emitter._output_end_time = T0 + timedelta(seconds=10)
@@ -275,7 +293,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         lines = [line for line in output.strip().split("\n") if line]
         assert len(lines) == 1
         assert "%ASA-6-302013:" in lines[0]
@@ -299,7 +317,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         assert "%ASA-6-302013:" in output
         assert "%ASA-6-305011:" in output
         assert "%ASA-6-302014:" not in output
@@ -312,7 +330,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         teardown = next(line for line in output.splitlines() if "%ASA-6-302014:" in line)
         byte_match = re.search(r"bytes (\d+)", teardown)
         assert byte_match is not None
@@ -342,7 +360,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        assert not (tmp_path / "fw01" / "cisco_asa.log").exists()
+        assert not (tmp_path / "fw01" / "2024" / "cisco_asa.log").exists()
 
     def test_same_interface_deny_is_not_rendered_as_perimeter_flow(self, asa_emitter, tmp_path):
         """ASA should not mirror same-interface internal denies by default."""
@@ -364,7 +382,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        assert not (tmp_path / "fw01" / "cisco_asa.log").exists()
+        assert not (tmp_path / "fw01" / "2024" / "cisco_asa.log").exists()
 
     def test_syn_timeout_requires_handshake_only_connection(self, asa_emitter, tmp_path):
         """SYN Timeout should not be used for connections with payload bytes."""
@@ -378,7 +396,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         teardown = [line for line in output.splitlines() if "%ASA-6-302014:" in line][0]
         assert "SYN Timeout" in teardown
         assert "bytes 0" in teardown
@@ -389,7 +407,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         lines = [line for line in output.strip().split("\n") if line]
         assert len(lines) == 2
         assert "%ASA-6-302015:" in lines[0]
@@ -402,7 +420,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         lines = [line for line in output.strip().split("\n") if line]
         assert len(lines) == 2
         assert "%ASA-6-302020:" in lines[0]
@@ -424,7 +442,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         built_line = next(line for line in output.splitlines() if "%ASA-6-302020:" in line)
         assert "Built inbound ICMP connection" in built_line
         assert "faddr outside:203.0.113.50/8" in built_line
@@ -442,7 +460,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         assert "Built inbound TCP connection" in output
 
     def test_permit_uses_firewall_context_connection_id_and_interfaces(self, asa_emitter, tmp_path):
@@ -459,7 +477,7 @@ class TestPermitRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         assert "TCP connection 424242" in output
         assert "vpn:10.0.10.50/54321" in output
         assert "egress:203.0.113.50/443" in output
@@ -486,7 +504,7 @@ class TestDenyRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         lines = [line for line in output.strip().split("\n") if line]
         assert len(lines) == 1
         assert "%ASA-4-106023:" in lines[0]
@@ -514,7 +532,7 @@ class TestDenyRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         assert "(type 8, code 0)" in output
         assert "Deny icmp" in output
 
@@ -537,7 +555,7 @@ class TestDenyRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        assert not (tmp_path / "fw01" / "cisco_asa.log").exists()
+        assert not (tmp_path / "fw01" / "2024" / "cisco_asa.log").exists()
 
     def test_deny_uses_firewall_context_message_id_and_interfaces(self, asa_emitter, tmp_path):
         """Deny records keep canonical firewall context metadata when provided."""
@@ -557,7 +575,7 @@ class TestDenyRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         assert "%ASA-4-106100:" in output
         assert "Deny tcp src inside:10.0.10.50/54321" in output
         assert "dst internet:203.0.113.53/53" in output
@@ -571,7 +589,7 @@ class TestSyslogFormat:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         first_line = output.strip().split("\n")[0]
         # Priority for severity 6: 20*8+6 = 166
         assert first_line.startswith("<166>")
@@ -591,7 +609,7 @@ class TestSyslogFormat:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         # Priority for severity 4: 20*8+4 = 164
         assert "<164>" in output
         assert "%ASA-4-106023:" in output
@@ -634,7 +652,7 @@ class TestThreatDetection:
         )
 
     def _get_output_lines(self, tmp_path):
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         return [line for line in output.strip().split("\n") if line]
 
     def test_threat_detection_fires_on_burst(self, asa_emitter, tmp_path):
@@ -821,7 +839,7 @@ class TestNatRecords:
         return _make_connection_event(protocol=protocol, firewall=fw, nat=nat)
 
     def _get_output_lines(self, tmp_path):
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         return [line for line in output.strip().split("\n") if line]
 
     def test_built_with_nat_shows_mapped_ips_in_parens(self, asa_emitter, tmp_path):
@@ -830,7 +848,7 @@ class TestNatRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         # The Built line should show mapped source in parens
         assert "(198.51.100.1/12345)" in output
         # Should NOT show the real pre-NAT source in parens
@@ -842,7 +860,7 @@ class TestNatRecords:
         asa_emitter.emit(event)
         asa_emitter.flush()
 
-        output = (tmp_path / "fw01" / "cisco_asa.log").read_text()
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         # Parens should reflect the real IPs since there is no NAT
         assert "(10.0.10.50/54321)" in output
         assert "(203.0.113.50/443)" in output
@@ -921,7 +939,7 @@ class TestNatRecords:
             emitter.emit(event)
             emitter.flush()
 
-            output = (sub_dir / "fw01" / "cisco_asa.log").read_text()
+            output = (sub_dir / "fw01" / "2024" / "cisco_asa.log").read_text()
             nat_built_lines = [line for line in output.strip().split("\n") if "305011" in line]
             assert len(nat_built_lines) >= 1, f"No 305011 line for {proto}"
             assert f"Built dynamic {proto.upper()} translation" in nat_built_lines[0]

--- a/tests/unit/test_cisco_asa_parser.py
+++ b/tests/unit/test_cisco_asa_parser.py
@@ -22,7 +22,9 @@
 
 """Tests for the Cisco ASA firewall log parser."""
 
+from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 from evidenceforge.evaluation.parsers.cisco_asa import CiscoAsaParser
 
@@ -31,6 +33,7 @@ class TestCanParse:
     def test_matches_cisco_asa_log(self):
         parser = CiscoAsaParser()
         assert parser.can_parse(Path("fw01/cisco_asa.log")) is True
+        assert parser.can_parse(Path("fw01/2026/cisco_asa.log")) is True
 
     def test_rejects_other_files(self):
         parser = CiscoAsaParser()
@@ -288,3 +291,37 @@ class TestMalformedLines:
         parser = CiscoAsaParser()
         records = list(parser.parse_file(log))
         assert len(records) == 0
+
+
+class TestTimestampYear:
+    def test_parent_year_overrides_current_year(self, tmp_path):
+        log = tmp_path / "fw01" / "2024" / "cisco_asa.log"
+        log.parent.mkdir(parents=True)
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-302015: Built outbound UDP connection "
+            "100043 for inside:10.0.10.50/54322 (10.0.10.50/54322) to "
+            "outside:8.8.8.8/53 (8.8.8.8/53)\n"
+        )
+
+        records = list(CiscoAsaParser().parse_file(log))
+
+        assert records[0].timestamp is not None
+        assert records[0].timestamp.year == 2024
+
+    def test_flat_layout_falls_back_to_scenario_year(self, tmp_path):
+        log = tmp_path / "fw01" / "cisco_asa.log"
+        log.parent.mkdir()
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-302015: Built outbound UDP connection "
+            "100043 for inside:10.0.10.50/54322 (10.0.10.50/54322) to "
+            "outside:8.8.8.8/53 (8.8.8.8/53)\n"
+        )
+        parser = CiscoAsaParser()
+        parser.scenario = SimpleNamespace(
+            time_window=SimpleNamespace(start=datetime(2025, 12, 31, 23, 59, 0))
+        )
+
+        records = list(parser.parse_file(log))
+
+        assert records[0].timestamp is not None
+        assert records[0].timestamp.year == 2025

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -37,6 +37,7 @@ from evidenceforge.cli.commands import (
     app,
 )
 from evidenceforge.events.observation_manifest import OBSERVATION_MANIFEST_FILENAME
+from evidenceforge.output_targets import OUTPUT_TARGET_FILENAME, OutputTarget
 
 runner = CliRunner()
 
@@ -108,6 +109,46 @@ name: test
         assert result.exit_code == EXIT_SUCCESS
         assert "✓" in result.stdout or "complete" in result.stdout.lower()
         assert mock_engine.generate.called
+        assert mock_engine_class.call_args.kwargs["output_target"] == OutputTarget.DEFAULT
+
+    @patch("evidenceforge.cli.commands.GenerationEngine")
+    def test_generate_accepts_sof_elk_target(self, mock_engine_class, scenarios_dir, tmp_path):
+        """--target sof-elk is passed to the generation engine."""
+        mock_engine = Mock()
+        mock_engine_class.return_value = mock_engine
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--target",
+                "sof-elk",
+            ],
+        )
+
+        assert result.exit_code == EXIT_SUCCESS
+        assert mock_engine_class.call_args.kwargs["output_target"] == OutputTarget.SOF_ELK
+        assert (tmp_path / OUTPUT_TARGET_FILENAME).read_text(encoding="utf-8") == "sof-elk\n"
+
+    def test_generate_invalid_target_fails_clearly(self, scenarios_dir, tmp_path):
+        """Invalid --target values should fail before generation starts."""
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                str(scenarios_dir / "minimal.yaml"),
+                "--output",
+                str(tmp_path),
+                "--target",
+                "splunk",
+            ],
+        )
+
+        assert result.exit_code == EXIT_INPUT_ERROR
+        assert "invalid output target" in result.stdout
 
     @patch("evidenceforge.cli.commands.GenerationEngine")
     def test_generate_verbose_mode(self, mock_engine_class, scenarios_dir, tmp_path):

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -941,7 +941,7 @@ class TestCanHandleDefault:
         timestamp = datetime(2024, 10, 14, 19, 0, 53, tzinfo=UTC)
         for message in [
             "Accepted password for admin from 10.0.10.50 port 51111 ssh2",
-            'Connection from 10.0.10.50 port 51111 on 10.0.20.10 port 22 rdomain ""',
+            "Connection from 10.0.10.50 port 51111 on 10.0.20.10 port 22",
             "pam_unix(sshd:session): session opened for user admin(uid=1001) by (uid=0)",
         ]:
             emitter.emit_raw(

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -726,8 +726,38 @@ class TestCanHandleDefault:
         emitter.close()
 
         lines = output_path.read_text(encoding="utf-8").splitlines()
-        assert lines[0].startswith("<86>1 2024-10-14T19:00:53.000000Z")
-        assert lines[1].startswith("<86>1 2024-10-14T20:01:25.000000Z")
+        assert lines[0].startswith("<86>Oct 14 19:00:53")
+        assert lines[1].startswith("<86>Oct 14 20:01:25")
+
+    def test_syslog_routes_generated_output_by_event_year(self, tmp_path):
+        """Directory-mode syslog output should split host logs by event year."""
+        from datetime import UTC, datetime
+
+        from evidenceforge.formats import load_format
+        from evidenceforge.generation.emitters.syslog import SyslogEmitter
+
+        format_def = load_format("syslog")
+        emitter = SyslogEmitter(format_def, tmp_path, buffer_size=10)
+        for timestamp in (
+            datetime(2024, 12, 31, 23, 59, 59, tzinfo=UTC),
+            datetime(2025, 1, 1, 0, 0, 1, tzinfo=UTC),
+        ):
+            emitter.emit_raw(
+                {
+                    "timestamp": timestamp,
+                    "hostname": "linux01",
+                    "app_name": "sshd",
+                    "pid": 500,
+                    "facility": 10,
+                    "severity": 6,
+                    "message": "Accepted password for admin from 10.0.0.1 port 50000 ssh2",
+                    "_host_fqdn": "linux01.example.test",
+                }
+            )
+        emitter.close()
+
+        assert (tmp_path / "linux01.example.test" / "2024" / "syslog.log").exists()
+        assert (tmp_path / "linux01.example.test" / "2025" / "syslog.log").exists()
 
     def test_syslog_normalizes_logind_session_ids_in_rendered_order(self, tmp_path):
         """Rendered New-session IDs should not move backward after final syslog sort."""

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -701,6 +701,7 @@ class TestCanHandleDefault:
         format_def = load_format("syslog")
         output_path = tmp_path / "syslog.log"
         emitter = SyslogEmitter(format_def, output_path, buffer_size=1)
+        emitter.configure_output_target("sof-elk")
         emitter.emit_raw(
             {
                 "timestamp": datetime(2024, 10, 14, 20, 1, 25, tzinfo=UTC),
@@ -738,6 +739,7 @@ class TestCanHandleDefault:
 
         format_def = load_format("syslog")
         emitter = SyslogEmitter(format_def, tmp_path, buffer_size=10)
+        emitter.configure_output_target("sof-elk")
         for timestamp in (
             datetime(2024, 12, 31, 23, 59, 59, tzinfo=UTC),
             datetime(2025, 1, 1, 0, 0, 1, tzinfo=UTC),
@@ -769,6 +771,7 @@ class TestCanHandleDefault:
         format_def = load_format("syslog")
         output_path = tmp_path / "syslog.log"
         emitter = SyslogEmitter(format_def, output_path, buffer_size=10)
+        emitter.configure_output_target("sof-elk")
         for timestamp, message in [
             (
                 datetime(2024, 3, 18, 12, 10, 9, tzinfo=UTC),
@@ -845,6 +848,7 @@ class TestCanHandleDefault:
         format_def = load_format("syslog")
         output_path = tmp_path / "syslog.log"
         emitter = SyslogEmitter(format_def, output_path, buffer_size=10)
+        emitter.configure_output_target("sof-elk")
         for timestamp, message in [
             (
                 datetime(2024, 3, 18, 12, 1, 55, tzinfo=UTC),
@@ -938,6 +942,7 @@ class TestCanHandleDefault:
         format_def = load_format("syslog")
         output_path = tmp_path / "syslog.log"
         emitter = SyslogEmitter(format_def, output_path, buffer_size=10)
+        emitter.configure_output_target("sof-elk")
         timestamp = datetime(2024, 10, 14, 19, 0, 53, tzinfo=UTC)
         for message in [
             "Accepted password for admin from 10.0.10.50 port 51111 ssh2",
@@ -972,6 +977,7 @@ class TestCanHandleDefault:
         format_def = load_format("syslog")
         output_path = tmp_path / "syslog.log"
         emitter = SyslogEmitter(format_def, output_path, buffer_size=10)
+        emitter.configure_output_target("sof-elk")
         timestamp = datetime(2024, 3, 18, 12, 11, 6, tzinfo=UTC)
         for message in [
             "DHCPACK of 10.10.1.99 from 10.10.2.10",

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -41,6 +41,7 @@ from evidenceforge.models import (
     User,
 )
 from evidenceforge.models.scenario import ConnectionEventSpec
+from evidenceforge.output_targets import OUTPUT_TARGET_FILENAME
 
 
 def test_service_wrapper_storyline_processes_are_long_lived():
@@ -970,8 +971,10 @@ class TestGenerationEngine:
 
         ground_truth = tmp_path / "GROUND_TRUTH.md"
         manifest = tmp_path / OBSERVATION_MANIFEST_FILENAME
+        target_marker = tmp_path / OUTPUT_TARGET_FILENAME
         assert ground_truth.exists()
         assert manifest.exists()
+        assert target_marker.read_text(encoding="utf-8") == "default\n"
         assert "No malicious activities" in ground_truth.read_text()
         assert "No malicious events were generated" in ground_truth.read_text()
 

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -118,7 +118,68 @@ class TestWindowsEventParser:
 
         parser = WindowsEventParser()
         assert parser.can_parse(Path("windows_event_security.xml"))
+        assert parser.can_parse(Path("windows_event_security_snare.log"))
         assert not parser.can_parse(Path("zeek_conn.json"))
+
+    def test_parses_snare_security_as_canonical_windows(self, tmp_path):
+        from evidenceforge.evaluation.parsers.windows import WindowsEventParser
+
+        log_dir = tmp_path / "win-01.example.test" / "2026"
+        log_dir.mkdir(parents=True)
+        log = log_dir / "windows_event_security_snare.log"
+        log.write_text(
+            "<86>Jun 15 14:23:05 win-01.example.test "
+            "win-01.example.test\tMSWinEventLog\t0\tSecurity\t101\t"
+            "Mon Jun 15 14:23:05 2026\t4624\t"
+            "Microsoft-Windows-Security-Auditing\talice\tN/A\tSuccess Audit\t"
+            "win-01.example.test\tLogon\tAn account was successfully logged on.:  "
+            "Account Name: alice  Logon ID: 0x46a3f  \n",
+            encoding="utf-8",
+        )
+
+        records = list(WindowsEventParser().parse_file(log))
+
+        assert len(records) == 1
+        assert records[0].source_format == "windows_event_security"
+        assert records[0].fields["EventID"] == 4624
+        assert records[0].fields["Channel"] == "Security"
+        assert records[0].timestamp.year == 2026
+        assert records[0].parse_errors == []
+
+
+class TestSysmonEventParser:
+    def test_can_parse_xml_and_snare_files(self):
+        from evidenceforge.evaluation.parsers.windows import SysmonEventParser
+
+        parser = SysmonEventParser()
+        assert parser.can_parse(Path("windows_event_sysmon.xml"))
+        assert parser.can_parse(Path("windows_event_sysmon_snare.log"))
+        assert not parser.can_parse(Path("windows_event_security.xml"))
+
+    def test_parses_snare_sysmon_as_canonical_sysmon(self, tmp_path):
+        from evidenceforge.evaluation.parsers.windows import SysmonEventParser
+
+        log_dir = tmp_path / "win-01.example.test" / "2026"
+        log_dir.mkdir(parents=True)
+        log = log_dir / "windows_event_sysmon_snare.log"
+        log.write_text(
+            "<14>Jun 15 14:23:06 win-01.example.test "
+            "win-01.example.test\tMSWinEventLog\t0\t"
+            "Microsoft-Windows-Sysmon/Operational\t101\t"
+            "Mon Jun 15 14:23:06 2026\t1\tMicrosoft-Windows-Sysmon\talice\tN/A\t"
+            "Information\twin-01.example.test\tProcess Create\tProcess Create:  "
+            "Image: C:\\Windows\\System32\\cmd.exe  ProcessId: 4321  \n",
+            encoding="utf-8",
+        )
+
+        records = list(SysmonEventParser().parse_file(log))
+
+        assert len(records) == 1
+        assert records[0].source_format == "windows_event_sysmon"
+        assert records[0].fields["EventID"] == 1
+        assert records[0].fields["Image"] == "C:\\Windows\\System32\\cmd.exe"
+        assert records[0].timestamp.year == 2026
+        assert records[0].parse_errors == []
 
 
 class TestZeekConnParser:
@@ -485,5 +546,5 @@ class TestParserDiscovery:
     def test_all_parsers_registered(self):
         from evidenceforge.evaluation.parsers import _PARSER_CLASSES
 
-        # 7 original + 12 new Zeek parsers + cisco_asa + proxy_access
-        assert len(_PARSER_CLASSES) == 21
+        # Original parsers + Sysmon + 12 Zeek parsers + cisco_asa + proxy_access
+        assert len(_PARSER_CLASSES) == 22

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -200,7 +200,7 @@ class TestSyslogParser:
         assert first.fields["pid"] == 12345
         assert first.fields["facility"] == 10
         assert first.fields["severity"] == 6
-        assert first.fields["syslog_protocol"] == "rfc5424"
+        assert first.fields["syslog_protocol"] == "rfc5424_legacy"
         assert "Accepted publickey" in first.fields["message"]
 
     def test_extracts_timestamps(self):
@@ -257,6 +257,32 @@ class TestSyslogParser:
         assert records[0].timestamp is not None
         assert records[0].timestamp.year == 2024
         assert records[0].fields["syslog_protocol"] == "rfc3164_legacy"
+
+    def test_parent_year_overrides_scenario_for_generated_rfc3164(self, tmp_path):
+        """Generated syslog uses the parent YYYY directory for BSD timestamps."""
+        from types import SimpleNamespace
+
+        from evidenceforge.evaluation.parsers.syslog import SyslogParser
+
+        log_dir = tmp_path / "host" / "2026"
+        log_dir.mkdir(parents=True)
+        log = log_dir / "syslog.log"
+        log.write_text(
+            "<86>Mar 18 12:00:00 host sshd[1]: Connected from 10.0.0.1\n",
+            encoding="utf-8",
+        )
+        scenario = SimpleNamespace(
+            time_window=SimpleNamespace(
+                start=__import__("datetime").datetime(2024, 3, 1, 0, 0, 0, tzinfo=UTC)
+            )
+        )
+        parser = SyslogParser()
+        parser.scenario = scenario
+        records = list(parser.parse_file(log))
+
+        assert records[0].timestamp is not None
+        assert records[0].timestamp.year == 2026
+        assert records[0].fields["syslog_protocol"] == "rfc3164"
 
     def test_mtime_fallback_when_no_scenario(self, tmp_path):
         """Without a scenario, year falls back to mtime."""

--- a/tests/unit/test_eval_strict_parsers.py
+++ b/tests/unit/test_eval_strict_parsers.py
@@ -30,12 +30,25 @@ from evidenceforge.formats.validator import STRICT_FORMATS, validate_strict
 
 
 class TestStrictSyslog:
-    def test_bsd_without_legacy_marker_is_invalid(self):
-        """Generated syslog strict mode requires RFC 5424."""
+    def test_rfc5424_without_legacy_marker_is_invalid(self):
+        """Generated syslog strict mode requires RFC3164."""
+        raw = "<86>1 2026-03-18T12:00:00.000000Z PROXY-01 sudo 50424 - - message"
+        result = validate_strict("syslog", raw, {})
+        assert not result.valid
+        assert any("rfc3164" in e.lower() for e in result.errors)
+
+    def test_valid_rfc3164_with_pri(self):
+        """RFC3164 with PRI < 192 is valid generated syslog."""
+        raw = "Mar 18 12:00:00 PROXY-01 sudo[50424]: root : TTY=pts/1"
+        result = validate_strict("syslog", f"<86>{raw}", {})
+        assert result.valid, result.errors
+
+    def test_bsd_without_pri_is_invalid(self):
+        """Generated syslog requires PRI."""
         raw = "Mar 18 12:00:00 PROXY-01 sudo[50424]: root : TTY=pts/1"
         result = validate_strict("syslog", raw, {})
         assert not result.valid
-        assert any("rfc 5424" in e.lower() for e in result.errors)
+        assert any("rfc3164" in e.lower() for e in result.errors)
 
     def test_legacy_bsd_parser_records_are_valid(self):
         """Legacy BSD remains acceptable when the parser marks it as eval fallback input."""
@@ -43,28 +56,28 @@ class TestStrictSyslog:
         result = validate_strict("syslog", raw, {"syslog_protocol": "rfc3164_legacy"})
         assert result.valid, result.errors
 
-    def test_valid_rfc5424_with_pri(self):
-        """RFC 5424 with PRI < 192 — valid."""
+    def test_legacy_rfc5424_with_marker_is_valid(self):
+        """Old RFC5424 generated datasets remain valid when parser marks them."""
         raw = "<86>1 2026-03-18T12:00:00.000000Z PROXY-01 sudo 50424 - - message"
-        result = validate_strict("syslog", raw, {})
+        result = validate_strict("syslog", raw, {"syslog_protocol": "rfc5424_legacy"})
         assert result.valid, result.errors
 
     def test_valid_pri_boundary_191(self):
         """PRI == 191 is the maximum valid priority."""
-        raw = "<191>1 2026-03-18T12:00:00Z host app 123 - - msg"
+        raw = "<191>Mar 18 12:00:00 host app[123]: msg"
         result = validate_strict("syslog", raw, {})
         assert result.valid, result.errors
 
     def test_invalid_bsd_no_pri_wrong_format(self):
-        """Plain text that is not RFC 5424 — fails."""
+        """Plain text that is not RFC3164 — fails."""
         raw = "not a syslog line"
         result = validate_strict("syslog", raw, {})
         assert not result.valid
-        assert any("rfc 5424" in e.lower() for e in result.errors)
+        assert any("rfc3164" in e.lower() for e in result.errors)
 
     def test_invalid_pri_exceeds_191(self):
         """PRI > 191 — fails."""
-        raw = "<200>1 2026-03-18T12:00:00Z host app 123 - - msg"
+        raw = "<200>Mar 18 12:00:00 host app[123]: msg"
         result = validate_strict("syslog", raw, {})
         assert not result.valid
         assert any("192" in e or "200" in e or "191" in e for e in result.errors)
@@ -75,10 +88,10 @@ class TestStrictSyslog:
         result = validate_strict("syslog", raw, {})
         assert not result.valid
 
-    def test_invalid_rfc5424_version(self):
-        """RFC 5424 VERSION must be 1."""
+    def test_invalid_legacy_rfc5424_version(self):
+        """Legacy RFC5424 VERSION must be 1."""
         raw = "<86>2 2026-03-18T12:00:00Z host app 123 - - msg"
-        result = validate_strict("syslog", raw, {})
+        result = validate_strict("syslog", raw, {"syslog_protocol": "rfc5424_legacy"})
         assert not result.valid
         assert any("version" in e.lower() for e in result.errors)
 

--- a/tests/unit/test_output_target_rendering.py
+++ b/tests/unit/test_output_target_rendering.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Focused renderer/layout tests for output targets."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from evidenceforge.formats import load_format
+from evidenceforge.generation.emitters.cisco_asa import CiscoAsaEmitter
+from evidenceforge.generation.emitters.syslog import SyslogEmitter
+
+
+def test_default_syslog_target_writes_rfc5424_flat_host_file(tmp_path: Path) -> None:
+    emitter = SyslogEmitter(load_format("syslog"), tmp_path, buffer_size=10)
+    emitter.configure_output_target("default")
+
+    emitter.emit_raw(_syslog_event())
+    emitter.close()
+
+    output_path = tmp_path / "linux01.example.test" / "syslog.log"
+    assert output_path.exists()
+    assert not (tmp_path / "linux01.example.test" / "2026" / "syslog.log").exists()
+    assert output_path.read_text(encoding="utf-8").startswith(
+        "<86>1 2026-06-15T14:23:05Z linux01 sshd 1234 - - Accepted password"
+    )
+
+
+def test_sof_elk_syslog_target_writes_rfc3164_year_partitioned_file(tmp_path: Path) -> None:
+    emitter = SyslogEmitter(load_format("syslog"), tmp_path, buffer_size=10)
+    emitter.configure_output_target("sof-elk")
+
+    emitter.emit_raw(_syslog_event())
+    emitter.close()
+
+    output_path = tmp_path / "linux01.example.test" / "2026" / "syslog.log"
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8").startswith(
+        "<86>Jun 15 14:23:05 linux01 sshd[1234]: Accepted password"
+    )
+
+
+def test_default_cisco_asa_target_writes_flat_sensor_file(tmp_path: Path) -> None:
+    emitter = CiscoAsaEmitter(
+        load_format("cisco_asa"),
+        tmp_path,
+        sensor_hostnames=["fw01"],
+    )
+    emitter.configure_output_target("default")
+
+    emitter.emit_event(_asa_event())
+    emitter.close()
+
+    output_path = tmp_path / "fw01" / "cisco_asa.log"
+    assert output_path.exists()
+    assert not (tmp_path / "fw01" / "2026" / "cisco_asa.log").exists()
+    assert "%ASA-6-302013: Built outbound TCP connection 7" in output_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_sof_elk_cisco_asa_target_writes_year_partitioned_sensor_file(tmp_path: Path) -> None:
+    emitter = CiscoAsaEmitter(
+        load_format("cisco_asa"),
+        tmp_path,
+        sensor_hostnames=["fw01"],
+    )
+    emitter.configure_output_target("sof-elk")
+
+    emitter.emit_event(_asa_event())
+    emitter.close()
+
+    output_path = tmp_path / "fw01" / "2026" / "cisco_asa.log"
+    assert output_path.exists()
+    assert "%ASA-6-302013: Built outbound TCP connection 7" in output_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def _syslog_event() -> dict[str, object]:
+    return {
+        "timestamp": datetime(2026, 6, 15, 14, 23, 5, tzinfo=UTC),
+        "hostname": "linux01",
+        "app_name": "sshd",
+        "pid": 1234,
+        "facility": 10,
+        "severity": 6,
+        "message": "Accepted password for alice from 198.51.100.25 port 54321 ssh2",
+        "_host_fqdn": "linux01.example.test",
+    }
+
+
+def _asa_event() -> dict[str, object]:
+    return {
+        "timestamp": datetime(2026, 6, 15, 14, 23, 5, tzinfo=UTC),
+        "hostname": "fw01",
+        "severity": 6,
+        "msg_id": 302013,
+        "message": "Built outbound TCP connection 7 for inside:10.0.10.5/54321 "
+        "to outside:198.51.100.10/443",
+        "pri": 166,
+        "_sensor_hostnames": ["fw01"],
+    }

--- a/tests/unit/test_output_targets.py
+++ b/tests/unit/test_output_targets.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for target-aware output policy."""
+
+from pathlib import Path
+
+import pytest
+
+from evidenceforge.generation.engine.emitter_setup import _build_emitter_classes
+from evidenceforge.output_targets import (
+    FORMAT_TARGET_POLICIES,
+    OutputTarget,
+    normalize_output_target,
+    read_output_target_marker,
+    target_dependent_formats,
+    write_output_target_marker,
+)
+
+
+def test_output_target_marker_defaults_to_default_for_legacy_data(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    assert read_output_target_marker(data_dir) == OutputTarget.DEFAULT
+
+
+def test_output_target_marker_round_trips_from_scenario_root_or_data_dir(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    marker = write_output_target_marker(tmp_path, "sof-elk")
+
+    assert marker.read_text(encoding="utf-8") == "sof-elk\n"
+    assert read_output_target_marker(tmp_path) == OutputTarget.SOF_ELK
+    assert read_output_target_marker(data_dir) == OutputTarget.SOF_ELK
+
+
+def test_invalid_output_target_raises_clear_error() -> None:
+    with pytest.raises(ValueError, match="expected one of: default, sof-elk"):
+        normalize_output_target("splunk")
+
+
+def test_every_emitted_canonical_format_has_target_policy() -> None:
+    assert set(_build_emitter_classes()) == set(FORMAT_TARGET_POLICIES)
+
+
+def test_target_policy_identifies_v1_target_dependent_formats() -> None:
+    assert target_dependent_formats() == {
+        "windows_event_security",
+        "windows_event_sysmon",
+        "syslog",
+        "cisco_asa",
+    }

--- a/tests/unit/test_phase5_logoff.py
+++ b/tests/unit/test_phase5_logoff.py
@@ -245,6 +245,7 @@ class TestLogoffLinux:
         )
         assert event.timestamp == close_time + expected_delta
         assert "Received disconnect from 10.0.10.50 port 51111" in event.syslog.message
+        assert event.syslog.message.endswith(":11:  [preauth]")
 
     def test_ssh_logoff_suppresses_syslog_when_far_from_transport_close(
         self, activity_gen, test_user, linux_system, timestamp, state_manager, mock_emitters

--- a/tests/unit/test_realism_quick_wins.py
+++ b/tests/unit/test_realism_quick_wins.py
@@ -347,6 +347,7 @@ def test_asa_output_sorted(tmp_path):
         output_path=tmp_path,
         sensor_hostnames=["fw01"],
     )
+    emitter.configure_output_target("sof-elk")
     emitter._segment_config = [
         {"name": "workstations", "cidr": "10.0.10.0/24"},
         {"name": "servers", "cidr": "10.0.20.0/24"},

--- a/tests/unit/test_realism_quick_wins.py
+++ b/tests/unit/test_realism_quick_wins.py
@@ -381,7 +381,7 @@ def test_asa_output_sorted(tmp_path):
 
     emitter.flush()
 
-    output_file = tmp_path / "fw01" / "cisco_asa.log"
+    output_file = tmp_path / "fw01" / "2024" / "cisco_asa.log"
     assert output_file.exists(), "ASA output file should exist"
     lines = [line for line in output_file.read_text().strip().split("\n") if line.strip()]
     assert len(lines) >= 10, (

--- a/tests/unit/test_syslog_family_renderer.py
+++ b/tests/unit/test_syslog_family_renderer.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for shared syslog-family rendering helpers."""
+
+from datetime import UTC, datetime
+
+from evidenceforge.generation.emitters.syslog_family import (
+    make_syslog_family_route_key,
+    render_rfc3164_syslog,
+    rfc3164_timestamp_sort_key,
+    sanitize_syslog_family_route_key,
+    syslog_family_writer_path,
+    syslog_priority,
+)
+
+
+def test_render_rfc3164_syslog_uses_bsd_timestamp_and_pid() -> None:
+    line = render_rfc3164_syslog(
+        pri=86,
+        timestamp=datetime(2026, 3, 8, 12, 0, 1, tzinfo=UTC),
+        hostname="linux-01",
+        app_name="sshd",
+        pid=1234,
+        message="Accepted password for alice",
+    )
+
+    assert line == "<86>Mar  8 12:00:01 linux-01 sshd[1234]: Accepted password for alice"
+
+
+def test_render_rfc3164_syslog_omits_empty_pid() -> None:
+    line = render_rfc3164_syslog(
+        pri=30,
+        timestamp=datetime(2026, 3, 18, 12, 0, 1, tzinfo=UTC),
+        hostname="linux-01",
+        app_name="systemd",
+        pid=None,
+        message="Started service.",
+    )
+
+    assert line == "<30>Mar 18 12:00:01 linux-01 systemd: Started service."
+
+
+def test_syslog_priority_clamps_facility_and_severity() -> None:
+    assert syslog_priority(10, 6) == 86
+    assert syslog_priority(99, 99) == 191
+
+
+def test_year_route_key_writes_source_year_path(tmp_path) -> None:
+    route_key = make_syslog_family_route_key(
+        "fw01",
+        datetime(2026, 6, 15, 14, 23, 5, tzinfo=UTC),
+        direct_file_mode=False,
+    )
+    safe_route_key = sanitize_syslog_family_route_key(route_key)
+    path = syslog_family_writer_path(
+        base_dir=tmp_path,
+        safe_route_key=safe_route_key,
+        log_filename="cisco_asa.log",
+        direct_file_path=None,
+        flat_filename="cisco_asa.log",
+    )
+
+    assert path == tmp_path / "fw01" / "2026" / "cisco_asa.log"
+
+
+def test_rfc3164_timestamp_sort_key_handles_single_digit_day() -> None:
+    assert rfc3164_timestamp_sort_key("<86>Mar  8 12:00:01 host app: one") < (
+        rfc3164_timestamp_sort_key("<86>Mar 18 12:00:01 host app: two")
+    )

--- a/tests/unit/test_windows_snare_sidecar.py
+++ b/tests/unit/test_windows_snare_sidecar.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for Windows Snare-over-syslog sidecar output."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from evidenceforge.formats.loader import load_format
+from evidenceforge.generation.emitters.sysmon import SysmonEventEmitter
+from evidenceforge.generation.emitters.windows import WindowsEventEmitter
+from evidenceforge.generation.emitters.windows_snare import (
+    render_windows_security_snare_syslog,
+)
+
+
+def test_windows_security_snare_renderer_uses_payload_marker_without_syslog_app_tag() -> None:
+    event = _security_event(datetime(2026, 6, 15, 14, 23, 5, tzinfo=UTC))
+
+    rendered = render_windows_security_snare_syslog(event)
+
+    assert rendered.startswith(
+        "<86>Jun 15 14:23:05 WIN-01.example.test "
+        "WIN-01.example.test\tMSWinEventLog\t0\tSecurity\t101\t"
+    )
+    assert "\t4624\tMicrosoft-Windows-Security-Auditing\talice\t" in rendered
+    assert "An account was successfully logged on.:  " in rendered
+    assert "Security ID: S-1-5-18" in rendered
+    assert "Account Name: alice" in rendered
+
+
+def test_windows_security_emitter_writes_xml_and_year_partitioned_snare_sidecar(
+    tmp_path: Path,
+) -> None:
+    emitter = WindowsEventEmitter(
+        load_format("windows_event_security"),
+        tmp_path,
+        buffer_size=10,
+    )
+    emitter.emit_event(_security_event(datetime(2025, 12, 31, 23, 59, 58, tzinfo=UTC)))
+    emitter.emit_event(_security_event(datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC)))
+    emitter.close()
+
+    xml_path = tmp_path / "WIN-01.example.test" / "windows_event_security.xml"
+    snare_2025 = tmp_path / "WIN-01.example.test" / "2025" / "windows_event_security_snare.log"
+    snare_2026 = tmp_path / "WIN-01.example.test" / "2026" / "windows_event_security_snare.log"
+
+    assert xml_path.exists()
+    assert snare_2025.exists()
+    assert snare_2026.exists()
+    assert "\tSecurity\t" in snare_2026.read_text(encoding="utf-8")
+    assert "\tMicrosoft-Windows-Security-Auditing\t" in snare_2026.read_text(encoding="utf-8")
+
+
+def test_sysmon_emitter_writes_xml_and_year_partitioned_snare_sidecar(tmp_path: Path) -> None:
+    emitter = SysmonEventEmitter(
+        load_format("windows_event_sysmon"),
+        tmp_path,
+        buffer_size=10,
+    )
+    emitter.emit_event(_sysmon_process_create_event(datetime(2026, 6, 15, 14, 23, 5, tzinfo=UTC)))
+    emitter.close()
+
+    xml_path = tmp_path / "WIN-01.example.test" / "windows_event_sysmon.xml"
+    snare_path = tmp_path / "WIN-01.example.test" / "2026" / "windows_event_sysmon_snare.log"
+    snare = snare_path.read_text(encoding="utf-8")
+
+    assert xml_path.exists()
+    assert snare.startswith(
+        "<14>Jun 15 14:23:05 WIN-01.example.test "
+        "WIN-01.example.test\tMSWinEventLog\t0\t"
+        "Microsoft-Windows-Sysmon/Operational\t"
+    )
+    assert "\t1\tMicrosoft-Windows-Sysmon\tCORP\\alice\t" in snare
+    assert "ProcessId: 4321" in snare
+    assert "Image: C:\\Windows\\System32\\cmd.exe" in snare
+    assert "UtcTime: 2026-06-15 14:23:05." in snare
+
+
+def _security_event(timestamp: datetime) -> dict[str, object]:
+    return {
+        "EventID": 4624,
+        "TimeCreated": timestamp,
+        "Computer": "WIN-01.example.test",
+        "Channel": "Security",
+        "Level": 0,
+        "EventRecordID": 101,
+        "ExecutionProcessID": 704,
+        "ExecutionThreadID": 812,
+        "SubjectUserSid": "S-1-5-18",
+        "SubjectUserName": "SYSTEM",
+        "SubjectDomainName": "NT AUTHORITY",
+        "SubjectLogonId": "0x3e7",
+        "TargetUserSid": "S-1-5-21-1000-1001",
+        "TargetUserName": "alice",
+        "TargetDomainName": "CORP",
+        "TargetLogonId": "0x46a3f",
+        "LogonType": 3,
+        "WorkstationName": "WS-01",
+        "ProcessId": "0x3e4",
+        "ProcessName": "C:\\Windows\\System32\\lsass.exe",
+        "IpAddress": "10.0.10.25",
+        "IpPort": 54321,
+    }
+
+
+def _sysmon_process_create_event(timestamp: datetime) -> dict[str, object]:
+    return {
+        "EventID": 1,
+        "TimeCreated": timestamp,
+        "Computer": "WIN-01.example.test",
+        "Channel": "Microsoft-Windows-Sysmon/Operational",
+        "Level": 4,
+        "EventRecordID": 100001,
+        "ExecutionProcessID": 4020,
+        "ExecutionThreadID": 4024,
+        "RuleName": "-",
+        "UtcTime": "2026-06-15 14:23:05.000",
+        "ProcessGuid": "{11111111-1111-1111-1111-111111111111}",
+        "ProcessId": 4321,
+        "Image": "C:\\Windows\\System32\\cmd.exe",
+        "CommandLine": "cmd.exe /c whoami",
+        "User": "CORP\\alice",
+        "LogonGuid": "{22222222-2222-2222-2222-222222222222}",
+        "LogonId": "0x46a3f",
+        "IntegrityLevel": "Medium",
+        "Hashes": "MD5=0123456789abcdef0123456789abcdef",
+        "ParentProcessGuid": "{33333333-3333-3333-3333-333333333333}",
+        "ParentProcessId": 4000,
+        "ParentImage": "C:\\Windows\\explorer.exe",
+        "ParentCommandLine": "C:\\Windows\\explorer.exe",
+    }

--- a/tests/unit/test_windows_snare_sidecar.py
+++ b/tests/unit/test_windows_snare_sidecar.py
@@ -50,7 +50,7 @@ def test_windows_security_snare_renderer_uses_payload_marker_without_syslog_app_
     assert "Account Name: alice" in rendered
 
 
-def test_windows_security_emitter_writes_xml_and_year_partitioned_snare_sidecar(
+def test_windows_security_emitter_default_target_writes_xml_only(
     tmp_path: Path,
 ) -> None:
     emitter = WindowsEventEmitter(
@@ -67,13 +67,61 @@ def test_windows_security_emitter_writes_xml_and_year_partitioned_snare_sidecar(
     snare_2026 = tmp_path / "WIN-01.example.test" / "2026" / "windows_event_security_snare.log"
 
     assert xml_path.exists()
+    assert not snare_2025.exists()
+    assert not snare_2026.exists()
+
+
+def test_windows_security_emitter_sof_elk_target_writes_snare_only(tmp_path: Path) -> None:
+    emitter = WindowsEventEmitter(
+        load_format("windows_event_security"),
+        tmp_path,
+        buffer_size=10,
+    )
+    emitter.configure_output_target("sof-elk")
+    emitter.emit_event(_security_event(datetime(2025, 12, 31, 23, 59, 58, tzinfo=UTC)))
+    emitter.emit_event(_security_event(datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC)))
+    emitter.close()
+
+    xml_path = tmp_path / "WIN-01.example.test" / "windows_event_security.xml"
+    snare_2025 = tmp_path / "WIN-01.example.test" / "2025" / "windows_event_security_snare.log"
+    snare_2026 = tmp_path / "WIN-01.example.test" / "2026" / "windows_event_security_snare.log"
+
+    assert not xml_path.exists()
     assert snare_2025.exists()
     assert snare_2026.exists()
     assert "\tSecurity\t" in snare_2026.read_text(encoding="utf-8")
     assert "\tMicrosoft-Windows-Security-Auditing\t" in snare_2026.read_text(encoding="utf-8")
 
 
-def test_sysmon_emitter_writes_xml_and_year_partitioned_snare_sidecar(tmp_path: Path) -> None:
+def test_sysmon_emitter_sof_elk_target_writes_year_partitioned_snare_only(
+    tmp_path: Path,
+) -> None:
+    emitter = SysmonEventEmitter(
+        load_format("windows_event_sysmon"),
+        tmp_path,
+        buffer_size=10,
+    )
+    emitter.configure_output_target("sof-elk")
+    emitter.emit_event(_sysmon_process_create_event(datetime(2026, 6, 15, 14, 23, 5, tzinfo=UTC)))
+    emitter.close()
+
+    xml_path = tmp_path / "WIN-01.example.test" / "windows_event_sysmon.xml"
+    snare_path = tmp_path / "WIN-01.example.test" / "2026" / "windows_event_sysmon_snare.log"
+    snare = snare_path.read_text(encoding="utf-8")
+
+    assert not xml_path.exists()
+    assert snare.startswith(
+        "<14>Jun 15 14:23:05 WIN-01.example.test "
+        "WIN-01.example.test\tMSWinEventLog\t0\t"
+        "Microsoft-Windows-Sysmon/Operational\t"
+    )
+    assert "\t1\tMicrosoft-Windows-Sysmon\tCORP\\alice\t" in snare
+    assert "ProcessId: 4321" in snare
+    assert "Image: C:\\Windows\\System32\\cmd.exe" in snare
+    assert "UtcTime: 2026-06-15 14:23:05." in snare
+
+
+def test_sysmon_emitter_default_target_writes_xml_only(tmp_path: Path) -> None:
     emitter = SysmonEventEmitter(
         load_format("windows_event_sysmon"),
         tmp_path,
@@ -84,18 +132,9 @@ def test_sysmon_emitter_writes_xml_and_year_partitioned_snare_sidecar(tmp_path: 
 
     xml_path = tmp_path / "WIN-01.example.test" / "windows_event_sysmon.xml"
     snare_path = tmp_path / "WIN-01.example.test" / "2026" / "windows_event_sysmon_snare.log"
-    snare = snare_path.read_text(encoding="utf-8")
 
     assert xml_path.exists()
-    assert snare.startswith(
-        "<14>Jun 15 14:23:05 WIN-01.example.test "
-        "WIN-01.example.test\tMSWinEventLog\t0\t"
-        "Microsoft-Windows-Sysmon/Operational\t"
-    )
-    assert "\t1\tMicrosoft-Windows-Sysmon\tCORP\\alice\t" in snare
-    assert "ProcessId: 4321" in snare
-    assert "Image: C:\\Windows\\System32\\cmd.exe" in snare
-    assert "UtcTime: 2026-06-15 14:23:05." in snare
+    assert not snare_path.exists()
 
 
 def _security_event(timestamp: datetime) -> dict[str, object]:

--- a/tests/unit/test_zeek_activity_contexts.py
+++ b/tests/unit/test_zeek_activity_contexts.py
@@ -473,7 +473,7 @@ class TestSslContextPopulation:
         messages = [event.syslog.message for event in syslog_events]
         times = [event.timestamp for event in syslog_events]
         assert messages == [
-            'Connection from 10.0.10.50 port 51111 on 10.0.20.10 port 22 rdomain ""',
+            "Connection from 10.0.10.50 port 51111 on 10.0.20.10 port 22",
             "Accepted password for admin from 10.0.10.50 port 51111 ssh2",
             "pam_unix(sshd:session): session opened for user admin(uid=1001) by (uid=0)",
         ]


### PR DESCRIPTION
## Summary

This PR extracts the license-neutral output-target and rendering work from the external parser validation branch onto current `dev`.

It adds:
- `eforge generate --target default|sof-elk`
- `OUTPUT_TARGET.txt` marker support
- target-aware Linux syslog, Cisco ASA, Windows Security, and Sysmon output layouts
- shared syslog-family rendering helpers
- Windows/Sysmon Snare-over-RFC3164 rendering for the `sof-elk` target
- evaluation discovery/parser support for both default and `sof-elk` output variants
- docs, skill references, and tests for the target split

Explicitly excluded from this PR:
- SOF-ELK/external-parser pipeline code
- Docker/Podman/Compose runtime code
- SOF-ELK download/prep/config handling
- parser validation docs, scripts, fixtures, and tests

## Validation

- `uv run pytest tests/unit/test_output_targets.py tests/unit/test_output_target_rendering.py tests/unit/test_syslog_family_renderer.py tests/unit/test_windows_snare_sidecar.py tests/unit/test_cli.py tests/unit/test_eval_parsers.py tests/unit/test_eval_strict_parsers.py tests/unit/test_cisco_asa_emitter.py tests/unit/test_cisco_asa_parser.py tests/unit/test_dispatcher.py --no-cov` — `242 passed`
- `uv run pytest --no-cov` — `3283 passed, 37 skipped`
- `uv run pytest --include-slow -m slow --no-cov --durations=20` — `13 passed, 1 skipped, 3306 deselected`
- `uv run pytest --include-slow --no-cov` — `3296 passed, 24 skipped`
- `uv run ruff check .`
- `uv run ruff format --check .`