### PR TITLE
fix: harden output target marker reads to prevent symlink exfiltration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,6 +60,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 ### Security Fixes
 
 - [x] Integrate final approved PR review outcomes into `dev` — accepted and adapted the remaining real fixes (#170, #171, #172, #188, #189, #191, #192, #194, #195, #196, #197, #212), then closed duplicate, superseded, or already-addressed PRs (#167, #168, #174, #190, #193, #213) with rationale.
+- [x] Harden eval output-target marker reads against symlink exfiltration and oversized marker-file abuse.
 - [x] Reworked remaining real-but-not-ready PR fixes #165, #169, #204, and #207 against current `dev` — landed sidecar symlink-safe writes, bounded bash template expansion, raw Zeek OCSP optional-field defaults, and generation-safe extra syslog weights with focused coverage.
 - [x] Fix unbounded session offset allocation caches for far-future scenario times — replaced minute/four-hour catch-up caches with direct deterministic offsets and covered far-future allocation cases.
 - [x] Harden Windows spool JSON encoding and flushing against scenario-triggered denial-of-service — replaced collision-prone datetime sentinels with typed spool field wrappers and kept final spooled rendering on SQLite-backed streaming fixup passes instead of materializing all rows.

--- a/src/evidenceforge/output_targets.py
+++ b/src/evidenceforge/output_targets.py
@@ -34,6 +34,7 @@ from enum import StrEnum
 from pathlib import Path
 
 OUTPUT_TARGET_FILENAME = "OUTPUT_TARGET.txt"
+MAX_OUTPUT_TARGET_MARKER_BYTES = 512
 
 
 class OutputTarget(StrEnum):
@@ -123,7 +124,7 @@ def normalize_output_target(value: str | OutputTarget | None) -> OutputTarget:
         return OutputTarget(normalized)
     except ValueError as exc:
         valid = ", ".join(target.value for target in OutputTarget)
-        raise ValueError(f"invalid output target {value!r}; expected one of: {valid}") from exc
+        raise ValueError(f"invalid output target value; expected one of: {valid}") from exc
 
 
 def write_output_target_marker(root_dir: Path, target: str | OutputTarget | None) -> Path:
@@ -151,6 +152,17 @@ def read_output_target_marker(path: Path) -> OutputTarget:
     for marker in candidates:
         if not marker.exists():
             continue
+        if marker.is_symlink():
+            raise ValueError("invalid output target marker: symlinks are not allowed")
+        resolved_marker = marker.resolve()
+        if not resolved_marker.is_relative_to(path):
+            raise ValueError("invalid output target marker: marker must stay under output directory")
+        marker_size = marker.stat().st_size
+        if marker_size > MAX_OUTPUT_TARGET_MARKER_BYTES:
+            raise ValueError(
+                "invalid output target marker: file is too large"
+                f" ({marker_size} bytes > {MAX_OUTPUT_TARGET_MARKER_BYTES} bytes)"
+            )
         value = marker.read_text(encoding="utf-8").strip()
         return normalize_output_target(value or None)
     return OutputTarget.DEFAULT

--- a/tests/unit/test_output_targets.py
+++ b/tests/unit/test_output_targets.py
@@ -29,6 +29,7 @@ import pytest
 from evidenceforge.generation.engine.emitter_setup import _build_emitter_classes
 from evidenceforge.output_targets import (
     FORMAT_TARGET_POLICIES,
+    MAX_OUTPUT_TARGET_MARKER_BYTES,
     OutputTarget,
     normalize_output_target,
     read_output_target_marker,
@@ -58,6 +59,30 @@ def test_output_target_marker_round_trips_from_scenario_root_or_data_dir(tmp_pat
 def test_invalid_output_target_raises_clear_error() -> None:
     with pytest.raises(ValueError, match="expected one of: default, sof-elk"):
         normalize_output_target("splunk")
+
+
+def test_invalid_output_target_error_does_not_echo_input_value() -> None:
+    secret = "CI_SECRET_TOKEN=super-secret-value"
+    with pytest.raises(ValueError, match="invalid output target value"):
+        normalize_output_target(secret)
+
+
+def test_output_target_marker_rejects_symlink(tmp_path: Path) -> None:
+    marker = tmp_path / "OUTPUT_TARGET.txt"
+    secret = tmp_path / "secret.txt"
+    secret.write_text("sof-elk", encoding="utf-8")
+    marker.symlink_to(secret)
+
+    with pytest.raises(ValueError, match="symlinks are not allowed"):
+        read_output_target_marker(tmp_path)
+
+
+def test_output_target_marker_enforces_size_limit(tmp_path: Path) -> None:
+    marker = tmp_path / "OUTPUT_TARGET.txt"
+    marker.write_text("a" * (MAX_OUTPUT_TARGET_MARKER_BYTES + 1), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="file is too large"):
+        read_output_target_marker(tmp_path)
 
 
 def test_every_emitted_canonical_format_has_target_policy() -> None:


### PR DESCRIPTION
### Motivation
- Reading `OUTPUT_TARGET.txt` during evaluation previously followed symlinks and echoed raw marker contents in error messages, which allowed an attacker-supplied generated-output directory to leak local files and oversized payloads to the CLI/CI logs. 

### Description
- Add a small maximum marker size constant `MAX_OUTPUT_TARGET_MARKER_BYTES = 512` and reject marker files larger than this limit in `read_output_target_marker()`. 
- Reject marker symlinks and verify the resolved marker path remains inside the evaluated output-root via `Path.resolve()` + containment check before reading. 
- Sanitize the `normalize_output_target()` error message to avoid echoing the raw (potentially attacker-controlled) marker value. 
- Add focused unit tests in `tests/unit/test_output_targets.py` for non-echoing errors, symlink rejection, and size-limit enforcement, and update `TODO.md` to track the security fix. 

### Testing
- Ran linter: `uv run ruff check src/evidenceforge/output_targets.py tests/unit/test_output_targets.py` which passed. 
- Attempted unit test run: `PYTHONPATH=src uv run pytest --no-cov tests/unit/test_output_targets.py`, but the test run could not complete in this environment due to a missing runtime dependency (`PyYAML`) during test collection; the new tests are unit-level and should pass in CI where dependencies are installed. 
- The change is minimal and preserves existing `write_output_target_marker()` behavior and the public `normalize_output_target()` semantics for valid inputs while closing the symlink/size/echoing disclosure vectors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc7b804d48325bd31dd80a9cee4c1)