### PR TITLE
fix: harden raw Windows EventID handling

### DIFF
--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -51,7 +51,11 @@ from evidenceforge.generation.emitters.windows import (
     _subject_domain,
 )
 from evidenceforge.generation.emitters.windows_event import format_windows_system_time
-from evidenceforge.generation.emitters.windows_record_ids import WindowsRecordIdSequence
+from evidenceforge.generation.emitters.windows_record_ids import (
+    WindowsRecordIdSequence,
+    coerce_windows_event_id,
+    normalize_windows_event_id_value,
+)
 from evidenceforge.generation.emitters.windows_snare import (
     WINDOWS_SYSMON_SNARE_FILENAME,
     render_windows_sysmon_snare_syslog,
@@ -1808,6 +1812,8 @@ class SysmonEventEmitter(LogEmitter):
         for field in ("ExecutionProcessID", "ExecutionThreadID"):
             value = event_data.get(field)
             event_data[field] = normalize_windows_id_value(value)
+        if "EventID" in event_data:
+            event_data["EventID"] = normalize_windows_event_id_value(event_data["EventID"])
         if self.threaded:
             self._emit_threaded(event_data)
         else:
@@ -1877,7 +1883,7 @@ class SysmonEventEmitter(LogEmitter):
             )
             event["EventRecordID"] = sequence_model.next(
                 event.get("TimeCreated"),
-                int(event.get("EventID") or 0),
+                coerce_windows_event_id(event.get("EventID")),
             )
             self._record_id_counters[counter_key] = sequence_model.current
 

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -55,7 +55,11 @@ from evidenceforge.generation.emitters.syslog_family import (
     syslog_family_writer_path,
 )
 from evidenceforge.generation.emitters.windows_event import format_windows_system_time
-from evidenceforge.generation.emitters.windows_record_ids import WindowsRecordIdSequence
+from evidenceforge.generation.emitters.windows_record_ids import (
+    WindowsRecordIdSequence,
+    coerce_windows_event_id,
+    normalize_windows_event_id_value,
+)
 from evidenceforge.generation.emitters.windows_snare import (
     WINDOWS_SECURITY_SNARE_FILENAME,
     render_windows_security_snare_syslog,
@@ -1577,6 +1581,8 @@ class WindowsEventEmitter(LogEmitter):
     def emit_event(self, event_data: dict[str, Any]) -> None:
         """Buffer a Windows Event dict for deferred rendering."""
         event_data = self._normalize_execution_ids(event_data)
+        if "EventID" in event_data:
+            event_data["EventID"] = normalize_windows_event_id_value(event_data["EventID"])
         if getattr(self, "_current_storyline_origin", False):
             event_data["_storyline_origin"] = True
         if self.threaded:
@@ -2162,7 +2168,7 @@ class WindowsEventEmitter(LogEmitter):
             )
             event["EventRecordID"] = sequence_model.next(
                 event.get("TimeCreated"),
-                int(event.get("EventID") or 0),
+                coerce_windows_event_id(event.get("EventID")),
             )
             self._record_id_counters[counter_key] = sequence_model.current
 

--- a/src/evidenceforge/generation/emitters/windows_record_ids.py
+++ b/src/evidenceforge/generation/emitters/windows_record_ids.py
@@ -24,9 +24,50 @@
 
 import random
 from datetime import datetime
+from typing import Any
 
 from evidenceforge.utils.rng import _stable_seed
 from evidenceforge.utils.time import ensure_utc
+
+
+def coerce_windows_event_id(value: Any) -> int | None:
+    """Return a numeric Windows Event ID when raw emitter input is safely parseable.
+
+    Raw scenario events intentionally carry arbitrary emitter fields. Event IDs
+    that are malformed should still render as authored, but should not abort
+    source-native EventRecordID sequencing.
+    """
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(stripped, 10)
+        except ValueError:
+            return None
+    return None
+
+
+def normalize_windows_event_id_value(value: Any) -> Any:
+    """Return an EventID value that is safe for Windows XML template helpers.
+
+    Jinja template lookups compare EventID against numeric IDs and use it as a
+    dictionary key for source-native metadata. Container values from raw events
+    should render as authored text instead of raising unhashable-type errors.
+    """
+    try:
+        hash(value)
+    except TypeError:
+        return str(value)
+    return value
 
 
 class WindowsRecordIdSequence:

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -200,6 +200,26 @@ class TestWindowsEventEmitter:
         content = temp_output.read_text()
         assert '<Execution ProcessID="544" ThreadID="116"/>' in content
 
