### PR TITLE
fix: keep process source-create timing tied to rendered emitters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@ Replaced manual per-emitter field coordination with SecurityEvent intermediate r
 
 ## Pre-MVP: Consolidated Quality Fixes — IN PROGRESS
 
+- [x] Aardvark process source-create timing regression fix — removed pre-dispatch process source timing recording so stored source-create timestamps only reflect rendered emitters; added regression coverage for zero-emitter path.
 - [x] Update the global `eforge-assess` Codex skill so iterative loops default to `scenarios/iteration-test`, prefer family-level realism improvements first, and treat automated eval as a regression guardrail rather than an optimization target. Added a progressive-disclosure family iteration reference, refreshed skill metadata, and verified with the lightweight skill validator only.
 - [x] Prepare the `dev` -> `main` PR for the loop-driven realism improvement batch — applied the required v0.9.0 minor version/changelog bump, refreshed `uv.lock`, and passed Ruff plus full normal `uv run pytest --no-cov` before opening the PR.
 - [x] Run a blind expert panel on the current loop-188 iteration-test output and summarize reviewer synthetic-confidence scores — panel average synthetic-confidence was 61.0 (Threat Hunter 68, Detection 68, Network 36, Host/EDR 72), with reports and `scores.json` saved under `scenarios/iteration-test/blind-test/loop-188/`.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -7279,8 +7279,6 @@ class ActivityGenerator:
             storyline_origin=from_storyline,
         )
 
-        self._record_process_source_create_time(system.hostname, pid, event)
-
         # Phase 3: Dispatch to matching emitters
         self.dispatcher.dispatch(event)
         self._record_process_source_create_time(system.hostname, pid, event)
@@ -7589,7 +7587,6 @@ class ActivityGenerator:
         event: SecurityEvent,
     ) -> None:
         """Remember the latest rendered source timestamp for a process create."""
-        self._plan_process_source_create_times(event)
         source_timing = event.source_timing
         if source_timing is None:
             return

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -371,7 +371,7 @@ class TestStorylineCommandNetworks:
         assert emitter.render_time is not None
         assert generator.process_source_create_time(system.hostname, pid) >= emitter.render_time
 
-    def test_activity_generator_preplans_process_create_time_before_threaded_dispatch(self):
+    def test_activity_generator_tracks_process_create_time_only_when_sources_render(self):
         captured: dict[str, Any] = {}
 
         class _CapturingDispatcher:
@@ -404,25 +404,8 @@ class TestStorylineCommandNetworks:
         )
 
         event = captured["event"]
-        assert event.source_timing is not None
-        source_keys = set(event.source_timing.source_times)
-        assert any(key.startswith("source.windows_security_process_create|") for key in source_keys)
-        assert any(key.startswith("source.sysmon_process_create|") for key in source_keys)
-        assert any(key.startswith("source.ecar_process_create|") for key in source_keys)
-        sysmon_time = next(
-            value
-            for key, value in event.source_timing.source_times.items()
-            if key.startswith("source.sysmon_process_create|")
-        )
-        security_time = next(
-            value
-            for key, value in event.source_timing.source_times.items()
-            if key.startswith("source.windows_security_process_create|")
-        )
-        assert security_time >= sysmon_time + timedelta(milliseconds=25)
-        assert generator.process_source_create_time(system.hostname, pid) == max(
-            event.source_timing.source_times.values()
-        )
+        assert event.source_timing is None
+        assert generator.process_source_create_time(system.hostname, pid) is None
 
     def test_process_owned_windows_connection_waits_for_visible_process_create(self):
         captured: list[Any] = []


### PR DESCRIPTION
### Motivation

- A pre-dispatch call recorded preplanned process-create source timestamps (Sysmon/Windows Security/eCAR) before the dispatcher determined which emitters actually rendered the process-create, allowing hypothetical (unrendered) source timestamps to delay/clamp later network evidence.

### Description

- Remove the pre-dispatch `_record_process_source_create_time(...)` call in `ActivityGenerator.generate_process` so source-create timing is recorded only after dispatch and real emitters have run.
- Stop `_record_process_source_create_time(...)` from invoking planning; it now reads and records only already-populated `event.source_timing` entries (i.e., rendered source timestamps) instead of precomputing them.
- Update `tests/unit/test_storyline_command_networks.py` to assert the zero-emitter path produces no `event.source_timing` and no stored process source-create timestamp.
- Mark the Aardvark timing-regression fix complete in `TODO.md` to follow project tracking requirements.

### Testing

- Ran linter/format checks which succeeded: `uv run ruff check .` and `uv run ruff format --check .` (both passed). 
- Adjusted unit test `tests/unit/test_storyline_command_networks.py` to cover the zero-emitter case; the test will validate the fix when run in a full dev environment with test dependencies installed.
- Attempted targeted pytest run `PYTHONPATH=src uv run pytest --no-cov tests/unit/test_storyline_command_networks.py` but it could not complete in this environment due to a missing test dependency (`yaml` / PyYAML).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10509e79988325a0a77442cddb267a)