### PR TITLE
Release v1.3.1 generation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Detailed development history for the EvidenceForge project. Transferred from TOD
 
 ## Unreleased
 
+## v1.3.1 (2026-06-06)
+
+This patch release fixes several generation edge cases reported from class
+exercise authoring and preserves a durable service-process state regression.
+The branch contains only `fix:` commits since v1.3.0, so the project moves from
+`1.3.0` to `1.3.1`.
+
+**Generation edge cases and backward-compatible controls**
+
+- Moved Windows Security event spool SQLite state out of final output
+  directories, optimized SOF-ELK syslog close-time normalization, allowed
+  concrete Zeek formats in output and sensor configuration, added opt-in
+  per-tick beacon DNS resolution, optimized high-volume DGA state handling,
+  preserved compatible explicit TCP payload byte overrides, and added explicit
+  storyline process lineage refs (`949faa26`).
+
+**Durable service process state**
+
+- Preserved durable service process state across activity generation paths and
+  added regression coverage for service process and spawn-rule behavior
+  (`7e3a3a52`).
+
 ## v1.3.0 (2026-06-05)
 
 This minor release adds the Splunk output target, Splunk parser validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "evidence-forge"
-version = "1.3.0"
+version = "1.3.1"
 description = "Generate realistic synthetic security logs for cybersecurity threat hunting training and research"
 readme = "README.md"
 license = "MIT"

--- a/src/evidenceforge/__init__.py
+++ b/src/evidenceforge/__init__.py
@@ -27,5 +27,5 @@ for cybersecurity threat hunting training and research. It uses a two-phase
 architecture combining LLM-driven scenario creation with deterministic log generation.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __all__ = []  # Will be expanded as modules are implemented

--- a/src/evidenceforge/generation/actions/network_connection.py
+++ b/src/evidenceforge/generation/actions/network_connection.py
@@ -99,6 +99,7 @@ class NetworkConnectionRequest:
     preserve_dst_ip: bool = False
     preserve_http_outcome: bool = False
     suppress_application_side_effects: bool = False
+    preserve_explicit_payload: bool = False
     packet_overhead_bytes: int | None = None
     responding_pid: int = -1
     source: str = "activity_generator"
@@ -121,7 +122,8 @@ class NetworkConnectionRequest:
             f"{_context_fingerprint(self.firewall)}:{self.hostname or ''}:"
             f"{self.proxy_bypass}:{self.process_image or ''}:{self.preserve_dst_ip}:"
             f"{self.preserve_http_outcome}:{self.suppress_application_side_effects}:"
-            f"{self.packet_overhead_bytes or ''}:{self.responding_pid}:{self.source}"
+            f"{self.preserve_explicit_payload}:{self.packet_overhead_bytes or ''}:"
+            f"{self.responding_pid}:{self.source}"
         )
         return f"network-connection-{seed:016x}"
 

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -246,6 +246,12 @@ _WINDOWS_SINGLETON_SERVICE_EXES = frozenset(
         "msdtc.exe",
     }
 )
