### PR TITLE
fix: reject symlinked external parser sources

### DIFF
--- a/src/evidenceforge/external_parsers/runner.py
+++ b/src/evidenceforge/external_parsers/runner.py
@@ -260,7 +260,11 @@ def _add_detected_log(
     validator: str | None,
     unsupported_reason: str | None = None,
 ) -> None:
+    if path.is_symlink():
+        return
     path = path.resolve()
+    if not path.is_relative_to(data_dir):
+        return
     logs_by_path[path] = DetectedLog(
         path=path,
         host=_host_for_path(data_dir, path),
@@ -273,13 +277,14 @@ def _add_detected_log(
 
 
 def _candidate_log_files(data_dir: Path) -> tuple[Path, ...]:
-    return tuple(
-        sorted(
-            path.resolve()
-            for path in data_dir.rglob("*")
-            if path.is_file() and path.suffix in _LOG_FILE_SUFFIXES
-        )
-    )
+    candidates: list[Path] = []
+    for path in data_dir.rglob("*"):
+        if path.is_symlink() or not path.is_file() or path.suffix not in _LOG_FILE_SUFFIXES:
+            continue
+        resolved_path = path.resolve()
+        if resolved_path.is_relative_to(data_dir):
+            candidates.append(resolved_path)
+    return tuple(sorted(candidates))
 
 
 def _host_for_path(data_dir: Path, path: Path) -> str:

--- a/src/evidenceforge/external_parsers/sof_elk_sources.py
+++ b/src/evidenceforge/external_parsers/sof_elk_sources.py
@@ -282,6 +282,7 @@ def stage_source_logs(
     logs: list[StagedSourceLog] = []
     for source_name in spec.source_names:
         for source in sorted(source_root.rglob(source_name)):
+            _validate_stage_source(source_root, source)
             sensor = _source_name(source_root, source)
             source_year = _source_year(source) if spec.staged_directory == "syslog" else None
             if spec.staged_directory == "syslog" and source_year is not None:
@@ -307,6 +308,21 @@ def stage_source_logs(
         )
 
     return SofElkSourceManifest(spec=spec, logstash_root=logstash_root, logs=tuple(logs))
+
+
+def _validate_stage_source(source_root: Path, source: Path) -> None:
+    """Reject staged source paths that could escape the generated output tree."""
+    if source.is_symlink():
+        raise SofElkHarnessError(
+            f"refusing to stage symlinked external parser source file {source}; "
+            "copy generated log files into the data directory instead"
+        )
+    resolved_source = source.resolve()
+    if not resolved_source.is_relative_to(source_root):
+        raise SofElkHarnessError(
+            f"refusing to stage external parser source file {source}; "
+            f"resolved path {resolved_source} is outside generated output {source_root}"
+        )
 
 
 def build_sof_elk_source_configs(

--- a/tests/unit/test_external_parser_runner.py
+++ b/tests/unit/test_external_parser_runner.py
@@ -146,6 +146,21 @@ def test_default_target_syslog_family_logs_are_reported_as_wrong_target(
     }
 
 
+def test_detect_external_parser_plan_ignores_symlinked_supported_logs(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    write_output_target_marker(tmp_path, "sof-elk")
+    source_dir = data_dir / "linux-01.example.test" / "2026"
+    source_dir.mkdir(parents=True)
+    secret = tmp_path / "secret-readable-by-operator.txt"
+    secret.write_text("SECRET_CANARY_SYMLINK_COPY\n", encoding="utf-8")
+    (source_dir / "syslog.log").symlink_to(secret)
+
+    plan = detect_external_parser_plan(data_dir)
+
+    assert plan.validators == ()
+    assert plan.logs == ()
+
+
 def test_group_logs_for_progress_uses_host_logtype_subtype_levels(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     (data_dir / "sensor-a").mkdir(parents=True)

--- a/tests/unit/test_sof_elk_sources_harness.py
+++ b/tests/unit/test_sof_elk_sources_harness.py
@@ -45,6 +45,7 @@ from evidenceforge.external_parsers.sof_elk_sources import (
 )
 from evidenceforge.external_parsers.sof_elk_zeek import (
     FAILURE_REPORT_FILENAME,
+    SofElkHarnessError,
     SofElkParserError,
 )
 
@@ -101,6 +102,20 @@ def test_stage_source_logs_preserves_syslog_subdirectories(tmp_path: Path) -> No
     assert {log.staged.relative_to(manifest.logstash_root) for log in manifest.logs} == {
         Path("syslog/2026/linux-01.example.test/syslog.log")
     }
+
+
+def test_stage_source_logs_rejects_symlink_sources(tmp_path: Path) -> None:
+    source_root = tmp_path / "generated"
+    source_dir = source_root / "linux-01.example.test" / "2026"
+    source_dir.mkdir(parents=True)
+    secret = tmp_path / "secret-readable-by-operator.txt"
+    secret.write_text("SECRET_CANARY_SYMLINK_COPY\n", encoding="utf-8")
+    (source_dir / "syslog.log").symlink_to(secret)
+
+    with pytest.raises(SofElkHarnessError, match="refusing to stage symlinked"):
+        stage_source_logs(source_root, tmp_path / "stage", SYSLOG_SPEC)
+
+    assert not (tmp_path / "stage" / "logstash" / "syslog" / "2026").exists()
 
 
 def test_stage_source_logs_preserves_windows_snare_year_subdirectories(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The syslog SOF-ELK source path used a plain `shutil.copyfile(source, destination)` on files discovered with `rglob`, which follows symlinks on POSIX and allowed attacker-supplied `syslog.log` symlinks to cause out-of-tree file copies.
- Detection also resolved and used symlinked paths which could crash or misclassify a supplied data directory when a symlink pointed outside the `data/` tree.

### Description
- Added `_validate_stage_source(source_root, source)` and call it from `stage_source_logs` to reject symlinked source files and any resolved source path that is not contained under `source_root`, raising `SofElkHarnessError` on violation (prevents `shutil.copyfile` from following symlinks). (`src/evidenceforge/external_parsers/sof_elk_sources.py`)
- Hardened detection in `_add_detected_log` to skip symlink paths and to ignore resolved paths that are not under `data_dir`. (`src/evidenceforge/external_parsers/runner.py`)
- Tightened `_candidate_log_files` to skip symlinks and only return resolved candidate files that are contained inside the `data_dir`. (`src/evidenceforge/external_parsers/runner.py`)
- Added regression tests: `test_stage_source_logs_rejects_symlink_sources` and `test_detect_external_parser_plan_ignores_symlinked_supported_logs` to verify staging rejects symlinks and detection ignores them. (`tests/unit/test_sof_elk_sources_harness.py`, `tests/unit/test_external_parser_runner.py`)

### Testing
- Ran unit tests with `uv run pytest --no-cov tests/unit/test_sof_elk_sources_harness.py tests/unit/test_external_parser_runner.py` and all tests passed (`23 passed`).
- Ran linters/format checks with `uv run ruff check .` and `uv run ruff format --check .`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203106ea188325b90669a0b9a576bd)