### PR TITLE
fix: render file_read side effects instead of crashing on action 'read'

### DIFF
--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -236,6 +236,18 @@ class _HttpPersistentConnection:
 
 _HTTP_PERSISTENT_REUSE_GUARD = timedelta(milliseconds=900)
 
+# Map a process-driven file side-effect `action` (from edr_pools.yaml's
+# file_side_effect_profiles + the command-semantic effects) to its canonical event
+# type. Must cover EVERY action those data sources can emit — a missing key is a
+# generation crash (e.g. the sshd `read` of /etc/ssh/sshd_config). `file_read` is a
+# fully-modeled event (FileContext action "read", eCAR FILE/READ).
+_FILE_EFFECT_EVENT_TYPE: dict[str, str] = {
+    "create": "file_create",
+    "modify": "file_modify",
+    "delete": "file_delete",
+    "read": "file_read",
+}
+
 
 _WINDOWS_SINGLETON_SERVICE_EXES = frozenset(
     {
@@ -9099,11 +9111,7 @@ class ActivityGenerator:
             semantic_file_effect = select_command_file_side_effect(process_name, command_line)
             if semantic_file_effect is not None:
                 action, path = semantic_file_effect
-                event_type = {
-                    "create": "file_create",
-                    "modify": "file_modify",
-                    "delete": "file_delete",
-                }[action]
+                event_type = _FILE_EFFECT_EVENT_TYPE[action]
                 self.dispatcher.dispatch(
                     SecurityEvent(
                         timestamp=time + timedelta(milliseconds=180),
@@ -9152,11 +9160,7 @@ class ActivityGenerator:
             )
             if side_effect is not None:
                 action, path = side_effect
-                event_type = {
-                    "create": "file_create",
-                    "modify": "file_modify",
-                    "delete": "file_delete",
-                }[action]
+                event_type = _FILE_EFFECT_EVENT_TYPE[action]
                 self.dispatcher.dispatch(
                     SecurityEvent(
                         timestamp=time + timedelta(milliseconds=rng.randint(110, 650)),

--- a/tests/unit/test_edr_pools.py
+++ b/tests/unit/test_edr_pools.py
@@ -834,3 +834,27 @@ class TestOverlayValidation:
         sanitized = _sanitize_edr_pools(defaults, merged)
 
         assert sanitized["registry_keys_hkcu"] == defaults["registry_keys_hkcu"]
+
+
+def test_file_side_effect_actions_all_have_an_event_type_mapping():
+    # Regression: a process-driven file side-effect whose action is not in the generator's
+    # action->event_type map crashes generation mid-run with KeyError (the sshd profile's
+    # `read` of /etc/ssh/sshd_config did exactly this). Every action the EDR config can emit
+    # must map to a real, eCAR-renderable event type.
+    from evidenceforge.generation.activity.generator import _FILE_EFFECT_EVENT_TYPE
+    from evidenceforge.generation.emitters.ecar import EcarEmitter
+
+    config_actions = {
+        str(action).lower()
+        for profile in load_edr_pools().get("file_side_effect_profiles", [])
+        for action in profile.get("actions", [])
+    }
+    missing = config_actions - set(_FILE_EFFECT_EVENT_TYPE)
+    assert not missing, f"file side-effect actions with no event-type mapping: {sorted(missing)}"
+    # the specific regressed case
+    assert _FILE_EFFECT_EVENT_TYPE.get("read") == "file_read"
+    # every mapped event type must be one the eCAR emitter actually renders
+    unrenderable = set(_FILE_EFFECT_EVENT_TYPE.values()) - EcarEmitter._supported_types
+    assert not unrenderable, (
+        f"file-effect event types the eCAR emitter cannot render: {unrenderable}"
+    )


### PR DESCRIPTION
## Summary

A process-driven file side-effect whose action is `read` crashes generation mid-run with `KeyError: 'read'`.

The activity generator maps a file side-effect's `action` to an event type in two places, but both maps only handled `create` / `modify` / `delete`. Meanwhile `config/activity/edr_pools.yaml`'s `file_side_effect_profiles` can emit a `read` action — for example `linux_sshd_listener_state`, where `sshd` reads `/etc/ssh/sshd_config` — so when baseline activity selects that side-effect, the lookup raises `KeyError: 'read'` and aborts the run.

`file_read` is already a fully-modeled event type (`FileContext` allows `action="read"`, and the eCAR emitter renders it as a `FILE` / `READ` record), so the read side-effect should simply be emitted rather than crashing.

## Fix

- Map `read` → `file_read`, so a file-read side-effect renders as a normal eCAR `FILE READ` event.
- Consolidate the two byte-identical inline maps into a single module-level `_FILE_EFFECT_EVENT_TYPE` constant.
- Add a regression test asserting the map covers every action the EDR config can emit, and that each maps to an event type the eCAR emitter renders.

## Notes

The crash was non-deterministic in practice: it only triggered when baseline activity happened to select an `sshd` file side-effect (more likely under sysadmin-persona / medium+ intensity). After the fix, a previously-crashing scenario generates cleanly and the `sshd_config` `FILE`/`READ` events render correctly.

`pytest --no-cov`, `ruff check`, and `ruff format --check` pass.