+    def test_emit_event_preserves_malformed_raw_event_id(self, format_def, temp_output):
+        """Malformed raw EventID should not abort Security XML rendering."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)
+
+        event_data = {
+            "EventID": "not-an-int",
+            "TimeCreated": datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC),
+            "Computer": "WIN-TEST-01.corp.local",
+            "Channel": "Security",
+            "Level": 0,
+            "ExecutionProcessID": 4,
+            "ExecutionThreadID": 100,
+        }
+
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        content = temp_output.read_text()
+        assert "<EventID>not-an-int</EventID>" in content
+
     def test_emit_event_preserves_oversized_decimal_execution_id(self, format_def, temp_output):
         """Oversized raw decimal PID/TID strings should not abort Security XML rendering."""
         emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=1)

--- a/tests/unit/test_sysmon_emitter.py
+++ b/tests/unit/test_sysmon_emitter.py
@@ -134,6 +134,26 @@ class TestSysmonEventEmitter:
         content = temp_output.read_text()
         assert '<Execution ProcessID="2756" ThreadID="1544"/>' in content
 
+    def test_emit_sysmon_preserves_malformed_raw_event_id(self, format_def, temp_output):
+        """Malformed raw EventID should not abort Sysmon XML rendering."""
+        emitter = SysmonEventEmitter(format_def, temp_output, buffer_size=1)
+
+        event_data = {
+            "EventID": [1],
+            "TimeCreated": datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
+            "Computer": "WKS-01.corp.local",
+            "Channel": "Microsoft-Windows-Sysmon/Operational",
+            "Level": 4,
+            "ExecutionProcessID": 2756,
+            "ExecutionThreadID": 3632,
+        }
+
+        emitter.emit_event(event_data)
+        emitter.close()
+
+        content = temp_output.read_text()
+        assert "<EventID>[1]</EventID>" in content
+
     def test_emit_sysmon_preserves_oversized_decimal_execution_id(self, format_def, temp_output):
         """Oversized raw decimal PID/TID strings should not abort Sysmon XML rendering."""
         emitter = SysmonEventEmitter(format_def, temp_output, buffer_size=1)

--- a/tests/unit/test_windows_record_ids.py
+++ b/tests/unit/test_windows_record_ids.py
@@ -3,7 +3,11 @@
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 
-from evidenceforge.generation.emitters.windows_record_ids import WindowsRecordIdSequence
+from evidenceforge.generation.emitters.windows_record_ids import (
+    WindowsRecordIdSequence,
+    coerce_windows_event_id,
+    normalize_windows_event_id_value,
+)
 
 
 def _sample_gaps(channel: str, host_key: str, count: int = 640) -> list[int]:
@@ -41,3 +45,20 @@ def test_record_id_sequence_is_deterministic_per_host_channel() -> None:
     second = _sample_gaps("security", "FILE-SRV-01", count=128)
 
     assert first == second
+
+
+def test_coerce_windows_event_id_ignores_malformed_raw_values() -> None:
+    """Malformed raw EventID values should not abort record-ID sequencing."""
+    assert coerce_windows_event_id("4624") == 4624
+    assert coerce_windows_event_id(1.0) == 1
+    assert coerce_windows_event_id("not-an-int") is None
+    assert coerce_windows_event_id([]) is None
+    assert coerce_windows_event_id({"EventID": 4624}) is None
+
+
+def test_normalize_windows_event_id_value_stringifies_unhashable_raw_values() -> None:
+    """Raw EventID containers should be safe for template metadata lookups."""
+    assert normalize_windows_event_id_value([1]) == "[1]"
+    assert normalize_windows_event_id_value({"EventID": 4624}) == "{'EventID': 4624}"
+    assert normalize_windows_event_id_value("not-an-int") == "not-an-int"
+    assert normalize_windows_event_id_value(4624) == 4624


### PR DESCRIPTION
### Motivation
- Raw `raw` scenario events may contain arbitrary `EventID` values that are non-numeric or unhashable, and the previous `int(event.get("EventID") or 0)` conversions caused `ValueError`/`TypeError` during emitter finalization, aborting generation.
- The change prevents untrusted or malformed scenario inputs from reliably crashing Windows Security/Sysmon emitters while preserving authored output.

### Description
- Add `coerce_windows_event_id(value: Any) -> int | None` to safely parse numeric EventID-like values and return `None` for unparseable inputs so sequencing logic skips the parse instead of raising. (`src/evidenceforge/generation/emitters/windows_record_ids.py`).
- Add `normalize_windows_event_id_value(value: Any) -> Any` to stringify unhashable container EventID values so Jinja template lookups do not raise `TypeError` while still rendering the authored value. (`src/evidenceforge/generation/emitters/windows_record_ids.py`).
- Use `coerce_windows_event_id(...)` when computing `EventRecordID` in the Windows Security and Sysmon emitters instead of unguarded `int(...)`. (`src/evidenceforge/generation/emitters/windows.py`, `src/evidenceforge/generation/emitters/sysmon.py`).
- Normalize `EventID` container values on emit so templates receive hashable/string-friendly values and the original malformed text still appears in rendered XML. (`src/evidenceforge/generation/emitters/windows.py`, `src/evidenceforge/generation/emitters/sysmon.py`).
- Add unit tests covering `coerce_windows_event_id`, normalization behavior, and regression tests ensuring malformed raw `EventID` values do not abort rendering for both Security and Sysmon emitters. (`tests/unit/test_windows_record_ids.py`, `tests/unit/test_emitters.py`, `tests/unit/test_sysmon_emitter.py`).

### Testing
- Ran targeted unit tests with `uv run pytest --no-cov tests/unit/test_windows_record_ids.py tests/unit/test_emitters.py::TestWindowsEventEmitter::test_emit_event_preserves_malformed_raw_event_id tests/unit/test_sysmon_emitter.py::TestSysmonEventEmitter::test_emit_sysmon_preserves_malformed_raw_event_id`, and all tests passed (7 passed).
- Ran linter/format checks with `uv run ruff check .` and `uv run ruff format --check .`, and they passed.
- The change resolves the previously reproducible failure where non-numeric or container `EventID` values caused emitter finalization crashes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2031063a38832590041d36c871aee1)