### PR TITLE
[codex] Add output target ingest guides

### DIFF
--- a/docs/output-targets/README.md
+++ b/docs/output-targets/README.md
@@ -1,0 +1,65 @@
+# Output Target Ingest Guides
+
+EvidenceForge output targets choose how generated evidence is rendered on disk.
+The canonical event model is the same, but the target may change file layout,
+line breaking, envelopes, or record shape so a parser can ingest the data.
+
+Use these guides when deciding which target to generate and what the downstream
+tooling proves.
+
+| Target | Best use | Guide |
+| --- | --- | --- |
+| `default` | Source-readable generated data, internal evaluation, manual review, and custom ingestion experiments. | [default.md](default.md) |
+| `sof-elk` | Developer-facing parser validation through SOF-ELK® Filebeat and Logstash. | [sof-elk.md](sof-elk.md) |
+| `splunk` | Developer-facing Splunk ingest validation and optional CIM/data-model validation. | [splunk.md](splunk.md) |
+
+## Choose A Target
+
+| Goal | Recommended target | Why |
+| --- | --- | --- |
+| Run `eforge eval` or inspect generated source-native logs by hand. | `default` | Keeps neutral, readable output and avoids parser-specific envelopes. |
+| Prove SOF-ELK can parse supported generated families. | `sof-elk` | Emits SOF-ELK-compatible Snare/RFC3164 layouts for Windows and syslog-family logs. |
+| Prove Splunk can ingest supported generated families. | `splunk` | Emits Splunk-friendly Windows XML event streams and target-specific web/proxy JSON records. |
+| Prove Splunk CIM visibility for supported families. | `splunk` plus supplied Splunk CIM/TAs | The Splunk harness can install caller-supplied apps ephemerally and run data-model searches. |
+
+Do not use a `default` dataset for the SOF-ELK or Splunk parser lanes. The
+external parser script checks `OUTPUT_TARGET.txt` and exits before staging when
+the target marker does not match the requested backend.
+
+## Validation Tiers
+
+The guides use these status terms.
+
+| Tier | Meaning |
+| --- | --- |
+| Generated | EvidenceForge emits the file when the scenario config enables the source. No external parser claim is made. |
+| Ingest validated | The external parser harness proved records were indexed or parsed at the expected count, with basic metadata and line breaking intact. |
+| Field validated | The harness proved required parser-visible fields were present for that family. |
+| CIM normalized | Splunk only. Events were found in the expected CIM data model or object with required CIM fields. |
+| Parsed-only | Splunk only. Events are ingested and basic fields are available, but no CIM data-model claim is made. |
+| Unsupported | The harness detects the file family but intentionally does not validate it for that target. |
+
+Parser validation proves format and parser compatibility for the stated fields.
+It does not prove that every generated record is realistic, complete for every
+analytics use case, or normalized by every possible third-party app version.
+
+## Source Presence
+
+Generated files follow the scenario topology. EvidenceForge does not emit source
+families when no corresponding source exists:
+
+- No Zeek sensors means no Zeek logs.
+- No IDS sensors means no Snort/Suricata alert logs.
+- No firewall sensors means no Cisco ASA logs.
+- No `web_server` hosts means no web access logs.
+- No `forward_proxy` hosts means no proxy access logs.
+- Host logs are scoped to concrete host directories.
+
+This matters when building parser smoke scenarios: a minimal scenario may be
+valid but still omit entire source families.
+
+## Related Developer Docs
+
+- [External parser validation](../external-parser-validation/README.md)
+- [Parser coverage matrix](../external-parser-validation/coverage-matrix.md)
+- [Evidence formats reference](../reference/EVIDENCE_FORMATS.md)

