### PR TITLE
fix: optimize web generation performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Detailed development history for the EvidenceForge project. Transferred from TOD
 
 ## Unreleased
 
+## v1.8.1 (2026-06-28)
+
+This patch release fixes a superlinear slowdown in web/proxy-heavy generation
+while preserving byte-identical output for short equivalence runs.
+
+**Generation performance**
+
+- Replaced count-triggered full rebuilds of the recent connection 5-tuple cache
+  with event-time lazy pruning, keeping tuple reuse protection bounded to the
+  existing 24-hour reuse window (`b5b10fc6`).
+- Added generated-output equivalence helpers, regression coverage for stale and
+  future tuple cache entries, and benchmark worklog notes for the high-volume
+  SOF-ELK scenario that reproduced the slowdown (`b5b10fc6`).
+
 ## v1.8.0 (2026-06-27)
 
 This minor release adds optional network-sensor topology support and updates

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -224,7 +224,11 @@ Use the `/eforge:references:evidence-formats` skill for detailed field documenta
 
 ## Performance Expectations
 
-- Small scenarios (5 users, 4 hours): a few seconds
-- Medium scenarios (100 users, 8 hours): ~14 seconds
+- Runtime scales with emitted evidence volume, selected formats, scenario length, warm-up
+  length, host count, and traffic rates. Web/proxy-heavy scenarios can emit many dependent
+  requests per top-level action.
+- For long scenarios, scope `output.logs` or use `--formats` to generate only the sources
+  needed for the exercise.
 - The engine uses parallel threaded emitters — one thread per log format
-- Memory stays under 500MB even for large datasets
+- If a run slows down progressively by hour, capture the scenario and generated format mix;
+  that usually points to a generator hot path rather than normal output-volume scaling.

--- a/docs/worklog/2026-06-28-web-generation-performance.md
+++ b/docs/worklog/2026-06-28-web-generation-performance.md
@@ -1,0 +1,58 @@
+# Web/proxy generation performance
+
+## Context
+
+The scenario at `/tmp/scenario.yaml` reproduces progressive slowdown during
+web/proxy-heavy generation. A 4h slice completes in roughly 30 seconds, while a
+12h pre-fix run from `dev` reached only Hour 9/12 after 8:23 and was interrupted
+to avoid spending the implementation session waiting on the known hot path.
+
+The hotspot is recent 5-tuple tracking in `ActivityGenerator`: once the cache
+crosses 100,000 entries, each additional reservation can rebuild the whole dict.
+Dense web/proxy sessions allocate many short-lived connections, so the cost grows
+with accumulated scenario history instead of the active reuse window.
+
+## Fix
+
+Replace count-triggered whole-dict pruning with event-time lazy pruning:
+
+- keep `_recent_connection_tuples` as the source-of-truth dict for compatibility;
+- add a min-heap of `(seen_at, tuple_key)` expiration candidates;
+- prune only entries older than the existing 24h reuse window relative to the
+  candidate event time;
+- preserve future tuple reservations for non-monotonic generation order;
+- ignore stale heap entries when the dict has a newer timestamp for the same key.
+
+## Validation Notes
+
+Completed:
+
+- Exact pre-fix `dev` 4h SOF-ELK® run:
+  `/private/tmp/eforge-equivalence/before-4h-exact`, 27.72s.
+- Fixed-branch 4h SOF-ELK run:
+  `/private/tmp/eforge-equivalence/after-4h`, 27.99s.
+- 4h generated-output equivalence:
+  byte-identical and normalized multiset-identical across `data/`,
+  `GROUND_TRUTH.json`, and `OBSERVATION_MANIFEST.json`.
+- Pre-fix `dev` 12h SOF-ELK run:
+  interrupted at Hour 9/12 after 8:23 because it reproduced the known slowdown.
+- Fixed-branch 12h SOF-ELK run:
+  `/private/tmp/eforge-equivalence/after-12h`, 44.36s, 6,147 web rows and
+  1,696 proxy rows.
+- Fixed-branch full 48h SOF-ELK run:
+  `/private/tmp/eforge-equivalence/after-48h`, 117.49s, 23,347 web rows and
+  2,307 proxy rows.
+- `eforge eval` on the 48h fixed output parsed 25,654 records and scored
+  88/100 overall. Acceptance failed for existing scenario/evaluator reasons:
+  SOF-ELK proxy combined rows are currently flagged as invalid ISO timestamps by
+  strict `proxy_access` validation, and storyline event presence is not matched
+  for this web/proxy-only scenario. This is not attributed to the tuple-cache
+  optimization.
+- Blind reviewer sampling was skipped after the clean 4h before/after gate proved
+  byte-identical generated output for an exact `dev` baseline.
+- Focused tests:
+  `uv run --no-sync pytest --no-cov tests/unit/test_activity.py tests/unit/test_dns_realism.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_storyline_command_networks.py tests/unit/test_output_equivalence.py tests/unit/test_install_skills.py`
+  passed with 548 tests.
+- Style gates:
+  `uv run --no-sync ruff check .` and `uv run --no-sync ruff format --check .`
+  passed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "evidence-forge"
-version = "1.8.0"
+version = "1.8.1"
 description = "Generate realistic synthetic security logs for cybersecurity threat hunting training and research"
 readme = "README.md"
 license = "MIT"

