### PR TITLE
fix: repair stale process parent pids

### DIFF
--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -8958,6 +8958,19 @@ class ActivityGenerator:
             parent_pid=parent_pid,
             process_username=process_username,
         )
+        parent_pid = self._repair_process_parent_pid(
+            system=system,
+            time=time,
+            logon_id=process_logon_id,
+            process_name=process_name,
+            command_line=command_line,
+            parent_pid=parent_pid,
+            process_username=process_username,
+        )
+        repaired_parent = self.state_manager.get_process(system.hostname, parent_pid)
+        if repaired_parent is not None and time <= repaired_parent.start_time:
+            time = repaired_parent.start_time + timedelta(milliseconds=50)
+        self.state_manager.set_current_time(time)
         self.state_manager.update_process_activity_time(system.hostname, parent_pid, time)
 
         # Phase 1: Allocate IDs from StateManager
@@ -13521,6 +13534,23 @@ class ActivityGenerator:
         if singleton_service_pid is not None:
             return singleton_service_pid
 
+        parent_pid = self._repair_process_parent_pid(
+            system=system,
+            time=time,
+            logon_id={
+                "SYSTEM": "0x3e7",
+                "LOCAL SERVICE": "0x3e5",
+                "NETWORK SERVICE": "0x3e4",
+            }.get(username, "0x3e7"),
+            process_name=process_name,
+            command_line=command_line,
+            parent_pid=parent_pid,
+            process_username=username,
+        )
+        repaired_parent = self.state_manager.get_process(system.hostname, parent_pid)
+        if repaired_parent is not None and time <= repaired_parent.start_time:
+            time = repaired_parent.start_time + timedelta(milliseconds=50)
+        self.state_manager.set_current_time(time)
         self.state_manager.update_process_activity_time(system.hostname, parent_pid, time)
         pid = self.state_manager.create_process(
             system=system.hostname,
@@ -18822,6 +18852,181 @@ class ActivityGenerator:
         proc = self.state_manager.get_process(system.hostname, pid)
         return proc is not None and proc.start_time <= time
 
+    def _is_valid_process_parent_at(
+        self,
+        *,
+        system: System,
+        parent_pid: int,
+        time: datetime,
+    ) -> bool:
+        """Return whether a PID can be passed to StateManager.create_process()."""
+        if parent_pid == 0:
+            return True
+        if parent_pid == 4 and _get_os_category(system.os) == "windows":
+            return True
+        return self._is_pid_active_at(system, parent_pid, time)
+
+    def _prune_user_process_history(
+        self,
+        *,
+        system: System,
+        username: str,
+        time: datetime,
+        logon_id: str = "",
+    ) -> list[tuple[int, str]]:
+        """Drop ended process PIDs from recent parent-selection history."""
+        key = (system.hostname, username)
+        history = self._user_process_history.get(key, [])
+        if not history:
+            return []
+
+        os_category = _get_os_category(system.os)
+        pruned = [
+            (pid, image)
+            for pid, image in history
+            if self._is_pid_active_at(system, pid, time)
+            and self._parent_process_matches_logon(
+                hostname=system.hostname,
+                parent_pid=pid,
+                logon_id=logon_id,
+                os_category=os_category,
+            )
+        ]
+        self._user_process_history[key] = pruned[-10:]
+        return self._user_process_history[key]
+
+    def _windows_system_parent_fallback(self, system: System, time: datetime) -> int:
+        """Return a live Windows service ancestry fallback for system processes."""
+        sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
+        for role in ("services", "svchost_netsvcs", "svchost_dcom", "wininit"):
+            pid = sys_pids.get(role)
+            if pid and self._is_pid_active_at(system, pid, time):
+                return pid
+        return 4
+
+    def _linux_system_parent_fallback(self, system: System, time: datetime) -> int:
+        """Return a live Linux service ancestry fallback for system processes."""
+        sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
+        for role in ("systemd", "init", "sshd", "bash"):
+            pid = sys_pids.get(role)
+            if pid and self._is_pid_active_at(system, pid, time):
+                return pid
+        return self._linux_anchor_pid(system, time)
+
+    def _repair_process_parent_pid(
+        self,
+        *,
+        system: System,
+        time: datetime,
+        logon_id: str,
+        process_name: str,
+        command_line: str,
+        parent_pid: int,
+        process_username: str,
+    ) -> int:
+        """Resolve a live parent PID before process state allocation."""
+        os_category = _get_os_category(system.os)
+        process_exe = process_name.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
+        user_context = process_username not in _SYSTEM_ACCOUNTS and not process_username.endswith(
+            "$"
+        )
+
+        if os_category == "windows":
+            if user_context:
+                repair_user = self._user_model_for_username(process_username)
+                if self._is_windows_same_exe_gui_child(process_name, command_line):
+                    same_exe_parent = self._windows_same_exe_gui_parent_pid(
+                        system=system,
+                        user=repair_user,
+                        time=time,
+                        logon_id=logon_id,
+                        process_name=process_name,
+                        parent_pid=parent_pid,
+                        process_username=process_username,
+                    )
+                    if (
+                        same_exe_parent is not None
+                        and self.state_manager.get_process(system.hostname, same_exe_parent)
+                        is not None
+                    ):
+                        return same_exe_parent
+                if self._is_valid_process_parent_at(
+                    system=system,
+                    parent_pid=parent_pid,
+                    time=time,
+                ):
+                    return parent_pid
+                if process_exe in self._WINDOWS_GUI_APPS or process_exe == "explorer.exe":
+                    explorer_pid = self._ensure_session_explorer_pid(
+                        system,
+                        repair_user,
+                        time,
+                        logon_id,
+                    )
+                    if explorer_pid is not None and self._is_valid_process_parent_at(
+                        system=system,
+                        parent_pid=explorer_pid,
+                        time=time,
+                    ):
+                        return explorer_pid
+                resolved = self._resolve_parent(
+                    system,
+                    repair_user,
+                    time,
+                    logon_id,
+                    process_name,
+                    command_line,
+                )
+                if self._is_valid_process_parent_at(
+                    system=system,
+                    parent_pid=resolved,
+                    time=time,
+                ):
+                    return resolved
+            if self._is_valid_process_parent_at(system=system, parent_pid=parent_pid, time=time):
+                return parent_pid
+            return self._windows_system_parent_fallback(system, time)
+
+        if user_context:
+            repair_user = self._user_model_for_username(process_username)
+            materialized_parent = self._materialize_visible_linux_shell_parent_for_child(
+                system=system,
+                time=time,
+                logon_id=logon_id,
+                parent_pid=parent_pid,
+                process_username=process_username,
+            )
+            if materialized_parent != parent_pid and self._is_valid_process_parent_at(
+                system=system, parent_pid=materialized_parent, time=time
+            ):
+                return materialized_parent
+            if (
+                materialized_parent != parent_pid
+                and self.state_manager.get_process(system.hostname, materialized_parent) is not None
+            ):
+                return materialized_parent
+            parent_proc = self.state_manager.get_process(system.hostname, parent_pid)
+            if parent_proc is not None and ensure_utc(parent_proc.start_time) > ensure_utc(time):
+                return parent_pid
+            if self._is_valid_process_parent_at(system=system, parent_pid=parent_pid, time=time):
+                return parent_pid
+            session_shell = self._active_session_shell_pid(system, repair_user, time, logon_id)
+            if session_shell is not None:
+                return session_shell
+            resolved = self._resolve_parent(
+                system,
+                repair_user,
+                time,
+                logon_id,
+                process_name,
+                command_line,
+            )
+            if self._is_valid_process_parent_at(system=system, parent_pid=resolved, time=time):
+                return resolved
+        if self._is_valid_process_parent_at(system=system, parent_pid=parent_pid, time=time):
+            return parent_pid
+        return self._linux_system_parent_fallback(system, time)
+
     def _lookup_parent_image(self, hostname: str, parent_pid: int) -> str:
         """Look up parent process image from StateManager, with fallback."""
         proc = self.state_manager.get_process(hostname, parent_pid)
@@ -19031,8 +19236,12 @@ class ActivityGenerator:
         rng = _get_rng()
         sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
         os_cat = _get_os_category(system.os)
-        key = (system.hostname, user.username)
-        history = self._user_process_history.get(key, [])
+        history = self._prune_user_process_history(
+            system=system,
+            username=user.username,
+            time=time or self.state_manager.state.current_time or datetime.now(UTC),
+            logon_id=logon_id,
+        )
         # Filter history to only include still-running processes
         alive_history = []
         for pid, name in history:
@@ -19254,8 +19463,12 @@ class ActivityGenerator:
         if is_network_logon:
             if remote_wrapper_pid is not None:
                 return remote_wrapper_pid
-            key = (system.hostname, user.username)
-            history = self._user_process_history.get(key, [])
+            history = self._prune_user_process_history(
+                system=system,
+                username=user.username,
+                time=time,
+                logon_id=logon_id,
+            )
             remote_wrappers = []
             shells = []
             for pid, name in history:
@@ -19370,8 +19583,12 @@ class ActivityGenerator:
             return self._select_parent_pid(system, user, process_name, time=time, logon_id=logon_id)
 
         # Check alive_history for a matching parent
-        key = (system.hostname, user.username)
-        history = self._user_process_history.get(key, [])
+        history = self._prune_user_process_history(
+            system=system,
+            username=user.username,
+            time=time,
+            logon_id=logon_id,
+        )
         alive_parents = []
         for pid, name in history:
             if not self._is_pid_active_at(system, pid, time):

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -1164,9 +1164,26 @@ class StateManager:
             key = (system, pid)
             if key in self.state.running_processes:
                 del self.state.running_processes[key]
+                self._clear_session_process_references(system, pid)
                 logger.debug(f"Ended process {pid} on {system}")
                 return True
             return False
+
+    def _clear_session_process_references(self, system: str, pid: int) -> None:
+        """Clear active-session pointers to a process that has ended."""
+        for session in self.state.active_sessions.values():
+            if session.system != system:
+                continue
+            if session.explorer_pid == pid:
+                session.explorer_pid = None
+            if session.session_winlogon_pid == pid:
+                session.session_winlogon_pid = None
+            if session.session_shell_pid == pid:
+                session.session_shell_pid = None
+            if session.process_tree_root == pid:
+                session.process_tree_root = None
+            if session.transport_pid == pid:
+                session.transport_pid = None
 
     def list_running_processes(self) -> list[RunningProcess]:
         """Get all running processes.

--- a/tests/unit/test_spawn_rules.py
+++ b/tests/unit/test_spawn_rules.py
@@ -260,6 +260,149 @@ class TestWindowsProcessTreeRealism:
         assert parent_proc.image.lower().endswith(r"\explorer.exe")
         assert session.explorer_pid == parent_proc.pid
 
+    def test_user_process_repairs_stale_explicit_parent_pid(
+        self, state_manager, mock_emitters, win_system, user
+    ):
+        """A stale explicit parent PID should be replaced before process allocation."""
+        ag, _pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        logon_id = ag.generate_logon(
+            user,
+            win_system,
+            datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC),
+            logon_type=2,
+        )
+        session = state_manager.get_session(logon_id)
+        assert session is not None
+        assert session.explorer_pid is not None
+
+        stale_parent = state_manager.create_process(
+            win_system.hostname,
+            session.explorer_pid,
+            r"C:\Windows\System32\cmd.exe",
+            "cmd.exe",
+            user.username,
+            "Medium",
+            logon_id,
+        )
+        ag._record_user_process(win_system, user, stale_parent, r"C:\Windows\System32\cmd.exe")
+        assert state_manager.end_process(win_system.hostname, stale_parent)
+
+        child_pid = ag.generate_process(
+            user,
+            win_system,
+            datetime(2024, 3, 18, 12, 0, 5, tzinfo=UTC),
+            logon_id,
+            r"C:\Windows\System32\ipconfig.exe",
+            "ipconfig.exe /all",
+            parent_pid=stale_parent,
+        )
+        child_proc = state_manager.get_process(win_system.hostname, child_pid)
+
+        assert child_proc is not None
+        assert child_proc.parent_pid != stale_parent
+        assert state_manager.get_process(win_system.hostname, child_proc.parent_pid) is not None
+
+    def test_gui_process_repairs_stale_session_explorer_pid(
+        self, state_manager, mock_emitters, win_system, user
+    ):
+        """Stale Explorer session pointers should be rematerialized for GUI children."""
+        ag, _pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        logon_id = ag.generate_logon(
+            user,
+            win_system,
+            datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC),
+            logon_type=2,
+        )
+        session = state_manager.get_session(logon_id)
+        assert session is not None
+        assert session.explorer_pid is not None
+        stale_explorer = session.explorer_pid
+        assert state_manager.end_process(win_system.hostname, stale_explorer)
+        session.explorer_pid = stale_explorer
+
+        child_pid = ag.generate_process(
+            user,
+            win_system,
+            datetime(2024, 3, 18, 12, 0, 5, tzinfo=UTC),
+            logon_id,
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+            r'"C:\Program Files\Google\Chrome\Application\chrome.exe" --single-argument https://example.com/',
+            parent_pid=stale_explorer,
+        )
+        child_proc = state_manager.get_process(win_system.hostname, child_pid)
+        assert child_proc is not None
+        parent_proc = state_manager.get_process(win_system.hostname, child_proc.parent_pid)
+
+        assert child_proc.parent_pid != stale_explorer
+        assert parent_proc is not None
+        assert parent_proc.image.lower().endswith(r"\explorer.exe")
+        assert session.explorer_pid == parent_proc.pid
+
+    def test_system_process_repairs_stale_service_parent_pid(self, state_manager, mock_emitters):
+        """System process creation should fall back from stale service parents."""
+        dc_system = System(
+            hostname="DC-01",
+            ip="10.0.10.10",
+            os="Windows Server 2019",
+            type="domain_controller",
+        )
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, dc_system)
+        timestamp = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+        stale_parent = ag.generate_system_process(
+            system=dc_system,
+            time=timestamp,
+            process_name=r"C:\Windows\System32\cmd.exe",
+            command_line="cmd.exe /c hostname",
+            parent_pid=pids["services"],
+            username="SYSTEM",
+        )
+        assert state_manager.end_process(dc_system.hostname, stale_parent)
+
+        child_pid = ag.generate_system_process(
+            system=dc_system,
+            time=timestamp + timedelta(minutes=1),
+            process_name=r"C:\Windows\System32\conhost.exe",
+            command_line="conhost.exe 0x4",
+            parent_pid=stale_parent,
+            username="SYSTEM",
+        )
+        child_proc = state_manager.get_process(dc_system.hostname, child_pid)
+
+        assert child_proc is not None
+        assert child_proc.parent_pid != stale_parent
+        assert child_proc.parent_pid == pids["services"]
+
+    def test_long_window_stale_parent_churn_does_not_crash(
+        self, state_manager, mock_emitters, win_system, user
+    ):
+        """Multi-week stale parent churn should repair parents instead of raising StateError."""
+        ag, _pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        start = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+        logon_id = ag.generate_logon(user, win_system, start, logon_type=2)
+        session = state_manager.get_session(logon_id)
+        assert session is not None
+        assert session.explorer_pid is not None
+        stale_parent = session.explorer_pid
+
+        for day in range(1, 17):
+            event_time = start + timedelta(days=day)
+            state_manager.end_process(win_system.hostname, stale_parent)
+            session.explorer_pid = stale_parent
+            child_pid = ag.generate_process(
+                user,
+                win_system,
+                event_time,
+                logon_id,
+                r"C:\Windows\System32\ipconfig.exe",
+                "ipconfig.exe /all",
+                parent_pid=stale_parent,
+            )
+            child_proc = state_manager.get_process(win_system.hostname, child_pid)
+            assert child_proc is not None
+            assert child_proc.parent_pid != stale_parent
+            assert state_manager.get_process(win_system.hostname, child_proc.parent_pid) is not None
+            stale_parent = child_pid
+
     def test_top_level_browser_reuses_existing_session_browser(
         self, state_manager, mock_emitters, win_system, user
     ):

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -924,6 +924,73 @@ class TestProcessManagement:
         result = sm.end_process("WS-01", 999)
         assert result is False
 
+    def test_end_process_clears_active_session_process_references(self):
+        """Ended processes should not remain as live session parent pointers."""
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        sm.set_current_time(start)
+        logon_id = sm.create_session("jdoe", "WS-01", 2, "192.168.1.1")
+        session = sm.get_session(logon_id)
+        assert session is not None
+
+        winlogon_pid = sm.create_process(
+            "WS-01",
+            4,
+            r"C:\Windows\System32\winlogon.exe",
+            "winlogon.exe",
+            "SYSTEM",
+            "System",
+            logon_id,
+        )
+        explorer_pid = sm.create_process(
+            "WS-01",
+            winlogon_pid,
+            r"C:\Windows\explorer.exe",
+            "explorer.exe",
+            "jdoe",
+            "Medium",
+            logon_id,
+        )
+        shell_pid = sm.create_process(
+            "WS-01",
+            explorer_pid,
+            r"C:\Windows\System32\cmd.exe",
+            "cmd.exe",
+            "jdoe",
+            "Medium",
+            logon_id,
+        )
+        transport_pid = sm.create_process(
+            "WS-01",
+            4,
+            r"C:\Windows\System32\svchost.exe",
+            "svchost.exe -k netsvcs",
+            "SYSTEM",
+            "System",
+            logon_id,
+        )
+        explorer_object_id = sm.get_process_object_id("WS-01", explorer_pid)
+
+        session.session_winlogon_pid = winlogon_pid
+        session.process_tree_root = winlogon_pid
+        session.explorer_pid = explorer_pid
+        session.session_shell_pid = shell_pid
+        session.transport_pid = transport_pid
+
+        assert sm.end_process("WS-01", explorer_pid) is True
+        assert session.explorer_pid is None
+        assert sm.get_process_object_id("WS-01", explorer_pid) == explorer_object_id
+
+        assert sm.end_process("WS-01", winlogon_pid) is True
+        assert session.session_winlogon_pid is None
+        assert session.process_tree_root is None
+
+        assert sm.end_process("WS-01", shell_pid) is True
+        assert session.session_shell_pid is None
+
+        assert sm.end_process("WS-01", transport_pid) is True
+        assert session.transport_pid is None
+
     def test_update_process_activity_time_keeps_latest(self):
         """Process activity marker should track the latest dependent event."""
         sm = StateManager()


### PR DESCRIPTION
## Summary

- Clear active session process pointers when their referenced process ends, while preserving historical process object IDs for rendered correlation.
- Add a final process-parent repair guard before user and system process creation so stale parent PIDs are re-resolved to live Windows/Linux anchors before reaching strict `StateManager.create_process()` validation.
- Prune recent user process history during parent resolution and add regression coverage for stale explicit parents, stale Explorer session pointers, stale service parents, and multi-week churn.

## Tests

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --no-cov tests/unit/test_state_manager.py tests/unit/test_activity.py tests/unit/test_spawn_rules.py`
- `uv run pytest --no-cov`
- `uv run pytest --include-slow --no-cov`