### PR TITLE
fix: harden Cisco ASA emitter parsing for malformed raw PRI/severity

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Harden Cisco ASA raw RFC3164 rendering against invalid `pri`/`severity` values so malformed raw fields cannot crash generation and added regression coverage for malformed raw inputs.
 - [x] Integrate final approved PR review outcomes into `dev` — accepted and adapted the remaining real fixes (#170, #171, #172, #188, #189, #191, #192, #194, #195, #196, #197, #212), then closed duplicate, superseded, or already-addressed PRs (#167, #168, #174, #190, #193, #213) with rationale.
 - [x] Reworked remaining real-but-not-ready PR fixes #165, #169, #204, and #207 against current `dev` — landed sidecar symlink-safe writes, bounded bash template expansion, raw Zeek OCSP optional-field defaults, and generation-safe extra syslog weights with focused coverage.
 - [x] Fix unbounded session offset allocation caches for far-future scenario times — replaced minute/four-hour catch-up caches with direct deterministic offsets and covered far-future allocation cases.

--- a/src/evidenceforge/generation/emitters/cisco_asa.py
+++ b/src/evidenceforge/generation/emitters/cisco_asa.py
@@ -852,10 +852,25 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
 
     def _render_event(self, event_data: dict[str, Any]) -> str | None:
         """Render ASA syslog line via the shared RFC3164 syslog-family layer."""
+        severity_value = event_data.get("severity", 6)
+        try:
+            severity = int(severity_value)
+        except (TypeError, ValueError):
+            severity = 6
+
+        pri_value = event_data.get("pri")
+        if pri_value is None:
+            pri = self._pri(severity)
+        else:
+            try:
+                pri = int(pri_value)
+            except (TypeError, ValueError):
+                pri = self._pri(severity)
+
         return render_rfc3164_syslog(
-            pri=int(event_data.get("pri") or self._pri(event_data.get("severity", 6))),
+            pri=pri,
             timestamp=event_data["timestamp"],
             hostname=str(event_data.get("hostname") or ""),
-            app_name=f"%ASA-{event_data.get('severity')}-{event_data.get('msg_id')}",
+            app_name=f"%ASA-{severity}-{event_data.get('msg_id')}",
             message=str(event_data.get("message") or ""),
         )

--- a/tests/unit/test_cisco_asa_emitter.py
+++ b/tests/unit/test_cisco_asa_emitter.py
@@ -615,6 +615,27 @@ class TestSyslogFormat:
         assert "<164>" in output
         assert "%ASA-4-106023:" in output
 
+    def test_emit_raw_invalid_pri_and_severity_falls_back_without_crash(
+        self, asa_emitter, tmp_path
+    ):
+        """Raw ASA records with invalid pri/severity should render with default severity."""
+        asa_emitter.emit_raw(
+            {
+                "timestamp": T0,
+                "hostname": "fw01",
+                "severity": "x",
+                "msg_id": 302013,
+                "message": "Built inbound TCP connection",
+                "pri": "x",
+            }
+        )
+        asa_emitter.flush()
+
+        output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
+        first_line = output.strip().split("\n")[0]
+        assert first_line.startswith("<166>")
+        assert "fw01 %ASA-6-302013:" in first_line
+
 
 class TestFormatDefinition:
     def test_cisco_asa_format_loads(self):


### PR DESCRIPTION
### Motivation
- Raw `type: raw` scenario events accept attacker-controlled `fields`, so `pri` and `severity` can be non-integer and previously crashed the Cisco ASA emitter during rendering. 
- Prevent generator termination when an untrusted raw record supplies malformed `pri`/`severity` by falling back to safe defaults instead of raising.

### Description
- Defensively coerce `severity` with `int(...)` and fall back to `6` on `TypeError`/`ValueError`, then compute `pri` via `_pri(severity)` when `pri` is missing or invalid in `src/evidenceforge/generation/emitters/cisco_asa.py`.
- Use the sanitized `severity` value when building the `app_name` header so the rendered header is consistent with the computed severity.
- Added a regression unit test `test_emit_raw_invalid_pri_and_severity_falls_back_without_crash` in `tests/unit/test_cisco_asa_emitter.py` that emits a malformed raw ASA record and asserts the emitter renders using default severity rather than crashing.
- Updated `TODO.md` per repository implementation-state rules to record the security fix completion.

### Testing
- Ran style checks with `uv run ruff check src/evidenceforge/generation/emitters/cisco_asa.py tests/unit/test_cisco_asa_emitter.py` which passed. 
- Ran formatter checks with `uv run ruff format --check src/evidenceforge/generation/emitters/cisco_asa.py tests/unit/test_cisco_asa_emitter.py` (file was reformatted and then checks passed).
- Attempted to run the targeted unit test via `PYTHONPATH=src uv run pytest --no-cov tests/unit/test_cisco_asa_emitter.py`, but the local container test bootstrap failed due to missing test-environment dependencies (`ModuleNotFoundError` for `yaml` / import path); the new regression test is included and will run in CI where the full test environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c52c367e08325b889dd3683421cf6)