### PR TITLE
fix: align web emitter role matching

### DIFF
--- a/src/evidenceforge/generation/emitters/web.py
+++ b/src/evidenceforge/generation/emitters/web.py
@@ -30,6 +30,7 @@ from urllib.parse import urlsplit
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.generation.activity.web_session_profiles import escape_log_control_chars
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
+from evidenceforge.generation.spillage import web_server_supported_schemes
 from evidenceforge.output_targets import OutputTarget
 
 
@@ -139,7 +140,7 @@ class WebEmitter(HostMultiplexEmitter):
             event.event_type in self._supported_types
             and event.http is not None
             and event.dst_host is not None
-            and "web_server" in event.dst_host.roles
+            and bool(web_server_supported_schemes(event.dst_host))
         )
 
     def emit(self, event: SecurityEvent) -> None:

--- a/tests/integration/test_spillage_generation.py
+++ b/tests/integration/test_spillage_generation.py
@@ -403,6 +403,20 @@ class TestSpillageAccuracy:
             for row in ecar_rows
         )
 
+    def test_http_spillage_with_normalized_web_server_role_lands_on_disk(self, tmp_path):
+        scenario = _linux_scenario(
+            [{"type": "spillage", "surface": "http_request_url", "family": "gcp_api_key"}],
+            logs=[{"format": "web_access"}],
+            web_server=True,
+            web_server_roles=["web-server"],
+        )
+        out = _generate(scenario, tmp_path / "out")
+        rec = next(r for r in _records(out) if r["surface"] == "http_request_url")
+        web = "\n".join(p.read_text() for p in out.rglob("web_access.log"))
+
+        assert rec["expected_sources"] == ["web_access"]
+        assert rec["rendered_value"] in web
+
     def test_db_uri_through_http_url_is_percent_encoded_on_disk(self, tmp_path):
         # db_uri is the heaviest-encoding family (:// @ : /). Through http_request_url
         # the on-disk form must be percent-encoded and the raw value absent unencoded.
@@ -1028,6 +1042,7 @@ def _linux_scenario(
     actor_os="Ubuntu 22.04 LTS",
     web_server_hostname="WEB-01",
     web_server_services=None,
+    web_server_roles=None,
     network=None,
 ):
     logs = logs or [{"format": "bash_history"}, {"format": "syslog"}, {"format": "ecar"}]
@@ -1047,7 +1062,7 @@ def _linux_scenario(
                 "ip": "192.168.20.40",
                 "os": "Ubuntu 22.04 LTS",
                 "type": "server",
-                "roles": ["web_server"],
+                "roles": web_server_roles or ["web_server"],
                 "services": web_server_services or [],
             }
         )

--- a/tests/unit/test_web_emitter.py
+++ b/tests/unit/test_web_emitter.py
@@ -92,6 +92,11 @@ class TestWebEmitterCanHandle:
         event = _make_event(dst_host=host, http=_HTTP)
         assert emitter.can_handle(event) is True
 
+    def test_normalized_web_server_role_accepted(self, emitter):
+        host = _make_host("server", ["web-server"])
+        event = _make_event(dst_host=host, http=_HTTP)
+        assert emitter.can_handle(event) is True
+
     def test_workstation_no_role_rejected(self, emitter):
         """Regression: WSUS→workstation HTTP (port 8530) must not emit web_access."""
         host = _make_host("workstation", [])


### PR DESCRIPTION
### Motivation
- Fix a validation/emit mismatch where spillage validation and target selection accepted normalized role spellings (e.g. `web-server`) but the `WebEmitter` only accepted the literal `web_server`, causing phantom ground-truth spillage records that did not appear in `web_access.log`.

### Description
- Updated `WebEmitter.can_handle()` to use `web_server_supported_schemes(event.dst_host)` for role/scheme detection instead of checking for the literal `"web_server"` role so emitter acceptance matches validation and selection logic (`src/evidenceforge/generation/emitters/web.py`).
- Imported the helper from `src/evidenceforge/generation/spillage.py` to keep role normalization centralized.
- Added a unit test to cover normalized role spellings (`tests/unit/test_web_emitter.py`).
- Added an integration test and extended the test scenario helper to validate that HTTP spillage with a normalized `web-server` role writes the credential into `web_access.log` and preserves `expected_sources` (`tests/integration/test_spillage_generation.py`).

### Testing
- Ran the unit and integration tests using `PYTHONPATH=src uv run python -m pytest --no-cov tests/unit/test_web_emitter.py tests/unit/test_spillage.py tests/integration/test_spillage_generation.py::TestSpillageAccuracy::test_http_spillage_with_normalized_web_server_role_lands_on_disk -q` and observed all tests pass (total test suite run later: `159 passed`).
- Ran style checks with `PYTHONPATH=src uv run ruff check .` and `PYTHONPATH=src uv run ruff format --check .` which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e41f8304832593997ed7b4f95f13)