### PR TITLE
fix: bound eCAR file churn counts

### DIFF
--- a/src/evidenceforge/config/schemas.py
+++ b/src/evidenceforge/config/schemas.py
@@ -1453,11 +1453,14 @@ class EcarFlowIdentityConfig(BaseModel, extra="forbid"):
     inbound_listener_probability: float = Field(ge=0.0, le=1.0)
 
 
+MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR = 100
+
+
 class EcarFileChurnOsConfig(BaseModel, extra="forbid"):
     """Per-OS ambient eCAR FILE event count and action policy."""
 
-    count_min: int = Field(ge=0)
-    count_max: int = Field(ge=0)
+    count_min: int = Field(ge=0, le=MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR)
+    count_max: int = Field(ge=0, le=MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR)
     action_weights: dict[Literal["read", "modify", "create"], int]
 
     @model_validator(mode="after")

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -4693,6 +4693,7 @@ class BaselineMixin:
         if "ecar" not in self.emitters:
             return
 
+        from evidenceforge.config.schemas import MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR
         from evidenceforge.events.base import SecurityEvent
         from evidenceforge.events.contexts import (
             AuthContext,
@@ -4716,6 +4717,8 @@ class BaselineMixin:
         count_max = int(os_cfg.get("count_max", count_min))
         if count_max <= 0 or count_min > count_max:
             return
+        count_min = min(count_min, MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR)
+        count_max = min(count_max, MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR)
 
         processes = []
         for pid in sorted(set(sys_pids.values())):
@@ -4732,12 +4735,15 @@ class BaselineMixin:
         if not actions or not path_templates:
             return
 
-        count = self._scaled_randint(
-            rng,
-            system,
-            "ecar_file_churn",
-            count_min,
-            count_max,
+        count = min(
+            self._scaled_randint(
+                rng,
+                system,
+                "ecar_file_churn",
+                count_min,
+                count_max,
+            ),
+            MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR,
         )
         host_ctx = self.activity_generator._build_host_context(system)
         assigned_user = getattr(system, "assigned_user", None) or ""

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -230,6 +230,64 @@ class TestValidateConfig:
             for issue in result.issues
         )
 
+    def test_validate_config_rejects_excessive_ecar_file_churn_counts(self, monkeypatch):
+        from evidenceforge.generation.activity import endpoint_noise
+
+        def load_invalid_endpoint_noise():
+            return {
+                "windows_scheduled_processes": {
+                    "count_min": 2,
+                    "count_max": 5,
+                    "trigger_window_start_seconds": 90,
+                    "trigger_window_end_seconds": 3510,
+                    "slot_spacing_seconds": 300,
+                    "host_phase_window_seconds": 900,
+                    "jitter_seconds_min": 20,
+                    "jitter_seconds_max": 120,
+                    "skip_probability": 0.05,
+                },
+                "registry_noise": {
+                    "dhcp_interface_values": {
+                        "value_names": ["DhcpIPAddress"],
+                        "require_dhcp_state": True,
+                        "emit_on_lease_events": True,
+                        "suppress_system_types": ["server", "domain_controller"],
+                        "suppress_roles": ["domain_controller"],
+                    }
+                },
+                "ecar_flow_identity": {
+                    "user_process_probability": 0.88,
+                    "service_process_probability": 0.48,
+                    "root_process_probability": 0.42,
+                    "inbound_listener_probability": 0.36,
+                },
+                "ecar_file_churn": {
+                    "enabled": True,
+                    "windows": {
+                        "count_min": 101,
+                        "count_max": 101,
+                        "action_weights": {"read": 1, "modify": 0, "create": 0},
+                    },
+                    "linux": {
+                        "count_min": 2,
+                        "count_max": 6,
+                        "action_weights": {"read": 1, "modify": 0, "create": 0},
+                    },
+                },
+            }
+
+        monkeypatch.setattr(endpoint_noise, "load_endpoint_noise", load_invalid_endpoint_noise)
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "endpoint_noise.yaml"
+            and "ecar_file_churn" in issue.message
+            and "less than or equal to 100" in issue.message
+            for issue in result.issues
+        )
+
     def test_validate_config_rejects_invalid_observation_profile_source(self, monkeypatch):
         from evidenceforge.config import observation_profiles
 


### PR DESCRIPTION
### Motivation
- Prevent unbounded eCAR FILE churn configured via project-local overlays from exhausting CPU, memory, and disk during `eforge generate` by limiting per-host-per-hour emitted events.
- Provide both schema-level validation and runtime defense-in-depth so malicious or accidental overlays are rejected and generation is capped.

### Description
- Introduce a global cap `MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR = 100` and enforce it on `EcarFileChurnOsConfig.count_min` and `count_max` via `Field(..., le=MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR)` in `src/evidenceforge/config/schemas.py`.
- Add runtime clamping in `_emit_ecar_file_churn()` to `min()` the configured/scaled count against `MAX_ECAR_FILE_CHURN_EVENTS_PER_HOST_HOUR` in `src/evidenceforge/generation/engine/baseline.py` as a defense-in-depth guard.
- Add a regression test `test_validate_config_rejects_excessive_ecar_file_churn_counts` to `tests/unit/test_validate_config.py` which verifies `validate_config()` reports an error for counts above the cap.

### Testing
- Ran the targeted unit tests with `uv run pytest --no-cov tests/unit/test_validate_config.py -k 'endpoint_noise or ecar_file_churn'` and both selected tests passed.
- Ran lint/format checks with `uv run ruff check .` and `uv run ruff format --check .` and fixes were applied where needed; checks passed afterward.
- Confirmed changed files: `src/evidenceforge/config/schemas.py`, `src/evidenceforge/generation/engine/baseline.py`, and `tests/unit/test_validate_config.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202efc7ba88325a40ab50a9f7e22a8)