### PR TITLE
fix: guard extra_syslog params flattening in validate-config

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -951,6 +951,7 @@ Data works but experienced analysts spot tells. Grouped by format for efficient 
 
 ### Tier 4: Eval Fixes
 
+- [x] Hardened `validate-config` extra_syslog schedule pre-check to avoid crashing on malformed `params` before schema validation; malformed entries now flow to structured schema errors.
 - [x] Harden temporal causal-account exclusion against non-string SubjectUserName/principal values to prevent evaluator exceptions on malformed logs
 - [x] Signal integrity misses web_scan traces in host-scoped web logs and responder-side Zeek HTTP records — generated evidence exists, but evaluator indexing could not find `web_access.log` records by host directory or inbound Zeek HTTP by destination IP. Parser records now carry source-host metadata, and signal-integrity indexing includes responder IPs. Event Presence improved from 1/9 to 9/9 on the HTTP/proxy eval sample.
 - [x] Causal Ordering hard failure on generated audit sample — root cause was future same-hour session reuse during non-chronological baseline generation. Session lookup now only reuses sessions whose start time is at or before the activity timestamp. Fresh HTTP/proxy sample eval improved Causal Ordering from 95.53% to 99.94%, and all hard acceptance criteria pass.

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -2138,7 +2138,13 @@ def validate_config() -> ValidationResult:
                 messages = []
             params = entry.get("params")
             param_strings = (
-                [value for values in params.values() for value in values if isinstance(value, str)]
+                [
+                    value
+                    for values in params.values()
+                    if isinstance(values, list)
+                    for value in values
+                    if isinstance(value, str)
+                ]
                 if isinstance(params, dict)
                 else []
             )

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -1451,6 +1451,34 @@ class TestValidateConfig:
             for issue in result.issues
         )
 
+    def test_validate_config_reports_extra_syslog_params_type_errors_without_crashing(
+        self, monkeypatch
+    ):
+        from evidenceforge.generation.activity import extra_syslog
+
+        def load_invalid_extra_syslog_messages():
+            return [
+                {
+                    "app": "attacker-controlled-bad-params",
+                    "messages": ["ordinary message"],
+                    "params": {"bad": 1},
+                }
+            ]
+
+        monkeypatch.setattr(
+            extra_syslog, "load_extra_syslog_messages", load_invalid_extra_syslog_messages
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "extra_syslog_messages.yaml"
+            and 'Entry "attacker-controlled-bad-params"' in issue.message
+            and "params" in issue.message
+            for issue in result.issues
+        )
+
     def test_validate_config_rejects_cron_hourly_in_extra_syslog_noise(self, monkeypatch):
         from evidenceforge.generation.activity import extra_syslog
 


### PR DESCRIPTION
### Motivation
- Prevent `validate_config()` from raising `TypeError` when an overlay `extra_syslog_messages.yaml` entry contains malformed `params` values (e.g., scalar `1`) that are not iterable, so such overlays are reported as structured schema errors instead of crashing the validator.

### Description
- Guard the `params` flattening logic in `src/evidenceforge/cli/validate_config.py` so it only iterates list-valued `params` entries (`if isinstance(values, list)`) before extracting string values. 
- Add a regression unit test `test_validate_config_reports_extra_syslog_params_type_errors_without_crashing` in `tests/unit/test_validate_config.py` that injects `params: {bad: 1}` and asserts the validator returns a structured `params` schema error instead of crashing. 
- Update `TODO.md` to mark the hardening task as completed per the project workflow.

### Testing
- Ran lint/format checks: `uv run ruff check src/evidenceforge/cli/validate_config.py tests/unit/test_validate_config.py` and `uv run ruff format --check src/evidenceforge/cli/validate_config.py tests/unit/test_validate_config.py`, which passed (formatting auto-applied where needed). 
- Attempted to run the focused unit tests with `PYTHONPATH=src uv run pytest --no-cov tests/unit/test_validate_config.py -k extra_syslog`, but execution failed in this environment due to a missing external dependency (`PyYAML` / `yaml`), so pytest could not be completed here; the added test is in place and should pass in CI or a dev environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10509e90ac8325b02f063c88f4e4af)