### PR TITLE
fix: tolerate malformed explicit proxy URIs

### DIFF
--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -5850,7 +5850,7 @@ class ActivityGenerator:
         if (http.method or "").upper() == "CONNECT":
             target = http.uri or http.host or ""
             _host, separator, port_text = target.rpartition(":")
-            if separator and port_text.isdigit():
+            if separator and port_text.isdigit() and len(port_text) <= 5:
                 port = int(port_text)
                 if 1 <= port <= 65535:
                     return port
@@ -5859,10 +5859,11 @@ class ActivityGenerator:
         if url.startswith(("http://", "https://")):
             try:
                 parsed = urlsplit(url)
+                parsed_port = parsed.port
             except ValueError:
                 return 443 if url.startswith("https://") else 80
-            if parsed.port is not None:
-                return parsed.port
+            if parsed_port is not None:
+                return parsed_port
             return 443 if parsed.scheme == "https" else 80
         return 80
 

--- a/tests/unit/test_explicit_proxy.py
+++ b/tests/unit/test_explicit_proxy.py
@@ -765,6 +765,66 @@ class TestExplicitProxyVisibility:
 
         assert hint is not None
 
+    def test_proxy_origin_port_ignores_malformed_author_supplied_uri(self):
+        generator = ActivityGenerator(StateManager(), {})
+        oversized_port_uri = f"example.com:{'9' * 5000}"
+
+        cases = [
+            ("GET", "http://example.com:abc/", 80),
+            ("GET", "http://example.com:99999/", 80),
+            ("GET", "https://example.com:abc/", 443),
+            ("CONNECT", oversized_port_uri, 443),
+        ]
+
+        for method, uri, expected_port in cases:
+            http = HttpContext(method=method, host="example.com", uri=uri, version="1.1")
+
+            assert generator._proxy_origin_port_from_http(http) == expected_port
+
+    def test_direct_proxy_listener_connection_tolerates_malformed_http_uri(self):
+        malformed_cases = [
+            ("GET", "http://example.com:abc/"),
+            ("GET", "http://example.com:99999/"),
+            ("CONNECT", f"example.com:{'9' * 5000}"),
+        ]
+
+        for method, uri in malformed_cases:
+            generator, emitters = _generator(
+                [
+                    NetworkSensor(
+                        type="network",
+                        name="client-tap",
+                        monitoring_segments=["workstations"],
+                        direction="outbound",
+                        log_formats=["zeek"],
+                    )
+                ]
+            )
+            generator.generate_connection(
+                src_ip="10.0.1.10",
+                dst_ip="10.0.3.10",
+                time=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                dst_port=8080,
+                proto="tcp",
+                service="http",
+                duration=1.0,
+                orig_bytes=500,
+                resp_bytes=5000,
+                source_system=generator._ip_to_system["10.0.1.10"],
+                hostname="example.com",
+                conn_state="SF",
+                http=HttpContext(
+                    method=method,
+                    host="example.com",
+                    uri=uri,
+                    version="1.1",
+                    user_agent="curl/8.0",
+                    status_code=200,
+                ),
+            )
+
+            assert emitters["zeek_conn"].emit.called
+
     def test_connect_target_browser_hint_uses_origin_https_url(self):
         generator = ActivityGenerator(StateManager(), {})
 


### PR DESCRIPTION
### Motivation
- Prevent generation from crashing when scenario-controlled HTTP URIs contain malformed, non-numeric, out-of-range, or extremely large port literals that can raise `ValueError` during proxy-origin port parsing.
- The previous explicit-proxy listener attribution path parsed `HttpContext.uri` without fully guarding `parsed.port` access or oversized `CONNECT` port conversion, which allowed crafted scenarios to abort generation.

### Description
- Guard `_proxy_origin_port_from_http()` CONNECT branch by only converting digit port fragments with `len(port_text) <= 5` and validating the numeric range before returning a port.
- Capture `parsed.port` inside the `try` block when parsing absolute URLs so `ValueError` from the url parser does not escape and cause an uncaught exception; fall back to scheme defaults on parse errors or invalid ports.
- Preserve existing fallback behavior (443 for HTTPS/CONNECT, 80 for HTTP) when ports are malformed or absent.
- Add regression tests in `tests/unit/test_explicit_proxy.py` that assert malformed URIs and oversized CONNECT port literals are tolerated both at the parser level and when routed through `generate_connection()` to the proxy-listener repair path.

### Testing
- Ran targeted unit tests: `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "proxy_origin_port_ignores_malformed_author_supplied_uri or direct_proxy_listener_connection_tolerates_malformed_http_uri"` and both selected tests passed.
- Ran the full explicit-proxy unit suite: `uv run pytest --no-cov tests/unit/test_explicit_proxy.py` and the entire file passed (`56 passed`).
- Ran lint/format checks: `uv run ruff check . && uv run ruff format --check .` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202ef71b788325bd00ad6752a50dd6)