--- a/docs/output-targets/default.md
+++ b/docs/output-targets/default.md
@@ -1,0 +1,69 @@
+# Default Output Target
+
+The `default` target is the neutral EvidenceForge output. It is intended for
+manual review, custom ingestion experiments, and `eforge eval`, not for proving
+that a specific third-party parser accepts the data without extra configuration.
+
+## High-Level Format Differences
+
+The default target keeps each family in a source-readable, SIEM-neutral shape.
+It does not add parser-specific envelopes, year-partitioned archive paths, or
+Splunk-specific JSON records.
+
+| Family | Default output | Notes |
+| --- | --- | --- |
+| Windows Security | `<host>/windows_event_security.xml` | Rooted XML document with `<Events>...</Events>`. |
+| Windows Sysmon | `<host>/windows_event_sysmon.xml` | Rooted XML document with `<Events>...</Events>`. |
+| Linux syslog | `<host>/syslog.log` | RFC5424 with full timestamp year. |
+| Cisco ASA | `<firewall>/cisco_asa.log` | Native ASA syslog payload in a flat firewall-sensor file. |
+| Zeek | `<sensor>/<log>.json` | NDJSON, emitted only for configured Zeek sensors. |
+| Web access | `<web-host>/web_access.log` | Apache/Nginx combined log format. |
+| Proxy access | `<proxy-host>/proxy_access.log` | W3C Extended-style forward proxy log. |
+| eCAR | `<host>/ecar.json` | Custom simulated EDR NDJSON. |
+| Snort/Suricata | `<ids-sensor>/snort_alert.log` | Fast alert style, emitted only for configured IDS sensors. |
+| Bash history | `<host>/bash_history/<user>.bash_history` | Command history text files. |
+
+## Generate
+
+```bash
+uv run eforge generate <scenario.yaml> --target default
+```
+
+Omitting `--target` also uses the default target. New datasets write
+`OUTPUT_TARGET.txt` with `default`; older legacy datasets with no marker are
+treated as default by EvidenceForge.
+
+## Ingest Expectations
+
+The default target does not ship target-specific Splunk, SOF-ELK®, or other SIEM
+configuration. If you ingest it manually, choose sourcetypes, line breaking,
+timestamp extraction, host/source metadata, and normalization rules yourself.
+
+Non-obvious gotchas:
+
+- Default Windows XML is a single rooted XML document per host. A file monitor
+  that expects one event per physical line should use `--target splunk` instead.
+- Default Linux syslog and Cisco ASA logs are not year-partitioned. SOF-ELK
+  validation expects `--target sof-elk` for those families.
+- Default web access is combined text. The Splunk target uses JSON for Apache
+  TA compatibility.
+- Default proxy access is W3C Extended text. The Splunk target uses JSON plus
+  generated EvidenceForge proxy eventtype/tag config.
+
+## Validation Status
+
+| Family | Default ingest status | Normalization status |
+| --- | --- | --- |
+| Windows Security | Generated only | No external parser claim. |
+| Windows Sysmon | Generated only | No external parser claim. |
+| Linux syslog | Generated only | No external parser claim. |
+| Cisco ASA | Generated only | No external parser claim. |
+| Zeek | Generated only | No external parser claim for this target. |
+| Web access | Generated only | No external parser claim for this target. |
+| Proxy access | Generated only | No external parser claim for this target. |
+| eCAR | Generated only | Custom format. |
+| Snort/Suricata | Generated only | No external parser claim. |
+| Bash history | Generated only | Command history text, not a parser-normalized log family. |
+
+For parser validation, regenerate with [sof-elk.md](sof-elk.md) or
+[splunk.md](splunk.md).

