### PR TITLE
Release EvidenceForge 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Detailed development history for the EvidenceForge project. Transferred from TOD
 
 ## Unreleased
 
+## v1.4.1 (2026-06-18)
+
+This patch release captures the accepted assessment-loop realism fixes queued on
+`dev` after `v1.4.0`. The work improves blind-review realism signals while
+preserving the public generation interface.
+
+**Assessment-loop realism improvements**
+
+- Added coherent collection-imperfection handling across Zeek sibling rows:
+  source-observation format missingness now promotes required same-sensor parent
+  rows and prunes HTTP/SSL reference vectors when dependent files or X.509 rows
+  are absent (`14dccc2f`).
+- Improved source-native web, proxy, eCAR, Linux, Zeek file-analysis, and NTP
+  texture, including cache-buster entropy, host-specific root response sizing,
+  actor-linked eCAR FLOW principals, realistic polkit process start ticks,
+  incomplete Zeek file-analysis rows, NTP precision/poll/cadence/metric
+  semantics, and Linux compound-command process rendering (`14dccc2f`).
+- Added focused regression coverage for the new observation, rendering,
+  lifecycle, and configuration contracts, and recorded the assessment-loop
+  handoff in the tracked worklog (`14dccc2f`).
+
 ## v1.4.0 (2026-06-17)
 
 This release integrates the accepted Codex hardening fixes queued on `dev`, the

--- a/docs/external-parser-validation/README.md
+++ b/docs/external-parser-validation/README.md
@@ -65,7 +65,9 @@ Splunk CIM validation is controlled with `--cim auto|require|off`. The default
 more local apps are supplied with repeatable `--splunk-app <path>`. `require`
 fails early without supplied apps. EvidenceForge never vendors or downloads
 Splunkbase apps; supplied app directories or archives are copied/unpacked only