--- a/src/evidenceforge/__init__.py
+++ b/src/evidenceforge/__init__.py
@@ -27,5 +27,5 @@ for cybersecurity threat hunting training and research. It uses a two-phase
 architecture combining LLM-driven scenario creation with deterministic log generation.
 """
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 __all__ = []  # Will be expanded as modules are implemented

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -27,6 +27,7 @@ activity events (logon, logoff, process creation, network connections) and
 coordinates them across multiple log formats for consistency.
 """
 
+import heapq
 import ipaddress
 import itertools
 import logging
@@ -236,6 +237,7 @@ class _HttpPersistentConnection:
 
 
 _HTTP_PERSISTENT_REUSE_GUARD = timedelta(milliseconds=900)
+_RECENT_CONNECTION_REUSE_WINDOW_SECONDS = 86_400.0
 
 
 _WINDOWS_SINGLETON_SERVICE_EXES = frozenset(
@@ -3918,6 +3920,7 @@ class ActivityGenerator:
             tuple[str, str, int, str, str], _HttpPersistentConnection
         ] = {}
         self._recent_connection_tuples: dict[tuple[str, int, str, int, str], float] = {}
+        self._recent_connection_tuple_heap: list[tuple[float, tuple[str, int, str, int, str]]] = []
         self._kerberos_source_port_reservations: dict[tuple[str, str], list[tuple[float, int]]] = {}
         self._kerberos_audit_tuple_times: dict[tuple[str, str, int], list[float]] = {}
         self._kerberos_tgt_cache_until: dict[tuple[str, str, str], datetime] = {}
@@ -4871,19 +4874,46 @@ class ActivityGenerator:
         if proto == "icmp":
             return
         ts_epoch = time.timestamp()
+        self._prune_recent_connection_tuples(ts_epoch)
         active_until = ts_epoch + max(0.0, duration or 0.0)
-        if len(self._recent_connection_tuples) > 100_000:
-            cutoff = ts_epoch - 86_400
-            self._recent_connection_tuples = {
-                key: seen_at
-                for key, seen_at in self._recent_connection_tuples.items()
-                if seen_at >= cutoff
-            }
         for key in self._connection_tuple_key_variants(src_ip, src_port, dst_ip, dst_port, proto):
