### PR TITLE
fix: render ASA ICMP messages without interface prefixes

### DIFF
--- a/src/evidenceforge/evaluation/parsers/cisco_asa.py
+++ b/src/evidenceforge/evaluation/parsers/cisco_asa.py
@@ -47,10 +47,10 @@ BUILT_TCP_UDP = re.compile(
     r"\((\S+)/(\d+)\)"
 )
 
-# Built ICMP: "Built {inbound/outbound} ICMP connection for faddr iface:ip/type ..."
+# Built ICMP: "Built {inbound/outbound} ICMP connection for faddr ip/type ..."
 BUILT_ICMP = re.compile(
     r"Built\s+(?:inbound|outbound)\s+ICMP\s+connection\s+for\s+faddr\s+"
-    r"(\w+):(\S+)/(\d+)"
+    r"(?:(\w+):)?([^/\s]+)/(\d+)"
 )
 
 # Teardown connection: "Teardown TCP connection 12345 for inside:10.0.10.50/54321 to ..."
@@ -61,10 +61,10 @@ TEARDOWN_TCP_UDP = re.compile(
     r"duration\s+(\S+)\s+bytes\s+(\d+)"
 )
 
-# Teardown ICMP: "Teardown ICMP connection for faddr iface:ip/type ..."
+# Teardown ICMP: "Teardown ICMP connection for faddr ip/type ..."
 TEARDOWN_ICMP = re.compile(
     r"Teardown\s+ICMP\s+connection\s+for\s+faddr\s+"
-    r"(\w+):(\S+)/(\d+)"
+    r"(?:(\w+):)?([^/\s]+)/(\d+)"
 )
 
 # Deny: "Deny tcp src outside:104.248.71.33/44231 dst inside:10.0.10.50/445 ..."
@@ -183,7 +183,8 @@ class CiscoAsaParser(LogParser):
         elif msg_id in (302020,):
             match = BUILT_ICMP.search(message)
             if match:
-                fields["dst_interface"] = match.group(1)
+                if match.group(1):
+                    fields["dst_interface"] = match.group(1)
                 fields["dst_ip"] = match.group(2)
                 fields["icmp_type"] = int(match.group(3))
         elif msg_id in (302014, 302016):
@@ -201,7 +202,8 @@ class CiscoAsaParser(LogParser):
         elif msg_id in (302021,):
             match = TEARDOWN_ICMP.search(message)
             if match:
-                fields["dst_interface"] = match.group(1)
+                if match.group(1):
+                    fields["dst_interface"] = match.group(1)
                 fields["dst_ip"] = match.group(2)
                 fields["icmp_type"] = int(match.group(3))
         elif msg_id == 106023:

--- a/src/evidenceforge/generation/emitters/cisco_asa.py
+++ b/src/evidenceforge/generation/emitters/cisco_asa.py
@@ -454,18 +454,18 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
             msg_id = 302020
             icmp_type = net.dst_port if net.dst_port else 8  # Default echo request
             if direction == "inbound":
-                foreign_iface, foreign_ip = src_iface, net.src_ip
-                global_iface, global_ip = dst_iface, net.dst_ip
-                local_iface, local_ip = dst_iface, net.dst_ip
+                foreign_ip = net.src_ip
+                global_ip = net.dst_ip
+                local_ip = net.dst_ip
             else:
-                foreign_iface, foreign_ip = dst_iface, net.dst_ip
-                global_iface, global_ip = src_iface, net.src_ip
-                local_iface, local_ip = src_iface, net.src_ip
+                foreign_ip = net.dst_ip
+                global_ip = net.src_ip
+                local_ip = net.src_ip
             message = (
                 f"Built {direction} ICMP connection for faddr "
-                f"{foreign_iface}:{foreign_ip}/{icmp_type} "
-                f"gaddr {global_iface}:{global_ip}/0 "
-                f"laddr {local_iface}:{local_ip}/0"
+                f"{foreign_ip}/{icmp_type} "
+                f"gaddr {global_ip}/0 "
+                f"laddr {local_ip}/0"
             )
         else:
             msg_id = 302013 if protocol == "tcp" else 302015
@@ -534,18 +534,18 @@ class CiscoAsaEmitter(SensorMultiplexEmitter):
             icmp_type = net.dst_port if net.dst_port else 8
             direction = "inbound" if src_iface == "outside" else "outbound"
             if direction == "inbound":
-                foreign_iface, foreign_ip = src_iface, net.src_ip
-                global_iface, global_ip = dst_iface, net.dst_ip
-                local_iface, local_ip = dst_iface, net.dst_ip
+                foreign_ip = net.src_ip
+                global_ip = net.dst_ip
+                local_ip = net.dst_ip
             else:
-                foreign_iface, foreign_ip = dst_iface, net.dst_ip
-                global_iface, global_ip = src_iface, net.src_ip
-                local_iface, local_ip = src_iface, net.src_ip
+                foreign_ip = net.dst_ip
+                global_ip = net.src_ip
+                local_ip = net.src_ip
             message = (
                 f"Teardown ICMP connection for faddr "
-                f"{foreign_iface}:{foreign_ip}/{icmp_type} "
-                f"gaddr {global_iface}:{global_ip}/0 "
-                f"laddr {local_iface}:{local_ip}/0"
+                f"{foreign_ip}/{icmp_type} "
+                f"gaddr {global_ip}/0 "
+                f"laddr {local_ip}/0"
             )
         else:
             msg_id = 302014 if protocol == "tcp" else 302016

