### PR TITLE
fix: preserve explicit plain-HTTP conn byte overrides

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
+- [x] Validate and remediate plain-HTTP conn.log byte override regression (explicit `orig_bytes`/`resp_bytes` discarded). `generate_connection()` now preserves caller-provided larger `orig_bytes`/`resp_bytes` for successful plain HTTP while still enforcing HTTP-derived minimums, with a unit-test regression asserting explicit override retention.
 - [x] Update the global `eforge-assess` Codex skill so iterative loops default to `scenarios/iteration-test`, prefer family-level realism improvements first, and treat automated eval as a regression guardrail rather than an optimization target. Added a progressive-disclosure family iteration reference, refreshed skill metadata, and verified with the lightweight skill validator only.
 - [x] Prepare the `dev` -> `main` PR for the loop-driven realism improvement batch — applied the required v0.9.0 minor version/changelog bump, refreshed `uv.lock`, and passed Ruff plus full normal `uv run pytest --no-cov` before opening the PR.
 - [x] Run a blind expert panel on the current loop-188 iteration-test output and summarize reviewer synthetic-confidence scores — panel average synthetic-confidence was 61.0 (Threat Hunter 68, Detection 68, Network 36, Host/EDR 72), with reports and `scores.json` saved under `scenarios/iteration-test/blind-test/loop-188/`.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -10376,8 +10376,12 @@ class ActivityGenerator:
             if event.http is not None:
                 method = (event.http.method or "GET").upper()
                 if event.network.service == "http" and method != "CONNECT":
-                    event.network.orig_bytes, event.network.resp_bytes = _http_flow_payload_bytes(
-                        event.http
+                    derived_orig_bytes, derived_resp_bytes = _http_flow_payload_bytes(event.http)
+                    event.network.orig_bytes = max(
+                        event.network.orig_bytes or 0, derived_orig_bytes
+                    )
+                    event.network.resp_bytes = max(
+                        event.network.resp_bytes or 0, derived_resp_bytes
                     )
                 else:
                     request_overhead = rng.randint(180, 620)

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -5176,10 +5176,10 @@ class TestActivityGenerator:
         assert second_event.network.application_layer_only is True
         assert second_event.http.trans_depth == 2
 
-    def test_generate_connection_derives_plain_http_bytes_from_http_context(
+    def test_generate_connection_plain_http_preserves_explicit_larger_bytes(
         self, activity_gen, state_manager, mock_emitters
     ):
-        """Single plain-HTTP transactions should not keep unrelated oversized conn bytes."""
+        """Plain HTTP should preserve explicit connection byte overrides when larger."""
         timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         state_manager.set_current_time(timestamp)
 
@@ -5210,8 +5210,8 @@ class TestActivityGenerator:
         event = mock_emitters["zeek_conn"].emit.call_args[0][0]
 
         assert event.network.conn_state == "SF"
-        assert event.network.orig_bytes < 1_200
-        assert 120 <= event.network.resp_bytes < 900
+        assert event.network.orig_bytes == 4_900
+        assert event.network.resp_bytes == 44_000
         assert event.network.resp_bytes > event.http.response_body_len
 
     def test_generate_connection_does_not_reuse_http_uid_after_parent_close(self, state_manager):


### PR DESCRIPTION
### Motivation
- A recent change unconditionally overwrote connection `orig_bytes`/`resp_bytes` for successful plain-HTTP flows with values derived from `HttpContext`, discarding explicit scenario-author overrides and weakening dataset integrity.
- The intent is to keep HTTP-derived minimums for realism while preserving caller-provided larger byte-count overrides used to model downloads/exfiltration.

### Description
- In `src/evidenceforge/generation/activity/generator.py` the plain-HTTP branch now computes `derived_orig_bytes, derived_resp_bytes = _http_flow_payload_bytes(event.http)` and sets `event.network.orig_bytes = max(event.network.orig_bytes or 0, derived_orig_bytes)` and `event.network.resp_bytes = max(event.network.resp_bytes or 0, derived_resp_bytes)` instead of unconditionally overwriting the values.
- The unit test `tests/unit/test_activity.py` was updated to assert that explicit larger `orig_bytes`/`resp_bytes` remain intact for plain HTTP flows (`test_generate_connection_plain_http_preserves_explicit_larger_bytes`).
- Implementation tracking was updated in `TODO.md` to record and mark this remediation complete, and changes were committed with the conventional-commit message `fix: preserve explicit plain-http conn byte overrides`.

### Testing
- Ran linter and formatter checks which succeeded: `uv run ruff check .` and `uv run ruff format --check .` (and reformatted the modified file via `uv run ruff format`).
- Attempted targeted unit test run with `PYTHONPATH=src uv run pytest --no-cov tests/unit/test_activity.py -k "plain_http_preserves_explicit_larger_bytes"`, but the test run failed in this environment due to missing runtime dependency `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`).
- The change is narrowly scoped and the updated unit test should pass when the repository test dependencies are available and `pytest` is run in a fully provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10509eb0fc8325a4189738d294bd1f)