### PR TITLE
fix: scope persisted Sysmon ProcessGuid cache by process lifetime

### DIFF
--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -746,16 +746,15 @@ class SysmonEventEmitter(LogEmitter):
         deterministic process-create source offset so Event 1 and all follow-on
         events share the same source-native identifier.
         """
-        cached_guid = self._final_process_guids.get((hostname, pid))
-        if cached_guid is not None:
-            return cached_guid
-
         ts = fallback_timestamp
         sm = getattr(self, "_state_manager", None)
         if sm and pid > 0:
             proc = sm.get_process(hostname, pid)
             if proc is not None and proc.start_time <= fallback_timestamp:
                 ts = proc.start_time
+        cached_guid = self._final_process_guids.get((hostname, pid, ts))
+        if cached_guid is not None:
+            return cached_guid
         rendered_create_time = _SOURCE_TIMING.source_time(
             SecurityEvent(timestamp=ts, event_type="process_create"),
             "source.sysmon_process_create",
@@ -1742,7 +1741,7 @@ class SysmonEventEmitter(LogEmitter):
         self._erid_rngs: dict[str, random.Random] = {}
         self._last_time_created_by_computer: dict[str, datetime] = {}
         self._time_collision_count_by_computer: dict[str, int] = {}
-        self._final_process_guids: dict[tuple[str, int], str] = {}
+        self._final_process_guids: dict[tuple[str, int, datetime], str] = {}
 
     def _get_host_writer(self, host_fqdn: str) -> _SingleHostWriter:
         safe_host = sanitize_path_component(host_fqdn)
@@ -1976,7 +1975,7 @@ class SysmonEventEmitter(LogEmitter):
             hostname = computer.split(".", 1)[0] if computer else ""
             new_guid = self._generate_process_guid(hostname, pid_int, ts)
             old_guid = str(guid)
-            self._final_process_guids[(hostname, pid_int)] = new_guid
+            self._final_process_guids[(hostname, pid_int, ts)] = new_guid
             if new_guid != old_guid:
                 replacements[(computer, old_guid)] = new_guid
                 event["ProcessGuid"] = new_guid

--- a/tests/unit/test_sysmon_emitter.py
+++ b/tests/unit/test_sysmon_emitter.py
@@ -978,3 +978,29 @@ class TestSysmonEventEmitter:
 
         assert emitter._event_dicts[0]["ProcessGuid"] == new_guid
         assert emitter._get_stable_process_guid("WKS-01", 1234, original) == new_guid
+
+    def test_event1_time_shift_cache_scopes_guid_to_process_lifetime(self, format_def, temp_output):
+        """Persisted Event 1 GUID cache should not leak across reused PID lifetimes."""
+        emitter = SysmonEventEmitter(format_def, temp_output)
+        first_start = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
+        first_shifted = first_start + timedelta(microseconds=453)
+        first_old_guid = emitter._generate_process_guid("WKS-01", 1234, first_start)
+        first_new_guid = emitter._generate_process_guid("WKS-01", 1234, first_shifted)
+        emitter._event_dicts = [
+            {
+                "EventID": 1,
+                "Computer": "WKS-01.corp.local",
+                "TimeCreated": first_shifted,
+                "ProcessGuid": first_old_guid,
+                "ProcessId": 1234,
+            }
+        ]
+
+        emitter._sync_process_guids_to_event1_times()
+
+        second_start = first_start + timedelta(hours=2)
+        second_guid = emitter._generate_process_guid("WKS-01", 1234, second_start)
+
+        assert emitter._event_dicts[0]["ProcessGuid"] == first_new_guid
+        assert emitter._get_stable_process_guid("WKS-01", 1234, first_start) == first_new_guid
+        assert emitter._get_stable_process_guid("WKS-01", 1234, second_start) == second_guid


### PR DESCRIPTION
### Motivation
- Finalized Sysmon Event 1 ProcessGuid mappings were previously cached using only `(hostname, pid)`, which allowed a later process that reused the same PID to incorrectly inherit an older lifetime's ProcessGuid and corrupt Sysmon lineage. 
- The intent is to persist rewritten Event 1 GUIDs across flushes while preventing cross-lifetime leakage when Windows PIDs are recycled. 

### Description
- Resolve the effective process lifetime timestamp (`ts`) from the state manager first, then consult the persisted cache keyed by `(hostname, pid, ts)` in `_get_stable_process_guid` by replacing the prior `(hostname, pid)` lookup with `(hostname, pid, ts)`. 
- Persist rewritten Event 1 GUIDs using the lifetime-aware key in `_sync_process_guids_to_event1_times` by storing entries as `(hostname, pid_int, ts) -> new_guid`. 
- Update the `_final_process_guids` annotation to `dict[tuple[str, int, datetime], str]` to reflect the new key shape. 
- Add a regression unit test `test_event1_time_shift_cache_scopes_guid_to_process_lifetime` that verifies reused PIDs in a later lifetime do not inherit a prior lifetime's persisted GUID. 

### Testing
- `uv run ruff check src/evidenceforge/generation/emitters/sysmon.py tests/unit/test_sysmon_emitter.py` completed successfully. 
- `uv run ruff format` was applied and `--check` confirms formatting is consistent. 
- Attempting to run the focused unit tests with `PYTHONPATH=src uv run pytest --no-cov tests/unit/test_sysmon_emitter.py -k process_guid` failed in this environment due to a missing runtime dependency (`yaml`), so the new regression test could not be executed here. 
- The change is minimal and lints/formatting pass; the added regression test exercises the new behavior and should pass in CI with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f7b43d008325892e327f93be2d38)