### PR TITLE
fix: handle deep x509 parser originals

### DIFF
--- a/src/evidenceforge/external_parsers/tag_policy.py
+++ b/src/evidenceforge/external_parsers/tag_policy.py
@@ -149,7 +149,7 @@ def _is_zeek_x509_post_2038_date_limitation(event: JsonMapping) -> bool:
         return False
     try:
         raw = json.loads(original)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, RecursionError):
         return False
     if not isinstance(raw, Mapping):
         return False

--- a/tests/unit/test_sof_elk_zeek_harness.py
+++ b/tests/unit/test_sof_elk_zeek_harness.py
@@ -373,6 +373,37 @@ def test_validate_parsed_output_ignores_x509_post_2038_date_parser_limitation(
     assert not (parsed_dir / FAILURE_REPORT_FILENAME).exists()
 
 
+def test_validate_parsed_output_keeps_deep_x509_original_dateparsefailure_fatal(
+    tmp_path: Path,
+) -> None:
+    manifest = ZeekStageManifest(
+        logstash_root=tmp_path / "logstash",
+        logs=(
+            StagedLog(
+                source=tmp_path / "x509.json",
+                staged=tmp_path / "logstash" / "zeek" / "sensor" / "x509.log",
+                log_type="zeek_x509",
+                record_count=1,
+            ),
+        ),
+    )
+    parsed_dir = tmp_path / "parsed"
+    parsed_dir.mkdir()
+    event = _parsed_x509(not_valid_after=2_289_254_400)
+    event["event"] = {"original": "[" * 10_000 + "0" + "]" * 10_000}
+    tags = event["tags"]
+    assert isinstance(tags, list)
+    tags.append("_dateparsefailure")
+    _write_jsonl(parsed_dir / "zeek_x509.jsonl", [event])
+
+    with pytest.raises(SofElkParserError, match="_dateparsefailure"):
+        validate_parsed_output(manifest, parsed_dir)
+
+    report = json.loads((parsed_dir / FAILURE_REPORT_FILENAME).read_text(encoding="utf-8"))
+    assert report["failure_tag_counts"]["zeek_x509"]["_dateparsefailure"] == 1
+    assert report["sample_failures"][0]["tags"] == ["_dateparsefailure"]
+
+
 def test_validate_parsed_output_keeps_x509_dateparsefailure_fatal_without_limitation(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- The Zeek x509 `_dateparsefailure` predicate reparses `event.original` with `json.loads()` but only caught `json.JSONDecodeError`, allowing a deeply nested JSON input to raise `RecursionError` and crash the external parser validation harness instead of following the normal failure-report path.

### Description
- Catch `RecursionError` together with `json.JSONDecodeError` in `_is_zeek_x509_post_2038_date_limitation` and add a regression test that feeds a deeply nested `event.original` through the SOF-ELK Zeek validation path to ensure the `_dateparsefailure` is handled via the usual `SofElkParserError`/failure-report flow.

### Testing
- Ran `uv sync --extra dev`, then `uv run pytest --no-cov tests/unit/test_sof_elk_zeek_harness.py -k x509` which ran the added regression and existing x509 tests (3 selected) and passed, and verified `uv run ruff check .` and `uv run ruff format --check .` all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203107ad8c8325b0d10f7ec7b035bf)