### PR TITLE
fix: preserve IPv6 ASA ICMP faddr parsing

### DIFF
--- a/src/evidenceforge/evaluation/parsers/cisco_asa.py
+++ b/src/evidenceforge/evaluation/parsers/cisco_asa.py
@@ -22,6 +22,7 @@
 
 """Parser for Cisco ASA firewall syslog files."""
 
+import ipaddress
 import re
 from collections.abc import Iterator
 from datetime import UTC, datetime
@@ -50,7 +51,7 @@ BUILT_TCP_UDP = re.compile(
 # Built ICMP: "Built {inbound/outbound} ICMP connection for faddr ip/type ..."
 BUILT_ICMP = re.compile(
     r"Built\s+(?:inbound|outbound)\s+ICMP\s+connection\s+for\s+faddr\s+"
-    r"(?:(\w+):)?([^/\s]+)/(\d+)"
+    r"([^/\s]+)/(\d+)"
 )
 
 # Teardown connection: "Teardown TCP connection 12345 for inside:10.0.10.50/54321 to ..."
@@ -64,7 +65,7 @@ TEARDOWN_TCP_UDP = re.compile(
 # Teardown ICMP: "Teardown ICMP connection for faddr ip/type ..."
 TEARDOWN_ICMP = re.compile(
     r"Teardown\s+ICMP\s+connection\s+for\s+faddr\s+"
-    r"(?:(\w+):)?([^/\s]+)/(\d+)"
+    r"([^/\s]+)/(\d+)"
 )
 
 # Deny: "Deny tcp src outside:104.248.71.33/44231 dst inside:10.0.10.50/445 ..."
@@ -99,6 +100,35 @@ THREAT_DETECTION = re.compile(
     r"max\s+configured\s+rate\s+is\s+(\d+);\s+"
     r"Cumulative\s+total\s+count\s+is\s+(\d+)"
 )
+
+
+def _parse_asa_address_token(token: str) -> tuple[str | None, str]:
+    """Split an ASA address token into optional interface and IP address.
+
+    ASA may render address tokens either as bare IPs or as ``interface:IP``.
+    Bare IPv6 addresses also contain colons, so validate the whole token before
+    treating the first colon-separated component as a legacy interface prefix.
+    """
+    try:
+        ipaddress.ip_address(token)
+    except ValueError:
+        pass
+    else:
+        return None, token
+
+    if ":" not in token:
+        return None, token
+
+    interface, address = token.split(":", 1)
+    if not re.fullmatch(r"\w+", interface):
+        return None, token
+
+    try:
+        ipaddress.ip_address(address)
+    except ValueError:
+        return None, token
+
+    return interface, address
 
 
 @register_parser
@@ -183,10 +213,11 @@ class CiscoAsaParser(LogParser):
         elif msg_id in (302020,):
             match = BUILT_ICMP.search(message)
             if match:
-                if match.group(1):
-                    fields["dst_interface"] = match.group(1)
-                fields["dst_ip"] = match.group(2)
-                fields["icmp_type"] = int(match.group(3))
+                interface, address = _parse_asa_address_token(match.group(1))
+                if interface:
+                    fields["dst_interface"] = interface
+                fields["dst_ip"] = address
+                fields["icmp_type"] = int(match.group(2))
         elif msg_id in (302014, 302016):
             match = TEARDOWN_TCP_UDP.search(message)
             if match:
@@ -202,10 +233,11 @@ class CiscoAsaParser(LogParser):
         elif msg_id in (302021,):
             match = TEARDOWN_ICMP.search(message)
             if match:
-                if match.group(1):
-                    fields["dst_interface"] = match.group(1)
-                fields["dst_ip"] = match.group(2)
-                fields["icmp_type"] = int(match.group(3))
+                interface, address = _parse_asa_address_token(match.group(1))
+                if interface:
+                    fields["dst_interface"] = interface
+                fields["dst_ip"] = address
+                fields["icmp_type"] = int(match.group(2))
         elif msg_id == 106023:
             match = DENY.search(message)
             if match:

--- a/tests/unit/test_cisco_asa_parser.py
+++ b/tests/unit/test_cisco_asa_parser.py
@@ -107,6 +107,35 @@ class TestParseBuiltRecords:
         assert records[0].fields["dst_ip"] == "203.0.113.50"
         assert records[0].fields["icmp_type"] == 8
 
+    def test_parse_302020_icmp_built_preserves_bare_ipv6(self, tmp_path):
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-302020: Built outbound ICMP connection "
+            "for faddr 2001:db8::50/8 gaddr fd00::10/0 laddr fd00::10/0\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        assert records[0].fields["msg_id"] == 302020
+        assert records[0].fields["dst_ip"] == "2001:db8::50"
+        assert records[0].fields["icmp_type"] == 8
+        assert "dst_interface" not in records[0].fields
+
+    def test_parse_302020_icmp_built_accepts_legacy_ipv6_interface_prefix(self, tmp_path):
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:23:05 fw01 %ASA-6-302020: Built outbound ICMP connection "
+            "for faddr outside:2001:db8::50/8 gaddr inside:fd00::10/0 "
+            "laddr inside:fd00::10/0\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        assert records[0].fields["msg_id"] == 302020
+        assert records[0].fields["dst_interface"] == "outside"
+        assert records[0].fields["dst_ip"] == "2001:db8::50"
+        assert records[0].fields["icmp_type"] == 8
+
 
 class TestParseTeardownRecords:
     def test_parse_302014_tcp_teardown(self, tmp_path):
@@ -141,6 +170,37 @@ class TestParseTeardownRecords:
         assert rec.fields["dst_ip"] == "203.0.113.50"
         assert rec.fields["icmp_type"] == 8
         assert "dst_interface" not in rec.fields
+
+    def test_parse_302021_icmp_teardown_preserves_bare_ipv6(self, tmp_path):
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:24:28 fw01 %ASA-6-302021: Teardown ICMP connection "
+            "for faddr 2001:db8::50/8 gaddr fd00::10/0 laddr fd00::10/0\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.fields["msg_id"] == 302021
+        assert rec.fields["dst_ip"] == "2001:db8::50"
+        assert rec.fields["icmp_type"] == 8
+        assert "dst_interface" not in rec.fields
+
+    def test_parse_302021_icmp_teardown_accepts_legacy_ipv6_interface_prefix(self, tmp_path):
+        log = tmp_path / "cisco_asa.log"
+        log.write_text(
+            "<166>Jun 15 14:24:28 fw01 %ASA-6-302021: Teardown ICMP connection "
+            "for faddr outside:2001:db8::50/8 gaddr inside:fd00::10/0 "
+            "laddr inside:fd00::10/0\n"
+        )
+        parser = CiscoAsaParser()
+        records = list(parser.parse_file(log))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.fields["msg_id"] == 302021
+        assert rec.fields["dst_interface"] == "outside"
+        assert rec.fields["dst_ip"] == "2001:db8::50"
+        assert rec.fields["icmp_type"] == 8
 
 
 class TestParseDenyRecords:


### PR DESCRIPTION
### Motivation
- The ASA ICMP Built/Teardown messages were being parsed ambiguously because the parser treated a leading word and colon as an interface prefix, which collides with bare unbracketed IPv6 addresses that contain colons (e.g., `2001:db8::50`).
- The emitter produces bare IPv6 faddr tokens, so the parser must preserve bare IPv6 addresses while still accepting legacy `interface:IP` tokens.

### Description
- Adjusted ICMP regexes to capture the full faddr token (no pre-split interface group) and added `_parse_asa_address_token()` which uses `ipaddress.ip_address()` and minimal validation to decide whether a token is a bare IP or `interface:IP` before splitting. (file: `src/evidenceforge/evaluation/parsers/cisco_asa.py`)
- Replaced direct group indexing in Built/Teardown ICMP extraction with a call to `_parse_asa_address_token()` and assign `dst_interface` only when a validated interface prefix is present. (file: `src/evidenceforge/evaluation/parsers/cisco_asa.py`)
- Added regression unit tests covering bare IPv6 and legacy interface-prefixed IPv6 for both Built and Teardown ICMP messages. (file: `tests/unit/test_cisco_asa_parser.py`)

### Testing
- Ran dependency sync: `uv sync` and `uv sync --extra dev`, both completed successfully. 
- Ran unit test suite for the impacted modules: `uv run pytest --no-cov tests/unit/test_cisco_asa_parser.py tests/unit/test_cisco_asa_emitter.py`, and all tests passed (`81 passed`).
- Ran linters/format checks: `uv run ruff check .` and `uv run ruff format --check .`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203106f5688325982c607ec4696e90)