### PR TITLE
fix: restore canonical session ownership for process spillage

### DIFF
--- a/docs/worklog/2026-06-03-pr-289-spillage-followup.md
+++ b/docs/worklog/2026-06-03-pr-289-spillage-followup.md
@@ -1,0 +1,33 @@
+# PR #289 Spillage Follow-Up
+
+Date: 2026-06-03
+PR: `#289` (`feat: add spillage event type for synthetic credential leakage`)
+
+## Decision
+
+Merge the contributor PR into `dev`, then handle the remaining architecture-specific
+cleanup as maintainer follow-up work.
+
+Reasoning:
+- The contributor addressed most review points from the June 2, 2026 follow-up comments.
+- The remaining `process_command_line` gap is narrow but tied to EvidenceForge's
+  canonical auth/session/process ownership model.
+- It is faster and lower-risk for maintainers to finish that integration on `dev`
+  than to push another contributor review round for a subtle architecture-specific fix.
+
+## Remaining Maintainer Follow-Up
+
+1. Fix `process_command_line` spillage so the emitted live process record uses a real
+   actor session/logon context instead of the current placeholder/default path.
+2. Add regression coverage for that fix, especially Windows `4688` / `ecar`
+   session/logon linkage.
+3. Keep vendor-published official test secrets, including the Stripe test key.
+4. Broaden `GROUND_TRUTH.jsonl` in a separate PR so it becomes the machine-readable
+   companion to `GROUND_TRUTH.md` for all event types, not just spillage.
+
+## Notes For Future Agents
+
+- Do not treat the broader `GROUND_TRUTH.jsonl` expansion as part of the same
+  narrow maintainer fix; it is a separate contract change.
+- If the `GROUND_TRUTH.jsonl` scope is expanded, update writer behavior, docs,
+  eval assumptions, and tests together.

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -17652,6 +17652,13 @@ class ActivityGenerator:
             default_proc = (
                 r"C:\Windows\System32\cmd.exe" if os_category == "windows" else "/usr/bin/sh"
             )
+            parent_pid = 4
+            if os_category == "linux" and logon_id:
+                parent_pid = self._spillage_process_parent_pid(
+                    system=system,
+                    time=time,
+                    logon_id=logon_id,
+                )
             pid = self.generate_process(
                 user=user,
                 system=system,
@@ -17659,6 +17666,7 @@ class ActivityGenerator:
                 logon_id=logon_id or "0x0",
                 process_name=render.process_name or default_proc,
                 command_line=render.command,
+                parent_pid=parent_pid,
                 from_storyline=True,
             )
             if not pid:
@@ -17769,6 +17777,45 @@ class ActivityGenerator:
             "time": emitted_time,
             "target_system": target_fqdn,
         }
