### PR TITLE
fix: harden output target marker reads

### DIFF
--- a/src/evidenceforge/output_targets.py
+++ b/src/evidenceforge/output_targets.py
@@ -29,6 +29,8 @@ file shape rendered on disk for those canonical formats.
 
 from __future__ import annotations
 
+import os
+import stat
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -151,22 +153,41 @@ def read_output_target_marker(path: Path) -> OutputTarget:
         candidates.append(path / "data" / OUTPUT_TARGET_FILENAME)
 
     for marker in candidates:
-        if not marker.exists():
+        try:
+            marker_stat = marker.lstat()
+        except FileNotFoundError:
             continue
-        if marker.is_symlink():
+
+        if stat.S_ISLNK(marker_stat.st_mode):
             raise ValueError("invalid output target marker: symlinks are not allowed")
-        resolved_marker = marker.resolve()
+        if not stat.S_ISREG(marker_stat.st_mode):
+            raise ValueError("invalid output target marker: marker must be a regular file")
+
+        resolved_marker = marker.resolve(strict=True)
         if not resolved_marker.is_relative_to(root_dir):
             raise ValueError(
                 "invalid output target marker: marker must stay under output directory"
             )
-        marker_size = marker.stat().st_size
+
+        marker_size = marker_stat.st_size
         if marker_size > MAX_OUTPUT_TARGET_MARKER_BYTES:
             raise ValueError(
                 "invalid output target marker: file is too large"
                 f" ({marker_size} bytes > {MAX_OUTPUT_TARGET_MARKER_BYTES} bytes)"
             )
-        value = marker.read_text(encoding="utf-8").strip()
+
+        open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        marker_fd = os.open(marker, open_flags)
+        with os.fdopen(marker_fd, "rb") as marker_file:
+            opened_stat = os.fstat(marker_file.fileno())
+            if not stat.S_ISREG(opened_stat.st_mode):
+                raise ValueError("invalid output target marker: marker must be a regular file")
+            if opened_stat.st_size > MAX_OUTPUT_TARGET_MARKER_BYTES:
+                raise ValueError(
+                    "invalid output target marker: file is too large"
+                    f" ({opened_stat.st_size} bytes > {MAX_OUTPUT_TARGET_MARKER_BYTES} bytes)"
+                )
+            value = marker_file.read(MAX_OUTPUT_TARGET_MARKER_BYTES + 1).decode("utf-8").strip()
         return normalize_output_target(value or None)
     return OutputTarget.DEFAULT
 

--- a/tests/unit/test_output_targets.py
+++ b/tests/unit/test_output_targets.py
@@ -22,6 +22,7 @@
 
 """Tests for target-aware output policy."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -77,6 +78,25 @@ def test_output_target_marker_rejects_symlink(tmp_path: Path) -> None:
     marker.symlink_to(secret)
 
     with pytest.raises(ValueError, match="symlinks are not allowed"):
+        read_output_target_marker(tmp_path)
+
+
+def test_output_target_marker_rejects_non_regular_file(tmp_path: Path) -> None:
+    marker = tmp_path / "OUTPUT_TARGET.txt"
+    marker.mkdir()
+
+    with pytest.raises(ValueError, match="regular file"):
+        read_output_target_marker(tmp_path)
+
+
+def test_output_target_marker_rejects_fifo_without_reading(tmp_path: Path) -> None:
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFO marker validation is POSIX-only")
+
+    marker = tmp_path / "OUTPUT_TARGET.txt"
+    os.mkfifo(marker)
+
+    with pytest.raises(ValueError, match="regular file"):
         read_output_target_marker(tmp_path)
 
 


### PR DESCRIPTION
### Motivation
- Reading `OUTPUT_TARGET.txt` markers from attacker-supplied dataset directories currently followed symlinks and performed unbounded reads, which can leak local file contents or block on special files.
- The eval and external-parser paths read the marker before other safe-path checks ran, so the marker read must be hardened at the helper level.

### Description
- Harden `read_output_target_marker()` to inspect candidates with `lstat()` and reject symlinks and non-regular files before opening them. (changes in `src/evidenceforge/output_targets.py`)
- Enforce containment by resolving the marker with `strict=True` and verifying it remains under the output root, and enforce the existing byte-size limit using file metadata read via `lstat()` and `fstat()`.
- Open the marker with `O_NOFOLLOW` when available and perform a bounded read (`MAX_OUTPUT_TARGET_MARKER_BYTES + 1`) to avoid unbounded blocking or large-file reads, then pass the normalized value to `normalize_output_target()`.
- Add regression tests to cover directory and FIFO (POSIX) marker cases so non-regular special files are rejected without attempting to read them. (changes in `tests/unit/test_output_targets.py`)

### Testing
- Ran `uv sync --extra dev` to install test/dev deps successfully. (succeeded)
- Ran the updated unit test suite for output-target logic with `uv run pytest --no-cov tests/unit/test_output_targets.py tests/unit/test_external_parser_script.py`, and all tests passed (15 passed). (succeeded)
- Ran lint/format checks with `uv run ruff check . && uv run ruff format --check .` and `git diff --check`, and static-checks/formatting passed. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203106510083259cc289350df4b7d4)