### PR TITLE
chore: bump version to 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Detailed development history for the EvidenceForge project. Transferred from TOD
 
 ## Unreleased
 
+## v1.3.2 (2026-06-06)
+
+This patch release fixes a long-window Windows process lifecycle regression
+found after v1.3.1. The branch contains only a `fix:` commit since v1.3.1, so
+the project moves from `1.3.1` to `1.3.2`.
+
+**Windows process lifecycle stability**
+
+- Cleared stale active-session process pointers when referenced processes end,
+  repaired stale user and system parent PIDs before strict process allocation,
+  and added regression coverage for multi-week Windows parent churn
+  (`60594ee4`).
+
 ## v1.3.1 (2026-06-06)
 
 This patch release fixes several generation edge cases reported from class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "evidence-forge"
-version = "1.3.1"
+version = "1.3.2"
 description = "Generate realistic synthetic security logs for cybersecurity threat hunting training and research"
 readme = "README.md"
 license = "MIT"

--- a/src/evidenceforge/__init__.py
+++ b/src/evidenceforge/__init__.py
@@ -27,5 +27,5 @@ for cybersecurity threat hunting training and research. It uses a two-phase
 architecture combining LLM-driven scenario creation with deterministic log generation.
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __all__ = []  # Will be expanded as modules are implemented

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "evidence-forge"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bump EvidenceForge from `1.3.1` to `1.3.2` after the long-window Windows stale parent PID fix landed on `main`.
- Update `pyproject.toml`, `src/evidenceforge/__init__.py`, and `uv.lock` so all version declarations match.
- Add a `v1.3.2` changelog entry for PR #303 / commit `60594ee4`.

## Validation

- `uv sync`
- `uv sync --extra dev`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -c "import tomllib, evidenceforge; version = tomllib.load(open('pyproject.toml', 'rb'))['project']['version']; print(version, evidenceforge.__version__); raise SystemExit(0 if version == evidenceforge.__version__ == '1.3.2' else 1)"`
- `git ls-remote --exit-code --tags origin v1.3.2` returned no tag, so `v1.3.2` is available.