### PR TITLE
fix: harden storyline shell friction templates

### DIFF
--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -38,6 +38,7 @@ import math
 import random
 import re
 import shlex
+import string
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -74,6 +75,7 @@ from evidenceforge.utils.time import parse_duration, parse_iso8601
 logger = logging.getLogger(__name__)
 
 _MAX_EMBEDDED_COMMAND_B64_CHARS = 16_384
+_STORYLINE_SHELL_TEMPLATE_FORMATTER = string.Formatter()
 _IPV4_LITERAL_RE = re.compile(r"\d{1,3}(?:\.\d{1,3}){3}")
 _NET_USER_ADD_WITH_PASSWORD_RE = re.compile(
     r"\bnet1?\s+user\s+(?P<username>\S+)\s+(?P<password>\S+)\s+/add\b",
@@ -162,23 +164,36 @@ def _storyline_shell_friction_pool(name: str) -> list[str]:
     return [item for item in raw if isinstance(item, str) and item.strip()]
 
 
-class _StorylineShellTemplateValues(dict[str, str]):
-    """Leave unknown placeholders visible so invalid templates can be skipped."""
-
-    def __missing__(self, key: str) -> str:
-        return "{" + key + "}"
-
-
 def _render_storyline_shell_friction_template(
     template: str,
     values: dict[str, str],
 ) -> str | None:
-    """Render one shell-friction template if all placeholders are known."""
-    rendered = template.format_map(_StorylineShellTemplateValues(values))
-    if re.search(r"{[^{}]+}", rendered):
+    """Render one shell-friction template if all placeholders are known and safe.
+
+    Shell-friction templates can come from project-local configuration overlays, so
+    keep this renderer to a small literal-plus-placeholder language. Rejecting
+    Python format conversions/specifiers prevents malformed or hostile overlay
+    entries from crashing generation or requesting excessive output widths.
+    """
+    try:
+        parsed = list(_STORYLINE_SHELL_TEMPLATE_FORMATTER.parse(template))
+    except ValueError:
         return None
-    rendered = re.sub(r"\s+", " ", rendered).strip()
-    return rendered or None
+
+    rendered: list[str] = []
+    for literal_text, field_name, format_spec, conversion in parsed:
+        rendered.append(literal_text)
+        if field_name is None:
+            continue
+        if field_name not in values or conversion is not None or format_spec:
+            return None
+        rendered.append(values[field_name])
+
+    rendered_text = "".join(rendered)
+    if re.search(r"{[^{}]+}", rendered_text):
+        return None
+    rendered_text = re.sub(r"\s+", " ", rendered_text).strip()
+    return rendered_text or None
 
 
 def _linux_storyline_shell_friction_commands(

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -24,6 +24,8 @@ from evidenceforge.generation.engine.storyline import (
     StorylineMixin,
     _estimate_process_lifetime,
     _linux_shell_process_command_line,
+    _linux_storyline_shell_friction_commands,
+    _render_storyline_shell_friction_template,
 )
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
@@ -31,6 +33,58 @@ from evidenceforge.models.scenario import BeaconEventSpec, ConnectionEventSpec, 
 
 
 class TestStorylineCommandNetworks:
+    def test_storyline_shell_friction_renderer_rejects_unsafe_formatting(self):
+        """Overlay-controlled shell-friction templates should not use Python format specs."""
+        values = {
+            "database": "appdb",
+            "directory": "/tmp",
+            "path": "/tmp/appdb.sql",
+            "output_path": "/tmp/appdb.sql",
+        }
+
+        assert (
+            _render_storyline_shell_friction_template("test -w {directory}", values)
+            == "test -w /tmp"
+        )
+        for template in (
+            "{path!x}",
+            "{path:1000000000}",
+            "{path.__class__}",
+            "{missing}",
+            "{path",
+        ):
+            assert _render_storyline_shell_friction_template(template, values) is None
+
+    def test_linux_storyline_shell_friction_skips_unsafe_overlay_templates(self, monkeypatch):
+        """Unsafe project-overlay shell-friction templates should be ignored, not raised."""
+        from evidenceforge.generation.activity import bash_commands
+
+        monkeypatch.setattr(
+            bash_commands,
+            "load_bash_commands",
+            lambda: {
+                "storyline_friction": {
+                    "common_probe": ["echo {path}"],
+                    "before_database_dump": [
+                        "{path!x}",
+                        "{path:1000000000}",
+                        "{path.__class__}",
+                        "test -s {output_path}",
+                    ],
+                }
+            },
+        )
+
+        commands = _linux_storyline_shell_friction_commands(
+            username="root",
+            process_name="mysqldump",
+            command_line="mysqldump appdb > /tmp/appdb.sql",
+            output_file="/tmp/appdb.sql",
+            rng=random.Random(1),
+        )
+
+        assert commands == ["echo /tmp/appdb.sql", "test -s /tmp/appdb.sql"]
+
     def test_explicit_storyline_process_ref_sets_child_parent_pid(self):
         """Explicit process_ref/parent_ref lineage should reach canonical process context."""
         captured: list[Any] = []


### PR DESCRIPTION
### Motivation
- Project-local overlays can supply `storyline_friction` templates that were being rendered with unrestricted `str.format_map()`, which allows conversion flags and format specs that can raise `ValueError` or request enormous allocations and thus abort local generation runs.

### Description
- Replace unrestricted formatting with a tiny safe renderer using `string.Formatter().parse()` that only accepts literal text plus explicit placeholders, and rejects conversion flags, format specifiers, unknown fields, and malformed braces.  
- Implement `_STORYLINE_SHELL_TEMPLATE_FORMATTER` and use it in `_render_storyline_shell_friction_template()` to build the output from parsed pieces instead of calling `format_map()`.  
- Skip/ignore unsafe templates during pool rendering so overlay-controlled bad entries do not raise during generation.  
- Add unit tests that exercise the renderer directly and ensure overlay-provided pools with hostile templates are ignored rather than raising.

### Testing
- Ran the focused unit tests with `PYTHONPATH=src uv run pytest --no-cov tests/unit/test_storyline_command_networks.py -k shell_friction` and both new tests passed.  
- Ran lint/format checks with `uv run ruff check .` and `uv run ruff format --check .` and fixed import ordering issues; checks passed.  
- Verified that unsafe templates such as `"{path!x}"`, `"{path:1000000000}"`, and attribute access patterns are rejected by the new renderer and do not abort the storyline shell-friction emission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e57779488325aa2d19162c7c5e17)