--- a/docs/output-targets/sof-elk.md
+++ b/docs/output-targets/sof-elk.md
@@ -1,0 +1,92 @@
+# SOF-ELK® Output Target
+
+The `sof-elk` target renders generated data for the EvidenceForge SOF-ELK
+external parser harness. The harness runs SOF-ELK Filebeat and Logstash without
+Elasticsearch, validates parser output, and writes structured reports.
+
+EvidenceForge does not vendor SOF-ELK assets. The harness clones the pinned
+SOF-ELK repository inside Compose-managed ephemeral volumes and writes only
+EvidenceForge-owned wrapper configuration to the host work directory.
+
+## High-Level Format Differences
+
+The SOF-ELK target changes the generated layout for families that need SOF-ELK
+parser-compatible envelopes or archive paths. Families that SOF-ELK already
+accepts in their source-native shape generally stay unchanged.
+
+| Family | SOF-ELK rendering |
+| --- | --- |
+| Windows Security | `<host>/<year>/windows_event_security_snare.log` as Snare-style Windows Event Log fields in an RFC3164 syslog envelope. |
+| Windows Sysmon | `<host>/<year>/windows_event_sysmon_snare.log` as Snare-style Windows Event Log fields in an RFC3164 syslog envelope. |
+| Linux syslog | `<host>/<year>/syslog.log` as RFC3164/BSD syslog. |
+| Cisco ASA | `<firewall>/<year>/cisco_asa.log`, keeping native ASA syslog content. |
+| Zeek | Unchanged NDJSON under concrete sensor directories. |
+| Web access | Apache/Nginx combined log text. |
+| Other families | Unchanged, but not necessarily supported by this backend. |
+
+## Generate And Validate
+
+```bash
+uv run eforge generate <scenario.yaml> --target sof-elk
+uv run python scripts/external_parser.py <scenario-output>/data \
+  --backend sof-elk \
+  --work-dir /tmp/eforge-sof-elk-validation
+```
+
+`--backend auto` also selects SOF-ELK when `OUTPUT_TARGET.txt` contains
+`sof-elk`.
+
+## Required Runtime
+
+You need Docker Compose v2 or Podman Compose. The harness handles staging,
+wrapper configs, parser startup, report generation, and cleanup.
+
+Extra requirements and gotchas:
+
+- The run environment needs access to the pinned SOF-ELK repository and pinned
+  Elastic OSS container images.
+- The dataset must have `OUTPUT_TARGET.txt = sof-elk`.
+- Reusing a work directory clears parser-owned `sof-elk/*` runtime directories.
+- Year-partitioned paths matter for syslog-family files because SOF-ELK recovers
+  the event year from the archive path.
+
+## Validation Status
+
+| Family | SOF-ELK ingest status | Parser/normalization status |
+| --- | --- | --- |
+| Zeek `conn`, `dns`, `http`, `files`, `ssl`, `x509`, `weird` | Supported | Dedicated SOF-ELK filters validate counts and required parsed fields. |
+| Zeek `dhcp`, `ntp`, `ocsp`, `packet_filter`, `pe`, `reporter` | Supported | JSON ingest and count validation through supplemental EvidenceForge inputs. |
+| Cisco ASA | Supported | SOF-ELK Cisco ASA filter validates parse completion and required fields. |
+| Web access | Supported | SOF-ELK HTTPD filters validate parse completion; documented optional enrichment misses may be ignored. |
+| Linux syslog | Supported | Syslog filters validate parse completion, required fields, and staged year. |
+| Windows Security Snare | Supported | Snare/syslog filters validate `winlog.*` fields, provider/channel metadata, and staged year. |
+| Sysmon Snare | Supported | Snare/syslog filters validate `winlog.*` fields, provider/channel metadata, and staged year. |
+| Proxy access | Unsupported in SOF-ELK backend | Detected outside this backend's supported validation scope. |
+| eCAR | Unsupported in SOF-ELK backend | Custom format with no stable SOF-ELK parser target. |
+| Snort/Suricata fast alert | Unsupported in SOF-ELK backend | Generated when IDS sensors exist, but not validated here. |
+| Bash history | Unsupported in SOF-ELK backend | Command history text, not a parser-normalized log family. |
+
+## Reports And Troubleshooting
+
+Useful paths under `--work-dir`:
+
+| Path | Purpose |
+| --- | --- |
+| `sof-elk/parsed/sof_elk_parser_failures.json` | Structured failure report. |
+| `sof-elk/parsed/*.jsonl` | Parsed events and raw parser tags. |
+| `sof-elk/stage/logstash/...` | Exact staged files as SOF-ELK saw them. |
+| `sof-elk/pipeline-logs/filebeat.log` | Filebeat runtime log. |
+| `sof-elk/pipeline-logs/logstash.log` | Logstash runtime log. |
+| `sof-elk/runtime-config-src/` | EvidenceForge-owned wrapper and supplemental configs. |
+| `sof-elk/compose.yaml` | Generated Compose topology. |
+
+Failures usually mean one of five things:
+
+- The dataset was generated with the wrong target.
+- Compose, image pull, or SOF-ELK checkout failed.
+- SOF-ELK line breaking or parsing produced fatal tags.
+- Required normalized fields were missing.
+- A source family appeared that the backend intentionally does not support.
+
+For implementation details, see
+[../external-parser-validation/sof-elk-harness.md](../external-parser-validation/sof-elk-harness.md).

