### PR TITLE
fix: reject symlinked external parser source logs

### DIFF
--- a/src/evidenceforge/external_parsers/runner.py
+++ b/src/evidenceforge/external_parsers/runner.py
@@ -260,7 +260,7 @@ def _add_detected_log(
     validator: str | None,
     unsupported_reason: str | None = None,
 ) -> None:
-    path = path.resolve()
+    path = path.absolute()
     logs_by_path[path] = DetectedLog(
         path=path,
         host=_host_for_path(data_dir, path),
@@ -275,9 +275,9 @@ def _add_detected_log(
 def _candidate_log_files(data_dir: Path) -> tuple[Path, ...]:
     return tuple(
         sorted(
-            path.resolve()
+            path.absolute()
             for path in data_dir.rglob("*")
-            if path.is_file() and path.suffix in _LOG_FILE_SUFFIXES
+            if not path.is_symlink() and path.is_file() and path.suffix in _LOG_FILE_SUFFIXES
         )
     )
 

--- a/src/evidenceforge/external_parsers/sof_elk_sources.py
+++ b/src/evidenceforge/external_parsers/sof_elk_sources.py
@@ -25,8 +25,10 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
+import stat
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -282,6 +284,7 @@ def stage_source_logs(
     logs: list[StagedSourceLog] = []
     for source_name in spec.source_names:
         for source in sorted(source_root.rglob(source_name)):
+            _validate_source_log_path(source_root, source)
             sensor = _source_name(source_root, source)
             source_year = _source_year(source) if spec.staged_directory == "syslog" else None
             if spec.staged_directory == "syslog" and source_year is not None:
@@ -289,7 +292,7 @@ def stage_source_logs(
             else:
                 destination = source_stage_root / sensor / spec.staged_name
             destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(source, destination)
+            _copy_regular_source_file(source, destination)
             logs.append(
                 StagedSourceLog(
                     source=source,
@@ -307,6 +310,43 @@ def stage_source_logs(
         )
 
     return SofElkSourceManifest(spec=spec, logstash_root=logstash_root, logs=tuple(logs))
+
+
+def _validate_source_log_path(source_root: Path, source: Path) -> None:
+    """Validate that a staged source log is a regular file contained by the source root."""
+    if source.is_symlink():
+        raise SofElkHarnessError(
+            f"refusing to stage symlinked {source.name} outside generated output boundary: {source}"
+        )
+    try:
+        resolved_source = source.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise SofElkHarnessError(f"source log disappeared before staging: {source}") from exc
+    try:
+        resolved_source.relative_to(source_root)
+    except ValueError as exc:
+        raise SofElkHarnessError(
+            f"refusing to stage {source.name} outside generated output boundary: {source}"
+        ) from exc
+    if not resolved_source.is_file():
+        raise SofElkHarnessError(f"refusing to stage non-file source log: {source}")
+
+
+def _copy_regular_source_file(source: Path, destination: Path) -> None:
+    """Copy a regular source file without following a final-path symlink race."""
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    try:
+        source_fd = os.open(source, flags)
+    except OSError as exc:
+        raise SofElkHarnessError(f"failed to open source log for staging: {source}") from exc
+    with os.fdopen(source_fd, "rb") as source_file:
+        if not stat.S_ISREG(os.fstat(source_fd).st_mode):
+            raise SofElkHarnessError(f"refusing to stage non-regular source log: {source}")
+        with destination.open("wb") as destination_file:
+            shutil.copyfileobj(source_file, destination_file)
 
 
 def build_sof_elk_source_configs(

--- a/tests/unit/test_external_parser_runner.py
+++ b/tests/unit/test_external_parser_runner.py
@@ -118,6 +118,23 @@ def test_detect_external_parser_plan_selects_zeek_validator_and_warns_unsupporte
     }
 
 
+def test_detect_external_parser_plan_keeps_symlink_logs_within_reported_data_path(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "data"
+    source_dir = data_dir / "fw-01.example.test"
+    source_dir.mkdir(parents=True)
+    secret = tmp_path / "operator_secret.txt"
+    secret.write_text("SECRET_CANARY_EFORGE_SYMLINK_LEAK\n", encoding="utf-8")
+    (source_dir / "cisco_asa.log").symlink_to(secret)
+
+    plan = detect_external_parser_plan(data_dir)
+
+    assert len(plan.logs) == 1
+    assert plan.logs[0].path == (source_dir / "cisco_asa.log").absolute()
+    assert plan.logs[0].host == "fw-01.example.test"
+
+
 def test_default_target_syslog_family_logs_are_reported_as_wrong_target(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_sof_elk_sources_harness.py
+++ b/tests/unit/test_sof_elk_sources_harness.py
@@ -45,6 +45,7 @@ from evidenceforge.external_parsers.sof_elk_sources import (
 )
 from evidenceforge.external_parsers.sof_elk_zeek import (
     FAILURE_REPORT_FILENAME,
+    SofElkHarnessError,
     SofElkParserError,
 )
 
@@ -65,6 +66,22 @@ def test_stage_source_logs_preserves_sensor_subdirectories(tmp_path: Path) -> No
     assert {log.staged.relative_to(manifest.logstash_root) for log in manifest.logs} == {
         Path("syslog/2026/fw-01.example.test/cisco_asa.log")
     }
+
+
+def test_stage_source_logs_rejects_symlinked_source_files(tmp_path: Path) -> None:
+    source_root = tmp_path / "generated"
+    source_dir = source_root / "fw-01.example.test" / "2026"
+    source_dir.mkdir(parents=True)
+    secret = tmp_path / "operator_secret.txt"
+    secret.write_text("SECRET_CANARY_EFORGE_SYMLINK_LEAK\n", encoding="utf-8")
+    symlink = source_dir / "cisco_asa.log"
+    symlink.symlink_to(secret)
+    stage_root = tmp_path / "stage"
+
+    with pytest.raises(SofElkHarnessError, match="refusing to stage symlinked"):
+        stage_source_logs(source_root, stage_root, CISCO_ASA_SPEC)
+
+    assert not list(stage_root.rglob("cisco_asa.log"))
 
 
 def test_stage_source_logs_preserves_web_access_subdirectories(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent staging from following attacker-controlled symlinks (e.g., `cisco_asa.log`) that could copy files outside the supplied generated-data directory and leak operator-readable files into parser artifacts.

### Description
- Validate discovered source files before staging by adding `_validate_source_log_path()` which rejects symlinks, non-files, or resolved paths outside `source_root` and raises `SofElkHarnessError` on violations (changed `src/evidenceforge/external_parsers/sof_elk_sources.py`).
- Replace `shutil.copyfile(source, destination)` with `_copy_regular_source_file()` that opens the source with `O_NOFOLLOW` where available and copies via an opened file descriptor to avoid following final-path symlink races (changed `src/evidenceforge/external_parsers/sof_elk_sources.py`).
- Keep discovery/reporting anchored to the generated data directory by avoiding resolution when recording detected paths and by skipping symlink entries in candidate-file discovery; use `path.absolute()` and filter out `path.is_symlink()` in `_candidate_log_files` / `_add_detected_log` (changed `src/evidenceforge/external_parsers/runner.py`).
- Add regression tests for both behaviors: `test_stage_source_logs_rejects_symlinked_source_files` and `test_detect_external_parser_plan_keeps_symlink_logs_within_reported_data_path` (changed `tests/unit/test_sof_elk_sources_harness.py` and `tests/unit/test_external_parser_runner.py`).

### Testing
- Ran targeted unit tests reproducing the issue: `uv run pytest --no-cov tests/unit/test_sof_elk_sources_harness.py::test_stage_source_logs_rejects_symlinked_source_files tests/unit/test_external_parser_runner.py::test_detect_external_parser_plan_keeps_symlink_logs_within_reported_data_path`, and both tests passed.
- Ran the full affected test modules `uv run pytest --no-cov tests/unit/test_sof_elk_sources_harness.py tests/unit/test_external_parser_runner.py`, and the suite passed (23 passed in ~0.33s).
- Ran lint/format checks `uv run ruff check .` and `uv run ruff format --check .`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20310622388325bf95fa86da985610)