### PR TITLE
fix: tolerate malformed HTTP file URIs

### DIFF
--- a/src/evidenceforge/generation/actions/file_transfer.py
+++ b/src/evidenceforge/generation/actions/file_transfer.py
@@ -187,7 +187,10 @@ def _http_content_identity_uri(host: str, uri: str) -> str:
 
     if not uri:
         return "/"
-    parsed = urlsplit(uri)
+    try:
+        parsed = urlsplit(uri)
+    except ValueError:
+        return uri
     if parsed.scheme and parsed.netloc:
         parsed_host = (parsed.hostname or "").rstrip(".").lower()
         expected_host = host.rstrip(".").lower()

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -1022,6 +1022,24 @@ class TestFileTransferActionBundles:
         assert first.pe.has_cert_table == second.pe.has_cert_table
         assert later.pe.has_cert_table == first.pe.has_cert_table
 
+    def test_http_file_transfer_bundle_tolerates_malformed_absolute_uri(self):
+        """Malformed absolute-form URIs should fall back to raw URI identity."""
+        request = HttpResponseFileTransferRequest(
+            host="cdn.example.test",
+            uri="http://[::1/path.exe",
+            dst_ip="93.184.216.34",
+            response_body_len=78_306_264,
+            response_mime_types=["application/x-msdownload"],
+            timestamp=datetime(2026, 5, 18, 12, 0, tzinfo=UTC),
+            parent_duration=6.0,
+        )
+
+        result = HttpResponseFileTransferActionBundle(request, random.Random(4)).execute()
+
+        assert result.file_transfer.source == "HTTP"
+        assert result.file_transfer.sha1
+        assert result.pe is not None
+
     def test_smb_file_transfer_metadata_bundle_preserves_direction(self):
         """SMB files.log metadata should preserve caller-owned transfer direction."""
         request = SmbFileTransferMetadataRequest(


### PR DESCRIPTION
### Motivation
- Prevent `eforge generate` from crashing when a scenario-controlled HTTP `uri` is malformed and `urllib.parse.urlsplit()` raises `ValueError`, causing an availability failure during file-transfer metadata generation.

### Description
- Add a `try/except ValueError` around `urlsplit(uri)` in `_http_content_identity_uri()` and fall back to returning the raw `uri` when parsing fails in `src/evidenceforge/generation/actions/file_transfer.py`.
- Add a regression unit test `test_http_file_transfer_bundle_tolerates_malformed_absolute_uri` to `tests/unit/test_storyline_command_networks.py` that exercises the malformed absolute-form URI case (`http://[::1/path.exe`).

### Testing
- Ran `uv run pytest --no-cov tests/unit/test_storyline_command_networks.py -k 'http_file_transfer_bundle'` and all selected tests passed (`4 passed`).
- Ran linter/format checks with `uv run ruff check .` and `uv run ruff format --check .`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2031071ac0832583758e9df556f66c)