### PR TITLE
fix: skip out-of-tree external parser logs

### DIFF
--- a/src/evidenceforge/external_parsers/runner.py
+++ b/src/evidenceforge/external_parsers/runner.py
@@ -260,10 +260,13 @@ def _add_detected_log(
     validator: str | None,
     unsupported_reason: str | None = None,
 ) -> None:
-    path = path.resolve()
-    logs_by_path[path] = DetectedLog(
-        path=path,
-        host=_host_for_path(data_dir, path),
+    resolved_path = _resolve_log_file_in_data_dir(data_dir, path)
+    if resolved_path is None:
+        return
+
+    logs_by_path[resolved_path] = DetectedLog(
+        path=resolved_path,
+        host=_host_for_path(data_dir, resolved_path),
         logtype=logtype,
         subtype=subtype,
         format_name=format_name,
@@ -273,13 +276,23 @@ def _add_detected_log(
 
 
 def _candidate_log_files(data_dir: Path) -> tuple[Path, ...]:
-    return tuple(
-        sorted(
-            path.resolve()
-            for path in data_dir.rglob("*")
-            if path.is_file() and path.suffix in _LOG_FILE_SUFFIXES
-        )
-    )
+    candidates: list[Path] = []
+    for path in data_dir.rglob("*"):
+        if path.suffix not in _LOG_FILE_SUFFIXES or not path.is_file():
+            continue
+        resolved_path = _resolve_log_file_in_data_dir(data_dir, path)
+        if resolved_path is not None:
+            candidates.append(resolved_path)
+    return tuple(sorted(candidates))
+
+
+def _resolve_log_file_in_data_dir(data_dir: Path, path: Path) -> Path | None:
+    resolved_path = path.resolve()
+    try:
+        resolved_path.relative_to(data_dir)
+    except ValueError:
+        return None
+    return resolved_path
 
 
 def _host_for_path(data_dir: Path, path: Path) -> str:

--- a/tests/unit/test_external_parser_runner.py
+++ b/tests/unit/test_external_parser_runner.py
@@ -172,3 +172,33 @@ def test_detect_external_parser_plan_reports_unknown_log_files(tmp_path: Path) -
 
     assert plan.validators == ()
     assert unsupported_summary(plan.unsupported_logs) == {"unknown": ["mystery.log"]}
+
+
+def test_detect_external_parser_plan_skips_symlinked_logs_outside_data_dir(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    outside_log = tmp_path / "outside.log"
+    outside_log.write_text("secret\n", encoding="utf-8")
+    (data_dir / "mystery.log").symlink_to(outside_log)
+
+    plan = detect_external_parser_plan(data_dir)
+
+    assert plan.validators == ()
+    assert plan.logs == ()
+
+
+def test_detect_external_parser_plan_skips_named_symlinked_logs_outside_data_dir(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    outside_log = tmp_path / "outside.log"
+    outside_log.write_text("secret\n", encoding="utf-8")
+    (data_dir / "conn.json").symlink_to(outside_log)
+
+    plan = detect_external_parser_plan(data_dir)
+
+    assert plan.validators == ()
+    assert plan.logs == ()


### PR DESCRIPTION
### Motivation

- Automatic external-parser discovery resolved symlink targets and could pass paths outside the supplied `data_dir` into `_host_for_path`, which raised an uncaught `ValueError` and aborted validation.

### Description

- Add `_resolve_log_file_in_data_dir(data_dir, path)` that resolves a path and rejects it if the resolved target is not contained under `data_dir`.
- Update `_candidate_log_files` to only return resolved candidates that pass the containment check instead of blindly returning `path.resolve()` results.
- Update `_add_detected_log` to use the containment helper and skip discovered files whose resolved target is outside `data_dir`.
- Add regression tests `test_detect_external_parser_plan_skips_symlinked_logs_outside_data_dir` and `test_detect_external_parser_plan_skips_named_symlinked_logs_outside_data_dir` to cover symlinked files pointing outside the data directory.

### Testing

- Ran `uv run pytest --no-cov tests/unit/test_external_parser_runner.py` and the test file passed (6 passed). 
- Ran linter/format checks with `uv run ruff check .` and `uv run ruff format --check .` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203106bf248325a1ee1577e52ac50f)