-            self._recent_connection_tuples[key] = max(
-                active_until,
-                self._recent_connection_tuples.get(key, ts_epoch),
+            previous_seen_at = self._recent_connection_tuples.get(key)
+            seen_at = max(
+                active_until, previous_seen_at if previous_seen_at is not None else ts_epoch
             )
+            if previous_seen_at == seen_at:
+                continue
+            self._recent_connection_tuples[key] = seen_at
+            heapq.heappush(self._recent_connection_tuple_heap, (seen_at, key))
+
+    def _prune_recent_connection_tuples(
+        self,
+        ts_epoch: float,
+        *,
+        reuse_window: float = _RECENT_CONNECTION_REUSE_WINDOW_SECONDS,
+    ) -> None:
+        """Remove tuple reservations older than the event-time reuse window."""
+        if self._recent_connection_tuples and not self._recent_connection_tuple_heap:
+            self._recent_connection_tuple_heap = [
+                (seen_at, key) for key, seen_at in self._recent_connection_tuples.items()
+            ]
+            heapq.heapify(self._recent_connection_tuple_heap)
+        cutoff = ts_epoch - reuse_window
+        while self._recent_connection_tuple_heap:
+            seen_at, key = self._recent_connection_tuple_heap[0]
+            if seen_at >= cutoff:
+                break
+            heapq.heappop(self._recent_connection_tuple_heap)
+            if self._recent_connection_tuples.get(key) == seen_at:
+                del self._recent_connection_tuples[key]
+        if (
+            len(self._recent_connection_tuple_heap) > 100_000
+            and len(self._recent_connection_tuple_heap) > len(self._recent_connection_tuples) * 4
+        ):
+            self._recent_connection_tuple_heap = [
+                (seen_at, key) for key, seen_at in self._recent_connection_tuples.items()
+            ]
+            heapq.heapify(self._recent_connection_tuple_heap)
 
     @staticmethod
     def _connection_tuple_key_variants(
@@ -4892,15 +4922,20 @@ class ActivityGenerator:
         dst_ip: str,
         dst_port: int,
         proto: str,
-    ) -> set[tuple[str, int, str, int, str]]:
+    ) -> tuple[tuple[str, int, str, int, str], ...]:
         """Return raw and IPv4-mapped-normalized tuple keys for reuse checks."""
-        src_values = {src_ip, src_ip.removeprefix("::ffff:")}
-        dst_values = {dst_ip, dst_ip.removeprefix("::ffff:")}
-        return {
-            (candidate_src, src_port, candidate_dst, dst_port, proto)
-            for candidate_src in src_values
-            for candidate_dst in dst_values
-        }
+        src_values = (src_ip, src_ip.removeprefix("::ffff:"))
+        dst_values = (dst_ip, dst_ip.removeprefix("::ffff:"))
+        variants: list[tuple[str, int, str, int, str]] = []
+        seen: set[tuple[str, int, str, int, str]] = set()
+        for candidate_src in src_values:
+            for candidate_dst in dst_values:
+                key = (candidate_src, src_port, candidate_dst, dst_port, proto)
+                if key in seen:
+                    continue
+                variants.append(key)
+                seen.add(key)
+        return tuple(variants)
 
     def _connection_tuple_recently_used(
         self,
@@ -4911,10 +4946,11 @@ class ActivityGenerator:
         proto: str,
         time: datetime,
         *,
-        reuse_window: float = 86_400.0,
+        reuse_window: float = _RECENT_CONNECTION_REUSE_WINDOW_SECONDS,
     ) -> bool:
         """Return whether a source port would visibly repeat a recent endpoint tuple."""
         ts_epoch = time.timestamp()
+        self._prune_recent_connection_tuples(ts_epoch, reuse_window=reuse_window)
         for key in self._connection_tuple_key_variants(src_ip, src_port, dst_ip, dst_port, proto):
             seen_at = self._recent_connection_tuples.get(key)
             if seen_at is not None and abs(ts_epoch - seen_at) <= reuse_window:
@@ -4954,7 +4990,7 @@ class ActivityGenerator:
     ) -> int:
         """Allocate an ephemeral port while avoiding exact 5-tuple reuse."""
         rng = _get_rng()
-        reuse_window = 86_400.0
+        reuse_window = _RECENT_CONNECTION_REUSE_WINDOW_SECONDS
         for _ in range(128):
             src_port = _ephemeral_port(rng, os_category)
             if not self._connection_tuple_recently_used(
@@ -10396,21 +10432,24 @@ class ActivityGenerator:
     ) -> int:
         """Reserve a per-source/destination SSH source port for unambiguous correlation."""
         candidate = source_port or _ephemeral_port(rng, source_os)
