### PR TITLE
fix: bound internal_url template expansion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
+- [x] Investigated and remediated `{internal_url}` placeholder expansion denial-of-service in command parameterization by bounding replacements to the original placeholder count and adding a regression test for crafted domain input.
 - [x] Update the global `eforge-assess` Codex skill so iterative loops default to `scenarios/iteration-test`, prefer family-level realism improvements first, and treat automated eval as a regression guardrail rather than an optimization target. Added a progressive-disclosure family iteration reference, refreshed skill metadata, and verified with the lightweight skill validator only.
 - [x] Prepare the `dev` -> `main` PR for the loop-driven realism improvement batch — applied the required v0.9.0 minor version/changelog bump, refreshed `uv.lock`, and passed Ruff plus full normal `uv run pytest --no-cov` before opening the PR.
 - [x] Run a blind expert panel on the current loop-188 iteration-test output and summarize reviewer synthetic-confidence scores — panel average synthetic-confidence was 61.0 (Threat Hunter 68, Detection 68, Network 36, Host/EDR 72), with reports and `scores.json` saved under `scenarios/iteration-test/blind-test/loop-188/`.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -3433,13 +3433,13 @@ class ActivityGenerator:
             target = self._pick_command_target_placeholder(rng, command_line, system)
             if target:
                 command_line = command_line.replace("{ssh_target}", target)
-        if "{internal_url}" in command_line:
-            while "{internal_url}" in command_line:
-                command_line = command_line.replace(
-                    "{internal_url}",
-                    self._pick_internal_url_placeholder(rng),
-                    1,
-                )
+        internal_url_count = command_line.count("{internal_url}")
+        for _ in range(internal_url_count):
+            command_line = command_line.replace(
+                "{internal_url}",
+                self._pick_internal_url_placeholder(rng),
+                1,
+            )
         if "{ldap_base_dn}" in command_line:
             command_line = command_line.replace(
                 "{ldap_base_dn}",

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -6549,6 +6549,23 @@ class TestActivityGenerator:
         assert "dc=corp,dc=local" not in command
         assert "{ldap_base_dn}" not in command
 
+    def test_parameterize_command_internal_url_replacement_is_bounded(self, activity_gen) -> None:
+        """Internal URL replacement should terminate even with placeholder-like domains."""
+        activity_gen._ad_domain = "{internal_url}"
+        command = activity_gen._parameterize_command_for_system(
+            random.Random(7),
+            "curl {internal_url}",
+            username="analyst",
+            system=System(
+                hostname="WKSTN-01",
+                ip="10.0.0.10",
+                os="Windows 11",
+                type="workstation",
+            ),
+        )
+        assert command.startswith("curl https://")
+        assert command.count("{internal_url}") >= 1
+
     def test_generate_bash_command_can_skip_process_telemetry(
         self, activity_gen, test_user, state_manager, mock_emitters
     ):


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service in command parameterization where an attacker-controlled `environment.domain` containing `{internal_url}` could cause an unbounded replacement loop during planner-driven command template expansion.
- Ensure planner-created connection-owner processes remain safe when environment-aware parameterization is used for catalog templates that include `{internal_url}`.
- Preserve existing placeholder substitution semantics while guaranteeing termination even for crafted scenario inputs.

### Description
- Replaced the unbounded `while "{internal_url}" in command_line` loop in `ActivityGenerator._parameterize_command_for_system()` with a bounded loop that iterates exactly `command_line.count("{internal_url}")` times and calls `_pick_internal_url_placeholder()` once per original placeholder, preventing self-reintroduction from causing non-termination (`src/evidenceforge/generation/activity/generator.py`).
- Added a unit regression test that sets `activity_gen._ad_domain = "{internal_url}"` and exercises `_parameterize_command_for_system()` to verify replacement completes and returns a substituted URL prefix (`tests/unit/test_activity.py`).
- Updated `TODO.md` to record the investigation and remediation of the `{internal_url}` placeholder expansion issue (`TODO.md`).

### Testing
- Ran static/format checks: `uv run ruff check` and `uv run ruff format --check` on the modified files, both succeeded.
- Added a unit regression test covering the crafted-domain DoS case; it is included in the test suite but `pytest` could not be executed in this environment due to a missing runtime dependency (`yaml`) when attempting to run the focused unit test command (`PYTHONPATH=src uv run pytest --no-cov ...`).
- The change is minimal and preserves existing behavior for normal domains while preventing the non-terminating expansion case; further CI runs with full deps should execute the new unit test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10509f837c832586f4e40190f10f7c)