### PR TITLE
fix: reject symlinked SOF-ELK staged logs

### DIFF
--- a/src/evidenceforge/external_parsers/sof_elk_sources.py
+++ b/src/evidenceforge/external_parsers/sof_elk_sources.py
@@ -282,14 +282,15 @@ def stage_source_logs(
     logs: list[StagedSourceLog] = []
     for source_name in spec.source_names:
         for source in sorted(source_root.rglob(source_name)):
+            safe_source = _safe_stage_source(source_root, source)
             sensor = _source_name(source_root, source)
-            source_year = _source_year(source) if spec.staged_directory == "syslog" else None
+            source_year = _source_year(safe_source) if spec.staged_directory == "syslog" else None
             if spec.staged_directory == "syslog" and source_year is not None:
                 destination = source_stage_root / str(source_year) / sensor / spec.staged_name
             else:
                 destination = source_stage_root / sensor / spec.staged_name
             destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(source, destination)
+            shutil.copyfile(safe_source, destination)
             logs.append(
                 StagedSourceLog(
                     source=source,
@@ -693,6 +694,22 @@ def _update_scope_progress(
             "subtype_total": expected_by_subtype[scope],
         },
     )
+
+
+def _safe_stage_source(source_root: Path, source: Path) -> Path:
+    """Return a resolved source path that is safe to copy into parser staging."""
+    if source.is_symlink():
+        raise SofElkHarnessError(f"refusing to stage symlinked generated log file: {source}")
+
+    resolved = source.resolve(strict=True)
+    try:
+        resolved.relative_to(source_root)
+    except ValueError as exc:
+        raise SofElkHarnessError(
+            f"refusing to stage generated log file outside generated output root {source_root}: "
+            f"{source} -> {resolved}"
+        ) from exc
+    return resolved
 
 
 def _source_name(source_root: Path, source: Path) -> str:

--- a/tests/unit/test_sof_elk_sources_harness.py
+++ b/tests/unit/test_sof_elk_sources_harness.py
@@ -39,12 +39,14 @@ from evidenceforge.external_parsers.sof_elk_sources import (
     SofElkSourceManifest,
     SofElkSourceSpec,
     StagedSourceLog,
+    _safe_stage_source,
     build_sof_elk_source_configs,
     stage_source_logs,
     validate_source_parsed_output,
 )
 from evidenceforge.external_parsers.sof_elk_zeek import (
     FAILURE_REPORT_FILENAME,
+    SofElkHarnessError,
     SofElkParserError,
 )
 
@@ -122,6 +124,41 @@ def test_stage_source_logs_preserves_windows_snare_year_subdirectories(tmp_path:
     assert {log.staged.relative_to(manifest.logstash_root) for log in manifest.logs} == {
         Path("syslog/2026/win-01.example.test/windows_event_security_snare.log")
     }
+
+
+def test_stage_source_logs_rejects_symlinked_web_access_log(tmp_path: Path) -> None:
+    source_root = tmp_path / "generated"
+    source_dir = source_root / "web-01.example.test"
+    source_dir.mkdir(parents=True)
+    outside_secret = tmp_path / "outside_secret.txt"
+    outside_secret.write_text("do not stage me\n", encoding="utf-8")
+    (source_dir / "web_access.log").symlink_to(outside_secret)
+
+    with pytest.raises(SofElkHarnessError, match="refusing to stage symlinked"):
+        stage_source_logs(source_root, tmp_path / "stage", WEB_ACCESS_SPEC)
+
+    staged_log = (
+        tmp_path / "stage" / "logstash" / "httpd" / "web-01.example.test" / "web_access.log"
+    )
+    assert not staged_log.exists()
+
+
+def test_safe_stage_source_rejects_source_resolving_outside_root(tmp_path: Path) -> None:
+    source_root = tmp_path / "generated"
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "web_access.log").write_text(
+        '198.51.100.25 - - [15/Jun/2026:14:23:05 +0000] "GET /index.html HTTP/1.1" '
+        '200 512 "-" "Mozilla/5.0"\n',
+        encoding="utf-8",
+    )
+    source_root.mkdir()
+    (source_root / "web-01.example.test").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(SofElkHarnessError, match="outside generated output root"):
+        _safe_stage_source(
+            source_root.resolve(), source_root / "web-01.example.test" / "web_access.log"
+        )
 
 
 def test_build_sof_elk_source_configs_requests_sof_elk_syslog_input(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Prevent accidental disclosure of local files when staging discovered logs for SOF-ELK by addressing an unsafe copy pattern that followed symlinks and allowed resolved targets outside the generated output root.

### Description

- Add `_safe_stage_source(source_root, source)` which rejects symlinked discovered files and verifies `source.resolve()` is inside `source_root` before staging.
- Use the safe resolved path in `stage_source_logs()` for year inference and the `shutil.copyfile()` source argument while preserving the original discovered `source` for metadata such as the sensor name.
- Update logic so year partitioning still works (compute `source_year` from the validated resolved path for `syslog` families).
- Add regression tests in `tests/unit/test_sof_elk_sources_harness.py` to assert that symlinked `web_access.log` files are rejected and that sources resolving outside the generated root are rejected.

### Testing

- Ran lint/format checks: `uv run ruff check .` and `uv run ruff format --check .`, both passed after autofix.
- Ran targeted unit tests: `uv run pytest --no-cov tests/unit/test_sof_elk_sources_harness.py` and `uv run pytest --no-cov tests/unit/test_external_parser_runner.py tests/unit/test_sof_elk_sources_harness.py`, both passed.
- Ran full test suite: `uv run pytest --no-cov` which completed successfully (3943 passed, 40 skipped in this environment).
- Verified the new tests fail on the vulnerable behavior and pass with the fix implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203107d43883258fe504139116ecda)