-into the ephemeral run work directory.
+into the ephemeral run work directory. See
+[the Splunk output-target guide](../output-targets/splunk.md#required-splunk-apps-for-cim-validation)
+for the required CIM app and TA download pages.
 
 Run the contributor smoke lane when changing emitted formats covered by this
 pipeline:

--- a/docs/external-parser-validation/splunk-harness.md
+++ b/docs/external-parser-validation/splunk-harness.md
@@ -93,10 +93,12 @@ are copied or unpacked only into `<work-dir>/splunk/runtime-config-src/` for the
 run. EvidenceForge does not download, commit, or redistribute those apps.
 
 For current CIM smoke coverage, provide the Splunk Common Information Model app
-plus local TA archives/directories for the source families under test, such as
-Microsoft Windows, Sysmon, Unix/Linux, Cisco ASA, Zeek, and Apache Web Server.
-Proxy and eCAR currently rely on EvidenceForge-owned base validation rather than
-third-party CIM TA mapping.
+plus local TA archives/directories for the source families under test: Microsoft
+Windows, Sysmon, Cisco ASA, Zeek, and Apache Web Server. The canonical download
+page list lives in
+[docs/output-targets/splunk.md](../output-targets/splunk.md#required-splunk-apps-for-cim-validation).
+Linux syslog and eCAR currently rely on EvidenceForge-owned base validation
+rather than third-party CIM TA mapping.
 
 ## Validation And Artifacts
 

--- a/docs/output-targets/splunk.md
+++ b/docs/output-targets/splunk.md
@@ -27,6 +27,28 @@ needs a different shape.
 No binary EVTX is generated in v1. The Linux Docker harness validates Windows
 Event XML file ingest instead.
 
+## Required Splunk Apps For CIM Validation
+
+EvidenceForge does not vendor, download, or redistribute Splunkbase apps. To run
+`--cim require`, download the needed apps from Splunkbase yourself, then pass the
+local app directories or archives with repeated `--splunk-app <path>` arguments.
+Splunkbase may require login before it allows archive downloads.
+
+The current CIM dataset checks cover Windows Security authentication, Sysmon
+process lifecycle, Zeek network/web records, Cisco ASA network traffic, web
+access, and proxy access. Linux syslog and eCAR receive base Splunk
+ingest/field validation only, so the Splunk Add-on for Unix and Linux is not
+required by the current CIM checks.
+
+| Validation area | Splunk app/add-on | Download page |
+| --- | --- | --- |
+| CIM data models | Splunk Common Information Model (CIM) | <https://splunkbase.splunk.com/app/1621> |
+| Windows Security | Splunk Add-on for Microsoft Windows | <https://splunkbase.splunk.com/app/742> |
+| Windows Sysmon | Splunk Add-on for Sysmon | <https://splunkbase.splunk.com/app/5709> |
+| Cisco ASA | Splunk Add-on for Cisco ASA | <https://splunkbase.splunk.com/app/1620> |
+| Zeek connection and HTTP logs | TA for Zeek | <https://splunkbase.splunk.com/app/5466> |
+| Web and proxy access logs | Splunk Add-on for Apache Web Server | <https://splunkbase.splunk.com/app/3186> |
+
 ## Generate And Validate
 
 Base ingest validation:
@@ -53,6 +75,9 @@ uv run python scripts/external_parser.py <scenario-output>/data \
   --splunk-app /path/to/ta-for-zeek.tgz \
   --splunk-app /path/to/splunk-add-on-for-apache-web-server.spl
 ```
+
+See [Required Splunk Apps For CIM Validation](#required-splunk-apps-for-cim-validation)
+for the official download pages for those local app archives.
 
 `--backend auto` also selects Splunk when `OUTPUT_TARGET.txt` contains
 `splunk`.

--- a/docs/worklog/2026-05-current-dev-assessment-continuation.md
+++ b/docs/worklog/2026-05-current-dev-assessment-continuation.md
@@ -912,6 +912,173 @@ or follow-up batch is needed.
   child-log gaps, fewer one-command SSH history stubs, denser primary-user bash
   histories, and the isolated Zeek files/protocol timestamp edge case.
 
+- Loop 278 started a new requested 10-loop assessment batch and tested
+  collection-imperfection texture by adding source-observation
+  `format_missingness` plus Zeek files/conn interval guards. Focused tests,
+  config validation, scenario validation, Ruff checks, generation, eval, and the
+  full `uv run pytest --no-cov` suite passed (`4446 passed, 19 skipped`).
+  Automated eval passed at 97.2183584632452 over 89427 records, with
+  Parseability 100.0, Plausibility 95.92217578332037, Causality
+  94.69898357220872, and Timing 97.81534312181459. The hard probe found 13198
+  Zeek conn UIDs and 0 `files.json` rows outside the parent conn interval. Blind initial
+  scores were 31/62/36/52, average 45.25; deliberation settled at 39/64/40/54,
+  final average 49.25. Reviewers judged the sparse Zeek child gaps realistic in
+  spirit but too independent: visible SSL/DNS/HTTP/files/x509 references can
+  survive after same-sensor sibling rows or conn parents are dropped. The next
+  target is coherent Zeek sibling suppression, then Linux server desktop/Polkit
+  gating and eCAR FLOW attribution.
+
+- Loop 279 fixed the loop-278 Zeek orphan-reference finding by batching
+  observation decisions per event, promoting required same-sensor parent rows,
+  and pruning HTTP/SSL reference vectors when dependent files/x509 rows are
+  absent. Focused dispatcher/Zeek tests, config validation, scenario validation,
+  Ruff checks, generation, eval, and the full `uv run pytest --no-cov` suite
+  passed (`4450 passed, 19 skipped`). Automated eval passed at
+  97.46871613111875 over 89448 records, with Parseability 100.0, Plausibility
+  96.9220144746488, Causality 94.70057555237452, and Timing
+  97.81534312181459. The hard probe found 0 Zeek protocol UID or FUID orphan
+  groups across core and DMZ sensors. Blind initial scores were 34/54/39/56,
+  average 45.75; deliberation was not triggered because all reviewers returned
+  Inconclusive and the score spread was below threshold. Both detection and
+  network reviewers explicitly called Zeek UID/FUID integrity strong. The next
+  target is proxy/web application texture: reduce generic inspected root `GET`
+  rows for CDN/API hosts, replace zero-heavy synthetic asset hashes with
+  vendor-specific path shapes, and keep Zeek integrity as a regression anchor.
+
+- Loop 280 fixed proxy/web texture by generating stable cache-buster `{hex16}`
+  tokens from full SHA-256 digest entropy instead of zero-padded 32-bit seeds
+  and by keeping root/index HTML response sizes host-specific while preserving
+  shared byte stability for true static assets. Focused HTTP/site-map tests,
+  config validation, scenario validation, Ruff checks, generation, eval, and the
+  full `uv run pytest --no-cov` suite passed (`4452 passed, 19 skipped`).
+  Automated eval passed at 96.88503046001232 over 83733 records, with
+  Parseability 100.0, Plausibility 97.22367794053588, Causality
+  93.03634850166482, and Timing 96.60011924731073. The hard probe found
+  zero-padded hex64 proxy URI rows reduced from 131 to 0, root HTML top-size
+  ratio reduced by 0.0095, and root HTML unique-size ratio improved by 0.2406.
+  Blind initial scores were 52/52/36/74, average 53.5; deliberation settled at
+  56/57/41/72, final average 56.5. Network reviewers validated the proxy/Zeek
+  texture improvement, while Host/EDR and Threat Hunter converged on a broader
+  next target: role-aware endpoint and server/DC behavior, including eCAR
+  identity propagation, Linux syslog role profiles, and suppressing
+  workstation-like browsing/scripting from infrastructure hosts.
+
+- Loop 281 fixed eCAR actor-linked user FLOW identity by preserving `principal`
+  whenever an outbound FLOW is safely linked to a known user-owned actor process,
+  while retaining service/root principal gaps. Focused eCAR tests, config
+  validation, scenario validation, Ruff checks, generation, eval, and the full
+  `uv run pytest --no-cov` suite passed (`4453 passed, 19 skipped`). Automated
+  eval held at 96.88503046001232 over 83733 records, with Parseability 100.0,
+  Plausibility 97.22367794053588, Causality 93.03634850166482, and Timing
+  96.60011924731073. The hard probe found actor-linked user outbound FLOW rows
+  with missing/mismatched principals reduced from 64 to 0 across 815 loop-281
+  candidate rows. Blind initial scores were 36/38/42/78, average 48.5;
+  deliberation settled at 40/45/46/76, final average 51.75. Detection and threat
+  hunting scores improved substantially, while Host/EDR surfaced sharper
+  source-native tells: Linux `polkitd` `unix-process:PID:<value>` values use
+  UID-like buckets (`0`, `1000`, `2000`), Windows 4800/4801 lock/unlock fields
+  have non-native `TargetUser*`/`TargetLogonId` shape, and server listener FLOW
+  attribution remains uneven. The next target is Host/EDR source-native
+  rendering and background texture, starting with polkit PID/starttime realism
+  and Windows 4800/4801 native field semantics.
+
+- Loop 282 fixed the strongest loop-281 Host/EDR source-native tell by rendering
+  realistic Linux polkit `unix-process:PID:STARTTIME` start ticks from host boot
+  time and transient PID identity instead of using YAML placeholder values
+  (`0`, `1000`, `2000`). Focused polkit tests, config validation, scenario
+  validation, Ruff checks, generation, eval, and the full
+  `uv run pytest --no-cov` suite passed (`4453 passed, 19 skipped`). Automated
+  eval passed at 97.34383523719569 over 89408 records, with Parseability 100.0,
+  Plausibility 97.18509319457112, Causality 94.62633938333698, and Timing
+  96.9548854635933. The hard probe found canned polkit process-start values
+  reduced from 238/238 rows to 0/288 rows, and unique start-tick values increased
+  from 3 to 288. Blind initial scores were 28/34/32/34, average 32.0; deliberation
+  was skipped because all reviewers judged the dataset Real and the score spread
+  was only 6. Host/EDR no longer repeated the polkit finding, and Detection did
+  not repeat the Windows 4800/4801 field-shape concern. The next target is
+  source-specific collection texture: endpoint/eCAR normalization asymmetry,
+  Zeek file-analysis imperfections, DHCP/NTP texture, and TLS edge cases.
+
+- Loop 283 added Zeek file-analysis collection texture by introducing low-rate
+  missing-byte/timeout imperfections for HTTP and SMB file-analysis rows and
+  suppressing analyzers/hashes when capture is incomplete. Focused Zeek files
+  tests, config validation, scenario validation, Ruff checks, generation, eval,
+  and the full `uv run pytest --no-cov` suite passed (`4455 passed, 19 skipped`).
+  Automated eval passed at 96.26962688034575 over 85795 records, with
+  Parseability 100.0, Plausibility 97.03030721919626, Causality
+  91.54145089770225, and Timing 95.6334367556056. The hard probe increased
+  imperfect non-SSL Zeek file rows from 1/231 to 10/223 while keeping hash
+  contradictions at 0. Blind initial scores were 43/34/34/30, average 35.25;
+  deliberation was skipped because the spread was only 13 and reviewers found no
+  hard source-native contradiction. The next target is Zeek NTP source-native
+  texture: normalize poll/precision representation and add host/server/poll
+  diversity without breaking conn/ntp UID correlation.
+
+- Loop 284 fixed Zeek NTP source-native representation by rendering precision as
+  a small interval in seconds and diversifying association poll values across
+  client/server pairs while preserving UID correlation. Focused NTP tests,
+  config validation, scenario validation, Ruff checks, generation, eval, and the
+  full `uv run pytest --no-cov` suite passed (`4456 passed, 19 skipped`).
+  Automated eval held at 96.26962688034575 over 85795 records, with Parseability
+  100.0, Plausibility 97.03030721919626, Causality 91.54145089770225, and
+  Timing 95.6334367556056. The hard probe changed NTP poll values from only
+  `[4096.0]` to `[1024.0, 2048.0, 4096.0]`, reduced negative precision rows
+  from 8 to 0, and preserved 0 orphan/non-response NTP UID rows. Blind initial
+  scores were 46/58/32/58, average 48.5; deliberation was skipped because the
+  spread was 26 and all reviewers stayed inconclusive. Network no longer flagged
+  the precision representation, but found a remaining cadence contradiction
+  where a `poll=2048.0` association repeated after about 241 seconds. Host/EDR
+  found a high-confidence shell-rendering tell (`make clean && make all`
+  attached to `/usr/bin/make`), and Detection flagged Squid inbound/outbound
+  FLOW principal asymmetry. Next targets: NTP cadence semantics, then Linux shell
+  compound command rendering and proxy process principal consistency.
+
+- Loop 285 tightened Zeek NTP cadence semantics by adding a canonical parser
+  cadence guard for same client/server NTP associations. Too-soon response-bearing
+  UDP/123 connections remain visible as `conn.log` evidence, but no longer fan out
+  to `ntp.log` before a plausible association interval has elapsed. Focused NTP
+  tests, config validation, scenario validation, Ruff checks, generation, eval,
+  and the full `uv run pytest --no-cov` suite passed (`4457 passed, 19 skipped`).
+  Automated eval passed at 96.65290772815344 over 85286 records. The hard probe
+  found 10 NTP rows, 0 cadence violations, 0 orphan UIDs, 0 non-response NTP rows,
+  0 negative precision rows, and poll values `[1024.0, 2048.0, 4096.0]`. Blind
+  initial scores were 38/32/34/30, average 33.5; deliberation was skipped. Network
+  and Threat Hunter reviewers still saw the suppressed NTP parser row as a possible
+  conn/detail contract gap because the corresponding `conn.log` row retained
+  `service="ntp"`. Next targets: Linux shell compound command rendering and then
+  proxy process principal consistency / NTP detail-label semantics.
+
+- Loop 286 fixed Linux catalog compound-command rendering by splitting shell
+  compound commands into source-native child process rows while preserving the
+  full typed command in bash history. Focused shell/catalog tests, config
+  validation, scenario validation, Ruff checks, generation, eval, and the full
+  `uv run pytest --no-cov` suite passed (`4459 passed, 19 skipped`). Automated
+  eval passed at 96.27765021125614 over 83339 records. The hard probe found
+  0 Linux non-shell compound process rows; `/usr/bin/make` rows now use
+  `make clean` and `make all` command lines, while bash history still includes
+  full compound shell text. Blind initial scores were 34/18/28/52, average 33.0;
+  deliberation was skipped. Host/EDR no longer repeated the Linux `make clean &&
+  make all` source-native process tell, while Network flagged repeated NTP
+  `root_delay`/`root_disp` values and Host/EDR flagged eCAR module-load /
+  one-shot process lifetime semantics. Next targets: NTP per-poll metric texture
+  and eCAR lifecycle semantics.
+
+- Loop 287 fixed NTP per-poll metric texture and parser-label semantics. Stable
+  server/association traits remain stable, while `root_delay` and `root_disp`
+  now vary deterministically per observed poll; too-soon UDP/123 responses remain
+  visible in `conn.json` but no longer retain `service=ntp` when the NTP parser
+  row is intentionally suppressed. Focused NTP tests, config validation,
+  scenario validation, Ruff checks, generation, eval, and the full
+  `uv run pytest --no-cov` suite passed (`4459 passed, 19 skipped`). Automated
+  eval passed at 96.27765021125614 over 83339 records. The hard probe reduced
+  exact repeated NTP metric excess from 3 to 0 and `conn.service=ntp` rows missing
+  NTP detail from 1 to 0, while cadence, orphan, non-response, and negative
+  precision checks stayed at 0. Blind initial scores were 34/41/38/42, average
+  38.75; deliberation was skipped because the spread was only 8. Reviewers did
+  not repeat the NTP metric finding. Next targets: proxy/web search-referrer and
+  cache semantics, Linux session parentage (`systemd -> -bash`), eCAR FLOW actor
+  attribution near known processes, and multi-sensor Zeek mirroring texture.
+
 ## Recent Completed Work Previously Kept in TODO
 
 - Codex fix-family PR disposition and rework completed: rejected PRs were closed
@@ -929,11 +1096,11 @@ or follow-up batch is needed.
 
 1. Start from the current `dev` state and read `TODO.md` for durable priorities.
 2. Select the next assessment target from the latest verified blind-review or
-   hard-probe findings.
+  hard-probe findings.
 3. Fix the owning layer, not an emitter symptom, unless the defect is truly
-   source-local rendering.
+  source-local rendering.
 4. Verify with focused tests, `uv run eforge validate-config`, Ruff checks, and
-   normal `uv run pytest --no-cov` unless the loop specifically requires slow
+  normal `uv run pytest --no-cov` unless the loop specifically requires slow
    coverage.
 5. Record only the concise loop outcome, next target, and validation result here.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "evidence-forge"
-version = "1.4.0"
+version = "1.4.1"
 description = "Generate realistic synthetic security logs for cybersecurity threat hunting training and research"
 readme = "README.md"
 license = "MIT"

--- a/src/evidenceforge/__init__.py
+++ b/src/evidenceforge/__init__.py
@@ -27,5 +27,5 @@ for cybersecurity threat hunting training and research. It uses a two-phase
 architecture combining LLM-driven scenario creation with deterministic log generation.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __all__ = []  # Will be expanded as modules are implemented

--- a/src/evidenceforge/config/activity/observation_profiles.yaml
+++ b/src/evidenceforge/config/activity/observation_profiles.yaml
@@ -52,7 +52,18 @@ profiles:
           min_ms: 0
           max_ms: 0
       zeek:
-        missingness: 0.002
+        missingness: 0.001
+        format_missingness:
+          zeek_conn: 0.001
+          zeek_dns: 0.003
+          zeek_http: 0.006
+          zeek_ssl: 0.006
+          zeek_files: 0.010
+          zeek_x509: 0.010
+          zeek_ocsp: 0.012
+          zeek_ntp: 0.003
+          zeek_weird: 0.006
+          zeek_pe: 0.010
         delay_ms:
           min_ms: 0
           max_ms: 3
@@ -114,7 +125,18 @@ profiles:
           min_ms: 0
           max_ms: 0
       zeek:
-        missingness: 0.006
+        missingness: 0.003
+        format_missingness:
+          zeek_conn: 0.003
+          zeek_dns: 0.008
+          zeek_http: 0.016
+          zeek_ssl: 0.016
+          zeek_files: 0.024
+          zeek_x509: 0.024
+          zeek_ocsp: 0.030
+          zeek_ntp: 0.008
+          zeek_weird: 0.014
+          zeek_pe: 0.024
         delay_ms:
           min_ms: 0
           max_ms: 8

--- a/src/evidenceforge/config/activity/smb_file_transfers.yaml
+++ b/src/evidenceforge/config/activity/smb_file_transfers.yaml
@@ -6,8 +6,8 @@
 # looks like.
 
 min_transfer_bytes: 32768
-missing_bytes_probability: 0.02
-timeout_probability: 0.005
+missing_bytes_probability: 0.06
+timeout_probability: 0.01
 
 mime_types:
   - mime_type: application/vnd.openxmlformats-officedocument.wordprocessingml.document

--- a/src/evidenceforge/config/schemas.py
+++ b/src/evidenceforge/config/schemas.py
@@ -1540,12 +1540,25 @@ class ObservationSourceProfile(BaseModel, extra="forbid"):
     """Source-level observation behavior for a profile."""
 
     missingness: float = Field(default=0.0, ge=0.0, le=1.0)
+    format_missingness: dict[str, float] = Field(default_factory=dict)
     delay_ms: ObservationDelayRange = Field(
         default_factory=lambda: ObservationDelayRange(min_ms=0, max_ms=0)
     )
     host_missingness_multiplier: ObservationMultiplierRange = Field(
         default_factory=lambda: ObservationMultiplierRange(min=1.0, max=1.0)
     )
+
+    @field_validator("format_missingness")
+    @classmethod
+    def format_missingness_probabilities_are_valid(cls, v: dict[str, float]) -> dict[str, float]:
+        """Reject invalid per-format missingness probabilities."""
+        invalid = sorted(name for name, probability in v.items() if not 0.0 <= probability <= 1.0)
+        if invalid:
+            raise ValueError(
+                "format_missingness probabilities must be between 0 and 1 for: "
+                + ", ".join(invalid)
+            )
+        return v
 
 
 class ObservationProfileEntry(BaseModel, extra="forbid"):
@@ -1563,6 +1576,30 @@ class ObservationProfileEntry(BaseModel, extra="forbid"):
         "asa",
         "ids",
     }
+    FORMAT_SOURCE_FAMILIES: ClassVar[dict[str, str]] = {
+        "windows_event_security": "windows_security",
+        "windows_event_sysmon": "sysmon",
+        "ecar": "ecar",
+        "syslog": "syslog",
+        "bash_history": "bash_history",
+        "zeek_conn": "zeek",
+        "zeek_dns": "zeek",
+        "zeek_http": "zeek",
+        "zeek_ssl": "zeek",
+        "zeek_files": "zeek",
+        "zeek_x509": "zeek",
+        "zeek_dhcp": "zeek",
+        "zeek_ntp": "zeek",
+        "zeek_weird": "zeek",
+        "zeek_ocsp": "zeek",
+        "zeek_pe": "zeek",
+        "zeek_packet_filter": "zeek",
+        "zeek_reporter": "zeek",
+        "proxy_access": "proxy",
+        "web_access": "web",
+        "cisco_asa": "asa",
+        "snort_alert": "ids",
+    }
 
     description: str = ""
     default: ObservationSourceProfile = Field(default_factory=ObservationSourceProfile)
@@ -1570,10 +1607,28 @@ class ObservationProfileEntry(BaseModel, extra="forbid"):
 
     @model_validator(mode="after")
     def source_names_are_known(self) -> Self:
-        """Reject source-family typos."""
+        """Reject source-family and format-level typos."""
         unknown = sorted(set(self.sources) - self.VALID_SOURCE_FAMILIES)
         if unknown:
             raise ValueError(f"unknown observation source families: {', '.join(unknown)}")
+        for source, profile in self.sources.items():
+            unknown_formats = sorted(
+                set(profile.format_missingness) - set(self.FORMAT_SOURCE_FAMILIES)
+            )
+            if unknown_formats:
+                raise ValueError(
+                    f"unknown observation formats for {source}: {', '.join(unknown_formats)}"
+                )
+            wrong_source = sorted(
+                format_name
+                for format_name in profile.format_missingness
+                if self.FORMAT_SOURCE_FAMILIES[format_name] != source
+            )
+            if wrong_source:
+                raise ValueError(
+                    f"format_missingness entries do not belong to {source}: "
+                    + ", ".join(wrong_source)
+                )
         return self
 
 

--- a/src/evidenceforge/events/base.py
+++ b/src/evidenceforge/events/base.py
@@ -155,6 +155,10 @@ class SecurityEvent:
     # Sensor routing metadata (not a context — set by dispatcher)
     # Maps format_name → list of sensor hostnames that produce that format
     _sensor_hostnames_by_format: dict[str, list[str]] = field(default_factory=dict)
+    # Format names that survived source-observation policy for this dispatch.
+    # Emitters use this to avoid rendering source-local references to sibling
+    # rows that the same observation profile intentionally dropped.
+    _observed_formats: set[str] = field(default_factory=set)
     # NAT swap metadata: maps sensor hostname → dict of IP/port swaps for post-NAT sensors
     _nat_swaps_by_sensor: dict[str, dict[str, Any]] = field(default_factory=dict)
 

--- a/src/evidenceforge/events/dispatcher.py
+++ b/src/evidenceforge/events/dispatcher.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING
 
 from evidenceforge.events.base import RawLogEntry, SecurityEvent
 from evidenceforge.events.observation import (
+    ObservationDecision,
     ObservationPolicy,
     ObservationStatus,
     ObservationSummary,
@@ -75,6 +76,8 @@ FORMAT_GROUPS: dict[str, set[str]] = {
 
 # Formats subject to network visibility filtering (expanded emitter names)
 _NETWORK_FORMATS = FORMAT_GROUPS["zeek"] | {"snort_alert", "cisco_asa"}
+_ZEEK_CONN_DEPENDENTS = FORMAT_GROUPS["zeek"] - {"zeek_conn"}
+_ZEEK_FILES_DEPENDENTS = {"zeek_x509", "zeek_ocsp", "zeek_pe"}
 
 
 def expand_formats(formats: list[str] | set[str]) -> set[str]:
@@ -158,8 +161,20 @@ class EventDispatcher:
         if self._is_suppressed(event.timestamp):
             self._record_observation(event, "all", "out_of_window")
             return
-        for format_name, emitter in self._get_matching_emitters(event):
-            decision = self.observation_policy.decide(format_name, event)
+        matching_emitters = self._get_matching_emitters(event)
+        decisions = {
+            format_name: self.observation_policy.decide(format_name, event)
+            for format_name, _emitter in matching_emitters
+        }
+        self._enforce_source_observation_contracts(decisions)
+        observed_formats = {
+            format_name
+            for format_name, decision in decisions.items()
+            if decision.status != "dropped"
+        }
+        event._observed_formats = observed_formats
+        for format_name, emitter in matching_emitters:
+            decision = decisions[format_name]
             if decision.status == "dropped":
                 self._record_observation(event, format_name, "dropped")
                 continue
@@ -168,12 +183,41 @@ class EventDispatcher:
             if decision.delay.total_seconds() > 0:
                 event_to_emit = replace(event, timestamp=event.timestamp + decision.delay)
                 status = "delayed"
+            event_to_emit._observed_formats = observed_formats
             event_to_emit = self.source_timing_planner.plan_event(event_to_emit)
             self._record_observation(event, format_name, status)
             if event.raw is not None:
                 emitter.emit_raw(event_to_emit.raw.fields)
             else:
                 emitter.emit(event_to_emit)
+
+    def _enforce_source_observation_contracts(
+        self,
+        decisions: dict[str, ObservationDecision],
+    ) -> None:
+        """Preserve source-local parent rows when child observations survive."""
+        self._promote_zeek_parent(decisions, "zeek_conn", _ZEEK_CONN_DEPENDENTS)
+        self._promote_zeek_parent(decisions, "zeek_files", _ZEEK_FILES_DEPENDENTS)
+        self._promote_zeek_parent(decisions, "zeek_conn", {"zeek_files"})
+
+    @staticmethod
+    def _promote_zeek_parent(
+        decisions: dict[str, ObservationDecision],
+        parent_format: str,
+        child_formats: set[str],
+    ) -> None:
+        parent_decision = decisions.get(parent_format)
+        if parent_decision is None or parent_decision.status != "dropped":
+            return
+        for child_format in child_formats:
+            child_decision = decisions.get(child_format)
+            if child_decision is None or child_decision.status == "dropped":
+                continue
+            decisions[parent_format] = ObservationDecision(
+                status=child_decision.status,
+                delay=child_decision.delay,
+            )
+            return
 
     def dispatch_raw(self, entry: RawLogEntry) -> None:
         """Route a raw log entry directly to a specific emitter (escape hatch).

--- a/src/evidenceforge/events/observation.py
+++ b/src/evidenceforge/events/observation.py
@@ -111,13 +111,21 @@ class ObservationPolicy:
         """Return the source-observation decision for an event/emitter pair."""
         source = source_family_for_format(format_name)
         settings = self._settings_for_source(source)
-        missingness = self._effective_missingness(source, event, settings)
-        identity = self._event_identity(source, format_name, event)
-        drop_rng = random.Random(_stable_seed(f"observation.drop|{self.profile_name}|{identity}"))
+        missingness = self._effective_missingness(source, format_name, event, settings)
+        drop_identity = self._event_identity(
+            source,
+            format_name,
+            event,
+            force_format_specific=self._has_format_missingness(settings, format_name),
+        )
+        delay_identity = self._event_identity(source, format_name, event)
+        drop_rng = random.Random(
+            _stable_seed(f"observation.drop|{self.profile_name}|{drop_identity}")
+        )
         if missingness > 0 and drop_rng.random() < missingness:
             return ObservationDecision(status="dropped")
 
-        delay = self._sample_delay(source, event, settings, identity)
+        delay = self._sample_delay(source, event, settings, delay_identity)
         if delay > timedelta(0):
             return ObservationDecision(status="delayed", delay=delay)
         return ObservationDecision(status="visible")
@@ -126,7 +134,12 @@ class ObservationPolicy:
         """Return the source-observation decision for a direct raw entry."""
         source = source_family_for_format(entry.target_emitter)
         settings = self._settings_for_source(source)
-        missingness = self._effective_missingness_for_host(source, "", settings)
+        missingness = self._effective_missingness_for_host(
+            source,
+            "",
+            settings,
+            format_name=entry.target_emitter,
+        )
         identity = self._raw_identity(source, entry)
         drop_rng = random.Random(_stable_seed(f"observation.drop|{self.profile_name}|{identity}"))
         if missingness > 0 and drop_rng.random() < missingness:
@@ -144,17 +157,22 @@ class ObservationPolicy:
         return merged
 
     def _effective_missingness(
-        self, source: str, event: SecurityEvent, settings: dict[str, Any]
+        self, source: str, format_name: str, event: SecurityEvent, settings: dict[str, Any]
     ) -> float:
         if self._preserve_ssh_session_lifecycle(source, event):
             return 0.0
         host = self._host_key_for_event(event)
-        return self._effective_missingness_for_host(source, host, settings)
+        return self._effective_missingness_for_host(source, host, settings, format_name=format_name)
 
     def _effective_missingness_for_host(
-        self, source: str, host: str, settings: dict[str, Any]
+        self,
+        source: str,
+        host: str,
+        settings: dict[str, Any],
+        *,
+        format_name: str | None = None,
     ) -> float:
-        base = _safe_probability(settings.get("missingness", 0.0))
+        base = self._base_missingness(settings, format_name)
         multiplier_range = settings.get("host_missingness_multiplier", {})
         if not isinstance(multiplier_range, dict):
             multiplier_range = {}
@@ -168,6 +186,21 @@ class ObservationPolicy:
             seed = _stable_seed(f"observation.host-mult|{self.profile_name}|{source}|{host}")
             multiplier = random.Random(seed).uniform(min_mult, max_mult)
         return max(0.0, min(base * multiplier, 1.0))
+
+    @staticmethod
+    def _base_missingness(settings: dict[str, Any], format_name: str | None) -> float:
+        """Return source-level missingness with an optional format override."""
+        if format_name:
+            format_missingness = settings.get("format_missingness", {})
+            if isinstance(format_missingness, dict) and format_name in format_missingness:
+                return _safe_probability(format_missingness.get(format_name, 0.0))
+        return _safe_probability(settings.get("missingness", 0.0))
+
+    @staticmethod
+    def _has_format_missingness(settings: dict[str, Any], format_name: str) -> bool:
+        """Return True when a source profile overrides missingness for a format."""
+        format_missingness = settings.get("format_missingness", {})
+        return isinstance(format_missingness, dict) and format_name in format_missingness
 
     def _sample_delay(
         self,
@@ -189,11 +222,18 @@ class ObservationPolicy:
         delay_ms = random.Random(seed).randint(min_ms, max_ms)
         return timedelta(milliseconds=delay_ms)
 
-    def _event_identity(self, source: str, format_name: str, event: SecurityEvent) -> str:
+    def _event_identity(
+        self,
+        source: str,
+        format_name: str,
+        event: SecurityEvent,
+        *,
+        force_format_specific: bool = False,
+    ) -> str:
         group = self._coherent_group_key(source, event)
         host = self._host_key_for_event(event)
         timestamp = int(event.timestamp.timestamp() * 1_000_000)
-        coherent = self._uses_coherent_source_identity(source, group)
+        coherent = self._uses_coherent_source_identity(source, group) and not force_format_specific
         return "|".join(
             [
                 source,

--- a/src/evidenceforge/generation/actions/file_transfer.py
+++ b/src/evidenceforge/generation/actions/file_transfer.py
@@ -73,6 +73,7 @@ _HTTP_PE_DEFINITE_MIME_TYPES = {
 _HTTP_ANALYZER_SHORT_BODY_BYTES = 64 * 1024
 _HTTP_BULK_BODY_BYTES = 1_000_000
 _HTTP_PARENT_ANALYZER_MARGIN_SECONDS = 0.75
+_HTTP_FILE_ANALYSIS_LOSS_MIN_BYTES = 128 * 1024
 _PE_COMPILE_EARLIEST_TS = int(datetime(2018, 1, 1, tzinfo=UTC).timestamp())
 _PE_COMPILE_LATEST_TS = int(datetime(2024, 6, 1, tzinfo=UTC).timestamp())
 _PE_COMPILE_OBSERVATION_MARGIN_SECONDS = 30 * 24 * 60 * 60
@@ -168,6 +169,41 @@ def file_transfer_hashes(seed_material: str, analyzers: list[str]) -> dict[str, 
     if "SHA256" in analyzer_names:
         hashes["sha256"] = hashlib.sha256(seed_material.encode()).hexdigest()
     return hashes
+
+
+def _file_analysis_missing_bytes(total_bytes: int, rng: random.Random, *, timedout: bool) -> int:
+    """Return source-observed bytes lost before file analyzers completed."""
+
+    if total_bytes <= 0:
+        return 0
+    upper_bound = max(1, min(262_144, total_bytes // (12 if timedout else 35)))
+    lower_bound = min(upper_bound, max(1, total_bytes // 600)) if timedout else 1
+    return rng.randint(lower_bound, upper_bound)
+
+
+def _http_file_analysis_loss(
+    response_body_len: int,
+    rng: random.Random,
+) -> tuple[int, bool]:
+    """Return low-rate HTTP files.log analyzer loss/timeout texture."""
+
+    if response_body_len < _HTTP_FILE_ANALYSIS_LOSS_MIN_BYTES:
+        return 0, False
+
+    if response_body_len >= _HTTP_BULK_BODY_BYTES:
+        missing_probability = 0.08
+        timeout_probability = 0.012
+    else:
+        missing_probability = 0.025
+        timeout_probability = 0.003
+
+    timedout = rng.random() < timeout_probability
+    missing_bytes = (
+        _file_analysis_missing_bytes(response_body_len, rng, timedout=timedout)
+        if timedout or rng.random() < missing_probability
+        else 0
+    )
+    return missing_bytes, timedout
 
 
 def _http_content_seed_material(
@@ -301,6 +337,12 @@ class HttpResponseFileTransferActionBundle:
         fuid = generate_zeek_uid("F")
         file_mime_type = self._request.response_mime_types[0]
         analyzers = ["SHA1"] if file_mime_type in _HTTP_HASH_ANALYZER_MIME_TYPES else []
+        missing_bytes, timedout = _http_file_analysis_loss(
+            self._request.response_body_len,
+            self._rng,
+        )
+        if missing_bytes or timedout:
+            analyzers = []
         content_seed_material = _http_content_seed_material(
             self._request.host,
             self._request.uri,
@@ -321,16 +363,18 @@ class HttpResponseFileTransferActionBundle:
             ),
             local_orig=_is_private_ip(self._request.dst_ip),
             is_orig=False,
-            seen_bytes=self._request.response_body_len,
+            seen_bytes=max(0, self._request.response_body_len - missing_bytes),
             total_bytes=self._request.response_body_len,
-            missing_bytes=0,
+            missing_bytes=missing_bytes,
             overflow_bytes=0,
-            timedout=False,
+            timedout=timedout,
             **file_hashes,
         )
         return HttpResponseFileTransferResult(
             file_transfer=file_transfer,
-            pe=self._maybe_build_pe_context(fuid, file_mime_type, content_seed_material),
+            pe=None
+            if missing_bytes or timedout
+            else self._maybe_build_pe_context(fuid, file_mime_type, content_seed_material),
         )
 
     def _maybe_build_pe_context(
@@ -425,11 +469,14 @@ class SmbFileTransferMetadataActionBundle:
         analyzers = self._pick_analyzers(smb_config)
         missing_probability = float(smb_config.get("missing_bytes_probability", 0.0))
         timeout_probability = float(smb_config.get("timeout_probability", 0.0))
+        timedout = self._rng.random() < timeout_probability
         missing_bytes = (
-            self._rng.randint(1, max(1, min(65536, self._request.transfer_bytes // 20)))
-            if self._rng.random() < missing_probability
+            _file_analysis_missing_bytes(self._request.transfer_bytes, self._rng, timedout=timedout)
+            if timedout or self._rng.random() < missing_probability
             else 0
         )
+        if missing_bytes or timedout:
+            analyzers = []
         fuid = generate_zeek_uid("F")
         file_hashes = file_transfer_hashes(
             f"smb:{self._request.src_ip}:{self._request.dst_ip}:"
@@ -457,7 +504,7 @@ class SmbFileTransferMetadataActionBundle:
             total_bytes=self._request.transfer_bytes,
             missing_bytes=missing_bytes,
             overflow_bytes=0,
-            timedout=self._rng.random() < timeout_probability,
+            timedout=timedout,
             **file_hashes,
         )
 

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -2903,6 +2903,17 @@ def _linux_command_process_from_shell(
     return processes[0] if processes else None
 
 
+def _linux_catalog_processes_from_shell_command(
+    process_name: str,
+    command_line: str,
+    *,
+    username: str = "",
+) -> list[tuple[str, str]]:
+    """Return source-native Linux process argv entries for a catalog shell command."""
+    processes = _linux_command_processes_from_shell(command_line, username=username)
+    return processes or [(process_name, command_line)]
+
+
 def _linux_command_processes_from_shell(
     command: str,
     *,
@@ -3547,11 +3558,34 @@ def _ntp_stratum_and_ref_id(dst_ip: str) -> tuple[int, str]:
     return rng.choice([1, 1, 2]), rng.choice([".GPS.", ".PPS.", ".GOES.", ".ACTS."])
 
 
+_NTP_ASSOCIATION_POLL_CYCLE = (1024, 2048, 2048, 4096, 4096)
+
+
+def _ntp_poll_component(ip: str) -> int:
+    """Return a stable integer component for poll selection."""
+    try:
+        return int(ipaddress.ip_address(ip))
+    except ValueError:
+        return _stable_seed(ip)
+
+
 def _ntp_association_poll_seconds(src_ip: str, dst_ip: str) -> int:
     """Return the stable poll interval for an NTP client/server association."""
-    profile_rng = random.Random(_stable_seed(f"ntp_association:{src_ip}:{dst_ip}"))
-    profile_rng.random()  # version draw; keep poll aligned with full profile generation
-    return int(profile_rng.choices([1024, 2048, 4096], weights=[20, 35, 45], k=1)[0])
+    bucket = (
+        _ntp_poll_component(src_ip)
+        + _stable_seed(f"ntp_poll_server:{dst_ip}") % len(_NTP_ASSOCIATION_POLL_CYCLE)
+    ) % len(_NTP_ASSOCIATION_POLL_CYCLE)
+    return _NTP_ASSOCIATION_POLL_CYCLE[bucket]
+
+
+def _ntp_precision_interval_seconds(precision_exponent: int) -> float:
+    """Convert the NTP wire precision exponent into Zeek's interval field."""
+    return float(2**precision_exponent)
+
+
+def _ntp_parser_min_gap_seconds(poll_seconds: float) -> float:
+    """Return the minimum plausible gap between successful parser observations."""
+    return max(300.0, poll_seconds * 0.40)
 
 
 def _ntp_payload_accounting(
@@ -3594,6 +3628,27 @@ def _ntp_payload_accounting(
     if normalized_resp > 0 and (normalized_duration is None or normalized_duration > 0.25):
         normalized_duration = rng.uniform(0.003, 0.12)
     return normalized_orig, normalized_resp, normalized_duration
+
+
+def _ntp_observed_response_fields(
+    server_response: dict[str, float],
+    *,
+    dst_ip: str,
+    event_time: datetime,
+) -> dict[str, float]:
+    """Return NTP response fields with stable server traits and per-poll texture."""
+    root_delay = float(server_response["root_delay"])
+    root_disp = float(server_response["root_disp"])
+    rng = random.Random(_stable_seed(f"ntp_observed_response:{dst_ip}:{event_time.isoformat()}"))
+    observed_delay = root_delay * rng.uniform(0.91, 1.12) + rng.uniform(-0.00025, 0.00035)
+    observed_disp = root_disp * rng.uniform(0.88, 1.16) + rng.uniform(-0.00015, 0.0004)
+    if rng.random() < 0.18:
+        observed_disp += rng.uniform(0.00035, 0.0018)
+    return {
+        "precision": float(server_response["precision"]),
+        "root_delay": round(max(0.00025, observed_delay), 6),
+        "root_disp": round(max(0.00025, observed_disp), 6),
+    }
 
 
 def _select_public_ntp_ip(src_ip: str, dst_ip: str, time: datetime) -> str | None:
@@ -3774,6 +3829,7 @@ class ActivityGenerator:
         self._tls_ocsp_response_sizes: dict[tuple[str, str, str, float, float, str], int] = {}
         self._ntp_association_profiles: dict[tuple[str, str], dict[str, float | int]] = {}
         self._ntp_server_response_profiles: dict[str, dict[str, float]] = {}
+        self._ntp_last_parser_times: dict[tuple[str, str], datetime] = {}
         self._bash_history_next_time: dict[tuple[str, str], datetime] = {}
         self._bash_history_command_counts: dict[tuple[str, str], int] = {}
         self._bash_history_quick_streaks: dict[tuple[str, str], int] = {}
@@ -4073,7 +4129,7 @@ class ActivityGenerator:
 
         profile_rng = random.Random(_stable_seed(f"ntp_association:{src_ip}:{dst_ip}"))
         version = 3 if profile_rng.random() < 0.08 else 4
-        poll = float(profile_rng.choices([1024, 2048, 4096], weights=[20, 35, 45], k=1)[0])
+        poll = float(_ntp_association_poll_seconds(src_ip, dst_ip))
         profile = {
             "version": version,
             "poll": poll,
@@ -4094,8 +4150,9 @@ class ActivityGenerator:
         else:
             root_delay = profile_rng.uniform(0.001, 0.08)
             root_disp = profile_rng.uniform(0.001, 0.04)
+        precision_exponent = profile_rng.randint(-24, -19)
         profile = {
-            "precision": float(profile_rng.randint(-24, -19)),
+            "precision": _ntp_precision_interval_seconds(precision_exponent),
             "root_delay": root_delay,
             "root_disp": root_disp,
         }
@@ -12178,29 +12235,45 @@ class ActivityGenerator:
             # Stratum-aware timing via log-normal distribution
             stratum, ref_id = _ntp_stratum_and_ref_id(dst_ip)
             association = self._ntp_association_profile(event.network.src_ip, dst_ip)
-            server_response = self._ntp_server_response_profile(dst_ip)
-            _ntp_mean_ms, _ntp_sigma = _NTP_STRATUM_TIMING.get(stratum, (10.0, 0.7))
-            _ntp_mu = math.log(_ntp_mean_ms) - (_ntp_sigma**2) / 2
-            rtt_sec = ntp_rng.lognormvariate(_ntp_mu, _ntp_sigma) / 1000.0
-            proc_sec = ntp_rng.lognormvariate(math.log(0.5) - 0.3**2 / 2, 0.3) / 1000.0
-            ntp_jitter = ntp_rng.uniform(-0.005, 0.005)
-            ntp_duration = max(0.001, rtt_sec + proc_sec + ntp_rng.uniform(0.001, 0.008))
-            if event.network.duration is None or event.network.duration < ntp_duration:
-                event.network.duration = ntp_duration
-            event.ntp = NtpContext(
-                version=int(association["version"]),
-                mode=4,  # server response
-                stratum=stratum,
-                poll=float(association["poll"]),
-                precision=float(server_response["precision"]),
-                root_delay=float(server_response["root_delay"]),
-                root_disp=float(server_response["root_disp"]),
-                ref_id=ref_id,
-                ref_ts=round(ntp_epoch - ntp_rng.uniform(30, 300), 6),
-                org_ts=round(ntp_epoch + ntp_jitter, 6),
-                rec_ts=round(ntp_epoch + ntp_jitter + rtt_sec, 6),
-                xmt_ts=round(ntp_epoch + ntp_jitter + rtt_sec + proc_sec, 6),
+            poll_seconds = float(association["poll"])
+            last_parser_time = self._ntp_last_parser_times.get((event.network.src_ip, dst_ip))
+            parser_gap = (
+                None
+                if last_parser_time is None
+                else (event.timestamp - last_parser_time).total_seconds()
             )
+            if parser_gap is None or parser_gap >= _ntp_parser_min_gap_seconds(poll_seconds):
+                self._ntp_last_parser_times[(event.network.src_ip, dst_ip)] = event.timestamp
+                server_response = self._ntp_server_response_profile(dst_ip)
+                observed_response = _ntp_observed_response_fields(
+                    server_response,
+                    dst_ip=dst_ip,
+                    event_time=event.timestamp,
+                )
+                _ntp_mean_ms, _ntp_sigma = _NTP_STRATUM_TIMING.get(stratum, (10.0, 0.7))
+                _ntp_mu = math.log(_ntp_mean_ms) - (_ntp_sigma**2) / 2
+                rtt_sec = ntp_rng.lognormvariate(_ntp_mu, _ntp_sigma) / 1000.0
+                proc_sec = ntp_rng.lognormvariate(math.log(0.5) - 0.3**2 / 2, 0.3) / 1000.0
+                ntp_jitter = ntp_rng.uniform(-0.005, 0.005)
+                ntp_duration = max(0.001, rtt_sec + proc_sec + ntp_rng.uniform(0.001, 0.008))
+                if event.network.duration is None or event.network.duration < ntp_duration:
+                    event.network.duration = ntp_duration
+                event.ntp = NtpContext(
+                    version=int(association["version"]),
+                    mode=4,  # server response
+                    stratum=stratum,
+                    poll=poll_seconds,
+                    precision=observed_response["precision"],
+                    root_delay=observed_response["root_delay"],
+                    root_disp=observed_response["root_disp"],
+                    ref_id=ref_id,
+                    ref_ts=round(ntp_epoch - ntp_rng.uniform(30, 300), 6),
+                    org_ts=round(ntp_epoch + ntp_jitter, 6),
+                    rec_ts=round(ntp_epoch + ntp_jitter + rtt_sec, 6),
+                    xmt_ts=round(ntp_epoch + ntp_jitter + rtt_sec + proc_sec, 6),
+                )
+            else:
+                event.network.service = ""
 
         # Enforce conn_state/HTTP consistency: if HTTP context exists,
         # the connection must have completed successfully (SF). A connection
@@ -14906,15 +14979,23 @@ class ActivityGenerator:
                         system=system,
                     )
                     process_time = time
+                    shell_command_line = command_line
+                    source_processes = [(process_name, command_line)]
                     if os_category == "linux":
-                        command_line = _background_linux_shell_command_if_needed(command_line)
+                        shell_command_line = _background_linux_shell_command_if_needed(command_line)
                         process_time = self._schedule_bash_history_time(
-                            user, system, time, command_line
+                            user, system, time, shell_command_line
                         )
                         if process_time is None or not self._is_within_scenario_window(
                             process_time
                         ):
                             return
+                        source_processes = _linux_catalog_processes_from_shell_command(
+                            process_name,
+                            shell_command_line,
+                            username=user.username,
+                        )
+                        process_name, command_line = source_processes[0]
                     parent_pid = self._resolve_parent(
                         system, user, process_time, logon_id, process_name
                     )
@@ -14925,20 +15006,46 @@ class ActivityGenerator:
                             logon_id=logon_id,
                             parent_pid=parent_pid,
                             requested_time=process_time,
-                            seed_text=command_line,
+                            seed_text=shell_command_line,
                         )
                         if not self._is_within_scenario_window(process_time):
                             return
-                    pid = self.generate_process(
-                        user,
-                        system,
-                        process_time,
-                        logon_id,
-                        process_name,
-                        command_line,
-                        parent_pid=parent_pid,
-                    )
-                    self._record_user_process(system, user, pid, process_name)
+                    pid = -1
+                    created_processes: list[tuple[int, str, str, datetime]] = []
+                    for process_index, (
+                        source_process_name,
+                        source_command_line,
+                    ) in enumerate(source_processes):
+                        source_process_time = process_time + timedelta(
+                            milliseconds=process_index * 35
+                        )
+                        if not self._is_within_scenario_window(source_process_time):
+                            continue
+                        source_pid = self.generate_process(
+                            user,
+                            system,
+                            source_process_time,
+                            logon_id,
+                            source_process_name,
+                            source_command_line,
+                            parent_pid=parent_pid,
+                        )
+                        if pid < 0:
+                            pid = source_pid
+                            process_name = source_process_name
+                            command_line = source_command_line
+                            process_time = source_process_time
+                        created_processes.append(
+                            (
+                                source_pid,
+                                source_process_name,
+                                source_command_line,
+                                source_process_time,
+                            )
+                        )
+                        self._record_user_process(system, user, source_pid, source_process_name)
+                    if not created_processes:
+                        return
                     if active_session:
                         active_session.last_activity_time = process_time
                     effect_process_name, effect_command_line = self._process_effect_context(
@@ -15020,26 +15127,35 @@ class ActivityGenerator:
                             user,
                             system,
                             process_time,
-                            effect_command_line,
+                            shell_command_line,
                         )
-                        lifetime = _linux_foreground_lifetime(
-                            effect_process_name,
-                            effect_command_line,
-                        )
-                        if lifetime is not None:
-                            running_proc = self.state_manager.get_process(system.hostname, pid)
+                        for (
+                            source_pid,
+                            source_process_name,
+                            source_command_line,
+                            source_process_time,
+                        ) in created_processes:
+                            lifetime = _linux_foreground_lifetime(
+                                source_process_name,
+                                source_command_line,
+                            )
+                            if lifetime is None:
+                                continue
+                            running_proc = self.state_manager.get_process(
+                                system.hostname, source_pid
+                            )
                             actual_process_start = (
                                 running_proc.start_time
                                 if running_proc is not None
-                                else process_time
+                                else source_process_time
                             )
                             termination_time = (
                                 self._generate_bounded_foreground_process_termination(
                                     user=user,
                                     system=system,
                                     start_time=actual_process_start,
-                                    pid=pid,
-                                    process_name=effect_process_name,
+                                    pid=source_pid,
+                                    process_name=source_process_name,
                                     logon_id=logon_id,
                                     lifetime=lifetime,
                                     rng=rng,
@@ -15051,7 +15167,7 @@ class ActivityGenerator:
                                 logon_id=logon_id,
                                 parent_pid=parent_pid,
                                 termination_time=termination_time,
-                                seed_text=effect_command_line,
+                                seed_text=source_command_line,
                             )
 
             # Legacy PROCESS_TEMPLATES only for process_system (not user apps/code/build/query)

--- a/src/evidenceforge/generation/activity/http_content.py
+++ b/src/evidenceforge/generation/activity/http_content.py
@@ -282,6 +282,14 @@ def is_stable_resource_path(uri: str) -> bool:
     }
 
 
+def _uses_shared_static_response_seed(uri: str) -> bool:
+    """Return whether stable bytes should be shared across virtual hosts."""
+    clean_path = uri.split("?", 1)[0].split("#", 1)[0].lower()
+    if clean_path in {"/", "/index.html"}:
+        return False
+    return is_stable_resource_path(uri)
+
+
 def response_size_for_status(status_code: int, host: str, uri: str) -> int:
     """Return a stable source-native web response body size for an HTTP status."""
     if status_code in {204, 304}:
@@ -293,7 +301,7 @@ def response_size_for_status(status_code: int, host: str, uri: str) -> int:
         return response_size_for_health_endpoint(status_code, host, uri)
     if status_code < 400:
         stable_resource = is_stable_resource_path(uri)
-        seed_host = "static-resource" if stable_resource else host
+        seed_host = "static-resource" if _uses_shared_static_response_seed(uri) else host
         seed_uri = uri.split("?", 1)[0].split("#", 1)[0] if stable_resource else uri
         rng = random.Random(_stable_seed(f"web_response:{status_code}:{seed_host}:{seed_uri}"))
         return response_size_for_mime(rng, normalize_mime_type_for_path(uri, "text/html"))

--- a/src/evidenceforge/generation/activity/site_maps.py
+++ b/src/evidenceforge/generation/activity/site_maps.py
@@ -10,6 +10,7 @@ definitions, and CDN domain associations.
 
 from __future__ import annotations
 
+import hashlib
 import random
 import uuid
 from dataclasses import dataclass, field
@@ -17,7 +18,6 @@ from typing import Any
 
 from evidenceforge.config import get_activity_directory
 from evidenceforge.config.overlay import deep_merge_dict, load_with_overlay
-from evidenceforge.utils.rng import _stable_seed
 
 _SITE_MAPS_PATH = get_activity_directory() / "site_maps.yaml"
 _CACHED_DATA: dict[str, Any] | None = None
@@ -114,9 +114,10 @@ def _uses_stable_asset_tokens(path: str, content_type: str | None) -> bool:
 def _stable_hex_token(hostname: str, template: str, token: str, occurrence: int) -> str:
     bits = 64 if token == "{hex16}" else 32
     width = bits // 4
-    mask = (1 << bits) - 1
-    seed = _stable_seed(f"site_map_asset:{hostname}:{template}:{token}:{occurrence}")
-    return f"{seed & mask:0{width}x}"
+    digest = hashlib.sha256(
+        f"site_map_asset:{hostname}:{template}:{token}:{occurrence}".encode()
+    ).hexdigest()
+    return digest[:width]
 
 
 def _replace_token_occurrences(

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -1070,6 +1070,13 @@ class EcarEmitter(HostMultiplexEmitter):
         username = str(getattr(process, "username", "") or "").strip()
         if not username or username == "-":
             return ""
+        if (
+            direction == "OUTBOUND"
+            and event.edr is not None
+            and event.edr.actor_id
+            and username.strip().lower() not in _SERVICE_PRINCIPAL_NAMES
+        ):
+            return username
         pid = int(getattr(process, "pid", -1) or -1)
         probability = _flow_principal_probability(username, direction)
         key = (

--- a/src/evidenceforge/generation/emitters/zeek.py
+++ b/src/evidenceforge/generation/emitters/zeek.py
@@ -168,7 +168,10 @@ class ZeekEmitter(SensorMultiplexEmitter):
             "service": self._render_service_name(net.service),
             "duration": duration,
             "_min_duration": event.dns.rtt if event.dns is not None else None,
-            "_lock_duration": event.dns is not None,
+            "_lock_duration": event.dns is not None
+            or event.file_transfer is not None
+            or event.x509 is not None
+            or bool(event.x509_chain),
             "orig_bytes": net.orig_bytes,
             "resp_bytes": net.resp_bytes,
             "conn_state": conn_state,

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -56,6 +56,16 @@ from evidenceforge.utils.rng import _stable_seed
 logger = logging.getLogger(__name__)
 
 
+def zeek_format_observed(event: Any, format_name: str) -> bool:
+    """Return whether a Zeek sibling format survived source observation.
+
+    Direct emitter tests and low-level callers do not run through the dispatcher,
+    so an empty observed-format set means "unknown" rather than "dropped".
+    """
+    observed_formats = getattr(event, "_observed_formats", set())
+    return not observed_formats or format_name in observed_formats
+
+
 def _swap_host_list_value(value: Any, original_ip: Any, visible_ip: Any) -> Any:
     """Apply a per-sensor NAT IP view to Zeek list-valued host fields."""
     if (

--- a/src/evidenceforge/generation/emitters/zeek_files.py
+++ b/src/evidenceforge/generation/emitters/zeek_files.py
@@ -398,6 +398,8 @@ def _bounded_file_transfer_observation(
     max_duration = max(0.0, conn_duration - epsilon)
     bounded_duration = min(max(0.0, file_duration), max_duration)
     latest_start = conn_end - timedelta(seconds=bounded_duration + epsilon)
+    if lower_bound > latest_start:
+        lower_bound = latest_start
     if file_ts > latest_start and lower_bound <= latest_start:
         file_ts = latest_start
     if file_ts < lower_bound:

--- a/src/evidenceforge/generation/emitters/zeek_http.py
+++ b/src/evidenceforge/generation/emitters/zeek_http.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
-from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
+from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter, zeek_format_observed
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 
 _MIN_HTTP_TRANSACTION_TIMESTAMP_GAP = timedelta(milliseconds=1)
@@ -140,6 +140,9 @@ class ZeekHttpEmitter(SensorMultiplexEmitter):
             event_ts,
             seed_parts=http_seed_parts,
         )
+        if resp_fuids and not zeek_format_observed(event, "zeek_files"):
+            resp_fuids = None
+            resp_mime_types = None
         event_data: dict[str, Any] = {
             "ts": event_ts,
             "uid": net.zeek_uid,

--- a/src/evidenceforge/generation/emitters/zeek_ssl.py
+++ b/src/evidenceforge/generation/emitters/zeek_ssl.py
@@ -26,7 +26,7 @@ from datetime import timedelta
 from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
-from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
+from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter, zeek_format_observed
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 
 _SOURCE_TIMING = SourceTimingPlanner()
@@ -85,6 +85,12 @@ class ZeekSslEmitter(SensorMultiplexEmitter):
             not_before=conn_ts,
             within=within,
         )
+        cert_chain_fuids = ssl.cert_chain_fuids or None
+        if cert_chain_fuids and (
+            not zeek_format_observed(event, "zeek_files")
+            or not zeek_format_observed(event, "zeek_x509")
+        ):
+            cert_chain_fuids = None
         event_data: dict[str, Any] = {
             "ts": event_ts,
             "uid": net.zeek_uid,
@@ -98,7 +104,7 @@ class ZeekSslEmitter(SensorMultiplexEmitter):
             "resumed": ssl.resumed,
             "established": ssl.established,
             "ssl_history": ssl.ssl_history or None,
-            "cert_chain_fuids": ssl.cert_chain_fuids or None,
+            "cert_chain_fuids": cert_chain_fuids,
             "_sensor_hostnames": event._sensor_hostnames_by_format.get(self.format_def.name, []),
         }
         if event._nat_swaps_by_sensor:

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -1523,6 +1523,43 @@ class BaselineMixin:
             return str(action), str(process)
         return rng.choice(profiles)
 
+    def _polkit_process_start_ticks(
+        self,
+        hostname: str,
+        process_id: int,
+        timestamp: datetime,
+    ) -> str:
+        """Return Linux clock ticks since boot for a polkit unix-process subject."""
+        event_time = timestamp if timestamp.tzinfo is not None else timestamp.replace(tzinfo=UTC)
+        boot_time = None
+        get_boot_time = getattr(self.state_manager, "get_boot_time", None)
+        if callable(get_boot_time):
+            boot_time = get_boot_time(hostname)
+
+        if boot_time is not None:
+            boot = boot_time if boot_time.tzinfo is not None else boot_time.replace(tzinfo=UTC)
+            uptime_seconds = max(60.0, (event_time - boot).total_seconds())
+        else:
+            boot_uptime = getattr(self, "_kernel_boot_uptimes", {}).get(hostname)
+            uptime_seconds = (
+                float(boot_uptime)
+                if boot_uptime is not None
+                else float(
+                    3 * 86400 + (_stable_seed(f"polkit_boot_uptime:{hostname}") % (27 * 86400))
+                )
+            )
+
+        rng = random.Random(
+            _stable_seed(f"polkit_process_start:{hostname}:{process_id}:{event_time.isoformat()}")
+        )
+        max_age_seconds = max(0.05, min(900.0, uptime_seconds - 0.01))
+        age_seconds = min(
+            max_age_seconds,
+            max(0.02, rng.lognormvariate(math.log(2.0), 0.85)),
+        )
+        start_ticks = int((uptime_seconds - age_seconds) * 100) + rng.randint(0, 99)
+        return str(max(100, start_ticks))
+
     def _render_polkit_syslog_message(
         self,
         entry: dict[str, Any],
@@ -1556,6 +1593,7 @@ class BaselineMixin:
         values = {
             "action_id": action_id,
             "bus_id": agent["bus_id"],
+            "monotonic_start": self._polkit_process_start_ticks(hostname, process_id, timestamp),
             "process_path": action_process_path
             if "action {action_id}" in template
             else agent["process_path"],

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -7858,6 +7858,78 @@ class TestActivityGenerator:
         assert bash_events
         assert bash_events[-1].shell.command == "cat /etc/hosts"
 
+    def test_linux_catalog_compound_command_uses_source_native_child_argv(
+        self,
+        activity_gen,
+        state_manager,
+        mock_emitters,
+        monkeypatch,
+    ):
+        """Linux catalog shell compounds should not render as one non-shell process argv."""
+        from evidenceforge.generation.activity import application_catalog
+
+        process_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        linux = System(
+            hostname="LNX-01",
+            ip="10.0.0.2",
+            os="Ubuntu 22.04",
+            type="workstation",
+            assigned_user="alice",
+        )
+        user = User(
+            username="alice",
+            full_name="Alice Example",
+            email="alice@example.com",
+            persona="developer",
+        )
+        state_manager.set_current_time(process_time)
+        mock_emitters["bash_history"] = Mock()
+        systemd_pid = state_manager.create_process(
+            linux.hostname,
+            0,
+            "/usr/lib/systemd/systemd",
+            "/usr/lib/systemd/systemd --system",
+            "root",
+            "System",
+        )
+        bash_pid = state_manager.create_process(
+            linux.hostname,
+            systemd_pid,
+            "/bin/bash",
+            "-bash",
+            user.username,
+            "Medium",
+        )
+        activity_gen._system_pids = {linux.hostname: {"systemd": systemd_pid, "bash": bash_pid}}
+
+        monkeypatch.setattr(
+            application_catalog,
+            "pick_app_and_command",
+            lambda *args, **kwargs: ("/usr/bin/make", "make clean && make all"),
+        )
+
+        activity_gen.execute_baseline_activity(user, linux, process_time, "process_build")
+
+        events = [
+            call.args[0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+        ]
+        make_commands = [
+            event.process.command_line
+            for event in events
+            if event.event_type == "process_create"
+            and event.process is not None
+            and event.process.image == "/usr/bin/make"
+        ]
+        bash_events = [
+            call.args[0]
+            for call in mock_emitters["bash_history"].emit.call_args_list
+            if call.args[0].event_type == "bash_command"
+        ]
+
+        assert make_commands[:2] == ["make clean", "make all"]
+        assert all("&&" not in command for command in make_commands)
+        assert bash_events[-1].shell.command == "make clean && make all"
+
     def test_generate_bash_command_emits_correlated_linux_process(
         self, activity_gen, test_user, state_manager, mock_emitters
     ):
@@ -8731,6 +8803,19 @@ class TestActivityGenerator:
             ("/usr/bin/id", "id"),
             ("/usr/bin/df", "df"),
             ("/usr/bin/uptime", "uptime"),
+        ]
+
+    def test_linux_catalog_compound_command_splits_process_argv(self):
+        """Catalog process commands should use child argv, not shell compound text."""
+        processes = generator_module._linux_catalog_processes_from_shell_command(
+            "/usr/bin/make",
+            "make clean && make all",
+            username="alice",
+        )
+
+        assert processes == [
+            ("/usr/bin/make", "make clean"),
+            ("/usr/bin/make", "make all"),
         ]
 
     def test_linux_shell_single_process_inference_stops_after_first_stage(self, monkeypatch):

--- a/tests/unit/test_baseline_canonical.py
+++ b/tests/unit/test_baseline_canonical.py
@@ -36,7 +36,11 @@ import pytest
 from evidenceforge.events.contexts import HttpContext, IdsContext
 from evidenceforge.generation.actions import DhcpLeaseActionBundle, DhcpLeaseRequest
 from evidenceforge.generation.activity import ActivityGenerator
-from evidenceforge.generation.activity.generator import _ntp_payload_accounting
+from evidenceforge.generation.activity.generator import (
+    _ntp_association_poll_seconds,
+    _ntp_parser_min_gap_seconds,
+    _ntp_payload_accounting,
+)
 from evidenceforge.generation.activity.linux_interfaces import linux_primary_interface
 from evidenceforge.generation.engine.baseline import (
     _LINUX_AMBIENT_SSH_NOISE_BAND,
@@ -491,13 +495,23 @@ class TestIdsAlertCorrelation:
         assert event.network.resp_bytes == 0
         assert event.network.resp_pkts == 0
 
-    def test_ntp_association_fields_are_stable(self, activity_gen, mock_emitters, timestamp):
-        """NTP association and server response fields should be stable."""
-        for minute in (0, 10):
+    def test_ntp_association_fields_keep_observed_response_texture(
+        self,
+        activity_gen,
+        mock_emitters,
+        timestamp,
+    ):
+        """NTP association traits should stay stable while per-poll metrics vary."""
+        src_ip = "10.0.1.50"
+        dst_ip = "129.6.15.28"
+        poll_seconds = _ntp_association_poll_seconds(src_ip, dst_ip)
+        min_gap = _ntp_parser_min_gap_seconds(float(poll_seconds))
+
+        for offset in (0, min_gap + 60):
             activity_gen.generate_connection(
-                src_ip="10.0.1.50",
-                dst_ip="129.6.15.28",
-                time=timestamp.replace(minute=minute),
+                src_ip=src_ip,
+                dst_ip=dst_ip,
+                time=timestamp + timedelta(seconds=offset),
                 dst_port=123,
                 proto="udp",
                 service="ntp",
@@ -512,11 +526,69 @@ class TestIdsAlertCorrelation:
         assert first.version == second.version
         assert first.poll == second.poll
         assert first.precision == second.precision
-        assert first.root_delay == second.root_delay
-        assert first.root_disp == second.root_disp
+        assert first.root_delay != second.root_delay
+        assert first.root_disp != second.root_disp
+        assert 0 < first.precision < 0.001
 
-    def test_ntp_response_fields_are_server_owned(self, activity_gen, mock_emitters, timestamp):
-        """Server-owned NTP response fields should not vary by requesting client."""
+    def test_ntp_association_poll_has_host_texture(self):
+        """NTP poll intervals should not collapse to one value across clients."""
+        polls = {
+            _ntp_association_poll_seconds(src_ip, dst_ip)
+            for src_ip, dst_ip in (
+                ("10.10.3.10", "17.253.34.125"),
+                ("10.10.3.10", "23.186.168.130"),
+                ("10.10.3.10", "91.189.89.198"),
+                ("10.10.3.20", "129.6.15.28"),
+                ("10.10.3.20", "162.159.200.1"),
+                ("10.10.3.20", "17.253.34.125"),
+            )
+        }
+
+        assert polls == {1024, 2048, 4096}
+
+    def test_ntp_parser_rows_respect_association_cadence(
+        self,
+        activity_gen,
+        mock_emitters,
+        timestamp,
+    ):
+        """Too-soon UDP/123 responses should stay as conn rows without ntp.log fan-out."""
+        src_ip = "10.10.3.20"
+        dst_ip = "162.159.200.1"
+        poll_seconds = _ntp_association_poll_seconds(src_ip, dst_ip)
+        min_gap = _ntp_parser_min_gap_seconds(float(poll_seconds))
+
+        assert poll_seconds == 2048
+        assert min_gap > 240
+
+        for offset in (0, 240, min_gap + 20):
+            activity_gen.generate_connection(
+                src_ip=src_ip,
+                dst_ip=dst_ip,
+                time=timestamp + timedelta(seconds=offset),
+                dst_port=123,
+                proto="udp",
+                service="ntp",
+                duration=0.02,
+                orig_bytes=48,
+                resp_bytes=48,
+            )
+
+        conn_rows = [call.args[0] for call in mock_emitters["zeek_conn"].emit.call_args_list]
+        ntp_rows = [
+            call.args[0]
+            for call in mock_emitters["zeek_ntp"].emit.call_args_list
+            if call.args[0].ntp is not None
+        ]
+
+        assert len(conn_rows) == 3
+        assert len(ntp_rows) == 2
+        assert [row.network.service for row in conn_rows] == ["ntp", "", "ntp"]
+        assert conn_rows[1].ntp is None
+        assert ntp_rows[1].timestamp - ntp_rows[0].timestamp >= timedelta(seconds=min_gap)
+
+    def test_ntp_response_traits_are_server_owned(self, activity_gen, mock_emitters, timestamp):
+        """Stable NTP server traits should not vary by requesting client."""
         for src_ip in ("10.0.1.50", "10.0.1.51", "10.0.2.10"):
             activity_gen.generate_connection(
                 src_ip=src_ip,
@@ -533,8 +605,14 @@ class TestIdsAlertCorrelation:
         ntp_rows = [call.args[0].ntp for call in mock_emitters["zeek_ntp"].emit.call_args_list]
         assert len(ntp_rows) == 3
         assert {row.precision for row in ntp_rows} == {ntp_rows[0].precision}
-        assert {row.root_delay for row in ntp_rows} == {ntp_rows[0].root_delay}
-        assert {row.root_disp for row in ntp_rows} == {ntp_rows[0].root_disp}
+        assert all(row.root_delay > 0 for row in ntp_rows)
+        assert all(row.root_disp > 0 for row in ntp_rows)
+        assert (
+            max(row.root_delay for row in ntp_rows) - min(row.root_delay for row in ntp_rows) < 0.01
+        )
+        assert (
+            max(row.root_disp for row in ntp_rows) - min(row.root_disp for row in ntp_rows) < 0.01
+        )
 
     def test_ntp_payload_accounting_clamps_udp_123_probe_sizes(self, timestamp):
         """UDP/123 conn rows should not inherit generic high-byte probe payloads."""

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -270,6 +270,189 @@ class TestObservationProfiles:
         assert conn_event.timestamp == http_event.timestamp
         assert conn_event.timestamp > event.timestamp
 
+    def test_zeek_format_missingness_can_drop_child_without_dropping_conn(self, monkeypatch):
+        """Zeek companion analyzers may be missing while conn.log stays visible."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "zeek": {
+                        "missingness": 0.0,
+                        "format_missingness": {"zeek_http": 1.0},
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    }
+                },
+            },
+        )
+        sm = MagicMock(spec=StateManager)
+        conn = _make_mock_emitter("zeek_conn", handles=True)
+        http = _make_mock_emitter("zeek_http", handles=True)
+        dispatcher = EventDispatcher(
+            state_manager=sm,
+            emitters={"zeek_conn": conn, "zeek_http": http},
+            observation_policy=ObservationPolicy("zeek_child_gap_test"),
+        )
+        dispatcher.storyline_cluster_id = "story-001"
+
+        event = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.1.10",
+                src_port=51111,
+                dst_ip="10.0.2.20",
+                dst_port=443,
+                protocol="tcp",
+                zeek_uid="CUID123456789",
+            ),
+        )
+        dispatcher.dispatch(event)
+
+        conn.emit.assert_called_once()
+        http.emit.assert_not_called()
+        assert conn.emit.call_args.args[0]._observed_formats == {"zeek_conn"}
+        assert dispatcher.source_evidence_status["story-001"]["zeek"] == {
+            "visible": 1,
+            "dropped": 1,
+        }
+
+    def test_zeek_visible_child_promotes_dropped_conn_parent(self, monkeypatch):
+        """A visible Zeek child row must not orphan its conn.log parent."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "zeek": {
+                        "missingness": 0.0,
+                        "format_missingness": {"zeek_conn": 1.0, "zeek_http": 0.0},
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    }
+                },
+            },
+        )
+        sm = MagicMock(spec=StateManager)
+        conn = _make_mock_emitter("zeek_conn", handles=True)
+        http = _make_mock_emitter("zeek_http", handles=True)
+        dispatcher = EventDispatcher(
+            state_manager=sm,
+            emitters={"zeek_conn": conn, "zeek_http": http},
+            observation_policy=ObservationPolicy("zeek_child_parent_test"),
+        )
+        dispatcher.storyline_cluster_id = "story-001"
+
+        event = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.1.10",
+                src_port=51111,
+                dst_ip="10.0.2.20",
+                dst_port=80,
+                protocol="tcp",
+                zeek_uid="CUID123456789",
+            ),
+        )
+        dispatcher.dispatch(event)
+
+        conn.emit.assert_called_once()
+        http.emit.assert_called_once()
+        assert conn.emit.call_args.args[0]._observed_formats == {"zeek_conn", "zeek_http"}
+        assert http.emit.call_args.args[0]._observed_formats == {"zeek_conn", "zeek_http"}
+        assert dispatcher.source_evidence_status["story-001"]["zeek"] == {"visible": 2}
+
+    def test_zeek_visible_x509_promotes_dropped_files_parent(self, monkeypatch):
+        """Visible x509 rows require visible files.log certificate objects."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "zeek": {
+                        "missingness": 0.0,
+                        "format_missingness": {"zeek_files": 1.0, "zeek_x509": 0.0},
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    }
+                },
+            },
+        )
+        sm = MagicMock(spec=StateManager)
+        files = _make_mock_emitter("zeek_files", handles=True)
+        x509 = _make_mock_emitter("zeek_x509", handles=True)
+        dispatcher = EventDispatcher(
+            state_manager=sm,
+            emitters={"zeek_files": files, "zeek_x509": x509},
+            observation_policy=ObservationPolicy("zeek_x509_parent_test"),
+        )
+
+        event = SecurityEvent(timestamp=_make_ts(), event_type="connection")
+        dispatcher.dispatch(event)
+
+        files.emit.assert_called_once()
+        x509.emit.assert_called_once()
+        assert files.emit.call_args.args[0]._observed_formats == {"zeek_files", "zeek_x509"}
+        assert x509.emit.call_args.args[0]._observed_formats == {"zeek_files", "zeek_x509"}
+
+    def test_zeek_format_missingness_keeps_delay_coherent_when_visible(self, monkeypatch):
+        """Format-specific drop policy must not split same-UID source delay."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "zeek": {
+                        "missingness": 0.0,
+                        "format_missingness": {"zeek_http": 0.0},
+                        "delay_ms": {"min_ms": 5, "max_ms": 1000},
+                    }
+                },
+            },
+        )
+        sm = MagicMock(spec=StateManager)
+        conn = _make_mock_emitter("zeek_conn", handles=True)
+        http = _make_mock_emitter("zeek_http", handles=True)
+        dispatcher = EventDispatcher(
+            state_manager=sm,
+            emitters={"zeek_conn": conn, "zeek_http": http},
+            observation_policy=ObservationPolicy("zeek_child_delay_test"),
+        )
+
+        event = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.1.10",
+                src_port=51111,
+                dst_ip="10.0.2.20",
+                dst_port=443,
+                protocol="tcp",
+                zeek_uid="CUID123456789",
+            ),
+        )
+        dispatcher.dispatch(event)
+
+        conn_event = conn.emit.call_args.args[0]
+        http_event = http.emit.call_args.args[0]
+        assert conn_event.timestamp == http_event.timestamp
+        assert conn_event.timestamp > event.timestamp
+
     def test_ecar_storyline_process_observation_delay_is_coherent(self, monkeypatch):
         """Storyline eCAR process graphs should not orphan source-local references."""
         monkeypatch.setattr(

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -1761,6 +1761,58 @@ class TestChronologicalOutput:
 
         assert "principal" not in emitted[0]
 
+    def test_actor_linked_user_flow_preserves_principal(self, emitter, monkeypatch, ts):
+        """Actor-linked user FLOW rows should not drop a known user principal."""
+        monkeypatch.setattr(
+            "evidenceforge.generation.emitters.ecar.ecar_flow_identity_config",
+            lambda: {
+                "user_process_probability": 0.0,
+                "service_process_probability": 0.0,
+                "root_process_probability": 0.0,
+                "inbound_listener_probability": 0.0,
+            },
+        )
+        emitted: list[dict] = []
+        monkeypatch.setattr(emitter, "emit_event", emitted.append)
+        event = SecurityEvent(
+            timestamp=ts,
+            event_type="connection",
+            src_host=HostContext(
+                hostname="WS-MCHEN-01",
+                ip="10.10.1.24",
+                os="Windows 11",
+                os_category="windows",
+                system_type="workstation",
+                fqdn="ws-mchen-01.example.org",
+            ),
+            process=ProcessContext(
+                pid=6124,
+                parent_pid=3340,
+                image=r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+                command_line="chrome.exe --type=utility",
+                username="marcus.chen",
+                start_time=ts,
+            ),
+            network=NetworkContext(
+                src_ip="10.10.1.24",
+                src_port=50124,
+                dst_ip="142.250.72.14",
+                dst_port=443,
+                protocol="tcp",
+                initiating_pid=6124,
+            ),
+            edr=EdrContext(
+                object_id="11111111-2222-3333-4444-555555555555",
+                actor_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            ),
+        )
+
+        emitter._render_connection(event)
+
+        assert emitted[0]["direction"] == "OUTBOUND"
+        assert emitted[0]["actorID"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert emitted[0]["principal"] == "marcus.chen"
+
     def test_inbound_flow_uses_destination_listener_pid(self, emitter, monkeypatch, ts):
         """Inbound host observations should use the local listener PID when known."""
         emitted: list[dict] = []

--- a/tests/unit/test_expert_round4.py
+++ b/tests/unit/test_expert_round4.py
@@ -48,14 +48,16 @@ class TestS0OrigBytes:
 
 
 class TestNtpPrecision:
-    """P1-5: NTP precision must be an integer."""
+    """P1-5: NTP precision must be a Zeek interval."""
 
-    def test_ntp_precision_is_integer(self):
-        """NTP precision should be a whole number (8-bit signed int)."""
+    def test_ntp_precision_is_interval_seconds(self):
+        """NTP precision should be converted from wire exponent to seconds."""
+        from evidenceforge.generation.activity.generator import _ntp_precision_interval_seconds
+
         rng = random.Random(42)
         for _ in range(100):
-            val = float(rng.randint(-25, -18))
-            assert val == int(val), f"NTP precision {val} is not an integer"
+            val = _ntp_precision_interval_seconds(rng.randint(-25, -18))
+            assert 0 < val < 0.001, f"NTP precision {val} is not an interval"
 
 
 class TestDnsIpPairing:

--- a/tests/unit/test_http_content.py
+++ b/tests/unit/test_http_content.py
@@ -166,6 +166,18 @@ def test_static_response_size_is_stable_across_virtual_hosts():
     assert dynamic_first != dynamic_second
 
 
+def test_root_document_response_size_is_host_specific():
+    first = response_size_for_status(200, "upload.wikimedia.org", "/")
+    second = response_size_for_status(200, "cdn.sstatic.net", "/")
+    repeat = response_size_for_status(200, "upload.wikimedia.org", "/")
+    index_first = response_size_for_status(200, "portal.example.com", "/index.html")
+    index_second = response_size_for_status(200, "intranet.example.net", "/index.html")
+
+    assert first == repeat
+    assert first != second
+    assert index_first != index_second
+
+
 def test_transfer_variant_keeps_static_resource_bytes_stable_across_clients():
     base = response_size_for_status(200, "portal.example.com", "/assets/main.css")
     client_a = apply_transfer_size_variance(

--- a/tests/unit/test_phase5_system_traffic.py
+++ b/tests/unit/test_phase5_system_traffic.py
@@ -180,6 +180,11 @@ def test_polkit_messages_use_low_session_and_bus_values(linux_system, state_mana
         for message in messages
         if (match := re.search(r"unix-process:(\d+):", message))
     ]
+    process_start_ticks = [
+        int(match.group(1))
+        for message in messages
+        if (match := re.search(r"unix-process:\d+:(\d+)", message))
+    ]
 
     assert session_ids
     assert max(session_ids) < 1000
@@ -188,6 +193,10 @@ def test_polkit_messages_use_low_session_and_bus_values(linux_system, state_mana
     assert len(set(bus_ids)) > 4
     assert process_ids
     assert min(process_ids) >= 300
+    assert process_start_ticks
+    assert set(process_start_ticks).isdisjoint({0, 1000, 2000})
+    assert min(process_start_ticks) > 10_000
+    assert len(set(process_start_ticks)) > 4
 
 
 def test_polkit_action_messages_pair_action_with_source_native_program(linux_system, state_manager):

--- a/tests/unit/test_site_maps.py
+++ b/tests/unit/test_site_maps.py
@@ -61,6 +61,22 @@ class TestHexTokenReplacement:
         assert segments[1] != segments[2]
         assert len(segments[3]) == 16
 
+    def test_stable_hex16_tokens_are_not_32_bit_values_zero_padded_to_64_bit(self):
+        rng = random.Random(42)
+        path = "/assets/app.{hex16}.js"
+
+        replaced = _replace_hex_tokens(
+            rng,
+            path,
+            hostname="cdn.example.com",
+            template=path,
+            stable_asset_tokens=True,
+        )
+
+        token = replaced.rsplit(".", 2)[1]
+        assert len(token) == 16
+        assert not token.startswith("00000000")
+
 
 class TestLoadSiteMaps:
     """Verify site_maps.yaml loads and has expected structure."""

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -321,6 +321,44 @@ class TestValidateConfig:
             for issue in result.issues
         )
 
+    def test_validate_config_rejects_mismatched_observation_format_missingness(self, monkeypatch):
+        from evidenceforge.config import observation_profiles
+
+        def load_invalid_observation_profiles():
+            return {
+                "profiles": {
+                    "complete": {
+                        "description": "bad",
+                        "default": {
+                            "missingness": 0.0,
+                            "delay_ms": {"min_ms": 0, "max_ms": 0},
+                            "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                        },
+                        "sources": {
+                            "zeek": {
+                                "missingness": 0.0,
+                                "format_missingness": {"proxy_access": 0.1},
+                            }
+                        },
+                    }
+                }
+            }
+
+        monkeypatch.setattr(
+            observation_profiles,
+            "load_observation_profiles",
+            load_invalid_observation_profiles,
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "observation_profiles.yaml"
+            and "format_missingness entries do not belong to zeek" in issue.message
+            for issue in result.issues
+        )
+
     def test_validate_config_rejects_unknown_host_activity_family(self, monkeypatch):
         from evidenceforge.generation.activity import host_activity_profiles
 

--- a/tests/unit/test_zeek_files.py
+++ b/tests/unit/test_zeek_files.py
@@ -43,7 +43,10 @@ from evidenceforge.formats import load_format
 from evidenceforge.generation.actions.file_transfer import (
     HttpResponseFileTransferActionBundle,
     HttpResponseFileTransferRequest,
+    SmbFileTransferMetadataActionBundle,
+    SmbFileTransferMetadataRequest,
 )
+from evidenceforge.generation.emitters.zeek import ZeekEmitter
 from evidenceforge.generation.emitters.zeek_files import ZeekFilesEmitter
 from evidenceforge.generation.emitters.zeek_http import ZeekHttpEmitter
 from evidenceforge.generation.emitters.zeek_pe import ZeekPeEmitter
@@ -312,6 +315,89 @@ class TestFilesUidCorrelation:
         assert data["ts"] >= event.timestamp.timestamp()
         assert data["ts"] + data["duration"] <= event.timestamp.timestamp() + 0.08
 
+    def test_file_transfer_lower_bound_conflict_prefers_parent_connection_interval(self):
+        """files.log rows must stay inside conn even when analyzer lower bounds conflict."""
+        fmt = load_format("zeek_files")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "files.json"
+            emitter = ZeekFilesEmitter(fmt, output)
+            event = SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                event_type="connection",
+                network=NetworkContext(
+                    src_ip="10.0.0.1",
+                    src_port=50000,
+                    dst_ip="10.0.0.10",
+                    dst_port=80,
+                    protocol="tcp",
+                    zeek_uid="CConnUID12345678",
+                    duration=0.15,
+                ),
+                file_transfer=FileTransferContext(
+                    fuid="FFileUID12345678",
+                    source="HTTP",
+                    duration=0.0,
+                    seen_bytes=1024,
+                    observation_not_before=datetime(2024, 1, 15, 10, 0, 1, tzinfo=UTC),
+                ),
+            )
+
+            emitter.emit(event)
+            emitter.close()
+
+            data = json.loads(output.read_text().splitlines()[0])
+
+        conn_start = event.timestamp.timestamp()
+        conn_end = conn_start + 0.15
+        assert conn_start <= data["ts"] <= conn_end
+        assert data["ts"] + data["duration"] <= conn_end
+
+    def test_conn_duration_is_locked_when_files_reference_connection(self):
+        """Per-sensor conn duration texture must not out-shrink dependent files rows."""
+        conn_fmt = load_format("zeek_conn")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir)
+            emitter = ZeekEmitter(conn_fmt, out_dir, sensor_hostnames=["core", "dmz"])
+            event = SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                event_type="connection",
+                network=NetworkContext(
+                    src_ip="10.0.0.1",
+                    src_port=50000,
+                    dst_ip="10.0.0.10",
+                    dst_port=80,
+                    protocol="tcp",
+                    service="http",
+                    zeek_uid="CConnUID12345678",
+                    duration=7.25,
+                    conn_state="SF",
+                    history="ShADadfF",
+                    missed_bytes=512,
+                    orig_bytes=1024,
+                    resp_bytes=8192,
+                    orig_pkts=4,
+                    orig_ip_bytes=1184,
+                    resp_pkts=10,
+                    resp_ip_bytes=8592,
+                ),
+                file_transfer=FileTransferContext(
+                    fuid="FFileUID12345678",
+                    source="HTTP",
+                    duration=7.0,
+                    seen_bytes=8192,
+                ),
+            )
+            event._sensor_hostnames_by_format = {"zeek_conn": ["core", "dmz"]}
+
+            emitter.emit(event)
+            emitter.close()
+
+            core_conn = json.loads((out_dir / "core" / "conn.json").read_text())
+            dmz_conn = json.loads((out_dir / "dmz" / "conn.json").read_text())
+
+        assert core_conn["duration"] == 7.25
+        assert dmz_conn["duration"] == 7.25
+
     def test_http_file_transfer_timestamp_follows_parent_http_record(self):
         """HTTP response files should not predate the owning http.log row."""
         files_fmt = load_format("zeek_files")
@@ -494,6 +580,29 @@ class TestFilesUidCorrelation:
         assert result.pe is not None
         assert isinstance(result.pe.compile_ts, int)
         assert result.pe.compile_ts <= int(request.timestamp.timestamp()) - (30 * 24 * 60 * 60)
+
+    def test_http_file_analysis_loss_suppresses_hash_and_pe_analyzers(self):
+        """Partial HTTP file observations should not claim full-content analyzers."""
+        request = HttpResponseFileTransferRequest(
+            host="updates.example.test",
+            uri="/agent.exe",
+            dst_ip="10.0.0.10",
+            response_body_len=2_000_000,
+            response_mime_types=["application/x-msdownload"],
+            timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+            parent_duration=1.0,
+        )
+
+        result = HttpResponseFileTransferActionBundle(request, _AlwaysPeRandom()).execute()
+        ft = result.file_transfer
+
+        assert ft.timedout is True
+        assert ft.missing_bytes > 0
+        assert ft.seen_bytes == request.response_body_len - ft.missing_bytes
+        assert ft.total_bytes == request.response_body_len
+        assert ft.analyzers == []
+        assert ft.sha1 == ""
+        assert result.pe is None
 
     def test_certificate_file_timestamp_follows_parent_ssl_record(self):
         """Certificate files should not predate the owning ssl.log row."""
@@ -785,6 +894,45 @@ class TestFilesUidCorrelation:
                 data = json.loads(f.readline())
 
             assert data["filename"] == r"\\files01\Shared\Finance\budget-review.xlsx"
+
+    def test_smb_file_analysis_loss_suppresses_hash_analyzers(self):
+        """Partial SMB file observations should not claim full-content hashes."""
+        request = SmbFileTransferMetadataRequest(
+            src_ip="10.0.0.5",
+            dst_ip="10.0.0.10",
+            transfer_bytes=4_000_000,
+            duration=2.5,
+            server="FILE-SRV-01",
+            user="alex",
+        )
+        smb_config = {
+            "min_transfer_bytes": 1,
+            "missing_bytes_probability": 1.0,
+            "timeout_probability": 1.0,
+            "mime_types": [{"mime_type": "application/zip", "weight": 1}],
+            "analyzer_sets": [{"analyzers": ["MD5", "SHA1"], "weight": 1}],
+            "filename_templates": [
+                {
+                    "mime_types": ["application/zip"],
+                    "templates": [r"\\{server}\Installers\agent.zip"],
+                    "weight": 1,
+                }
+            ],
+        }
+
+        ft = SmbFileTransferMetadataActionBundle(
+            request,
+            _AlwaysPeRandom(),
+            smb_config=smb_config,
+        ).execute()
+
+        assert ft is not None
+        assert ft.timedout is True
+        assert ft.missing_bytes > 0
+        assert ft.seen_bytes == request.transfer_bytes - ft.missing_bytes
+        assert ft.analyzers == []
+        assert ft.md5 == ""
+        assert ft.sha1 == ""
 
 
 class TestSmbFileTransferConfig:

--- a/tests/unit/test_zeek_http.py
+++ b/tests/unit/test_zeek_http.py
@@ -227,6 +227,46 @@ class TestHttpFormatAccuracy:
         assert "resp_fuids" not in data
         assert "resp_mime_types" not in data
 
+    def test_resp_fuids_omitted_when_files_observation_is_absent(self):
+        """http.log should not reference files.log rows dropped by observation policy."""
+        fmt = load_format("zeek_http")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "http.json"
+            emitter = ZeekHttpEmitter(fmt, output)
+            event = SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                event_type="connection",
+                network=NetworkContext(
+                    src_ip="10.0.0.1",
+                    src_port=50000,
+                    dst_ip="93.184.216.34",
+                    dst_port=80,
+                    protocol="tcp",
+                    service="http",
+                    zeek_uid="CHttpFilesAbsent1",
+                    duration=1.0,
+                ),
+                http=HttpContext(
+                    method="GET",
+                    host="example.com",
+                    uri="/index.html",
+                    status_code=200,
+                    status_msg="OK",
+                    response_body_len=2048,
+                    resp_fuids=["FHttpFileAbsent1"],
+                    resp_mime_types=["text/html"],
+                ),
+                _observed_formats={"zeek_conn", "zeek_http"},
+            )
+
+            emitter.emit(event)
+            emitter.close()
+
+            data = json.loads(output.read_text().splitlines()[0])
+
+        assert "resp_fuids" not in data
+        assert "resp_mime_types" not in data
+
 
 class TestHttpCanHandle:
     """Verify can_handle() filtering."""

--- a/tests/unit/test_zeek_ssl.py
+++ b/tests/unit/test_zeek_ssl.py
@@ -289,6 +289,49 @@ class TestSslUidCorrelation:
             assert len(files_data["sha1"]) == 40
             assert files_data["ts"] >= ssl_data["ts"]
 
+    def test_ssl_cert_chain_fuids_omitted_when_x509_observation_is_absent(self):
+        """ssl.log should not reference certificate rows absent from x509/files logs."""
+        ssl_fmt = load_format("zeek_ssl")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "ssl.json"
+            ssl_emitter = ZeekSslEmitter(ssl_fmt, output)
+            event = SecurityEvent(
+                timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                event_type="connection",
+                network=NetworkContext(
+                    src_ip="10.0.0.1",
+                    src_port=50000,
+                    dst_ip="8.8.8.8",
+                    dst_port=443,
+                    protocol="tcp",
+                    zeek_uid="CNoX509Observation",
+                    conn_state="SF",
+                    duration=1.5,
+                ),
+                ssl=SslContext(
+                    version="TLSv12",
+                    cipher="TLS_AES_128_GCM_SHA256",
+                    cert_chain_fuids=["Fabcdef1234567890"],
+                ),
+                x509=X509Context(
+                    fuid="Fabcdef1234567890",
+                    fingerprint="a" * 40,
+                    certificate_serial="01",
+                    certificate_subject="CN=example.com",
+                    certificate_issuer="CN=Example CA",
+                    certificate_not_valid_before=1700000000.0,
+                    certificate_not_valid_after=1730000000.0,
+                ),
+                _observed_formats={"zeek_conn", "zeek_ssl", "zeek_files"},
+            )
+
+            ssl_emitter.emit(event)
+            ssl_emitter.close()
+
+            ssl_data = json.loads(output.read_text().splitlines()[0])
+
+        assert "cert_chain_fuids" not in ssl_data
+
     def test_files_host_lists_follow_sensor_nat_view(self):
         """files.log tx/rx hosts should agree with the same-sensor conn endpoint view."""
         files_fmt = load_format("zeek_files")

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "evidence-forge"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Improve assessment-loop realism signals across source-observation missingness, Zeek sibling integrity, proxy/web texture, eCAR FLOW principals, Linux source-native rendering, Zeek file-analysis imperfections, NTP semantics, and Linux compound-command process rendering.
- Add focused regression coverage and worklog handoff for the 10-loop assessment batch.
- Bump EvidenceForge to `1.4.1` and add the release changelog entry.

## Validation
- `uv run pytest --include-slow --no-cov` (`4472 passed, 6 skipped`)
- `uv run ruff check .`
- `uv run ruff format --check .`

## Release Notes
- SemVer bump: patch, driven by `fix: improve assessment realism signals`.
- Remote tag guard: `v1.4.1` was not present before creating this PR.