+
+    def _spillage_process_parent_pid(
+        self,
+        *,
+        system: "System",
+        time: datetime,
+        logon_id: str,
+    ) -> int:
+        """Choose a non-shell parent for session-bound Linux process spillage."""
+        if _get_os_category(system.os) != "linux" or not logon_id:
+            return 4
+
+        session = self.state_manager.get_session(logon_id)
+        if session is not None:
+            for candidate in (session.transport_pid, session.process_tree_root):
+                if (
+                    candidate
+                    and self.state_manager.get_process(system.hostname, candidate) is not None
+                    and self._is_pid_active_at(system, candidate, time)
+                ):
+                    parent_proc = self.state_manager.get_process(system.hostname, candidate)
+                    parent_exe = (
+                        parent_proc.image.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
+                        if parent_proc is not None
+                        else ""
+                    )
+                    if parent_exe not in {"bash", "sh", "zsh"}:
+                        return candidate
+
+        sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
+        for role in ("sshd", "systemd", "init"):
+            candidate = sys_pids.get(role)
+            if (
+                candidate
+                and self.state_manager.get_process(system.hostname, candidate) is not None
+                and self._is_pid_active_at(system, candidate, time)
+            ):
+                return candidate
+        return 4
 
     def _normalize_apache_raw_syslog(
         self,

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1374,6 +1374,63 @@ class StorylineMixin:
             return None
         return logon_id
 
+    def _resolve_storyline_process_spill_logon_id(
+        self,
+        actor: User,
+        system: System,
+        time: datetime,
+        rng: random.Random,
+    ) -> str:
+        """Resolve canonical session ownership for a standalone process-command spill."""
+        from evidenceforge.validation.schema import BUILTIN_ACCOUNTS
+
+        os_category = _get_os_category(system.os)
+        service_accounts = set(self.scenario.environment.service_accounts)
+        is_local_account = actor.username in BUILTIN_ACCOUNTS or actor.username in service_accounts
+        is_interactive_linux_root = os_category == "linux" and actor.username == "root"
+        if is_local_account and not is_interactive_linux_root:
+            linux_daemon_users = {"apache", "www-data", "nginx", "httpd", "tomcat"}
+            if os_category == "linux" and actor.username.lower() in linux_daemon_users:
+                return ""
+            sessions = self.state_manager.get_sessions_for_user_at(actor.username, time)
+            target_session = max(
+                (s for s in sessions if s.system == system.hostname),
+                key=lambda session: session.start_time,
+                default=None,
+            )
+            if target_session is not None:
+                return target_session.logon_id
+            logon_time = time - timedelta(seconds=rng.uniform(0.5, 2.0))
+            return self.activity_generator.generate_service_logon(
+                system=system,
+                time=logon_time,
+                service_account=actor.username,
+            )
+
+        logon_id = self._last_storyline_logon_for_actor_system(actor, system, at_time=time)
+        if logon_id is not None:
+            return logon_id
+
+        required_until = self._next_storyline_logoff_time_for_actor_system(actor, system, time)
+        if required_until is not None:
+            required_until += timedelta(minutes=2)
+        plan = self.world_model.plan_session(
+            user=actor,
+            target_system=system,
+            rng=rng,
+        )
+        target_session = self.world_planner.ensure_user_session(
+            actor,
+            system,
+            time,
+            rng,
+            session_kind=plan.session_kind,
+            storyline_protected=True,
+            required_until=required_until,
+        )
+        self._record_storyline_logon(actor, system, target_session.logon_id)
+        return target_session.logon_id
+
     def _select_web_server_for_spillage(self, actor_system: System) -> System | None:
         """Pick the destination web server for an http_* spillage surface.
 
@@ -4207,6 +4264,13 @@ class StorylineMixin:
             # can be shifted and dropped during eCAR post-flush normalization —
             # leaving a labeled-but-unwritten credential (a phantom). A standalone
             # process keeps a stable, unique identity and always lands.
+            if spec.surface == "process_command_line":
+                spill_logon_id = self._resolve_storyline_process_spill_logon_id(
+                    actor,
+                    system,
+                    time,
+                    rng,
+                )
             if spec.surface in HTTP_SURFACES:
                 # The credential leaks into a web server's access log; pick the
                 # destination web server (the validator requires one to exist).

--- a/tests/integration/test_spillage_generation.py
+++ b/tests/integration/test_spillage_generation.py
@@ -7,6 +7,7 @@ accurate ground truth, passes `eforge eval`, and validates safely."""
 import datetime
 import json
 import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -58,6 +59,50 @@ def _records_or_empty(out: Path) -> list[dict]:
 
 def _iso(epoch: int) -> str:
     return datetime.datetime.fromtimestamp(epoch, datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_windows_log(file_path: Path) -> list[dict]:
+    with open(file_path) as f:
+        content = f.read()
+
+    root = ET.fromstring(content if "<Events>" in content else f"<Events>{content}</Events>")
+    ns = {"ns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+
+    events = []
+    for event_elem in root.findall("ns:Event", ns):
+        event: dict[str, str | datetime.datetime] = {}
+        system = event_elem.find("ns:System", ns)
+        if system is not None:
+            event["EventID"] = system.findtext("ns:EventID", namespaces=ns) or ""
+            time_created = system.find("ns:TimeCreated", ns)
+            if time_created is not None:
+                time_str = time_created.get("SystemTime")
+                if time_str:
+                    event["TimeCreated"] = datetime.datetime.fromisoformat(
+                        time_str.replace("Z", "+00:00")
+                    )
+            event["Computer"] = system.findtext("ns:Computer", namespaces=ns) or ""
+
+        event_data = event_elem.find("ns:EventData", ns)
+        if event_data is not None:
+            for data in event_data.findall("ns:Data", ns):
+                name = data.get("Name")
+                if name:
+                    event[name] = data.text or ""
+
+        events.append(event)
+
+    return events
+
+
+def _ecar_records(out: Path) -> list[dict]:
+    rows: list[dict] = []
+    for path in out.rglob("ecar.json"):
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
 
 
 @pytest.fixture
@@ -270,6 +315,63 @@ class TestSpillageAccuracy:
         assert url_line.split()[0] == "192.168.20.30"  # client_ip = the Windows actor host
         # …and the process-command-line spill lands in EDR/ecar telemetry.
         assert recs["process_command_line"]["rendered_value"] in ecar
+
+    def test_windows_process_spill_uses_visible_session_logon_context(self, tmp_path):
+        scenario = _linux_scenario(
+            [{"type": "spillage", "surface": "process_command_line", "family": "bearer_token"}],
+            logs=[{"format": "windows_event_security"}, {"format": "ecar"}],
+            actor_os="Windows 11 Pro",
+        )
+        scenario["storyline"].insert(
+            0,
+            {
+                "id": "login",
+                "time": "+5m",
+                "actor": "nina",
+                "system": "APP-SRV-01",
+                "activity": "remote interactive login",
+                "events": [{"type": "logon", "logon_type": 10, "source_ip": "203.0.113.10"}],
+            },
+        )
+        out = _generate(scenario, tmp_path / "out")
+        rec = next(r for r in _records(out) if r["surface"] == "process_command_line")
+
+        windows_events = [
+            event
+            for path in out.rglob("windows_event_security.xml")
+            for event in _parse_windows_log(path)
+        ]
+        proc_event = next(
+            event
+            for event in windows_events
+            if event.get("EventID") == "4688"
+            and rec["rendered_value"] in str(event.get("CommandLine") or "")
+        )
+        subject_logon_id = str(proc_event.get("SubjectLogonId") or "")
+        assert subject_logon_id not in {"", "-", "0x0", "0x3e4", "0x3e5", "0x3e7"}
+        assert any(
+            event.get("EventID") == "4624"
+            and event.get("TargetLogonId") == subject_logon_id
+            and str(event.get("TargetUserName") or "").lower() == "nina"
+            for event in windows_events
+        )
+
+        ecar_rows = _ecar_records(out)
+        proc_row = next(
+            row
+            for row in ecar_rows
+            if row.get("object") == "PROCESS"
+            and row.get("action") == "CREATE"
+            and rec["rendered_value"] in str(row.get("properties", {}).get("command_line") or "")
+        )
+        assert proc_row.get("principal") == "nina"
+        assert any(
+            row.get("object") == "USER_SESSION"
+            and row.get("action") == "LOGIN"
+            and row.get("principal") == "nina"
+            and int(row.get("timestamp_ms", 0)) <= int(proc_row.get("timestamp_ms", 0))
+            for row in ecar_rows
+        )
 
     def test_db_uri_through_http_url_is_percent_encoded_on_disk(self, tmp_path):
         # db_uri is the heaviest-encoding family (:// @ : /). Through http_request_url


### PR DESCRIPTION
## Summary
- route `process_command_line` spillage through the existing storyline/world-planner session ownership path instead of falling back to a placeholder logon ID
- keep Linux spills standalone by selecting a non-shell parent from existing session/system state so they retain real session ownership without re-entering the interactive shell timeline
- add integration coverage for Windows session/logon linkage, Linux interactive-session survival, and record the maintainer follow-up in the worklog

## Testing
- `uv run pytest --no-cov --include-slow`
- `uv run pytest --no-cov tests/integration/test_spillage_generation.py -k 'windows_process_spill_uses_visible_session_logon_context or process_command_line_spills_survive_interactive_session or http_and_process_spills_land_from_a_windows_actor'`
- `uv run pytest --no-cov tests/integration/test_spillage_generation.py -k 'process_command_line_lands_in_ecar or eval_acceptance_passes'`