### PR TITLE
fix: tolerate malformed Splunk request URLs

### DIFF
--- a/src/evidenceforge/generation/emitters/proxy.py
+++ b/src/evidenceforge/generation/emitters/proxy.py
@@ -133,10 +133,16 @@ def _proxy_url_parts(
             "",
         )
 
-    parsed = urlsplit(url or "/")
-    server = parsed.hostname or host
-    if parsed.port is not None:
-        dest_port = parsed.port
+    request_url = url or "/"
+    try:
+        parsed = urlsplit(request_url)
+        server = parsed.hostname or host
+        parsed_port = parsed.port
+    except ValueError:
+        return host, fallback_port, request_url or "/", ""
+
+    if parsed_port is not None:
+        dest_port = parsed_port
     elif parsed.scheme.lower() == "https":
         dest_port = 443
     elif parsed.scheme.lower() == "http":

--- a/src/evidenceforge/generation/emitters/web.py
+++ b/src/evidenceforge/generation/emitters/web.py
@@ -62,7 +62,10 @@ def _splunk_json_timestamp(value: datetime | str | None) -> str:
 def _split_uri_for_apache_json(uri: str | None) -> tuple[str, str]:
     """Split a request target into Apache TA JSON path and query fields."""
     request_uri = uri or "/"
-    parsed = urlsplit(request_uri)
+    try:
+        parsed = urlsplit(request_uri)
+    except ValueError:
+        return request_uri or "/", ""
     if parsed.scheme or parsed.netloc:
         path = parsed.path or "/"
     else:

--- a/tests/unit/test_proxy_referrer.py
+++ b/tests/unit/test_proxy_referrer.py
@@ -413,6 +413,21 @@ class TestProxyActionSemantics:
         assert inspected["response_time_microseconds"] == 23000
         assert inspected["url_category"] == "Software/Updates"
 
+    def test_splunk_url_parts_falls_back_for_malformed_url(self):
+        from evidenceforge.generation.emitters.proxy import _proxy_url_parts
+
+        server, dest_port, uri_path, uri_query = _proxy_url_parts(
+            method="GET",
+            url="https://example.test:notaport/download?q=1",
+            host="example.test",
+            fallback_port=443,
+        )
+
+        assert server == "example.test"
+        assert dest_port == 443
+        assert uri_path == "https://example.test:notaport/download?q=1"
+        assert uri_query == ""
+
     def test_connect_setup_row_differs_from_inspected_request_accounting(self):
         from pathlib import Path
 

--- a/tests/unit/test_web_emitter.py
+++ b/tests/unit/test_web_emitter.py
@@ -30,7 +30,7 @@ import pytest
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext, HttpContext, NetworkContext
 from evidenceforge.formats import load_format
-from evidenceforge.generation.emitters.web import WebEmitter
+from evidenceforge.generation.emitters.web import WebEmitter, _split_uri_for_apache_json
 
 
 def _make_host(system_type: str, roles: list[str]) -> HostContext:
@@ -189,6 +189,13 @@ class TestWebEmitterCanHandle:
         assert record["bytes_out"] == 512
         assert record["response_time_microseconds"] == 23000
         assert record["http_content_type"] == "text/html"
+
+    def test_splunk_uri_splitter_preserves_malformed_uri_as_fallback(self):
+        """Malformed absolute URIs should not abort Splunk web rendering."""
+        path, query = _split_uri_for_apache_json("http://[not-an-ipv6]/index.html?q=1")
+
+        assert path == "http://[not-an-ipv6]/index.html?q=1"
+        assert query == ""
 
     def test_combined_log_quoted_fields_are_escaped(self, emitter):
         """Referer and User-Agent quotes should not break combined-log fields."""


### PR DESCRIPTION
### Motivation
- The Splunk Apache-JSON renderers called `urllib.parse.urlsplit()` on scenario- or raw-event-controlled URI/URL fields without catching `ValueError`, allowing malformed request targets (invalid bracketed IPv6, non-numeric ports) to abort generation.
- The goal is to make Splunk rendering robust to attacker-controlled or malformed `uri`/`url` values by producing a safe fallback record instead of raising.

### Description
- In `src/evidenceforge/generation/emitters/web.py` the helper ` _split_uri_for_apache_json()` now wraps `urlsplit()` in a `try/except ValueError` and returns the original request-target (and empty query) as a safe fallback when parsing fails.
- In `src/evidenceforge/generation/emitters/proxy.py` the `_proxy_url_parts()` helper now validates `urlsplit()` in a `try/except ValueError` path and falls back to `(host, fallback_port, original_url, "")` when the URL/authority is malformed, avoiding accidental access to `ParseResult.port` that can raise.
- Added targeted regression tests: `test_splunk_uri_splitter_preserves_malformed_uri_as_fallback` and `test_splunk_url_parts_falls_back_for_malformed_url` to cover malformed absolute URIs and non-numeric ports while preserving existing behavior.

### Testing
- Ran unit tests: `uv run --extra dev pytest --no-cov tests/unit/test_web_emitter.py tests/unit/test_proxy_referrer.py`, all tests passed (`31 passed`).
- Ran linter/format checks: `uv run --extra dev ruff check .` and `uv run --extra dev ruff format --check .`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e57715f48325aed4be107efef371)