### PR TITLE
fix: avoid orphan Linux logons for dropped bash commands

### DIFF
--- a/src/evidenceforge/generation/actions/linux_shell_command.py
+++ b/src/evidenceforge/generation/actions/linux_shell_command.py
@@ -162,13 +162,6 @@ class LinuxShellCommandActionBundle:
             return None
 
         command = self._executor._prepare_bash_history_command(self._request.system, command)
-        if self._request.emit_process_telemetry:
-            self._executor._prepare_bash_process_session(
-                self._request.user,
-                self._request.system,
-                self._request.time,
-                command,
-            )
         scheduled_time = self._executor._schedule_bash_history_time(
             self._request.user,
             self._request.system,
@@ -179,6 +172,13 @@ class LinuxShellCommandActionBundle:
             return None
         if not self._executor._is_within_scenario_window(scheduled_time):
             return None
+        if self._request.emit_process_telemetry:
+            self._executor._prepare_bash_process_session(
+                self._request.user,
+                self._request.system,
+                scheduled_time,
+                command,
+            )
         self._executor._emit_bash_command_event(
             self._request.user,
             self._request.system,

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -8056,6 +8056,48 @@ class TestActivityGenerator:
         assert process_events[-1].process.image == "/usr/bin/git"
         assert process_events[-1].process.parent_pid == shell_events[-1].process.pid
 
+    def test_dropped_workstation_bash_command_does_not_bootstrap_local_session(
+        self, activity_gen, test_user, state_manager, mock_emitters
+    ):
+        """Rejected Linux workstation shell commands should not leave orphan logon evidence."""
+        scenario_end = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        linux = System(
+            hostname="WS-LNGUYEN-01",
+            ip="10.0.0.2",
+            os="Ubuntu 22.04",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        activity_gen._scenario_start_time = scenario_end - timedelta(minutes=30)
+        activity_gen._scenario_end_time = scenario_end
+        state_manager.set_current_time(scenario_end - timedelta(minutes=30))
+        systemd_pid = state_manager.create_process(
+            linux.hostname,
+            0,
+            "/usr/lib/systemd/systemd",
+            "/usr/lib/systemd/systemd --system",
+            "root",
+            "System",
+        )
+        activity_gen._system_pids = {linux.hostname: {"systemd": systemd_pid}}
+
+        scheduled = activity_gen.generate_bash_command(test_user, linux, scenario_end, "git status")
+
+        assert scheduled is None
+        assert [
+            session
+            for session in state_manager.get_sessions_for_user(test_user.username)
+            if session.system == linux.hostname
+        ] == []
+        emitted_events = [
+            call.args[0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+        ]
+        assert not [
+            event
+            for event in emitted_events
+            if event.event_type in {"logon", "process_create", "bash_command"}
+        ]
+
     def test_generate_bash_command_serializes_foreground_children(
         self, activity_gen, test_user, state_manager, mock_emitters
     ):


### PR DESCRIPTION
### Motivation
- Prevent generation of orphan local Linux `logon`/session evidence when a bash-history command is later dropped due to scheduling or scenario-window bounds. 
- The previous flow prepared a bootstrap session (which can call `generate_logon()`) before confirming the bash-history would actually be emitted, causing dataset integrity issues for commands near or past the scenario end.

### Description
- Defer preparatory session creation by moving the call to `self._executor._prepare_bash_process_session(...)` until after `scheduled_time` is computed and validated by `_is_within_scenario_window` in `LinuxShellCommandActionBundle.execute()` in `src/evidenceforge/generation/actions/linux_shell_command.py`.
- Remove the earlier preparatory invocation that ran before scheduling, ensuring `generate_logon()` side effects do not occur for commands that will not be emitted.
- Add a regression test `test_dropped_workstation_bash_command_does_not_bootstrap_local_session` to `tests/unit/test_activity.py` that asserts a command requested at the exclusive scenario end returns `None` and does not create `logon`, `process_create`, or `bash_command` events.

### Testing
- Ran the focused unit tests with `uv run pytest --no-cov tests/unit/test_activity.py -k 'workstation_bash_command or dropped_workstation_bash_command'` and both selected tests passed.
- Ran lint/format checks with `uv run ruff check .` and `uv run ruff format --check .` and they passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e5781a9c8325a52ade6cd2e97b68)