### PR TITLE
fix: reject Linux-only spillage surfaces on any non-Linux host

### DIFF
--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -1235,19 +1235,21 @@ class ScenarioValidator:
                     continue
                 field_path = f"storyline.{idx}.events.{spec_idx}"
 
-                # shell_history/syslog are Linux-modeled; emitting them on Windows
-                # would silently drop the credential while still labeling it in
-                # ground truth — a phantom positive — so this is a hard error.
-                # (process_command_line is cross-OS, so it is exempt.)
-                if os_cat == "windows" and spec.surface in LINUX_ONLY_SURFACES:
+                # shell_history/syslog are Linux-modeled; emitting them on any non-Linux
+                # host (Windows OR an unknown OS such as macOS/BSD/Solaris) would silently
+                # drop the credential while still labeling it in ground truth — a phantom
+                # positive — so this is a hard error. The emitter only handles linux, so
+                # gate on != "linux", not == "windows". (process_command_line is cross-OS,
+                # so it is exempt.)
+                if os_cat != "linux" and spec.surface in LINUX_ONLY_SURFACES:
                     self.issues.append(
                         ValidationIssue(
                             severity="error",
                             field_path=field_path,
                             message=(
                                 f"[{event.id}] Spillage surface '{spec.surface}' is "
-                                f"Linux-modeled but system '{event.system}' is windows; the "
-                                "credential would not be emitted"
+                                f"Linux-modeled but system '{event.system}' is not Linux "
+                                f"(detected: {os_cat}); the credential would not be emitted"
                             ),
                             suggestion="Target a Linux host for this spillage surface",
                         )

--- a/tests/integration/test_spillage_generation.py
+++ b/tests/integration/test_spillage_generation.py
@@ -1131,6 +1131,27 @@ class TestSpillageValidation:
         )
         assert any("needs output format 'bash_history'" in m for m in errs)
 
+    @pytest.mark.parametrize("actor_os", ["macOS 14", "FreeBSD 14", "Windows 10"])
+    def test_linux_only_surface_on_non_linux_host_rejected(self, actor_os):
+        # Regression: the Linux-only-surface gate must reject ANY non-Linux host (Windows OR
+        # an unknown OS such as macOS/BSD), not just Windows — else shell_history/syslog on a
+        # macOS/BSD actor validates clean but is dropped at emit (a phantom positive). A Linux
+        # host is present so the bash_history format has a valid home.
+        scenario = _linux_scenario(
+            [{"type": "spillage", "surface": "shell_history", "family": "aws_iam"}],
+            actor_os=actor_os,
+        )
+        scenario["environment"]["systems"].append(
+            {
+                "hostname": "LIN-AUX",
+                "ip": "192.168.20.99",
+                "os": "Ubuntu 22.04 LTS",
+                "type": "server",
+            }
+        )
+        msgs = _errors(scenario)
+        assert any("Linux-modeled" in m and "not Linux" in m for m in msgs), (actor_os, msgs)
+
     def test_noninteractive_actor_is_error(self):
         errs = _errors(
             _linux_scenario(


### PR DESCRIPTION
## Summary

The `spillage` validator (added in #289) has a latent phantom-positive bug — the same one I hit while hardening the sibling `adversarial_payload` validator in #296. The Linux-only-surface check gates on `os_cat == "windows"`, but `_get_os_category` returns `windows` / `linux` / **`unknown`**.

As a result, a `shell_history` or `syslog_message` spill placed on a host whose OS is neither Windows nor Linux — e.g. macOS, FreeBSD, Solaris, AIX (all classified `unknown`) — passes `eforge validate` cleanly, yet the emitter (which only models `linux`) silently drops it at generation. The outcome is a **ground-truthed-but-never-emitted label**: `GROUND_TRUTH` claims the credential is present, but it never lands on disk — a guaranteed false positive for any scrubber/DLP scored against the dataset, with no signal to the author that anything went wrong.

## Fix

Gate the check on `os_cat != "linux"` (the emitter only models `linux`) and report the detected OS category in the error message. `eforge generate` already aborts on a validation error, so the phantom positive is blocked end to end.

## Notes

- Found while addressing the review on #296; split into this standalone PR so the fix to already-released code can ship independently of that larger feature.
- Regression test added in `tests/integration/test_spillage_generation.py`, parametrized over macOS / FreeBSD / Windows.
- `uv run pytest --no-cov`, `ruff check`, and `ruff format --check` all pass.