--- a/docs/output-targets/splunk.md
+++ b/docs/output-targets/splunk.md
@@ -1,0 +1,163 @@
+# Splunk Output Target
+
+The `splunk` target renders generated data for Splunk file monitoring and the
+EvidenceForge Splunk external parser harness. The harness starts an ephemeral
+`splunk/splunk:10.2.3` container, installs generated EvidenceForge-owned config,
+optionally stages caller-supplied apps, and validates ingest with REST searches.
+
+EvidenceForge does not vendor Splunk, Splunkbase apps, TAs, or CIM content.
+
+## High-Level Format Differences
+
+The Splunk target keeps source-native shapes when Splunk and the supplied apps
+can parse them, and changes rendering where file monitoring or CIM validation
+needs a different shape.
+
+| Family | Splunk rendering |
+| --- | --- |
+| Windows Security | `<host>/windows_event_security.xml`, one complete `<Event>...</Event>` per physical line. |
+| Windows Sysmon | `<host>/windows_event_sysmon.xml`, one complete `<Event>...</Event>` per physical line. |
+| Linux syslog | `<host>/syslog.log` as RFC5424 with full timestamp year. |
+| Cisco ASA | `<firewall>/cisco_asa.log`, native ASA syslog content in a flat firewall-sensor file. |
+| Zeek | Unchanged NDJSON under concrete sensor directories. |
+| Web access | Target-specific JSON records for the Apache TA `apache:access:json` sourcetype. |
+| Proxy access | Target-specific JSON records for `apache:access:json`, plus EvidenceForge-generated proxy eventtype/tag config for CIM `Web.Proxy`. |
+| eCAR | Custom NDJSON under host directories. |
+
+No binary EVTX is generated in v1. The Linux Docker harness validates Windows
+Event XML file ingest instead.
+
+## Generate And Validate
+
+Base ingest validation:
+
+```bash
+uv run eforge generate <scenario.yaml> --target splunk
+uv run python scripts/external_parser.py <scenario-output>/data \
+  --backend splunk \
+  --accept-splunk-license \
+  --work-dir /tmp/eforge-splunk-validation
+```
+
+CIM validation with caller-supplied local apps:
+
+```bash
+uv run python scripts/external_parser.py <scenario-output>/data \
+  --backend splunk \
+  --accept-splunk-license \
+  --cim require \
+  --splunk-app /path/to/splunk-common-information-model-cim.tgz \
+  --splunk-app /path/to/splunk-add-on-for-microsoft-windows.spl \
+  --splunk-app /path/to/splunk-add-on-for-sysmon.tgz \
+  --splunk-app /path/to/splunk-add-on-for-cisco-asa.spl \
+  --splunk-app /path/to/ta-for-zeek.tgz \
+  --splunk-app /path/to/splunk-add-on-for-apache-web-server.spl
+```
+
+`--backend auto` also selects Splunk when `OUTPUT_TARGET.txt` contains
+`splunk`.
+
+## Licensing And Apps
+
+`--accept-splunk-license` is required before the container starts. The generated
+Compose file accepts the Splunk license and Splunk General Terms for that
+ephemeral validation run. The caller remains responsible for Splunk container
+licensing and any Splunkbase app terms.
+
+`--splunk-app <path>` may point to a local app directory or archive. Apps are
+copied or unpacked only into the run work directory. EvidenceForge never
+downloads them silently.
+
+## CIM Mode
+
+| Mode | Behavior |
+| --- | --- |
+| `--cim auto` | Default. Run base ingest validation. If apps are supplied, also run CIM checks. If apps are absent, mark CIM skipped. |
+| `--cim require` | Fail early unless at least one app is supplied. |
+| `--cim off` | Skip CIM checks even when apps are supplied. |
+
+Use `require` when the goal is to prove CIM visibility. Use `auto` for a
+pipeline smoke that should still succeed when local TA paths are unavailable.
+
+## Ingest Config
+
+The harness writes an EvidenceForge-owned Splunk app under:
+
+```text
+<work-dir>/splunk/runtime-config-src/apps/evidenceforge_parser_validation/
+```
+
+Important generated files:
+
+| File | Purpose |
+| --- | --- |
+| `inputs.conf` | File monitors with explicit `index`, `host`, `source`, and `sourcetype`. |
+| `props.conf` | Line breaking, timestamp hints, XML/JSON modes, and base extractions. |
+| `transforms.conf` | Header/comment filtering and parser helpers. |
+| `indexes.conf` | Dedicated `eforge` index. |
+| `eventtypes.conf` and `tags.conf` | EvidenceForge-owned proxy/web classification needed for current validation. |
+
+For manual ingestion outside the harness, mirror the generated app config or
+use it as the source of truth for sourcetypes and line breaking.
+
+## Validation Status
+
+| Family | Splunk sourcetype | Ingest status | CIM status |
+| --- | --- | --- | --- |
+| Windows Security | `XmlWinEventLog` with `source=XmlWinEventLog:Security` when the Windows TA is present | Supported, count and core fields validated | Authentication events validated in `Authentication.Authentication`; non-auth Security events are parsed but not CIM-validated. |
+| Windows Sysmon | `XmlWinEventLog` with `source=XmlWinEventLog:Microsoft-Windows-Sysmon/Operational` when the Sysmon TA is present | Supported, count and core fields validated | Event IDs 1 and 5 validated in `Endpoint.Processes`; 7, 8, and 10 enter the data model but remain partial-CIM for now. |
+| Zeek `conn` | `bro:conn:json` | Supported | Validated in `Network_Traffic.All_Traffic`. |
+| Zeek `http` | `bro:http:json` | Supported | Validated in `Web.Web`. |
+| Zeek `dns`, `dhcp`, `files`, `ssl`, `x509`, `ntp`, `ocsp`, `pe`, `weird`, `packet_filter`, `reporter` | `bro:<log>:json` | Supported | Parsed-only for now. |
+| Cisco ASA | `cisco:asa` | Supported | Validated in `Network_Traffic.All_Traffic`. |
+| Linux syslog | `syslog` | Supported | Parsed-only for now. |
+| Web access | `apache:access:json` | Supported | Validated in `Web.Web`. |
+| Proxy access | `apache:access:json` | Supported | Validated in `Web.Proxy`. |
+| eCAR | `evidenceforge:ecar:json` | Supported | Custom format, no CIM claim. |
+| Snort/Suricata fast alert | Not staged in Splunk v1 | Unsupported | Not CIM-normalized. |
+| Bash history | Not staged in Splunk v1 | Unsupported | Not CIM-normalized. |
+
+## What CIM Validation Proves
+
+For families marked CIM validated, the harness proves:
+
+- The records were indexed at the expected count.
+- Splunk search can find the expected sourcetype/source family.
+- Required base fields were extracted.
+- The relevant CIM data model and object returned the expected event subset.
+- Required CIM fields were populated for the validated event families.
+- Splunk `_internal` searches did not report ingest or parser warnings that the
+  harness treats as fatal.
+
+For parsed-only families, the harness proves ingest and basic field visibility,
+but it does not claim data-model normalization.
+
+## Reports And Troubleshooting
+
+Useful paths under `--work-dir`:
+
+| Path | Purpose |
+| --- | --- |
+| `splunk/parsed/splunk_validation_report.json` | Success report. |
+| `splunk/parsed/splunk_parser_failures.json` | Structured failure report. |
+| `splunk/search-results/*.jsonl` | Raw REST search/export rows used for validation. |
+| `splunk/stage/data/...` | Exact staged files as Splunk monitored them. |
+| `splunk/pipeline-logs/splunkd.log` | Recent Splunk daemon log. |
+| `splunk/pipeline-logs/btool-*.txt` | Effective Splunk config snapshots. |
+| `splunk/runtime-config-src/` | Generated app config and ephemeral supplied app copies. |
+| `splunk/compose.yaml` | Generated Compose topology. |
+
+Common failure interpretations:
+
+- Count mismatch: file monitor, line breaking, CRC, source path, or unsupported
+  source-family issue.
+- Required base field missing: generated config or record shape issue.
+- `_internal` parser warning: timestamp, line breaking, tailing, or monitor
+  issue.
+- CIM data-model count mismatch: app visibility, search shape, tags/eventtypes,
+  or source/sourcetype mismatch.
+- CIM field missing: either the TA does not map that event family to the field,
+  or the generated native record is missing data the TA expects.
+
+For implementation details, see
+[../external-parser-validation/splunk-harness.md](../external-parser-validation/splunk-harness.md).

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -53,6 +53,8 @@ formats. Scenario YAML and `--formats` remain canonical: request
 on, then choose the target at generation time.
 When `OUTPUT_TARGET.txt` is missing, `eforge eval` treats the dataset as
 legacy/default output.
+For practical ingestion and validation guidance by target, see
+[Output Target Ingest Guides](../output-targets/README.md).
 
 Target-specific behavior in V1:
 


### PR DESCRIPTION
## Summary
- Add user-facing output target ingest guides for `default`, `sof-elk`, and `splunk`
- Define validation tiers and source-presence expectations for generated log families
- Document target-specific format differences before generation commands
- Document ingest requirements, validation commands, reports, and known limitations
- Link the new guide set from the evidence formats reference

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --no-cov tests/unit/test_external_parser_docs.py`

## Notes
This PR is intentionally stacked on `codex/splunk-output-target`. After the Splunk feature merges to `dev`, this can be rebased/retargeted to `dev`. Feature branches intentionally do not bump the version.