### PR TITLE
fix: bound bash_history discovery to avoid unbounded traversal

### DIFF
--- a/src/evidenceforge/evaluation/parsers/__init__.py
+++ b/src/evidenceforge/evaluation/parsers/__init__.py
@@ -103,10 +103,25 @@ def _is_safe_path(path: Path, root: Path) -> bool:
 def _discover_bash_history_files(output_dir: Path, output_root: Path) -> list[Path]:
     """Discover bash history files across supported output layouts."""
     files: dict[Path, None] = {}
-    for history_dir in output_dir.rglob("bash_history"):
+    candidate_dirs: dict[Path, None] = {}
+
+    direct_bash_history = output_dir / "bash_history"
+    candidate_dirs[direct_bash_history] = None
+
+    for child in output_dir.iterdir():
+        if not _is_safe_path(child, output_root) or not child.is_dir():
+            continue
+        candidate_dirs[child / "bash_history"] = None
+
+        for subdir in child.iterdir():
+            if not _is_safe_path(subdir, output_root) or not subdir.is_dir():
+                continue
+            candidate_dirs[subdir / "bash_history"] = None
+
+    for history_dir in candidate_dirs:
         if not _is_safe_path(history_dir, output_root) or not history_dir.is_dir():
             continue
-        for candidate in history_dir.rglob("*"):
+        for candidate in history_dir.iterdir():
             if not _is_safe_path(candidate, output_root) or not candidate.is_file():
                 continue
             if candidate.suffix in (".history", ".bash_history"):

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -552,6 +552,22 @@ class TestParserDiscovery:
 
         assert files["bash_history"] == [history_file]
 
+    def test_bash_history_discovery_does_not_use_recursive_rglob(self, tmp_path, monkeypatch):
+        from evidenceforge.evaluation.parsers import discover_log_files
+
+        history_file = tmp_path / "host01" / "bash_history" / "alice.history"
+        history_file.parent.mkdir(parents=True)
+        history_file.write_text("#1718431208\nid\n", encoding="utf-8")
+
+        def _fail_rglob(*_args, **_kwargs):
+            raise AssertionError("discover_log_files should not use unbounded Path.rglob")
+
+        monkeypatch.setattr(Path, "rglob", _fail_rglob)
+
+        files = discover_log_files(tmp_path)
+
+        assert files["bash_history"] == [history_file]
+
     def test_skips_symlinked_sensor_directories(self, tmp_path):
         """Symlinked subdirectories should be skipped during discovery."""
         from evidenceforge.evaluation.parsers import discover_log_files


### PR DESCRIPTION
### Motivation
- Prevent unbounded filesystem traversal when discovering `bash_history` under an attacker-controlled `output_dir`, which previously used `rglob("bash_history")` and `rglob("*")` and could cause excessive CPU/IO. 

### Description
- Replace recursive `rglob` discovery in `_discover_bash_history_files()` with bounded `iterdir()` checks that inspect only the expected `bash_history` locations at root, per-host, and one nested level. 
- Preserve existing behavior by still populating `result["bash_history"]` when matching files are found and by keeping the same suffix checks for `".history"` and `".bash_history"`. 
- Add a regression test `test_bash_history_discovery_does_not_use_recursive_rglob` that monkeypatches `Path.rglob` to fail to ensure discovery does not regress to unbounded traversal.
- Files changed: `src/evidenceforge/evaluation/parsers/__init__.py` and `tests/unit/test_eval_parsers.py`.

### Testing
- Ran linting checks: `uv run ruff check src/evidenceforge/evaluation/parsers/__init__.py tests/unit/test_eval_parsers.py` which passed. 
- Ran formatting check: `uv run ruff format --check src/evidenceforge/evaluation/parsers/__init__.py tests/unit/test_eval_parsers.py` which passed. 
- Added unit test guarding against `Path.rglob` use; running `pytest` in this environment failed due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`), so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f7b356e483258fe625f31d55589f)