### PR TITLE
fix: require explicit eCAR shell concurrency groups

### DIFF
--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -101,6 +101,7 @@ class ProcessContext:
     mandatory_label: str = ""  # MandatoryLabel SID
     start_time: datetime | None = None  # Process creation time for stable cross-event GUIDs
     current_directory: str = ""  # Sysmon Event 1 CurrentDirectory / process working dir
+    concurrency_group_id: str = ""  # Explicit same-shell concurrency group (for pipelines)
 
 
 @dataclass(slots=True)

--- a/src/evidenceforge/generation/actions/process_execution.py
+++ b/src/evidenceforge/generation/actions/process_execution.py
@@ -49,19 +49,21 @@ class ProcessExecutionRequest:
     suppress_command_file_effect: bool = False
     allow_existing_browser_reuse: bool = True
     allow_browser_launch_spacing: bool = True
+    concurrency_group_id: str = ""
     source: str = "activity_generator"
 
     @property
     def stable_id(self) -> str:
         """Return a deterministic intent identifier for durable references."""
 
+        concurrency_suffix = f":{self.concurrency_group_id}" if self.concurrency_group_id else ""
         seed = _stable_seed(
             "action_bundle:process_execution:"
             f"{self.user.username}:{self.system.hostname}:{self.time.isoformat()}:"
             f"{self.logon_id}:{self.process_name}:{self.command_line}:"
             f"{self.parent_pid}:{self.ensure_file_event}:{self.from_storyline}:"
             f"{self.suppress_command_file_effect}:{self.allow_existing_browser_reuse}:"
-            f"{self.allow_browser_launch_spacing}:{self.source}"
+            f"{self.allow_browser_launch_spacing}{concurrency_suffix}:{self.source}"
         )
         return f"process-execution-{seed:016x}"
 

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -2746,6 +2746,30 @@ def _split_linux_pipeline(
     return list(_iter_linux_pipeline_stages(command, max_stages=max_stages))
 
 
+def _contains_unquoted_shell_pipe(command: str) -> bool:
+    """Return whether a shell command contains an unquoted pipe operator."""
+    quote: str | None = None
+    escaped = False
+    scan_limit = min(len(command), _LINUX_SHELL_MAX_SCAN_CHARS)
+    for char in command[:scan_limit]:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char == "|":
+            return True
+    return False
+
+
 def _iter_linux_pipeline_stages(command: str, *, max_stages: int) -> Iterator[str]:
     """Yield bounded unquoted pipeline/control stages from a Linux shell command."""
     if max_stages <= 0:
@@ -8427,6 +8451,7 @@ class ActivityGenerator:
         suppress_command_file_effect: bool = False,
         allow_existing_browser_reuse: bool = True,
         allow_browser_launch_spacing: bool = True,
+        concurrency_group_id: str = "",
     ) -> int:
         """Generate process creation event across all applicable log formats.
 
@@ -8453,6 +8478,7 @@ class ActivityGenerator:
             allow_browser_launch_spacing: Apply anti-burst spacing to top-level browser
                 launches. Causal connection-owner processes disable this so process
                 creation stays before the socket evidence they own.
+            concurrency_group_id: Explicit same-shell concurrency group for true pipelines.
 
         Returns:
             PID of the new process
@@ -8470,6 +8496,7 @@ class ActivityGenerator:
             suppress_command_file_effect=suppress_command_file_effect,
             allow_existing_browser_reuse=allow_existing_browser_reuse,
             allow_browser_launch_spacing=allow_browser_launch_spacing,
+            concurrency_group_id=concurrency_group_id,
         )
         return ProcessExecutionActionBundle(self, request).execute()
 
@@ -8489,6 +8516,7 @@ class ActivityGenerator:
         suppress_command_file_effect = request.suppress_command_file_effect
         allow_existing_browser_reuse = request.allow_existing_browser_reuse
         allow_browser_launch_spacing = request.allow_browser_launch_spacing
+        concurrency_group_id = request.concurrency_group_id
 
         self.state_manager.set_current_time(time)
         if _get_os_category(system.os) == "windows":
@@ -8748,6 +8776,7 @@ class ActivityGenerator:
                     parent_pid=parent_pid,
                     logon_type=process_logon_type,
                 ),
+                concurrency_group_id=concurrency_group_id,
             ),
             edr=EdrContext(object_id=proc_obj_id, actor_id=parent_obj_id),
             storyline_origin=from_storyline,
@@ -12784,6 +12813,14 @@ class ActivityGenerator:
 
         shell_release_times: list[tuple[int, datetime, str]] = []
         base_process_time: datetime | None = None
+        concurrency_group_id = ""
+        if len(processes) > 1 and _contains_unquoted_shell_pipe(command):
+            pipeline_seed = _stable_seed(
+                "linux_shell_pipeline:"
+                f"{system.hostname}:{user.username}:{session.logon_id}:"
+                f"{time.isoformat()}:{command}"
+            )
+            concurrency_group_id = f"linux-shell-pipeline-{pipeline_seed:016x}"
         for index, (image, process_command_line) in enumerate(processes):
             parent_pid = self._resolve_parent(system, user, time, session.logon_id, image)
             if base_process_time is None:
@@ -12815,6 +12852,7 @@ class ActivityGenerator:
                 command_line=process_command_line,
                 parent_pid=parent_pid,
                 suppress_command_file_effect=True,
+                concurrency_group_id=concurrency_group_id,
             )
             running_proc = self.state_manager.get_process(system.hostname, pid)
             actual_process_start = (

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -499,6 +499,8 @@ class EcarEmitter(HostMultiplexEmitter):
         }
         if proc.parent_image:
             event_data["parent_image_path"] = proc.parent_image
+        if proc.concurrency_group_id:
+            event_data["_concurrency_group_id"] = proc.concurrency_group_id
         self._apply_edr_context(event_data, event)
         event_data.setdefault(
             "tid",
@@ -1681,7 +1683,6 @@ class EcarEmitter(HostMultiplexEmitter):
         "whoami",
         "zip",
     }
-    _LINUX_SHELL_PIPELINE_CREATE_WINDOW_MS = 1000
 
     @classmethod
     def _is_linux_shell_foreground_create(cls, record: dict[str, Any]) -> bool:
@@ -1762,21 +1763,20 @@ class EcarEmitter(HostMultiplexEmitter):
             )
             next_available_ms = 0
             groups: list[list[int]] = []
+            group_by_concurrency_id: dict[str, list[int]] = {}
             for index in indexes:
                 record = records[index]
                 if record is None:
                     continue
-                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                if groups:
-                    first_record = records[groups[-1][0]]
-                    first_ms = (
-                        cls._ecar_int(first_record.get("timestamp_ms"), 0)
-                        if first_record is not None
-                        else 0
-                    )
-                    if timestamp_ms <= first_ms + cls._LINUX_SHELL_PIPELINE_CREATE_WINDOW_MS:
-                        groups[-1].append(index)
-                        continue
+                concurrency_group_id = str(record.get("_concurrency_group_id") or "")
+                if concurrency_group_id:
+                    group = group_by_concurrency_id.get(concurrency_group_id)
+                    if group is None:
+                        group = []
+                        group_by_concurrency_id[concurrency_group_id] = group
+                        groups.append(group)
+                    group.append(index)
+                    continue
                 groups.append([index])
 
             for group in groups:
@@ -1832,6 +1832,7 @@ class EcarEmitter(HostMultiplexEmitter):
                 and record.get("action") == "TERMINATE"
             ):
                 record["timestamp_ms"] = cls._ecar_int(record.get("timestamp_ms"), 0) + shift_ms
+            record.pop("_concurrency_group_id", None)
             normalized.append(json.dumps(record, separators=(",", ":")))
         return normalized
 
@@ -2193,6 +2194,8 @@ class EcarEmitter(HostMultiplexEmitter):
         }
         if "_canonical_ms" in event_data:
             record["_canonical_ms"] = event_data["_canonical_ms"]
+        if event_data.get("_concurrency_group_id"):
+            record["_concurrency_group_id"] = event_data["_concurrency_group_id"]
 
         if event_data.get("actorID"):
             record["actorID"] = event_data["actorID"]

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -693,6 +693,66 @@ def test_ecar_flow_connect_keeps_network_time_for_close_process_conflict() -> No
     assert "parent_image_path" not in rows[0]["properties"]
 
 
+def test_ecar_linux_shell_foreground_order_serializes_close_unrelated_commands() -> None:
+    """Same-shell commands without an explicit pipeline group should not overlap."""
+    sleep_create = {
+        "timestamp_ms": 1_000_000,
+        "id": "sleep-create",
+        "hostname": "DB-PROD-01",
+        "object": "PROCESS",
+        "action": "CREATE",
+        "objectID": "sleep-process",
+        "actorID": "bash-process",
+        "pid": 706031,
+        "ppid": 705932,
+        "principal": "root",
+        "properties": {
+            "image_path": "/usr/bin/sleep",
+            "command_line": "sleep 5",
+            "parent_image_path": "/bin/bash",
+        },
+    }
+    whoami_create = {
+        "timestamp_ms": 1_000_500,
+        "id": "whoami-create",
+        "hostname": "DB-PROD-01",
+        "object": "PROCESS",
+        "action": "CREATE",
+        "objectID": "whoami-process",
+        "actorID": "bash-process",
+        "pid": 706032,
+        "ppid": 705932,
+        "principal": "root",
+        "properties": {
+            "image_path": "/usr/bin/whoami",
+            "command_line": "whoami",
+            "parent_image_path": "/bin/bash",
+        },
+    }
+    sleep_terminate = {
+        "timestamp_ms": 1_005_000,
+        "id": "sleep-terminate",
+        "hostname": "DB-PROD-01",
+        "object": "PROCESS",
+        "action": "TERMINATE",
+        "objectID": "sleep-process",
+        "pid": 706031,
+        "principal": "root",
+        "properties": {"image_path": "/usr/bin/sleep"},
+    }
+
+    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
+        [
+            json.dumps(sleep_create, separators=(",", ":")),
+            json.dumps(whoami_create, separators=(",", ":")),
+            json.dumps(sleep_terminate, separators=(",", ":")),
+        ]
+    )
+    rows = [json.loads(line) for line in normalized]
+
+    assert rows[1]["timestamp_ms"] > rows[2]["timestamp_ms"]
+
+
 def test_ecar_linux_shell_foreground_order_keeps_pipeline_children_concurrent() -> None:
     """Pipeline children are concurrent shell work, not sequential foreground prompts."""
     cat_create = {
@@ -702,6 +762,7 @@ def test_ecar_linux_shell_foreground_order_keeps_pipeline_children_concurrent() 
         "object": "PROCESS",
         "action": "CREATE",
         "objectID": "cat-process",
+        "_concurrency_group_id": "pipeline-1",
         "actorID": "bash-process",
         "pid": 706031,
         "ppid": 705932,
@@ -719,6 +780,7 @@ def test_ecar_linux_shell_foreground_order_keeps_pipeline_children_concurrent() 
         "object": "PROCESS",
         "action": "CREATE",
         "objectID": "head-process",
+        "_concurrency_group_id": "pipeline-1",
         "actorID": "bash-process",
         "pid": 706032,
         "ppid": 705932,
@@ -763,6 +825,8 @@ def test_ecar_linux_shell_foreground_order_keeps_pipeline_children_concurrent() 
     rows = [json.loads(line) for line in normalized]
 
     assert rows[1]["timestamp_ms"] == head_create["timestamp_ms"]
+    assert "_concurrency_group_id" not in rows[0]
+    assert "_concurrency_group_id" not in rows[1]
     assert max(rows[0]["timestamp_ms"], rows[1]["timestamp_ms"]) < min(
         rows[2]["timestamp_ms"], rows[3]["timestamp_ms"]
     )


### PR DESCRIPTION
### Motivation
- The eCAR normalizer previously grouped same-shell foreground CREATEs solely by a fixed 1000ms window, which could incorrectly treat unrelated rapid commands as a pipeline and leave a later CREATE before an earlier TERMINATE, producing impossible timelines.
- The intent is to preserve true pipeline concurrency while preventing accidental grouping of unrelated foreground commands that simply happened close in time.

### Description
- Add an explicit `concurrency_group_id: str` field to `ProcessContext` and carry that metadata through `ProcessExecutionRequest` so a pipeline relationship can be expressed and propagated to emitters. (files: `src/evidenceforge/events/contexts.py`, `src/evidenceforge/generation/actions/process_execution.py`)
- Only assign a deterministic concurrency group when the generator detects an actual unquoted pipe in the shell command; pass `concurrency_group_id` into `generate_process()` calls for inferred pipeline stages. (file: `src/evidenceforge/generation/activity/generator.py`)
- Change the eCAR normalization to stop batching foreground creates by timestamp proximity; instead honor only explicit `_concurrency_group_id` markers when grouping concurrent pipeline children, and strip the marker before final output. (file: `src/evidenceforge/generation/emitters/ecar.py`)
- Add a regression test to ensure two unrelated same-shell foreground commands created within 500ms are serialized (no impossible overlap) and update the pipeline test to use an explicit concurrency marker. (file: `tests/unit/test_source_timing.py`)

### Testing
- Ran linter/format checks: `uv run ruff check .` and `uv run ruff format --check .` and fixed formatting issues; checks passed.
- Ran the unit timing test file: `uv run pytest --no-cov tests/unit/test_source_timing.py`; all collected tests in that module passed (24 passed, 0 failed).
- No other automated tests were changed; the new/updated timing tests exercise both the explicit pipeline path and the non-pipeline close-create scenario and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20310734508325a5643834a3fd456e)