+        ts_epoch = time.timestamp() if time is not None else None
+        if ts_epoch is not None:
+            self._prune_recent_connection_tuples(ts_epoch)
         for _ in range(100):
             key = (source_ip, target_ip, candidate)
             recent_key = (source_ip, candidate, target_ip, 22, "tcp")
             recent_seen = self._recent_connection_tuples.get(recent_key)
             recent_is_active = (
-                time is not None
+                ts_epoch is not None
                 and recent_seen is not None
-                and time.timestamp() - recent_seen <= 86_400.0
+                and ts_epoch - recent_seen <= _RECENT_CONNECTION_REUSE_WINDOW_SECONDS
             )
             if (
                 source_port is not None
                 and key in self._ssh_source_ports
-                and time is not None
+                and ts_epoch is not None
                 and recent_seen is not None
-                and abs(time.timestamp() - recent_seen) <= 1.0
+                and abs(ts_epoch - recent_seen) <= 1.0
             ):
                 return candidate
             if key not in self._ssh_source_ports and not recent_is_active:

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test support helpers."""

--- a/tests/support/output_equivalence.py
+++ b/tests/support/output_equivalence.py
@@ -1,0 +1,114 @@
+"""Helpers for comparing generated EvidenceForge output bundles."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_IGNORED_NAMES = {
+    "generation.log",
+    "GROUND_TRUTH.md",
+    "scenario.yaml",
+}
+_INCLUDED_ROOT_NAMES = {
+    "GROUND_TRUTH.json",
+    "OBSERVATION_MANIFEST.json",
+}
+
+
+@dataclass(frozen=True)
+class OutputEquivalenceResult:
+    """Comparison result for two generated output bundles."""
+
+    byte_identical: bool
+    normalized_multiset_identical: bool
+    missing_from_after: tuple[str, ...]
+    extra_in_after: tuple[str, ...]
+    byte_differences: tuple[str, ...]
+    normalized_differences: tuple[str, ...]
+
+    @property
+    def same_events(self) -> bool:
+        """Return whether the generated event artifacts are equivalent."""
+        return (
+            not self.missing_from_after
+            and not self.extra_in_after
+            and self.normalized_multiset_identical
+        )
+
+
+def compare_generated_outputs(before: Path, after: Path) -> OutputEquivalenceResult:
+    """Compare two generated output roots for byte and normalized event equivalence."""
+    before = before.resolve()
+    after = after.resolve()
+    before_artifacts = _event_artifacts(before)
+    after_artifacts = _event_artifacts(after)
+
+    missing = tuple(sorted(str(path) for path in before_artifacts.keys() - after_artifacts.keys()))
+    extra = tuple(sorted(str(path) for path in after_artifacts.keys() - before_artifacts.keys()))
+    shared_paths = sorted(before_artifacts.keys() & after_artifacts.keys())
+
+    byte_differences = []
+    normalized_differences = []
+    for relative_path in shared_paths:
+        before_path = before_artifacts[relative_path]
+        after_path = after_artifacts[relative_path]
+        if before_path.read_bytes() != after_path.read_bytes():
+            byte_differences.append(str(relative_path))
+        if _normalized_record_multiset(before_path, before) != _normalized_record_multiset(
+            after_path, after
+        ):
+            normalized_differences.append(str(relative_path))
+
+    return OutputEquivalenceResult(
+        byte_identical=not missing and not extra and not byte_differences,
+        normalized_multiset_identical=not missing and not extra and not normalized_differences,
+        missing_from_after=missing,
+        extra_in_after=extra,
+        byte_differences=tuple(byte_differences),
+        normalized_differences=tuple(normalized_differences),
+    )
+
+
+def _event_artifacts(root: Path) -> dict[Path, Path]:
+    artifacts: dict[Path, Path] = {}
+    data_dir = root / "data"
+    if data_dir.exists():
+        for path in data_dir.rglob("*"):
+            if path.is_file() and path.name not in _IGNORED_NAMES:
+                artifacts[path.relative_to(root)] = path
+    for name in _INCLUDED_ROOT_NAMES:
+        path = root / name
+        if path.is_file():
+            artifacts[path.relative_to(root)] = path
+    return artifacts
+
+
+def _normalized_record_multiset(path: Path, root: Path) -> Counter[str]:
+    if path.suffix == ".json" and path.parent == root:
+        return Counter({_normalize_json_artifact(path, root): 1})
+    records = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return Counter(_normalize_text_record(record, root) for record in records)
+
+
+def _normalize_json_artifact(path: Path, root: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    normalized = _normalize_json_value(payload, root)
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+
+def _normalize_json_value(value: Any, root: Path) -> Any:
+    if isinstance(value, dict):
+        return {key: _normalize_json_value(item, root) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_json_value(item, root) for item in value]
+    if isinstance(value, str):
+        return _normalize_text_record(value, root)
+    return value
+
+
+def _normalize_text_record(record: str, root: Path) -> str:
+    return record.replace(str(root), "<OUTPUT_ROOT>")

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -6232,6 +6232,121 @@ class TestActivityGenerator:
 
         assert allocated == 45653
 
+    def test_recent_connection_tuple_cache_prunes_stale_entries(self, activity_gen):
+        """Tuple reservations older than the reuse window should be removed by event time."""
+        old_time = datetime(2024, 3, 17, 12, 0, tzinfo=UTC)
+        current_time = old_time + timedelta(hours=25)
+        old_key = ("10.10.4.10", 42430, "10.10.2.10", 389, "tcp")
+
+        activity_gen._remember_connection_tuple(*old_key, time=old_time)
+        assert old_key in activity_gen._recent_connection_tuples
+
+        activity_gen._remember_connection_tuple(
+            "10.10.4.10",
+            42431,
+            "10.10.2.10",
+            389,
+            "tcp",
+            current_time,
+        )
+
+        assert old_key not in activity_gen._recent_connection_tuples
+
+    def test_recent_connection_tuple_cache_preserves_recent_entries(self, activity_gen):
+        """Tuple reservations inside the reuse window should still block reuse."""
+        seen_time = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+        check_time = seen_time + timedelta(hours=23, minutes=59)
+        activity_gen._remember_connection_tuple(
+            "10.10.4.10",
+            42430,
+            "10.10.2.10",
+            389,
+            "tcp",
+            seen_time,
+        )
+
+        assert activity_gen._connection_tuple_recently_used(
+            "10.10.4.10",
+            42430,
+            "10.10.2.10",
+            389,
+            "tcp",
+            check_time,
+        )
+
+    def test_recent_connection_tuple_cache_preserves_future_entries(self, activity_gen):
+        """Future tuple reservations should still protect non-monotonic generation order."""
+        check_time = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+        future_time = check_time + timedelta(hours=2)
+        activity_gen._remember_connection_tuple(
+            "10.10.4.10",
+            45652,
+            "10.10.2.10",
+            389,
+            "tcp",
+            future_time,
+        )
+
+        assert activity_gen._connection_tuple_recently_used(
+            "10.10.4.10",
+            45652,
+            "10.10.2.10",
+            389,
+            "tcp",
+            check_time,
+        )
+
+    def test_recent_connection_tuple_cache_ignores_stale_heap_entries(self, activity_gen):
+        """Old heap records must not delete newer reservations for the same tuple."""
+        first_time = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+        second_time = first_time + timedelta(hours=1)
+        prune_time = first_time + timedelta(hours=25)
+        key = ("10.10.4.10", 42430, "10.10.2.10", 389, "tcp")
+
+        activity_gen._remember_connection_tuple(*key, time=first_time)
+        activity_gen._remember_connection_tuple(*key, time=second_time)
+        activity_gen._prune_recent_connection_tuples(prune_time.timestamp())
+
+        assert activity_gen._recent_connection_tuples[key] == second_time.timestamp()
+
+    def test_recent_connection_tuple_cache_prunes_many_old_entries(self, activity_gen):
+        """Large stale tuple sets should shrink to the active event-time window."""
+        old_time = datetime(2024, 3, 17, 12, 0, tzinfo=UTC)
+        current_time = old_time + timedelta(hours=25)
+        for src_port in range(20_000, 22_000):
+            activity_gen._remember_connection_tuple(
+                "10.10.4.10",
+                src_port,
+                "10.10.2.10",
+                389,
+                "tcp",
+                old_time,
+            )
+
+        activity_gen._remember_connection_tuple(
+            "10.10.4.10",
+            42430,
+            "10.10.2.10",
+            389,
+            "tcp",
+            current_time,
+        )
+
+        assert len(activity_gen._recent_connection_tuples) == 1
+        assert len(activity_gen._recent_connection_tuple_heap) == 1
+
+    def test_recent_connection_tuple_cache_prunes_directly_seeded_entries(self, activity_gen):
+        """Compatibility fixture seeds should still follow event-time pruning."""
+        old_time = datetime(2024, 3, 17, 12, 0, tzinfo=UTC)
+        current_time = old_time + timedelta(hours=25)
+        old_key = ("10.10.4.10", 42430, "10.10.2.10", 389, "tcp")
+        activity_gen._recent_connection_tuples[old_key] = old_time.timestamp()
+
+        activity_gen._prune_recent_connection_tuples(current_time.timestamp())
+
+        assert activity_gen._recent_connection_tuples == {}
+        assert activity_gen._recent_connection_tuple_heap == []
+
     def test_generate_connection_does_not_infer_dns_for_non_resolver_port_53(
         self, activity_gen, test_system, state_manager, mock_emitters
     ):

--- a/tests/unit/test_output_equivalence.py
+++ b/tests/unit/test_output_equivalence.py
@@ -1,0 +1,71 @@
+"""Tests for generated output equivalence helpers."""
+
+import json
+from pathlib import Path
+
+from tests.support.output_equivalence import compare_generated_outputs
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_compare_generated_outputs_reports_byte_identical(tmp_path: Path):
+    """Matching event artifacts should pass both comparison levels."""
+    before = tmp_path / "before"
+    after = tmp_path / "after"
+    _write(before / "data" / "webapp02" / "web_access.log", "a\nb\n")
+    _write(after / "data" / "webapp02" / "web_access.log", "a\nb\n")
+    _write(before / "generation.log", "slow before\n")
+    _write(after / "generation.log", "fast after\n")
+
+    result = compare_generated_outputs(before, after)
+
+    assert result.byte_identical
+    assert result.normalized_multiset_identical
+    assert result.same_events
+
+
+def test_compare_generated_outputs_accepts_reordered_text_records(tmp_path: Path):
+    """The required event gate should pass when only line order changes."""
+    before = tmp_path / "before"
+    after = tmp_path / "after"
+    _write(before / "data" / "proxy01" / "proxy_access.log", "a\nb\na\n")
+    _write(after / "data" / "proxy01" / "proxy_access.log", "b\na\na\n")
+
+    result = compare_generated_outputs(before, after)
+
+    assert not result.byte_identical
+    assert result.normalized_multiset_identical
+    assert result.same_events
+
+
+def test_compare_generated_outputs_normalizes_root_paths_in_json(tmp_path: Path):
+    """Machine-readable artifacts should ignore destination-root path differences."""
+    before = tmp_path / "before"
+    after = tmp_path / "after"
+    before_payload = {"events": [{"artifact": str(before / "data" / "x.log")}]}
+    after_payload = {"events": [{"artifact": str(after / "data" / "x.log")}]}
+    _write(before / "GROUND_TRUTH.json", json.dumps(before_payload))
+    _write(after / "GROUND_TRUTH.json", json.dumps(after_payload))
+
+    result = compare_generated_outputs(before, after)
+
+    assert not result.byte_identical
+    assert result.normalized_multiset_identical
+    assert result.same_events
+
+
+def test_compare_generated_outputs_reports_changed_event_counts(tmp_path: Path):
+    """Duplicate record counts are part of the same-events contract."""
+    before = tmp_path / "before"
+    after = tmp_path / "after"
+    _write(before / "data" / "webapp02" / "web_access.log", "a\na\n")
+    _write(after / "data" / "webapp02" / "web_access.log", "a\n")
+
+    result = compare_generated_outputs(before, after)
+
+    assert not result.normalized_multiset_identical
+    assert not result.same_events
+    assert result.normalized_differences == ("data/webapp02/web_access.log",)

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "evidence-forge"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- fix recent connection tuple cache pruning with event-time lazy heap eviction
- add output-equivalence helpers/tests and tuple-cache regression coverage
- update generation performance guidance and worklog
- bump version to 1.8.1 for the dev-to-main release

## Validation
- `uv run pytest --no-cov --include-slow` — 4606 passed, 28 skipped
- `uv run pytest --no-cov tests/unit/test_external_parser_docs.py::test_sof_elk_trademark_notice_and_first_references` — 1 passed
- focused unit/regression suite — 548 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- 4h before/after SOF-ELK output equivalence — byte-identical
- fixed 12h scenario completed in 44.36s
- fixed full 48h scenario completed in 117.49s

## Notes
- `eforge eval` on the fixed 48h output scored 88/100; the remaining acceptance failures match existing scenario/evaluator behavior documented in the worklog, not the tuple-cache fix.
