### PR TITLE
docs: harden manual release fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,49 @@ correct SemVer version before merging to `main`.
 unavailable and a maintainer must validate a `main` PR by hand, run:
 
 ```
-VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+VERSION=$(python - <<'PY'
+import ast
+import re
+import tomllib
+from pathlib import Path
+
+pyproject_version = tomllib.loads(
+    Path("pyproject.toml").read_text(encoding="utf-8")
+)["project"]["version"]
+
+init_tree = ast.parse(Path("src/evidenceforge/__init__.py").read_text(encoding="utf-8"))
+init_version = None
+for node in init_tree.body:
+    if not isinstance(node, ast.Assign):
+        continue
+    for target in node.targets:
+        if isinstance(target, ast.Name) and target.id == "__version__":
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                init_version = node.value.value
+
+lock = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
+lock_version = None
+for package in lock.get("package", []):
+    if package.get("name") == "evidence-forge":
+        lock_version = package.get("version")
+        break
+
+if not re.fullmatch(r"\d+\.\d+\.\d+", pyproject_version):
+    raise SystemExit(f"pyproject.toml version must be X.Y.Z, got {pyproject_version!r}")
+if init_version != pyproject_version:
+    raise SystemExit(
+        "src/evidenceforge/__init__.py __version__ "
+        f"({init_version!r}) does not match pyproject.toml ({pyproject_version!r})"
+    )
+if lock_version != pyproject_version:
+    raise SystemExit(
+        f"uv.lock evidence-forge version ({lock_version!r}) "
+        f"does not match pyproject.toml ({pyproject_version!r})"
+    )
+print(pyproject_version)
+PY
+)
 TAG="v${VERSION}"
-test "$(uv run python -c "import evidenceforge; print(evidenceforge.__version__)")" = "$VERSION"
 git ls-remote --exit-code --tags origin "$TAG" && {
   echo "Remote release tag $TAG already exists; bump the version before opening the main PR."
   exit 1
@@ -175,7 +215,48 @@ so it appears under Releases.
 
 ```
 git fetch origin main:refs/remotes/origin/main --tags
-VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+VERSION=$(python - <<'PY'
+import ast
+import re
+import tomllib
+from pathlib import Path
+
+pyproject_version = tomllib.loads(
+    Path("pyproject.toml").read_text(encoding="utf-8")
+)["project"]["version"]
+
+init_tree = ast.parse(Path("src/evidenceforge/__init__.py").read_text(encoding="utf-8"))
+init_version = None
+for node in init_tree.body:
+    if not isinstance(node, ast.Assign):
+        continue
+    for target in node.targets:
+        if isinstance(target, ast.Name) and target.id == "__version__":
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                init_version = node.value.value
+
+lock = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
+lock_version = None
+for package in lock.get("package", []):
+    if package.get("name") == "evidence-forge":
+        lock_version = package.get("version")
+        break
+
+if not re.fullmatch(r"\d+\.\d+\.\d+", pyproject_version):
+    raise SystemExit(f"pyproject.toml version must be X.Y.Z, got {pyproject_version!r}")
+if init_version != pyproject_version:
+    raise SystemExit(
+        "src/evidenceforge/__init__.py __version__ "
+        f"({init_version!r}) does not match pyproject.toml ({pyproject_version!r})"
+    )
+if lock_version != pyproject_version:
+    raise SystemExit(
+        f"uv.lock evidence-forge version ({lock_version!r}) "
+        f"does not match pyproject.toml ({pyproject_version!r})"
+    )
+print(pyproject_version)
+PY
+)
 TAG="v${VERSION}"
 MERGE_SHA=$(git rev-parse origin/main)
 test -z "$(git tag --list "$TAG")" || {


### PR DESCRIPTION
### Motivation
- The manual fallback instructions in `AGENTS.md` used `uv run` and `import evidenceforge`, which can execute attacker-controlled code from an untrusted PR checkout and therefore turn a data-only version check into a local code-execution path.

### Description
- Replaced the unsafe `uv run python -c` / `import evidenceforge` commands in both the manual release tag guard and the manual release tagging fallback with a plain `python` here-doc that performs data-only extraction by parsing `pyproject.toml` with `tomllib`, parsing `src/evidenceforge/__init__.py` with `ast.parse` to read `__version__`, and validating `uv.lock` before computing `TAG="v${VERSION}"`.
- Kept the original validation semantics (SemVer format check and cross-file version consistency) while avoiding package build/installation or imports from the checked-out repository.
- Change is confined to documentation (`AGENTS.md`) only and does not modify runtime source code.

### Testing
- Executed the hardened data-only version extraction via `python - <<'PY' ... PY` against the repository files and confirmed it prints the validated version and enforces the same checks.
- Ran `uv run ruff check .` and `uv run ruff format --check .` and both completed successfully.
- No unit tests were changed or required for this documentation-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20d359114083258e9a6a02f544deb9)