### PR TITLE
fix: prevent quadratic scan in syslog PAM opener backfill

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,6 +111,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ### Security Fixes
 
+- [x] Fix quadratic syslog PAM opener backfill scan by using sorted per-user opener timestamps with `bisect_right` bounded-window lookup in close-path normalization; added regression coverage for future-only opener rows.
 - [x] Integrate final approved PR review outcomes into `dev` — accepted and adapted the remaining real fixes (#170, #171, #172, #188, #189, #191, #192, #194, #195, #196, #197, #212), then closed duplicate, superseded, or already-addressed PRs (#167, #168, #174, #190, #193, #213) with rationale.
 - [x] Reworked remaining real-but-not-ready PR fixes #165, #169, #204, and #207 against current `dev` — landed sidecar symlink-safe writes, bounded bash template expansion, raw Zeek OCSP optional-field defaults, and generation-safe extra syslog weights with focused coverage.
 - [x] Fix unbounded session offset allocation caches for far-future scenario times — replaced minute/four-hour catch-up caches with direct deterministic offsets and covered far-future allocation cases.

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -28,6 +28,7 @@ just formats the context fields into the syslog template.
 """
 
 import re
+from bisect import bisect_right
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -604,6 +605,9 @@ class SyslogEmitter(HostMultiplexEmitter):
                 _parse_rfc5424_timestamp(pam_match.group("timestamp"))
             )
 
+        for open_times in open_times_by_user.values():
+            open_times.sort()
+
         normalized: list[str] = []
         for index, line in enumerate(lines):
             new_match = _RFC5424_LOGIND_NEW_SESSION_RE.match(line)
@@ -616,9 +620,11 @@ class SyslogEmitter(HostMultiplexEmitter):
 
             user = new_match.group("user")
             new_time = _parse_rfc5424_timestamp(new_match.group("timestamp"))
-            has_recent_open = any(
-                open_time <= new_time and new_time - open_time <= _PAM_OPEN_VISIBLE_WINDOW
-                for open_time in open_times_by_user.get(user, [])
+            open_times = open_times_by_user.get(user, [])
+            newest_index = bisect_right(open_times, new_time) - 1
+            has_recent_open = (
+                newest_index >= 0
+                and new_time - open_times[newest_index] <= _PAM_OPEN_VISIBLE_WINDOW
             )
             if not has_recent_open:
                 normalized.append(

--- a/tests/unit/test_syslog_family_renderer.py
+++ b/tests/unit/test_syslog_family_renderer.py
@@ -142,6 +142,21 @@ def test_backfill_missing_logind_pam_openers_adds_native_opener() -> None:
     assert pam_index < logind_index
 
 
+def test_backfill_missing_logind_pam_openers_ignores_future_openers() -> None:
+    lines = [
+        "<86>1 2024-03-18T12:00:45.000000Z app sudo 1234 - - pam_unix(sudo:session): session opened for user admin(uid=1001) by (uid=0)",
+        "<86>1 2024-03-18T12:00:10.000000Z app systemd-logind 456 - - New session 42 of user admin.",
+    ]
+
+    normalized = SyslogEmitter._backfill_missing_logind_pam_openers_for_lines(
+        lines,
+        "app.example",
+    )
+
+    pam_openers = [line for line in normalized if "session opened for user admin(uid=1001)" in line]
+    assert len(pam_openers) == 2
+
+
 def test_backfill_missing_logind_pam_openers_preserves_existing_opener() -> None:
     lines = [
         "<86>1 2024-03-18T12:00:05.000000Z app login 1234 - - pam_unix(login:session): session opened for user admin(uid=1001) by LOGIN(uid=0)",


### PR DESCRIPTION
### Motivation
- A backfill routine in the syslog emitter scanned every per-user PAM opener timestamp with `any(...)` for each `systemd-logind` row, producing O(N*M) work on attacker-controlled raw syslog input and enabling a CPU denial-of-service during emitter `close()`/normalization.

### Description
- Replace the unbounded per-row scan with a sorted per-user opener timestamp list and an indexed lookup using `bisect_right` to check only the most-recent opener at-or-before each `systemd-logind` event, preserving the existing `_PAM_OPEN_VISIBLE_WINDOW` semantics in `src/evidenceforge/generation/emitters/syslog.py`.
- Sort per-user opener lists immediately after collection to enable efficient indexed lookups rather than iteration.
- Add a unit test `test_backfill_missing_logind_pam_openers_ignores_future_openers` in `tests/unit/test_syslog_family_renderer.py` to cover a future-only-opener case and ensure backfill behavior remains correct when opener rows occur after the logind row.
- Update `TODO.md` to track and mark this security fix per project workflow.

### Testing
- Ran code style/linters: `uv run ruff check .` and `uv run ruff format --check .`; issues were fixed and checks passed after applying import sorting (`ruff --fix`) and formatting.
- Executed formatter on the modified test file with `uv run ruff format tests/unit/test_syslog_family_renderer.py` to keep repository formatting consistent.
- Attempted to run the unit test file with `pytest` (`uv run pytest tests/unit/test_syslog_family_renderer.py --no-cov`), but the execution environment lacked runtime dependency `PyYAML` causing an import failure before tests could run; the new test is included and expected to pass in a normal development environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10509e7f7483259da8ecaa6ec1b7c1)