### PR TITLE
fix: harden Splunk app tar extraction

### DIFF
--- a/src/evidenceforge/external_parsers/splunk.py
+++ b/src/evidenceforge/external_parsers/splunk.py
@@ -1241,7 +1241,9 @@ def _safe_tar_extract(archive: tarfile.TarFile, destination: Path) -> None:
         target = (destination / member.name).resolve()
         if not target.is_relative_to(destination):
             raise SplunkHarnessError(f"unsafe path in Splunk app archive: {member.name}")
-    archive.extractall(destination)
+        if not (member.isdir() or member.isfile()):
+            raise SplunkHarnessError(f"unsupported file type in Splunk app archive: {member.name}")
+        archive.extract(member, destination)
 
 
 def _unique_app_destination(destination_root: Path, app_name: str) -> Path:

--- a/tests/unit/test_splunk_harness.py
+++ b/tests/unit/test_splunk_harness.py
@@ -24,7 +24,9 @@
 
 from __future__ import annotations
 
+import io
 import json
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -47,6 +49,7 @@ from evidenceforge.external_parsers.splunk import (
     _required_field_validation_search,
     _search_result_rows,
     build_splunk_configs,
+    stage_splunk_apps,
     stage_splunk_logs,
 )
 from evidenceforge.external_parsers.splunk_runtime import create_splunk_compose_run
@@ -146,6 +149,54 @@ def test_build_splunk_configs_writes_generated_app_and_supplied_apps(
     assert config.supplied_app_count == 1
     assert config.supplied_app_names == ("Splunk_TA_windows",)
     assert (config.supplied_apps_dir / "Splunk_TA_windows" / "default" / "props.conf").exists()
+
+
+def test_stage_splunk_apps_rejects_tar_symlink_pivot(tmp_path: Path) -> None:
+    """Tar archives must not write through symlink members outside staging."""
+    archive_path = tmp_path / "evil.tar"
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    with tarfile.open(archive_path, "w") as archive:
+        root = tarfile.TarInfo("EvilApp")
+        root.type = tarfile.DIRTYPE
+        archive.addfile(root)
+
+        link = tarfile.TarInfo("EvilApp/link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = str(outside_dir)
+        archive.addfile(link)
+
+        payload = b"owned via tar symlink pivot"
+        member = tarfile.TarInfo("EvilApp/link/owned.txt")
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+
+    with pytest.raises(SplunkHarnessError, match="unsupported file type"):
+        stage_splunk_apps((archive_path,), tmp_path / "apps")
+
+    assert not (outside_dir / "owned.txt").exists()
+
+
+def test_stage_splunk_apps_extracts_safe_tar_archive(tmp_path: Path) -> None:
+    archive_path = tmp_path / "safe.tar"
+    with tarfile.open(archive_path, "w") as archive:
+        root = tarfile.TarInfo("SafeApp")
+        root.type = tarfile.DIRTYPE
+        archive.addfile(root)
+        default = tarfile.TarInfo("SafeApp/default")
+        default.type = tarfile.DIRTYPE
+        archive.addfile(default)
+        payload = b"[source::dummy]\n"
+        member = tarfile.TarInfo("SafeApp/default/props.conf")
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+
+    app_names = stage_splunk_apps((archive_path,), tmp_path / "apps")
+
+    assert app_names == ("SafeApp",)
+    assert (tmp_path / "apps" / "SafeApp" / "default" / "props.conf").read_text(
+        encoding="utf-8"
+    ) == "[source::dummy]\n"
 
 
 def test_splunk_runtime_requires_explicit_license_acceptance(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent an exploitation vector in Splunk app staging where `tar` archives containing symlink members can pivot later file extraction outside the intended ephemeral extraction directory and write arbitrary files as the harness user.

### Description
- Replace unsafe bulk extraction with per-member validation and extraction in `_safe_tar_extract`, resolving each member target and rejecting any member whose final path is not strictly inside the destination.
- Reject non-regular/non-directory tar members (symlinks, hardlinks, device files, etc.) with a clear `SplunkHarnessError` to block symlink-pivot and special-file abuse.
- Add regression tests covering a malicious symlink-pivot tar that must be rejected and a normal safe tar archive that must extract successfully, and adjust test imports accordingly.
- Keep Zip handling unchanged (path checks remain) and preserve existing staging semantics and unique-app destination logic.

### Testing
- Ran formatting and lint checks: `uv run ruff format --check .` and `uv run ruff check .`, both passed.
- Ran unit tests: `uv run pytest --no-cov tests/unit/test_splunk_harness.py`, all tests passed (17 passed).
- Verified the new tests assert rejection of symlink-pivot archives and successful extraction of a safe tar archive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23627c7a988325ba0e11e97855befc)