+_FILE_ACTION_EVENT_TYPES = {
+    "read": "file_read",
+    "create": "file_create",
+    "modify": "file_modify",
+    "delete": "file_delete",
+}
 _SYSTEM_ACCOUNTS = {"SYSTEM", "NETWORK SERVICE", "LOCAL SERVICE"}
 _USER_MODEL_USERNAME_RE = re.compile(r"^[a-zA-Z0-9._$-]+$")
 _LINUX_LOCAL_ACCOUNTS = {
@@ -9099,11 +9105,7 @@ class ActivityGenerator:
             semantic_file_effect = select_command_file_side_effect(process_name, command_line)
             if semantic_file_effect is not None:
                 action, path = semantic_file_effect
-                event_type = {
-                    "create": "file_create",
-                    "modify": "file_modify",
-                    "delete": "file_delete",
-                }[action]
+                event_type = _FILE_ACTION_EVENT_TYPES[action]
                 self.dispatcher.dispatch(
                     SecurityEvent(
                         timestamp=time + timedelta(milliseconds=180),
@@ -9152,11 +9154,7 @@ class ActivityGenerator:
             )
             if side_effect is not None:
                 action, path = side_effect
-                event_type = {
-                    "create": "file_create",
-                    "modify": "file_modify",
-                    "delete": "file_delete",
-                }[action]
+                event_type = _FILE_ACTION_EVENT_TYPES[action]
                 self.dispatcher.dispatch(
                     SecurityEvent(
                         timestamp=time + timedelta(milliseconds=rng.randint(110, 650)),
@@ -13580,6 +13578,10 @@ class ActivityGenerator:
         """
         from evidenceforge.events.contexts import ProcessContext
 
+        if self._is_protected_windows_system_pid(system, pid):
+            self.state_manager.update_process_activity_time(system.hostname, pid, time)
+            return
+
         running_proc = self.state_manager.get_process(system.hostname, pid)
         if running_proc is not None:
             process_name = running_proc.image
@@ -13650,6 +13652,13 @@ class ActivityGenerator:
             )
 
         self.dispatcher.dispatch(event)
+
+    def _is_protected_windows_system_pid(self, system: System, pid: int) -> bool:
+        """Return whether a PID belongs to the durable seeded Windows process tree."""
+        if _get_os_category(system.os) != "windows":
+            return False
+        system_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
+        return pid in set(system_pids.values())
 
     def _dns_observed_ttls(
         self,

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -2362,6 +2362,38 @@ def _align_tcp_network_payload_with_history(
     return True
 
 
+def _preserve_explicit_tcp_payload_overrides(
+    net: NetworkContext,
+    *,
+    explicit_orig_bytes: int | None,
+    explicit_resp_bytes: int | None,
+    rng: random.Random,
+) -> bool:
+    """Re-apply explicit author payload intent after protocol shaping."""
+    if net.protocol != "tcp" or net.conn_state != "SF":
+        return False
+
+    changed = False
+    if explicit_orig_bytes is not None and explicit_orig_bytes > (net.orig_bytes or 0):
+        net.orig_bytes = explicit_orig_bytes
+        changed = True
+    if explicit_resp_bytes is not None and explicit_resp_bytes > (net.resp_bytes or 0):
+        net.resp_bytes = explicit_resp_bytes
+        changed = True
+    if not changed:
+        return False
+
+    net.orig_pkts, net.resp_pkts = _tcp_packet_counts_from_payload_and_history(
+        net.orig_bytes,
+        net.resp_bytes,
+        net.history,
+        rng,
+    )
+    net.orig_ip_bytes = _tcp_ip_byte_count(net.orig_bytes, net.orig_pkts, rng)
+    net.resp_ip_bytes = _tcp_ip_byte_count(net.resp_bytes, net.resp_pkts, rng)
+    return True
+
+
 def _tcp_ip_byte_count(
     payload_bytes: int | None,
     packet_count: int,
@@ -4637,7 +4669,10 @@ class ActivityGenerator:
 
         wanted_src = src_ip.removeprefix("::ffff:")
         wanted_dst = dst_ip.removeprefix("::ffff:")
+        terminal_states = getattr(self.state_manager, "_TERMINAL_CONN_STATES", frozenset())
         for connection in self.state_manager.state.open_connections.values():
+            if connection.state in terminal_states:
+                continue
             if (
                 connection.src_ip.removeprefix("::ffff:") != wanted_src
                 or connection.src_port != src_port
@@ -10280,6 +10315,7 @@ class ActivityGenerator:
         preserve_dst_ip: bool = False,
         preserve_http_outcome: bool = False,
         suppress_application_side_effects: bool = False,
+        preserve_explicit_payload: bool = False,
         packet_overhead_bytes: int | None = None,
         responding_pid: int = -1,
     ) -> str:
@@ -10345,6 +10381,7 @@ class ActivityGenerator:
             preserve_dst_ip=preserve_dst_ip,
             preserve_http_outcome=preserve_http_outcome,
             suppress_application_side_effects=suppress_application_side_effects,
+            preserve_explicit_payload=preserve_explicit_payload,
             packet_overhead_bytes=packet_overhead_bytes,
             responding_pid=responding_pid,
         )
@@ -10364,6 +10401,8 @@ class ActivityGenerator:
         duration = request.duration
         orig_bytes = request.orig_bytes
         resp_bytes = request.resp_bytes
+        explicit_orig_bytes = request.orig_bytes
+        explicit_resp_bytes = request.resp_bytes
         src_port = request.src_port
         emit_dns = request.emit_dns
         pid = request.pid
@@ -10384,6 +10423,7 @@ class ActivityGenerator:
         preserve_dst_ip = request.preserve_dst_ip
         preserve_http_outcome = request.preserve_http_outcome
         suppress_application_side_effects = request.suppress_application_side_effects
+        preserve_explicit_payload = request.preserve_explicit_payload
         packet_overhead_bytes = request.packet_overhead_bytes
         responding_pid = request.responding_pid
 
@@ -12230,6 +12270,17 @@ class ActivityGenerator:
             )
 
         if _align_tcp_network_payload_with_history(event.network, rng):
+            self.state_manager.update_connection_bytes(
+                event.network.conn_id,
+                event.network.orig_bytes or 0,
+                event.network.resp_bytes or 0,
+            )
+        if preserve_explicit_payload and _preserve_explicit_tcp_payload_overrides(
+            event.network,
+            explicit_orig_bytes=explicit_orig_bytes,
+            explicit_resp_bytes=explicit_resp_bytes,
+            rng=rng,
+        ):
             self.state_manager.update_connection_bytes(
                 event.network.conn_id,
                 event.network.orig_bytes or 0,

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -403,6 +403,10 @@ class SyslogEmitter(HostMultiplexEmitter):
         """Close emitter after normalizing source-native syslog presentation state."""
         if self.threaded:
             self.stop_thread()
+        if self.output_target == OutputTarget.SOF_ELK:
+            self._normalize_sof_elk_buffers()
+            self.flush(force=True)
+            return
         self._normalize_logind_session_ids()
         self._backfill_missing_logind_pam_openers()
         self._normalize_pam_uid_collisions()
@@ -410,6 +414,19 @@ class SyslogEmitter(HostMultiplexEmitter):
         self._normalize_kernel_uptime_stamps()
         self._normalize_sshd_child_pids()
         self.flush(force=True)
+
+    def _normalize_sof_elk_buffers(self) -> None:
+        """Normalize SOF-ELK RFC3164 syslog rows with one final sort pass."""
+        with self._writers_lock:
+            for host_key, rows in self._sorted_lines_by_host().items():
+                if not rows:
+                    continue
+                normalized = [line for _year, _sort_key, _route_key, line in rows]
+                normalized = self._normalize_logind_session_ids_for_lines(normalized, host_key)
+                normalized = self._normalize_sudo_session_lifecycles_for_lines(normalized)
+                normalized = self._normalize_kernel_uptime_stamps_for_lines(normalized)
+                normalized = self._normalize_sshd_child_pids_for_lines(normalized, host_key)
+                self._replace_buffers_by_sorted_rows(rows, normalized)
 
     def _sorted_lines_by_host(self) -> dict[str, list[tuple[int, tuple[Any, ...], str, str]]]:
         """Return buffered rows grouped by host and sorted in final render order."""

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import random
+import shutil
 import sqlite3
 import tempfile
 from bisect import bisect_left
@@ -1517,6 +1518,8 @@ class WindowsEventEmitter(LogEmitter):
         self._last_record_time_created_by_computer: dict[str, datetime] = {}
         self._time_collision_count_by_computer: dict[str, int] = {}
         self._current_storyline_origin: bool = False
+        self._spool_dir: Path | None = None
+        self._owns_spool_dir: bool = False
         self._spool_path: Path | None = None
         self._spool_conn: sqlite3.Connection | None = None
         self._spooled_count: int = 0
@@ -1639,9 +1642,9 @@ class WindowsEventEmitter(LogEmitter):
     def _get_spool_conn_unlocked(self) -> sqlite3.Connection:
         """Open the on-disk Windows event spool database while holding _file_lock."""
         if self._spool_conn is None:
-            self._base_dir.mkdir(parents=True, exist_ok=True)
+            spool_dir = self._get_spool_dir_unlocked()
             fd, path = tempfile.mkstemp(
-                prefix=".windows_event_spool_", suffix=".sqlite3", dir=self._base_dir
+                prefix=".windows_event_spool_", suffix=".sqlite3", dir=spool_dir
             )
             os.close(fd)
             Path(path).unlink(missing_ok=True)
@@ -1654,6 +1657,23 @@ class WindowsEventEmitter(LogEmitter):
                 "payload TEXT NOT NULL)"
             )
         return self._spool_conn
+
+    def _get_spool_dir_unlocked(self) -> Path:
+        """Return the local runtime directory used for SQLite spool state."""
+        if self._spool_dir is not None:
+            return self._spool_dir
+
+        configured = os.environ.get("EFORGE_SPOOL_DIR")
+        if configured:
+            spool_dir = Path(configured).expanduser().resolve()
+            spool_dir.mkdir(parents=True, exist_ok=True)
+            self._spool_dir = spool_dir
+            self._owns_spool_dir = False
+            return spool_dir
+
+        self._spool_dir = Path(tempfile.mkdtemp(prefix="evidenceforge-windows-spool-"))
+        self._owns_spool_dir = True
+        return self._spool_dir
 
     def _spool_event_dicts_unlocked(self) -> None:
         """Move buffered event dictionaries to disk to bound emitter memory usage."""
@@ -2116,6 +2136,10 @@ class WindowsEventEmitter(LogEmitter):
         if self._spool_path is not None:
             self._spool_path.unlink(missing_ok=True)
             self._spool_path = None
+        if self._owns_spool_dir and self._spool_dir is not None:
+            shutil.rmtree(self._spool_dir, ignore_errors=True)
+            self._spool_dir = None
+            self._owns_spool_dir = False
         self._spooled_count = 0
 
     def _flush_unlocked(self) -> None:

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1061,6 +1061,33 @@ class StorylineMixin:
         self._last_storyline_image = image
         self._last_storyline_system = system.hostname
 
+    def _record_storyline_process_ref(
+        self,
+        *,
+        actor: User,
+        system: System,
+        process_ref: str,
+        pid: int,
+        image: str,
+    ) -> None:
+        """Record an explicit storyline process reference for later parentage."""
+        if not hasattr(self, "_storyline_process_refs"):
+            self._storyline_process_refs: dict[tuple[str, str, str], tuple[int, str]] = {}
+        self._storyline_process_refs[(system.hostname, actor.username, process_ref)] = (pid, image)
+
+    def _storyline_process_ref_for_parent(
+        self,
+        *,
+        actor: User,
+        system: System,
+        parent_ref: str | None,
+    ) -> tuple[int, str] | None:
+        """Resolve an explicit parent_ref to a known storyline process."""
+        if parent_ref is None:
+            return None
+        refs = getattr(self, "_storyline_process_refs", {})
+        return refs.get((system.hostname, actor.username, parent_ref))
+
     def _record_storyline_service_install(
         self,
         system: System,
@@ -2522,23 +2549,31 @@ class StorylineMixin:
 
             output_file = self._extract_output_file(command_line, os_category)
             process_logon_id = logon_id
-            service_context = self._storyline_service_context_for_process(
+            explicit_parent = self._storyline_process_ref_for_parent(
                 actor=process_actor,
                 system=system,
-                time=time,
-                process_name=process_name,
+                parent_ref=getattr(spec, "parent_ref", None),
             )
-            if service_context is not None:
-                process_actor, process_logon_id, parent_pid = service_context
+            if explicit_parent is not None:
+                parent_pid, _parent_image = explicit_parent
             else:
-                parent_pid = self.activity_generator._resolve_parent(
-                    system,
-                    process_actor,
-                    time,
-                    process_logon_id,
-                    process_name,
-                    process_command_line,
+                service_context = self._storyline_service_context_for_process(
+                    actor=process_actor,
+                    system=system,
+                    time=time,
+                    process_name=process_name,
                 )
+                if service_context is not None:
+                    process_actor, process_logon_id, parent_pid = service_context
+                else:
+                    parent_pid = self.activity_generator._resolve_parent(
+                        system,
+                        process_actor,
+                        time,
+                        process_logon_id,
+                        process_name,
+                        process_command_line,
+                    )
             if os_category == "linux":
                 self._emit_linux_storyline_shell_friction(
                     actor=process_actor,
@@ -2590,6 +2625,15 @@ class StorylineMixin:
             )
             self.activity_generator._record_user_process(system, process_actor, pid, process_name)
             self._record_last_storyline_process(system, pid, process_name)
+            process_ref = getattr(spec, "process_ref", None)
+            if process_ref is not None:
+                self._record_storyline_process_ref(
+                    actor=process_actor,
+                    system=system,
+                    process_ref=process_ref,
+                    pid=pid,
+                    image=process_name,
+                )
             malicious_event["process_name"] = process_name
             malicious_event["command_line"] = command_line
             malicious_event["pid"] = pid
@@ -3179,6 +3223,9 @@ class StorylineMixin:
                 process_image=story_image,
                 hostname=conn_hostname,
                 preserve_dst_ip=bool(spec.hostname),
+                preserve_explicit_payload=(
+                    spec.orig_bytes is not None or spec.resp_bytes is not None
+                ),
             )
             logged_dst_ip = getattr(
                 self.activity_generator,
@@ -3815,6 +3862,9 @@ class StorylineMixin:
                 start, interval_sec, duration_sec, count, spec.jitter, rng
             ):
                 self.state_manager.set_current_time(tick_time)
+                tick_emit_dns = emit_dns and (
+                    spec.dns_resolution == "each_tick" or attempt_count == 0
+                )
                 tick_http_ctx = http_ctx
                 tick_resp_bytes = s_rb
                 if http_ctx is not None and http_is_c2 and spec.response_body_len is None:
@@ -3896,7 +3946,7 @@ class StorylineMixin:
                             orig_bytes=s_ob,
                             resp_bytes=tick_resp_bytes,
                             conn_state="SF",
-                            emit_dns=emit_dns and attempt_count == 0,
+                            emit_dns=tick_emit_dns,
                             source_system=src_sys,
                             http=tick_http_ctx,
                             proxy=proxy_ctx,
@@ -3904,6 +3954,9 @@ class StorylineMixin:
                             pid=story_pid,
                             process_image=story_image,
                             preserve_dst_ip=bool(spec.hostname),
+                            preserve_explicit_payload=(
+                                spec.orig_bytes is not None or spec.resp_bytes is not None
+                            ),
                         )
                     else:
                         self.activity_generator.generate_connection(
@@ -3929,13 +3982,16 @@ class StorylineMixin:
                         orig_bytes=s_ob,
                         resp_bytes=tick_resp_bytes,
                         conn_state=s_conn_state,
-                        emit_dns=emit_dns and attempt_count == 0,
+                        emit_dns=tick_emit_dns,
                         source_system=src_sys,
                         http=tick_http_ctx,
                         hostname=conn_hostname,
                         pid=story_pid,
                         process_image=story_image,
                         preserve_dst_ip=bool(spec.hostname),
+                        preserve_explicit_payload=(
+                            spec.orig_bytes is not None or spec.resp_bytes is not None
+                        ),
                     )
                 attempt_count += 1
 
@@ -4220,6 +4276,8 @@ class StorylineMixin:
                     duration=rng.uniform(0.001, 0.05),
                 )
                 query_count += 1
+                if query_count % 500 == 0:
+                    self.state_manager.sweep_closed_connections()
                 if len(domain_sample) < 5:
                     domain_sample.append(domain)
 

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -423,6 +423,8 @@ class ProcessEventSpec(_EventSpecBase):
     type: Literal["process"] = "process"
     process_name: str
     command_line: str | None = None  # defaults to process_name at generation time
+    process_ref: str | None = None  # Optional durable ref for explicit parent/child lineage
+    parent_ref: str | None = None  # Optional process_ref to use as this process parent
     supplementary: Literal["auto", "none"] = "auto"
 
 
@@ -689,6 +691,13 @@ class BeaconEventSpec(_PeriodicEventBase):
     orig_bytes: int | None = None
     resp_bytes: int | None = None
     conn_state: str | None = None
+    dns_resolution: Literal["cached", "each_tick"] = Field(
+        default="cached",
+        description=(
+            "DNS cadence for hostname beacons. 'cached' emits resolver evidence only "
+            "on the first tick; 'each_tick' emits resolver evidence for every tick."
+        ),
+    )
 
     @field_validator("hostname")
     @classmethod

--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -457,6 +457,9 @@ class ScenarioValidator:
             "proxy_access",
         }
 
+        process_refs: set[tuple[str, str, str]] = set()
+        incompatible_payload_states = {"S0", "REJ", "S1", "SH", "SHR", "RSTO", "RSTR"}
+
         for idx, event in enumerate(self.scenario.storyline):
             for spec_idx, spec in enumerate(event.events):
                 # Validate connection dst_ip is a valid IP
@@ -474,6 +477,67 @@ class ScenarioValidator:
                                 suggestion="Use a valid IPv4 or IPv6 address",
                             )
                         )
+
+                if getattr(spec, "type", "") in {"connection", "beacon"}:
+                    conn_state = getattr(spec, "conn_state", None)
+                    has_payload_override = (
+                        getattr(spec, "orig_bytes", None) is not None
+                        or getattr(spec, "resp_bytes", None) is not None
+                    )
+                    if has_payload_override and conn_state in incompatible_payload_states:
+                        self.issues.append(
+                            ValidationIssue(
+                                severity="warning",
+                                field_path=f"storyline.{idx}.events.{spec_idx}.conn_state",
+                                message=(
+                                    f"{spec.type} specifies byte overrides with conn_state "
+                                    f"'{conn_state}', but that state cannot reliably carry "
+                                    "application payload bytes"
+                                ),
+                                suggestion=(
+                                    "Use conn_state: SF for explicit payload sizing, or omit "
+                                    "orig_bytes/resp_bytes for failed/handshake-only flows."
+                                ),
+                            )
+                        )
+
+                if getattr(spec, "type", "") == "process":
+                    ref_key_base = (event.system, event.actor)
+                    parent_ref = getattr(spec, "parent_ref", None)
+                    if parent_ref is not None and (*ref_key_base, parent_ref) not in process_refs:
+                        self.issues.append(
+                            ValidationIssue(
+                                severity="warning",
+                                field_path=f"storyline.{idx}.events.{spec_idx}.parent_ref",
+                                message=(
+                                    f"Process parent_ref '{parent_ref}' has no earlier matching "
+                                    "process_ref for the same storyline actor and system"
+                                ),
+                                suggestion=(
+                                    "Define the parent process earlier with process_ref, or omit "
+                                    "parent_ref to use the default shell/service parent inference."
+                                ),
+                            )
+                        )
+                    process_ref = getattr(spec, "process_ref", None)
+                    if process_ref is not None:
+                        ref_key = (*ref_key_base, process_ref)
+                        if ref_key in process_refs:
+                            self.issues.append(
+                                ValidationIssue(
+                                    severity="warning",
+                                    field_path=f"storyline.{idx}.events.{spec_idx}.process_ref",
+                                    message=(
+                                        f"Duplicate process_ref '{process_ref}' for the same "
+                                        "storyline actor and system"
+                                    ),
+                                    suggestion=(
+                                        "Use unique process_ref values when later events need "
+                                        "unambiguous parentage."
+                                    ),
+                                )
+                            )
+                        process_refs.add(ref_key)
 
                 # Validate raw event target_format
                 if hasattr(spec, "target_format") and spec.target_format:
@@ -552,13 +616,12 @@ class ScenarioValidator:
 
         from evidenceforge.events.dispatcher import FORMAT_GROUPS
 
-        # Valid sensor log_formats: group names + standalone non-group formats
+        # Valid sensor log_formats: group aliases plus concrete emitter names.
+        # This preserves "zeek" as the full-group alias while allowing narrow
+        # sensor scopes such as "zeek_conn" and "zeek_dns".
         known_sensor_formats = set(FORMAT_GROUPS.keys()) | {"snort_alert", "cisco_asa"}
-        # Individual emitter names that must use their group instead
-        _group_members = {}
-        for group, members in FORMAT_GROUPS.items():
-            for member in members:
-                _group_members[member] = group
+        for members in FORMAT_GROUPS.values():
+            known_sensor_formats.update(members)
 
         for idx, sensor in enumerate(self.scenario.environment.network.sensors):
             for seg_idx, seg_name in enumerate(sensor.monitoring_segments):
@@ -573,16 +636,7 @@ class ScenarioValidator:
                     )
 
             for fmt_idx, fmt in enumerate(sensor.log_formats):
-                if fmt in _group_members:
-                    self.issues.append(
-                        ValidationIssue(
-                            severity="error",
-                            field_path=f"environment.network.sensors.{idx}.log_formats.{fmt_idx}",
-                            message=f"Sensor '{sensor.name}' uses individual format '{fmt}'",
-                            suggestion=f"Use the group name '{_group_members[fmt]}' instead",
-                        )
-                    )
-                elif fmt not in known_sensor_formats:
+                if fmt not in known_sensor_formats:
                     self.issues.append(
                         ValidationIssue(
                             severity="warning",
@@ -760,12 +814,15 @@ class ScenarioValidator:
         monitored_segments: set[str] = set()
         link_local_span_segments: set[str] = set()
         for sensor in self.scenario.environment.network.sensors:
+            from evidenceforge.events.dispatcher import expand_formats
+
+            expanded_sensor_formats = expand_formats(sensor.log_formats)
             monitored_segments.update(sensor.monitoring_segments)
             if (
                 sensor.type != "firewall"
                 and sensor.placement == "span"
                 and sensor.direction in {"bidirectional", "outbound"}
-                and "zeek" in sensor.log_formats
+                and "zeek_conn" in expanded_sensor_formats
             ):
                 link_local_span_segments.update(sensor.monitoring_segments)
 

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -695,6 +695,61 @@ class TestActivityGenerator:
         assert event.auth.logon_id == logon_id
         assert event.dst_host.os_category == "windows"
 
+    def test_linux_read_file_side_effect_maps_to_file_read(self, monkeypatch):
+        """Linux read side effects from EDR pools should emit file_read events."""
+        state_manager = StateManager()
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        state_manager.set_current_time(timestamp)
+        ecar_emitter = Mock()
+        emitters = {"ecar": ecar_emitter}
+        dispatcher = EventDispatcher(state_manager=state_manager, emitters=emitters)
+        activity_gen = ActivityGenerator(state_manager, emitters, dispatcher=dispatcher)
+        system = System(hostname="LNX-01", ip="10.0.0.2", os="Ubuntu 22.04", type="server")
+        user = User(username="root", full_name="Root", email="root@example.com")
+        systemd_pid = state_manager.create_process(
+            system=system.hostname,
+            parent_pid=0,
+            image="/usr/lib/systemd/systemd",
+            command_line="/usr/lib/systemd/systemd",
+            username="root",
+            integrity_level="System",
+        )
+
+        class AlwaysSideEffectRng(random.Random):
+            def random(self) -> float:
+                return 0.0
+
+        monkeypatch.setattr(
+            "evidenceforge.generation.activity.generator._get_rng",
+            lambda: AlwaysSideEffectRng(1),
+        )
+        monkeypatch.setattr(
+            "evidenceforge.generation.activity.edr_pools.select_file_side_effect",
+            lambda **_kwargs: ("read", "/etc/ssh/sshd_config"),
+        )
+
+        activity_gen.generate_process(
+            user=user,
+            system=system,
+            time=timestamp + timedelta(seconds=1),
+            logon_id="",
+            process_name="/usr/sbin/sshd",
+            command_line="/usr/sbin/sshd -D [listener]",
+            parent_pid=systemd_pid,
+            allow_existing_browser_reuse=False,
+            allow_browser_launch_spacing=False,
+        )
+
+        file_events = [
+            call.args[0]
+            for call in ecar_emitter.emit.call_args_list
+            if call.args[0].event_type == "file_read"
+        ]
+        assert len(file_events) == 1
+        assert file_events[0].file is not None
+        assert file_events[0].file.action == "read"
+        assert file_events[0].file.path == "/etc/ssh/sshd_config"
+
     def test_auth_session_bundle_anchors_are_stable(self, test_user, test_system):
         """Auth/session requests should expose durable deterministic anchors."""
         timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -103,6 +103,42 @@ class TestWindowsEventEmitter:
         assert "<Computer>WIN-TEST-01.corp.local</Computer>" in content
         assert '<Data Name="TargetUserName">jsmith</Data>' in content
 
+    def test_spool_database_uses_local_runtime_directory(self, format_def, tmp_path, monkeypatch):
+        """Windows Security spool state should stay out of the final output directory."""
+        output_dir = tmp_path / "onedrive-like-output"
+        spool_dir = tmp_path / "local-spool"
+        monkeypatch.setenv("EFORGE_SPOOL_DIR", str(spool_dir))
+        emitter = WindowsEventEmitter(format_def, output_dir, buffer_size=1)
+
+        emitter.emit_event(
+            {
+                "EventID": 4624,
+                "TimeCreated": datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC),
+                "Computer": "WIN-TEST-01.corp.local",
+                "Channel": "Security",
+                "Level": 0,
+                "EventRecordID": 12345,
+                "ExecutionProcessID": 4,
+                "ExecutionThreadID": 100,
+                "TargetUserName": "jsmith",
+                "TargetDomainName": "CORP",
+                "TargetLogonId": "0x3e7abc",
+                "LogonType": 2,
+                "WorkstationName": "WIN-TEST-01",
+                "IpAddress": "192.168.1.100",
+                "LogonProcessName": "User32",
+                "AuthenticationPackageName": "Negotiate",
+            }
+        )
+
+        assert emitter._spool_path is not None
+        assert emitter._spool_path.parent == spool_dir.resolve()
+        assert not list(output_dir.glob(".windows_event_spool_*.sqlite3"))
+
+        emitter.close()
+
+        assert not list(spool_dir.glob(".windows_event_spool_*.sqlite3"))
+
     def test_windows_pid_hex_rejects_oversized_decimal_pid(self) -> None:
         """Oversized decimal PID text should not raise and should remain unchanged."""
         oversized_pid = "9" * 5000

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -427,6 +427,61 @@ class TestStorylineEvent:
         assert event.events[0].type == "process_access"
         assert event.events[0].target_process == "lsass.exe"
 
+    def test_storyline_process_event_accepts_explicit_lineage_refs(self):
+        """Process events should accept opt-in lineage references."""
+        event = StorylineEvent(
+            id="evt-test-4",
+            time="+45m",
+            actor="jdoe",
+            system="WS-01",
+            activity="Launch child through rundll32",
+            events=[
+                {
+                    "type": "process",
+                    "process_name": "rundll32.exe",
+                    "process_ref": "loader",
+                },
+                {
+                    "type": "process",
+                    "process_name": "powershell.exe",
+                    "parent_ref": "loader",
+                },
+            ],
+        )
+
+        assert event.events[0].process_ref == "loader"
+        assert event.events[1].parent_ref == "loader"
+
+    def test_beacon_event_dns_resolution_defaults_cached(self):
+        """Beacon DNS cadence remains cached unless explicitly opted in."""
+        event = StorylineEvent(
+            id="evt-test-5",
+            time="+45m",
+            actor="jdoe",
+            system="WS-01",
+            activity="Beacon with repeated DNS exercise signal",
+            events=[
+                {
+                    "type": "beacon",
+                    "dst_ip": "198.51.100.10",
+                    "hostname": "rare-c2.example",
+                    "interval": "3m",
+                    "count": 3,
+                },
+                {
+                    "type": "beacon",
+                    "dst_ip": "198.51.100.11",
+                    "hostname": "rare-c2-2.example",
+                    "interval": "3m",
+                    "count": 3,
+                    "dns_resolution": "each_tick",
+                },
+            ],
+        )
+
+        assert event.events[0].dns_resolution == "cached"
+        assert event.events[1].dns_resolution == "each_tick"
+
 
 class TestOutputSpec:
     """Tests for OutputSpec model."""

--- a/tests/unit/test_spawn_rules.py
+++ b/tests/unit/test_spawn_rules.py
@@ -124,6 +124,69 @@ class TestSpawnRulesYaml:
 class TestWindowsProcessTreeRealism:
     """Windows process trees should use spawn rules for parent selection."""
 
+    def test_singleton_service_reuse_does_not_reap_seeded_windows_parent(
+        self, state_manager, mock_emitters
+    ):
+        """Reused boot-seeded Windows services should not be terminated as transient noise."""
+        dc_system = System(
+            hostname="DC-01",
+            ip="10.0.10.10",
+            os="Windows Server 2019",
+            type="domain_controller",
+        )
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, dc_system)
+        dns_pid = pids["dns"]
+        services_pid = pids["services"]
+        timestamp = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+
+        reused_pid = ag.generate_system_process(
+            system=dc_system,
+            time=timestamp,
+            process_name=r"C:\Windows\System32\dns.exe",
+            command_line="dns.exe",
+            parent_pid=services_pid,
+            username="SYSTEM",
+        )
+
+        assert reused_pid == dns_pid
+        assert state_manager.get_process(dc_system.hostname, dns_pid) is not None
+        system_create_events = [
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type == "system_process_create"
+        ]
+        assert system_create_events == []
+
+        ag.generate_system_process_termination(
+            system=dc_system,
+            time=timestamp + timedelta(seconds=30),
+            pid=reused_pid,
+            process_name=r"C:\Windows\System32\dns.exe",
+            parent_pid=services_pid,
+            username="SYSTEM",
+        )
+
+        assert state_manager.get_process(dc_system.hostname, dns_pid) is not None
+        terminate_events = [
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type == "process_terminate"
+        ]
+        assert terminate_events == []
+
+        child_pid = ag.generate_system_process(
+            system=dc_system,
+            time=timestamp + timedelta(minutes=1),
+            process_name=r"C:\Windows\System32\conhost.exe",
+            command_line="conhost.exe 0x4",
+            parent_pid=dns_pid,
+            username="SYSTEM",
+        )
+        child_proc = state_manager.get_process(dc_system.hostname, child_pid)
+
+        assert child_proc is not None
+        assert child_proc.parent_pid == dns_pid
+
     def test_cli_process_gets_shell_parent(self, state_manager, mock_emitters, win_system, user):
         """CLI process (dotnet.exe) should get cmd.exe or powershell.exe as parent."""
         ag, pids = _setup_activity_gen(state_manager, mock_emitters, win_system)

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -27,10 +27,130 @@ from evidenceforge.generation.engine.storyline import (
 )
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
-from evidenceforge.models.scenario import ConnectionEventSpec, System, User
+from evidenceforge.models.scenario import BeaconEventSpec, ConnectionEventSpec, System, User
 
 
 class TestStorylineCommandNetworks:
+    def test_explicit_storyline_process_ref_sets_child_parent_pid(self):
+        """Explicit process_ref/parent_ref lineage should reach canonical process context."""
+        captured: list[Any] = []
+
+        class _CapturingDispatcher:
+            visibility_engine = None
+
+            @staticmethod
+            def dispatch(event: Any) -> None:
+                captured.append(event)
+
+        state = StateManager()
+        generator = ActivityGenerator(state, {})
+        generator.dispatcher = _CapturingDispatcher()
+        actor = User(username="alice", full_name="Alice Example", email="alice@example.com")
+        system = System(
+            hostname="SRC",
+            ip="10.10.0.10",
+            os="Windows 11 Enterprise",
+            type="workstation",
+        )
+        event_time = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
+        state.set_current_time(event_time)
+        engine = object.__new__(StorylineMixin)
+
+        parent_pid = generator.generate_process(
+            actor,
+            system,
+            event_time,
+            "0x3e7",
+            r"C:\Windows\System32\rundll32.exe",
+            r"rundll32.exe C:\Users\alice\AppData\Local\stage.dll,Run",
+            parent_pid=4,
+        )
+        engine._record_storyline_process_ref(
+            actor=actor,
+            system=system,
+            process_ref="loader",
+            pid=parent_pid,
+            image=r"C:\Windows\System32\rundll32.exe",
+        )
+
+        resolved_parent = engine._storyline_process_ref_for_parent(
+            actor=actor,
+            system=system,
+            parent_ref="loader",
+        )
+        assert resolved_parent is not None
+
+        child_pid = generator.generate_process(
+            actor,
+            system,
+            event_time + timedelta(seconds=2),
+            "0x3e7",
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            "powershell.exe -NoProfile -EncodedCommand SQBFAFgA",
+            parent_pid=resolved_parent[0],
+        )
+
+        child_event = next(
+            event
+            for event in captured
+            if event.event_type == "process_create"
+            and event.process is not None
+            and event.process.pid == child_pid
+        )
+        assert child_event.process.parent_pid == parent_pid
+
+    def test_beacon_dns_resolution_each_tick_controls_emit_dns_cadence(self):
+        """Beacon DNS remains cached by default and can opt into per-tick queries."""
+        calls: list[dict[str, Any]] = []
+        actor = User(username="alice", full_name="Alice Example", email="alice@example.com")
+        system = System(
+            hostname="SRC",
+            ip="10.10.0.10",
+            os="Windows 11 Enterprise",
+            type="workstation",
+        )
+        start = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
+
+        def run_beacon(spec: BeaconEventSpec) -> list[bool]:
+            calls.clear()
+            engine = object.__new__(StorylineMixin)
+            engine.state_manager = SimpleNamespace(set_current_time=lambda _time: None)
+            engine.activity_generator = SimpleNamespace(
+                _ip_to_system={system.ip: system},
+                _proxy_routes={},
+                generate_connection=lambda **kwargs: calls.append(kwargs),
+            )
+            engine._ensure_storyline_service_process_for_beacon = lambda *_args, **_kwargs: (
+                -1,
+                None,
+            )
+            engine._execute_typed_event(
+                spec=spec,
+                actor=actor,
+                system=system,
+                time=start,
+                activity="Beacon cadence",
+                explicit_types={"beacon"},
+            )
+            return [bool(call["emit_dns"]) for call in calls]
+
+        cached_spec = BeaconEventSpec(
+            dst_ip="198.51.100.20",
+            hostname="rare-c2.example",
+            interval="3m",
+            count=3,
+        )
+        each_tick_spec = BeaconEventSpec(
+            dst_ip="198.51.100.20",
+            hostname="rare-c2.example",
+            interval="3m",
+            count=3,
+            dns_resolution="each_tick",
+        )
+
+        assert run_beacon(cached_spec) == [True, False, False]
+        assert run_beacon(each_tick_spec) == [True, True, True]
+
     def test_recorded_storyline_logon_expires_at_transport_close(self):
         """Recorded storyline SSH sessions should not be reused after TCP close."""
         state = StateManager()

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -77,6 +77,188 @@ class TestScenarioValidator:
             for issue in issues
         )
 
+    def test_network_sensor_accepts_individual_zeek_formats(self):
+        """Sensor log_formats may narrow Zeek to concrete emitters."""
+        scenario = Scenario(
+            version="1.0",
+            name="test-zeek-sensor",
+            description="Test scenario",
+            environment=Environment(
+                description="Test env",
+                users=[
+                    User(
+                        username="testuser",
+                        full_name="Test User",
+                        email="test@example.com",
+                        primary_system="TEST-01",
+                    )
+                ],
+                systems=[
+                    System(
+                        hostname="TEST-01",
+                        ip="10.0.0.10",
+                        os="Windows 10",
+                        type="workstation",
+                    )
+                ],
+                network=NetworkConfig(
+                    segments=[
+                        NetworkSegment(
+                            name="workstations",
+                            cidr="10.0.0.0/24",
+                            systems=["TEST-01"],
+                            exposure="internal",
+                        )
+                    ],
+                    sensors=[
+                        NetworkSensor(
+                            type="network",
+                            name="sensor-1",
+                            monitoring_segments=["workstations"],
+                            log_formats=["zeek_conn"],
+                        )
+                    ],
+                ),
+            ),
+            time_window=TimeWindow(start=datetime(2024, 1, 15, 10, 0, 0), duration="1h"),
+            baseline_activity=BaselineActivity(
+                description="Test", intensity="medium", variation="low"
+            ),
+            output=OutputSpec(
+                logs=[{"format": "windows_event_security"}, {"format": "zeek_conn"}],
+                destination="./output",
+                compression=False,
+            ),
+        )
+
+        issues = ScenarioValidator(scenario).validate()
+
+        assert not any(issue.severity == "error" for issue in issues)
+        assert not any("uses individual format" in issue.message for issue in issues)
+
+    def test_incompatible_explicit_connection_bytes_warn(self):
+        """Failed/handshake-only states should warn when authors set payload bytes."""
+        scenario = Scenario(
+            version="1.0",
+            name="test-byte-warning",
+            description="Test scenario",
+            environment=Environment(
+                description="Test env",
+                users=[
+                    User(
+                        username="testuser",
+                        full_name="Test User",
+                        email="test@example.com",
+                        primary_system="TEST-01",
+                    )
+                ],
+                systems=[
+                    System(
+                        hostname="TEST-01",
+                        ip="10.0.0.10",
+                        os="Windows 10",
+                        type="workstation",
+                    )
+                ],
+            ),
+            time_window=TimeWindow(start=datetime(2024, 1, 15, 10, 0, 0), duration="1h"),
+            baseline_activity=BaselineActivity(
+                description="Test", intensity="medium", variation="low"
+            ),
+            storyline=[
+                StorylineEvent(
+                    id="evt-byte-warning",
+                    time="+5m",
+                    actor="testuser",
+                    system="TEST-01",
+                    activity="Failed exfil flow",
+                    events=[
+                        {
+                            "type": "connection",
+                            "dst_ip": "198.51.100.10",
+                            "conn_state": "S0",
+                            "orig_bytes": 50_000_000,
+                        }
+                    ],
+                )
+            ],
+            output=OutputSpec(
+                logs=[{"format": "windows_event_security"}, {"format": "zeek_conn"}],
+                destination="./output",
+                compression=False,
+            ),
+        )
+
+        issues = ScenarioValidator(scenario).validate()
+
+        assert any(
+            issue.severity == "warning"
+            and issue.field_path == "storyline.0.events.0.conn_state"
+            and "byte overrides" in issue.message
+            for issue in issues
+        )
+
+    def test_missing_process_parent_ref_warns(self):
+        """Explicit parent refs should warn when they cannot be resolved."""
+        scenario = Scenario(
+            version="1.0",
+            name="test-parent-ref-warning",
+            description="Test scenario",
+            environment=Environment(
+                description="Test env",
+                users=[
+                    User(
+                        username="testuser",
+                        full_name="Test User",
+                        email="test@example.com",
+                        primary_system="TEST-01",
+                    )
+                ],
+                systems=[
+                    System(
+                        hostname="TEST-01",
+                        ip="10.0.0.10",
+                        os="Windows 10",
+                        type="workstation",
+                    )
+                ],
+            ),
+            time_window=TimeWindow(start=datetime(2024, 1, 15, 10, 0, 0), duration="1h"),
+            baseline_activity=BaselineActivity(
+                description="Test", intensity="medium", variation="low"
+            ),
+            storyline=[
+                StorylineEvent(
+                    id="evt-parent-ref-warning",
+                    time="+5m",
+                    actor="testuser",
+                    system="TEST-01",
+                    activity="Launch child without parent ref",
+                    events=[
+                        {
+                            "type": "process",
+                            "process_name": "powershell.exe",
+                            "parent_ref": "missing-loader",
+                        }
+                    ],
+                )
+            ],
+            output=OutputSpec(
+                logs=[{"format": "windows_event_security"}],
+                destination="./output",
+                compression=False,
+            ),
+        )
+
+        issues = ScenarioValidator(scenario).validate()
+
+        assert any(
+            issue.severity == "warning"
+            and issue.field_path == "storyline.0.events.0.parent_ref"
+            and "missing-loader" in issue.message
+            for issue in issues
+        )
+
     def test_invalid_persona_reference(self):
         """User referencing non-existent persona should error."""
         scenario = Scenario(

--- a/tests/unit/test_zeek_activity_contexts.py
+++ b/tests/unit/test_zeek_activity_contexts.py
@@ -111,6 +111,78 @@ def _make_activity_gen() -> tuple[ActivityGenerator, list[SecurityEvent]]:
     return gen, captured_events
 
 
+def test_closed_connections_do_not_force_tuple_recent_scan_matches():
+    """Closed state should not make high-volume DNS source-port scans grow quadratically."""
+    gen, _events = _make_activity_gen()
+    now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    gen.state_manager.set_current_time(now)
+    conn_id = gen.state_manager.open_connection(
+        "10.0.0.10",
+        53124,
+        "10.0.0.1",
+        53,
+        "udp",
+    )
+    gen.state_manager.state.open_connections[conn_id].state = "closed"
+
+    assert not gen._connection_tuple_recently_used(
+        "10.0.0.10",
+        53124,
+        "10.0.0.1",
+        53,
+        "udp",
+        now,
+    )
+
+
+def test_explicit_http_upload_bytes_survive_protocol_shaping():
+    """Explicit server-egress orig_bytes should not be shrunk by HTTP shaping."""
+    gen, events = _make_activity_gen()
+    server = System(
+        hostname="APP-01",
+        ip="10.0.20.10",
+        os="Windows Server 2022",
+        type="server",
+    )
+    gen._ip_to_system = {server.ip: server}
+    now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+    gen.generate_connection(
+        src_ip=server.ip,
+        dst_ip="198.51.100.25",
+        time=now,
+        dst_port=80,
+        proto="tcp",
+        service="http",
+        source_system=server,
+        hostname="collector.example",
+        preserve_dst_ip=True,
+        http=HttpContext(
+            method="POST",
+            host="collector.example",
+            uri="/upload",
+            request_body_len=1024,
+            response_body_len=512,
+            status_code=200,
+        ),
+        orig_bytes=50_000_000,
+        resp_bytes=2_048,
+        conn_state="SF",
+        duration=12.0,
+        preserve_explicit_payload=True,
+    )
+
+    connection = next(
+        event
+        for event in events
+        if event.event_type == "connection"
+        and event.network is not None
+        and event.network.dst_ip == "198.51.100.25"
+    )
+    assert connection.network.orig_bytes >= 50_000_000
+    assert connection.network.resp_bytes >= 2_048
+
+
 def _event_signature(event: SecurityEvent) -> tuple:
     """Return a deterministic signature for SSH bundle evidence events."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "evidence-forge"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Fix Windows Security event SQLite spooling on OneDrive-like output paths by moving runtime spool state outside final output directories.
- Add backward-compatible generation controls for concrete Zeek formats, beacon DNS cadence, explicit process lineage refs, compatible byte overrides, and high-volume DGA state handling.
- Optimize SOF-ELK syslog close-time normalization and include the durable service process state fix in the patch release.
- Bump release version to `1.3.1` and update `CHANGELOG.md`/`uv.lock`.

## Validation

- `uv run pytest --include-slow --no-cov` passed before the release bump: `4236 passed, 28 skipped`.
- `uv run ruff check .` passed.
- `uv run ruff format --check .` passed.
- `uv run pytest --no-cov` passed after the release bump: `4223 passed, 41 skipped`.
- Version guard passed locally: `pyproject.toml`, `evidenceforge.__version__`, and `uv.lock` all report `1.3.1`.
- Remote tag guard checked: `v1.3.1` does not exist on origin.