### PR TITLE
fix: harden external parser target marker reads

### DIFF
--- a/scripts/external_parser.py
+++ b/scripts/external_parser.py
@@ -63,7 +63,7 @@ from evidenceforge.external_parsers.sof_elk_zeek import (
 from evidenceforge.output_targets import (
     OUTPUT_TARGET_FILENAME,
     OutputTarget,
-    normalize_output_target,
+    read_output_target_marker,
 )
 
 INGEST_STEP_TOTAL = 5
@@ -176,13 +176,11 @@ def _require_sof_elk_output_target(data_dir: Path) -> bool:
         error_console.print(f"Searched for `{OUTPUT_TARGET_FILENAME}` in:\n{searched}")
         return False
 
-    raw_value = marker.read_text(encoding="utf-8").strip()
     try:
-        output_target = normalize_output_target(raw_value)
-    except ValueError:
+        output_target = read_output_target_marker(data_dir)
+    except ValueError as error:
         error_console.print(
-            f"[bold red]error:[/bold red] {marker} contains unsupported output target "
-            f"{raw_value!r}; expected `sof-elk`."
+            f"[bold red]error:[/bold red] {marker} is not a valid output target marker: {error}."
         )
         return False
     if output_target != OutputTarget.SOF_ELK:
@@ -199,7 +197,7 @@ def _require_sof_elk_output_target(data_dir: Path) -> bool:
 
 def _find_output_target_marker(data_dir: Path) -> Path | None:
     for candidate in _output_target_marker_candidates(data_dir):
-        if candidate.exists():
+        if candidate.is_symlink() or candidate.is_file():
             return candidate
     return None
 

--- a/tests/unit/test_external_parser_script.py
+++ b/tests/unit/test_external_parser_script.py
@@ -76,8 +76,28 @@ def test_external_parser_script_rejects_invalid_output_target(
     assert not external_parser._require_sof_elk_output_target(data_dir)
 
     message = _normalize_console_text(error_output.getvalue())
-    assert "contains unsupported output target 'splunk'" in message
-    assert "expected `sof-elk`" in message
+    assert "is not a valid output target marker" in message
+    assert "invalid output target value" in message
+    assert "splunk" not in message
+
+
+def test_external_parser_script_rejects_symlink_marker_without_leaking_contents(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("SUPER_SECRET_TOKEN=talos-validation-secret\n", encoding="utf-8")
+    (data_dir / "OUTPUT_TARGET.txt").symlink_to(secret_file)
+    error_output = _capture_error_console(monkeypatch)
+
+    assert not external_parser._require_sof_elk_output_target(data_dir)
+
+    message = _normalize_console_text(error_output.getvalue())
+    assert "symlinks are not allowed" in message
+    assert "SUPER_SECRET_TOKEN" not in message
+    assert "talos-validation-secret" not in message
 
 
 def test_external_parser_script_accepts_sof_elk_output_target(


### PR DESCRIPTION
### Motivation
- Prevent information disclosure from attacker-controlled dataset directories by avoiding direct reads of `OUTPUT_TARGET.txt` that could follow symlinks and print local secret files to logs. 
- Reuse the existing safe marker reader that enforces symlink, containment, and size checks instead of duplicating ad-hoc logic.

### Description
- Replaced direct `marker.read_text()` + `normalize_output_target()` usage with the safe helper `read_output_target_marker()` in `scripts/external_parser.py` so symlink/containment/size protections are applied centrally. 
- Stopped echoing raw marker contents in error messages so unsupported marker values are not printed to logs. 
- Tightened candidate discovery in `scripts/external_parser.py:_find_output_target_marker` to use `is_symlink()`/`is_file()` and rely on the centralized reader to validate and reject symlinks. 
- Added a unit test `test_external_parser_script_rejects_symlink_marker_without_leaking_contents` and updated invalid-marker assertions in `tests/unit/test_external_parser_script.py` to assert no secret-like contents are leaked.

### Testing
- Ran linter/format checks with `uv run ruff check .` and `uv run ruff format --check .` and they passed. 
- Ran the modified unit tests with `uv run pytest --no-cov tests/unit/test_external_parser_script.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1933f32a748325ac8bad423ef12eec)