--- a/tests/unit/test_cisco_asa_emitter.py
+++ b/tests/unit/test_cisco_asa_emitter.py
@@ -426,7 +426,15 @@ class TestPermitRecords:
         assert len(lines) == 2
         assert "%ASA-6-302020:" in lines[0]
         assert "Built outbound ICMP connection" in lines[0]
+        assert "faddr 203.0.113.50/8" in lines[0]
+        assert "gaddr 10.0.10.50/0" in lines[0]
+        assert "laddr 10.0.10.50/0" in lines[0]
+        assert "faddr outside:" not in lines[0]
         assert "%ASA-6-302021:" in lines[1]
+        assert "faddr 203.0.113.50/8" in lines[1]
+        assert "gaddr 10.0.10.50/0" in lines[1]
+        assert "laddr 10.0.10.50/0" in lines[1]
+        assert "faddr outside:" not in lines[1]
 
     def test_inbound_icmp_keeps_foreign_and_local_addresses_directional(
         self, asa_emitter, tmp_path
@@ -446,9 +454,12 @@ class TestPermitRecords:
         output = (tmp_path / "fw01" / "2024" / "cisco_asa.log").read_text()
         built_line = next(line for line in output.splitlines() if "%ASA-6-302020:" in line)
         assert "Built inbound ICMP connection" in built_line
-        assert "faddr outside:203.0.113.50/8" in built_line
-        assert "gaddr dmz:172.16.0.5/0" in built_line
-        assert "laddr dmz:172.16.0.5/0" in built_line
+        assert "faddr 203.0.113.50/8" in built_line
+        assert "gaddr 172.16.0.5/0" in built_line
+        assert "laddr 172.16.0.5/0" in built_line
+        assert "faddr outside:" not in built_line
+        assert "gaddr dmz:" not in built_line
+        assert "laddr dmz:" not in built_line
 
     def test_inbound_direction_for_external_source(self, asa_emitter, tmp_path):
         """External source -> internal destination should be 'inbound'."""

--- a/tests/unit/test_cisco_asa_parser.py
+++ b/tests/unit/test_cisco_asa_parser.py
@@ -82,6 +82,20 @@ class TestParseBuiltRecords:
         log = tmp_path / "cisco_asa.log"
         log.write_text(
             "<166>Jun 15 14:23:05 fw01 %ASA-6-302020: Built outbound ICMP connection "
+            "for faddr 203.0.113.50/8 gaddr 10.0.10.50/0 laddr 10.0.10.50/0\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        assert records[0].fields["msg_id"] == 302020
+        assert records[0].fields["dst_ip"] == "203.0.113.50"
+        assert records[0].fields["icmp_type"] == 8
+        assert "dst_interface" not in records[0].fields
+
+    def test_parse_302020_icmp_built_accepts_legacy_interface_prefix(self, tmp_path):
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-302020: Built outbound ICMP connection "
             "for faddr outside:203.0.113.50/8 gaddr inside:10.0.10.50/0 "
             "laddr inside:10.0.10.50/0\n"
         )
@@ -89,6 +103,7 @@ class TestParseBuiltRecords:
         records = list(parser.parse_file(log))
         assert len(records) == 1
         assert records[0].fields["msg_id"] == 302020
+        assert records[0].fields["dst_interface"] == "outside"
         assert records[0].fields["dst_ip"] == "203.0.113.50"
         assert records[0].fields["icmp_type"] == 8
 
@@ -111,6 +126,21 @@ class TestParseTeardownRecords:
         assert rec.fields["bytes"] == 5120
         assert rec.fields["src_ip"] == "10.0.10.50"
         assert rec.fields["dst_ip"] == "203.0.113.50"
+
+    def test_parse_302021_icmp_teardown(self, tmp_path):
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:24:28 fw01 %ASA-6-302021: Teardown ICMP connection "
+            "for faddr 203.0.113.50/8 gaddr 10.0.10.50/0 laddr 10.0.10.50/0\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.fields["msg_id"] == 302021
+        assert rec.fields["dst_ip"] == "203.0.113.50"
+        assert rec.fields["icmp_type"] == 8
+        assert "dst_interface" not in rec.fields
 
 
 class TestParseDenyRecords:


### PR DESCRIPTION
## Summary
- Render ASA 302020/302021 ICMP messages without interface prefixes in `faddr`, `gaddr`, and `laddr`
- Keep the local ASA eval parser backward-compatible with legacy prefixed ICMP rows
- Add emitter/parser tests for canonical ICMP output and legacy parsing

## Validation
- `uv run pytest tests/unit/test_cisco_asa_emitter.py tests/unit/test_cisco_asa_parser.py --no-cov`
- `uv run ruff check .`
- `uv run ruff format --check .`