### PR TITLE
[codex] improve iteration-test-expanded realism

### DIFF
--- a/docs/worklog/2026-07-03-iteration-test-expanded-assessment.md
+++ b/docs/worklog/2026-07-03-iteration-test-expanded-assessment.md
@@ -1,0 +1,2697 @@
+# Iteration-Test-Expanded Assessment
+
+## Context
+
+Running 10 additional eforge-assess loops for
+`scenarios/iteration-test-expanded/scenario.yaml`, continuing after prior loops 1-7 from the
+original assessment history. This worktree is using branch
+`codex/iteration-test-expanded-assessment`.
+
+## Loop 8
+
+- Automated eval passed at `96.07106951276535` over 93,947 records.
+- Blind panel final deliberated mean synthetic-confidence: `53.75` (`mixed/inconclusive`).
+- Main selected fixes for loop 9:
+  - SSH/RDP native auth/session rows must not visibly precede same-tuple eCAR `FLOW CONNECT`.
+  - Sysmon Event ID 1 Version 5 must include `ParentUser`.
+  - Same-millisecond endpoint FLOW texture remained a lower-priority issue.
+
+## Loop 9
+
+- Automated eval passed at `95.48480741954764` over 88,731 records.
+- Blind initial mean synthetic-confidence: `62.5`; deliberated mean: `61.0`.
+- Hard probe results:
+  - RDP login-before-flow: `0 / 23`; missing inbound eCAR FLOW: `0 / 23`.
+  - SSH login-before-flow: `0 / 123`; missing inbound eCAR FLOW: `2 / 123`.
+  - Sysmon Event ID 1 missing `ParentUser`: `0 / 881`.
+  - Same-millisecond endpoint FLOW pairs: `6`.
+- Deliberation downgraded the host reviewer claim that syslog files were absent; syslog files were
+  present. Proxy exfil byte accounting was downgraded from impossible contradiction to ambiguous
+  source-native accounting.
+- Selected loop 10 fixes:
+  - Make eCAR remote-session source observation coherent for SSH/RDP transport plus session rows.
+  - Merge duplicate same-source/same-destination email route hops before Postfix/syslog/EML
+    rendering.
+  - Add proxy `cs_bytes`/`sc_bytes` metadata to the default combined-log tail.
+  - Resolve known remote 4648 target endpoints so remote explicit-credential events are joinable.
+  - Exclude `COLLECTION_PROFILE.json` from blind reviewer bundles.
+
+## Loop 10
+
+- Automated eval passed at `95.47312087705855` over 87,796 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.14681535601788`
+  - Causality: `88.86552396878484`
+  - Timing: `96.10018022928934`
+- Hard probe results:
+  - RDP login-before-flow: `0 / 26`; missing inbound eCAR FLOW: `0 / 26`.
+  - SSH login-before-flow: `0 / 92`; missing inbound eCAR FLOW: `0 / 92`.
+  - Sysmon Event ID 1 missing `ParentUser`: `0 / 870`.
+  - Postfix duplicate queue lifecycles: `0`.
+  - Duplicate EML `Received` hops: `0`.
+  - Proxy upload rows missing `cs_bytes` metadata: `0 / 30`; max upload `cs_bytes`:
+    `314782942`.
+  - Remote-target Windows 4648 blank endpoints: `0 / 48`.
+  - Same-millisecond endpoint FLOW pairs: `4`.
+- Blind bundle was copied to `loop-10/review-data` without `COLLECTION_PROFILE.json`.
+- Blind initial mean synthetic-confidence: `49.75`; deliberation was not triggered.
+- Loop 10 reviewer priorities:
+  - Mail queue identity split across Zeek SMTP `last_reply`, Postfix queue IDs, and EML
+    `Received` headers.
+  - Short-lived endpoint process lifecycles, especially RDP clients and one-shot Linux/Windows
+    wrapper commands.
+  - Admin-share browser upload path requiring stronger access evidence or a normal staging path.
+  - Linux PAM/sudo actor texture and public web-client diversity.
+
+## Loop 11 Fix Target
+
+- Selected family: mail queue identity.
+- Owning abstraction: email delivery bundle / canonical SMTP hop construction in
+  `ActivityGenerator`, with Postfix receive-side lifecycle IDs as the source-native identity for
+  Linux receiving MTAs.
+- Invariant: for any plaintext SMTP hop accepted by a Linux Postfix receiver, Zeek SMTP
+  `last_reply`, the receiver's Postfix queue lifecycle, and EML `Received` relay ID share the
+  receiver's queue identity; upstream Postfix delivery rows reporting `queued as ...` use the
+  downstream receiver's queue identity.
+- Entry paths: storyline `email_message`, baseline background email, inbound external mail,
+  internal submission, internal relay, mixed internal/external recipient routing, and outbound
+  external relay paths.
+- Consumers: Zeek `smtp.json`, Postfix `syslog.log`, EML artifacts, email artifact manifest,
+  ground truth SMTP UID references, plausibility/causality eval, and blind reviewer mail pivots.
+- Layer rationale: the delivery bundle knows message ID, route hop, receiver system, TLS
+  visibility, and Postfix-vs-Exchange receiver family before renderers run; emitter-only string
+  rewrites would not fix syslog/EML/Zeek agreement across sibling hops.
+- Residual sibling risks: encrypted STARTTLS rows intentionally hide message fields and may expose
+  only STARTTLS replies; Exchange-like Windows receivers use native InternalId-style replies rather
+  than Postfix queue IDs.
+- Implemented tests:
+  - `test_plaintext_smtp_reply_uses_postfix_receive_queue_id`
+  - `test_plaintext_external_inbound_reply_uses_postfix_receive_queue_id`
+  - `test_mixed_internal_external_outbound_hops_scope_recipients`
+- Focused verification passed:
+  `uv run pytest --no-cov tests/unit/test_email_evidence.py::test_plaintext_smtp_reply_uses_postfix_receive_queue_id tests/unit/test_email_evidence.py::test_plaintext_external_inbound_reply_uses_postfix_receive_queue_id tests/unit/test_email_evidence.py::test_mixed_internal_external_outbound_hops_scope_recipients`
+
+## Loop 11
+
+- Automated eval passed at `95.47312087705855` over 87,796 records.
+- Hard probe `hard_probe_mail_identity.json`:
+  - In-scope SMTP queue rows checked: `14`.
+  - Postfix/EML queue mismatches: `0`.
+  - Distinct Windows/Exchange-style MTA rows skipped: `1`.
+- Blind initial mean synthetic-confidence: `46.5`; deliberation was not triggered.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `70`, synthetic-confidence `44`.
+  - Detection Engineer: Inconclusive, confidence `74`, synthetic-confidence `45`.
+  - Network Forensics: Inconclusive, confidence `73`, synthetic-confidence `38`.
+  - Host/EDR: Inconclusive, confidence `72`, synthetic-confidence `59`.
+- Selected loop 12 candidates:
+  - P1 short-lived endpoint process lifecycle closure for `mstsc.exe`, `cmd.exe /c`,
+    PowerShell wrappers, `runas.exe`, `systemctl`, and `timedatectl`.
+  - P1 admin-share browser upload path, either via normal staging or visible access evidence.
+
+## Loop 12 Fix Target
+
+- Selected family: browser/upload staging path.
+- Owning abstraction: staged archive SMB-read action bundle plus storyline exfil handoff helpers.
+- Invariant: SMB/network file evidence can preserve the server-side archive filename, but an upload
+  browser reads only a user-accessible local staged path. The local stage has a visible source create
+  before the browser read and the copy/staging process terminates.
+- Entry paths: storyline `Compress-Archive` staging followed by large exfil `connection` events from
+  the same or different source host.
+- Consumers: Zeek `files.json`, eCAR file/process rows, proxy upload rows, host forensic pivots, and
+  threat-hunting cross-source staging timelines.
+- Implemented tests:
+  - `test_compress_archive_exfil_emits_archive_sized_smb_download`
+  - `test_compress_archive_exfil_handoff_uses_upload_host_source_read`
+  - `test_staged_archive_smb_read_bundle_anchor_is_stable`
+- Focused verification passed:
+  `uv run pytest --no-cov tests/unit/test_storyline_command_networks.py -k "compress_archive_exfil or staged_archive_smb_read_bundle_anchor"`
+- Broader focused verification passed:
+  `uv run pytest --no-cov tests/unit/test_storyline_command_networks.py tests/unit/test_activity.py tests/unit/test_email_evidence.py tests/unit/test_proxy_referrer.py tests/unit/test_zeek_eval_parsers.py tests/unit/test_dispatcher.py tests/unit/test_ecar_spec_compliance.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_world_model.py tests/unit/test_sysmon_new_events.py`
+  (`815 passed, 10 skipped`).
+- Ruff verification passed:
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+
+## Loop 12
+
+- Automated eval passed at `95.52322362070365` over 87,803 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.34722633059829`
+  - Causality: `88.86552396878484`
+  - Timing: `96.10018022928934`
+- Hard probe `hard_probe_upload_staging.json`:
+  - Copy process creates: `1`; copy process terminates: `1`.
+  - Browser/admin-share file reads: `0`.
+  - Local staged file creates: `1`; local staged file reads: `1`.
+  - Copy process created local stage: `1`; Chrome read local stage: `1`.
+  - Local stage create before read: `true`.
+  - SMB `files.json` preserved server-side admin-share filename: `true`.
+- Blind initial mean synthetic-confidence: `33.5`; deliberation mean: `37.0`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `74`, synthetic-confidence `40`.
+  - Detection Engineer: Real, confidence `74`, synthetic-confidence `24`.
+  - Network Forensics: Real, confidence `66`, synthetic-confidence `32`.
+  - Host/EDR: Inconclusive, confidence `66`, synthetic-confidence `38`.
+- Deliberation was triggered by verdict disagreement. The panel agreed there were no hard
+  contradictions and ranked the remaining issues as source texture/cache-contract problems.
+- Selected loop 13 target:
+  - P1 Linux eCAR user/admin CLI ancestry. `systemctl`, `loginctl`, `pkcon`, and
+    `timedatectl` rows should not repeatedly appear as direct PID 1 children for user/admin
+    principals unless the action is modeled as service/timer owned.
+  - P1 backup candidate: machine-account Kerberos TGT caching.
+
+## Loop 13 Fix Target
+
+- Selected family: Linux polkit companion CLI ancestry.
+- Owning abstraction: baseline polkit action companion process materialization.
+- Invariant: user-facing polkit CLI tools (`systemctl`, `loginctl`, `pkcon`,
+  `timedatectl`, `nmcli`) are foreground user processes with visible shell parents and bounded
+  termination; daemon helpers (`packagekitd`, `NetworkManager`) may remain service/systemd-owned.
+- Implemented tests:
+  - `test_polkit_cli_companion_process_uses_visible_user_shell`
+  - Existing daemon-companion assertion preserved in
+    `test_polkit_action_messages_materialize_companion_process`.
+- Focused verification passed:
+  `uv run pytest --no-cov tests/unit/test_phase5_system_traffic.py -k "polkit"`.
+- Broader focused verification passed after formatting:
+  `uv run pytest --no-cov tests/unit/test_phase5_system_traffic.py tests/unit/test_activity.py tests/unit/test_email_evidence.py tests/unit/test_proxy_referrer.py tests/unit/test_zeek_eval_parsers.py tests/unit/test_dispatcher.py tests/unit/test_ecar_spec_compliance.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_world_model.py tests/unit/test_sysmon_new_events.py`
+  (`809 passed, 10 skipped`).
+
+## Loop 13
+
+- Automated eval passed at `95.9069928415457` over 95,978 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `97.10299166795664`
+  - Causality: `90.65955111711948`
+  - Timing: `94.83178572638337`
+- Hard probe `hard_probe_linux_polkit_cli_ancestry.json`:
+  - CLI creates: `59`.
+  - CLI rows with direct system/PID1 parent: `0`.
+  - CLI rows terminated: `59`.
+  - Daemon/systemd child rows preserved: `1`.
+- Blind initial mean synthetic-confidence: `47.25`; deliberation mean: `52.0`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `78`, synthetic-confidence `47`.
+  - Detection Engineer: Inconclusive, confidence `74`, synthetic-confidence `52`.
+  - Network Forensics: Inconclusive, confidence `72`, synthetic-confidence `38`.
+  - Host/EDR: Inconclusive, confidence `74`, synthetic-confidence `52`.
+- Deliberation calibrated scores to Threat Hunter `53`, Detection Engineer `55`, Network
+  Forensics `44`, Host/EDR `56`.
+- Selected loop 14 target:
+  - P0 transport-to-auth/session contract for SMB baseline traffic. Failed/reset SMB transport
+    must not anchor a successful Windows Type 3 logon on the same tuple.
+
+## Loop 14 Fix Target
+
+- Selected family: SMB baseline transport plus Windows network logon pairing.
+- Owning abstraction: baseline SMB connection generation in the file-server and workstation SMB
+  browsing paths, before `_emit_smb_logon_pair` creates successful Type 3 logon/logoff evidence.
+- Invariant: an SMB transport that is intentionally reused as the source tuple for a successful
+  Windows Type 3 logon must be `conn_state="SF"` across Zeek/eCAR/Windows evidence; generic SMB
+  traffic that does not produce successful auth may still use reset/failure texture.
+- Implemented test:
+  - `test_successful_logon_requires_successful_smb_transport_state`.
+- Focused verification passed:
+  `uv run pytest --no-cov tests/unit/test_file_server_logon.py tests/unit/test_phase5_system_traffic.py -k "smb or polkit"`.
+  (`13 passed, 56 deselected`).
+
+## Loop 15 Fix Target
+
+- Selected family: browser/proxy application realism for modern SaaS browsing.
+- Owning abstraction: browser session site-map rendering plus proxy/browser User-Agent selection.
+- Invariant: modern SaaS/browser page-load sessions should use supported Chrome/Firefox/Edge-style
+  browser identities, not legacy IE11/Trident, and time-bearing browser API paths should be derived
+  from the modeled session time instead of a fixed future date.
+- Entry paths: baseline browser-session action bundle, direct `ActivityGenerator` HTTP/proxy URI
+  synthesis, web/session profile browser UA selection, and proxy access rendering via `ProxyContext`.
+- Consumers: proxy access logs, Zeek HTTP rows, eCAR source process ownership for browser/proxy
+  flows, detection-review browser/SaaS pivots, and browser-session tests.
+- Layer rationale: the site-map and UA catalogs own the semantic browser/application identity before
+  emitters render rows; proxy emitters should only serialize the already-selected path and UA.
+- Residual sibling risks: non-browser API/tool traffic can still intentionally use tool UAs such as
+  curl or python-requests, and broader proxy appliance format realism remains a separate follow-up.
+
+## Loop 15
+
+- Automated eval passed at `95.26504771703925` over 94,496 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.35468821926963`
+  - Causality: `89.62248219110784`
+  - Timing: `95.10377557222441`
+- Hard probe `hard_probe_proxy_browser_calendar.json`:
+  - Proxy access rows scanned: `2078`.
+  - Legacy IE/Trident proxy rows: `0`.
+  - Legacy IE/Trident modern SaaS rows: `0`.
+  - Fixed future calendar rows: `0`.
+  - Calendar `timeMin` values: `2024-03-01T00:00:00Z`.
+- Blind initial mean synthetic-confidence: `37.75`; deliberation mean: `38.0`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `64`, synthetic-confidence `58`.
+  - Detection Engineer: Real, confidence `64`, synthetic-confidence `29`.
+  - Network Forensics: Real, confidence `72`, synthetic-confidence `26`.
+  - Host/EDR: Inconclusive, confidence `68`, synthetic-confidence `38`.
+- Deliberation kept the dataset mostly realistic but identified identity/software placement as the
+  highest-value next fix: `svc_mhsync` was created in-window for the attack and later appeared in
+  unrelated Veeam/Commvault baseline service-account activity on several hosts.
+
+## Loop 16 Fix Target
+
+- Selected family: service-account lifecycle boundaries between storyline-created identities and
+  generic baseline service-account noise.
+- Owning abstraction: baseline service-account selection in `BaselineGenerator`, while preserving
+  storyline account lifecycle availability for the attack narrative itself.
+- Invariant: accounts created, deleted, or otherwise lifecycle-owned by the storyline must not be
+  selected for unrelated backup, Commvault, Veeam, scheduled-service, or generic explicit-credential
+  baseline noise unless a visible provisioning/configuration event connects them to that family.
+- Entry paths: Windows service-account delegation baseline, explicit credential noise, backup-agent
+  maintenance flows, and storyline-created service-account activity such as `svc_mhsync`.
+- Consumers: Windows Security 4648/4624/4634, Sysmon process evidence, eCAR process/file/FLOW rows,
+  host and threat-hunting account-lifecycle pivots, and blind review environment-realism checks.
+- Layer rationale: the generator owns which identities are eligible for baseline noise before
+  source-specific renderers materialize Security, Sysmon, and eCAR rows; emitter-side suppression
+  would only hide symptoms and risk cross-source disagreement.
+- Residual sibling risks: preexisting durable service accounts can still be overused across
+  workstation backup/software cohorts; host-role software placement remains a likely follow-up.
+
+## Loop 16
+
+- Automated eval passed at `95.74646190719345` over 87,850 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.54449051656928`
+  - Causality: `89.09209230336289`
+  - Timing: `96.68658101105204`
+- Hard probe `hard_probe_service_account_lifecycle.json`:
+  - `svc_mhsync` baseline delegation bad count in Windows Security: `0`.
+  - `svc_mhsync` baseline delegation bad count in eCAR: `0`.
+  - Storyline `svc_mhsync` Security events preserved: `20`.
+  - Storyline `svc_mhsync` eCAR events preserved: `18`.
+- Blind initial mean synthetic-confidence: `51.0`; deliberation mean: `57.0`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `68`, synthetic-confidence `52`.
+  - Detection Engineer: Synthetic, confidence `72`, synthetic-confidence `68`.
+  - Network Forensics: Real, confidence `72`, synthetic-confidence `28`.
+  - Host/EDR: Inconclusive, confidence `68`, synthetic-confidence `56`.
+- Deliberation calibrated scores to Threat Hunter `58`, Detection Engineer `70`, Network
+  Forensics `40`, Host/EDR `60`.
+- Selected loop 17 target:
+  - P1 Type 3 network-logon lifecycle closure for anonymous Windows network logons. MAIL-FIN-01
+    had 46 successful Type 3 logons and no Type 3 logoffs, while peer Windows servers had paired
+    network sessions.
+
+## Loop 17 Fix Target
+
+- Selected family: Windows anonymous network-logon lifecycle completeness.
+- Owning abstraction: anonymous Windows network-logon action bundle adapter in
+  `ActivityGenerator`, not the Windows emitter.
+- Invariant: every generated successful anonymous Type 3 logon is short-lived and paired with
+  same-logon-id logoff evidence within the visible session interval, while still avoiding durable
+  `StateManager` session creation for anonymous enumeration noise.
+- Entry paths: Windows server/DC anonymous SMB enumeration and mail-server background network-logon
+  noise that calls `generate_anonymous_logon`.
+- Consumers: Windows Security 4624/4634, eCAR USER_SESSION LOGIN/LOGOUT, Type 3 session-duration
+  detections, detection-review lifecycle checks, and host forensic pivots.
+- Layer rationale: anonymous-logon generation owns the canonical LUID, remote source metadata, and
+  SMB transport timing before renderers serialize Windows/eCAR rows; emitters should not invent
+  lifecycle companions after the fact.
+- Residual sibling risks: named MAIL-FIN-01 Type 3 sessions from protocol-specific mailbox access
+  can still need family-specific logoff ownership if reviewers continue to find gaps after the
+  anonymous-logon repair.
+
+## Loop 17
+
+- Automated eval passed at `94.77476489808859` over 98,924 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.79078689066739`
+  - Causality: `89.09298159908809`
+  - Timing: `94.01911387824856`
+- Hard probe `hard_probe_type3_logon_lifecycle.json`:
+  - MAIL-FIN Type 3 logons: `39`; logoffs: `39`; unpaired: `0`.
+  - Anonymous logons: `38`; logoffs: `38`; unpaired: `0`.
+  - All anonymous unpaired logons: `0`.
+- Blind initial mean synthetic-confidence: `36.5`; deliberation mean: `39.5`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `68`, synthetic-confidence `44`.
+  - Detection Engineer: Real, confidence `64`, synthetic-confidence `32`.
+  - Network Forensics: Real, confidence `72`, synthetic-confidence `28`.
+  - Host/EDR: Inconclusive, confidence `72`, synthetic-confidence `42`.
+- Deliberation calibrated scores to Threat Hunter `46`, Detection Engineer `36`, Network
+  Forensics `30`, Host/EDR `46`.
+- Residual top findings:
+  - eCAR `USER_SESSION.objectID` stability across login/logout.
+  - More natural source-window/eCAR cutoff texture.
+  - Less mechanically tight Security/Sysmon/eCAR timestamp deltas.
+  - SMTP recipient/header mapping and lower-impact email/proxy/Linux command texture.
+
+## Loop 18 Fix Target
+
+- Selected family: eCAR `USER_SESSION.objectID` lifecycle stability.
+- Owning abstraction: canonical session event construction for unmanaged anonymous Windows
+  network-logon rows, using `EdrContext` to carry source-native session identity into eCAR.
+- Invariant: every visible successful session lifecycle pair that shares a concrete session key
+  (`logon_id`/`session_id`) or a remote source tuple must render the same eCAR `objectID` on
+  `LOGIN` and `LOGOUT`.
+- Entry paths: normal managed logon/logoff action bundles, SSH/RDP bundles, and anonymous Windows
+  Type 3 network-logon noise.
+- Consumers: eCAR `USER_SESSION` rows, Windows Security 4624/4634 pivots, host/threat-hunting
+  session lifecycle analysis, and blind-review source-contract checks.
+- Layer rationale: event construction owns the canonical LUID and remote source tuple before eCAR
+  renders rows. The emitter should render a supplied session object identity rather than inventing
+  one per row.
+- Residual sibling risks: local desktop sessions can share the same visible host/principal/local
+  tuple across multiple distinct LUIDs; reviewers should key those by `logon_id` or session id
+  rather than by host/principal alone.
+- Focused verification passed:
+  `uv run pytest --no-cov tests/unit/test_baseline_canonical.py::TestAnonymousLogon`.
+- Automated eval passed at `94.77476489808859` over 98,924 records.
+- Hard probe `hard_probe_ecar_user_session_objectid.json`:
+  - Exact session pairs: `682`; objectID mismatches: `0`.
+  - Remote visible tuple pairs: `669`; objectID mismatches: `0`.
+  - Anonymous exact session pairs: `132`; objectID mismatches: `0`.
+- Blind initial mean synthetic-confidence: `41.5`; deliberation mean: `41.5`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `58`, synthetic-confidence `46`; deliberated to
+    Inconclusive, confidence `60`, synthetic-confidence `42`.
+  - Detection Engineer: Inconclusive, confidence `68`, synthetic-confidence `42`; deliberated to
+    Inconclusive, confidence `70`, synthetic-confidence `42`.
+  - Network Forensics: Inconclusive, confidence `64`, synthetic-confidence `38`; deliberated to
+    Inconclusive, confidence `66`, synthetic-confidence `39`.
+  - Host/EDR: Inconclusive, confidence `64`, synthetic-confidence `40`; deliberated to
+    Inconclusive, confidence `68`, synthetic-confidence `43`.
+- Deliberation consensus: no hard contradiction; the strongest concrete remaining issue was
+  DB-PROD local eCAR `USER_SESSION LOGIN` rows for `lina.nguyen` and `priya.patel` without
+  nearby `systemd-logind`/PAM companions despite active DB-PROD syslog collection.
+- Selected loop 19 target:
+  - P1 Linux/syslog/eCAR local-session companion evidence, especially self-sourced Linux Type 3
+    compatibility paths that render as local endpoint sessions.
+
+## Loop 19 Fix Target
+
+- Selected family: Linux local session companion evidence across eCAR and syslog.
+- Owning abstraction: successful logon action bundle compatibility adapter plus
+  `StateManager` session metadata and source-observation policy.
+- Invariant: every successful Linux local endpoint `USER_SESSION LOGIN` row has a source-native
+  logind session ID and, when syslog is collected for the host, a nearby `systemd-logind`
+  `New session ... of user ...` companion. Linux self-sourced Type 3 compatibility calls are
+  normalized to local Type 2 sessions before canonical/eCAR rendering.
+- Entry paths: baseline/suspicious-noise successful logons, generic activity-created logons,
+  storyline compatibility logons, world-planner interactive Linux sessions, and local-looking
+  legacy sessions that may carry stale session-kind metadata.
+- Consumers: eCAR `USER_SESSION` rows, syslog `systemd-logind` rows, session IDs in
+  `StateManager`, host forensic pivots, and source-observation missingness policy.
+- Layer rationale: the logon adapter owns the semantic distinction between remote network logon
+  and local Linux session before eCAR or syslog renderers run. Observation policy owns whether a
+  correlated lifecycle row may be dropped.
+- Residual sibling risks: true SSH sessions remain owned by the SSH action bundle; unrelated
+  Linux service or network logons intentionally do not get local logind companions.
+- Implemented changes:
+  - `generate_syslog_event` can carry an optional `AuthContext`, so logind syslog companions share
+    logon/session identity with endpoint session rows.
+  - Linux self-sourced Type 3 successful logons are normalized to local Type 2 before canonical
+    event construction.
+  - Local-looking Linux sessions with stale `ssh` session kind no longer skip logind allocation.
+  - Observation policy preserves `systemd-logind` open/close lifecycle rows from syslog
+    missingness.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "linux_local_session or self_sourced_type3 or stale_ssh_kind or overlapping_linux_local_sessions"`
+  - `uv run pytest --no-cov tests/unit/test_dispatcher.py -k "logind_lifecycle or ssh_lifecycle_rows_are_not_dropped"`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+
+## Loop 19
+
+- Automated eval passed at `95.0356755211698` over 92,803 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.55280860042693`
+  - Causality: `88.49221306685368`
+  - Timing: `95.12210052174817`
+- Hard probe `hard_probe_linux_local_logind_companions.json`:
+  - Local eCAR successful logins checked: `19`.
+  - Local eCAR successful logins with companion: `19`.
+  - Missing companions: `0`.
+  - The former DB-PROD self-sourced Type 3 local-looking reviewer samples no longer render as
+    eCAR-local orphan sessions.
+- Blind review started against `loop-19/review-data` with `COLLECTION_PROFILE.json` excluded.
+- Blind initial mean synthetic-confidence: `33.5`; deliberation mean: `36.75`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `68`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `70`, synthetic-confidence `38`.
+  - Detection Engineer: Real, confidence `64`, synthetic-confidence `28`; deliberated to
+    Inconclusive, confidence `66`, synthetic-confidence `34`.
+  - Network Forensics: Inconclusive, confidence `66`, synthetic-confidence `36`; deliberated to
+    Inconclusive, confidence `68`, synthetic-confidence `38`.
+  - Host/EDR: Inconclusive, confidence `66`, synthetic-confidence `36`; deliberated to
+    Inconclusive, confidence `67`, synthetic-confidence `37`.
+- Deliberation consensus: the Linux local-session companion contract held, and the strongest
+  remaining concrete gap was an RDP session with source endpoint FLOW, target endpoint FLOW, and
+  Windows Type 10 logon evidence for `10.10.1.35:56156 -> 10.10.2.20:3389` but no matching
+  Zeek/firewall transport tuple.
+- Selected loop 20 target:
+  - P1 RDP transport visibility and timing, especially successful visible RDP sessions whose
+    endpoint/target telemetry survives while Zeek/firewall transport evidence is missing or whose
+    transport-to-auth timing is overly uniform.
+
+## Loop 20 Fix Target
+
+- Selected family: RDP transport visibility and timing.
+- Owning abstraction: RDP action bundle plus the canonical network-connection contract and
+  source-observation policy.
+- Invariant: when a successful RDP session renders both endpoint source/target session evidence
+  and a Type 10 target logon for a concrete source tuple, the corresponding network transport
+  evidence must either render in Zeek/firewall sources or be omitted coherently by an explicit
+  collection-loss decision that also explains dependent endpoint evidence.
+- Entry paths: storyline/modelled RDP sessions, baseline remote-admin RDP sessions, and
+  compatibility Type 10 logon paths that delegate into the RDP bundle.
+- Consumers: Zeek `conn.log`, ASA/firewall connection rows, eCAR endpoint `FLOW` rows, Windows
+  Security 4624/4634 Type 10 rows, source-side RDP client process telemetry, and reviewer
+  cross-source transport pivots.
+- Layer rationale: RDP owns the remote-session intent and target authentication ordering, while
+  the network-connection bundle owns tuple allocation, transport visibility, Zeek UID/state, and
+  firewall rendering. Fixing this at the bundle/observation boundary avoids emitter-local patches
+  and keeps endpoint/session evidence aligned with the transport contract.
+- Residual sibling risks: real packet sensors can miss isolated flows, so the fix should preserve
+  source-observation texture rather than forcing all RDP traffic to be globally complete.
+- Implemented changes:
+  - Dispatcher source-observation contracts now promote dropped `zeek_conn`/`cisco_asa` rows back
+    to visible only for successful SSH/RDP transport events when the same event's endpoint eCAR
+    transport telemetry survives.
+  - Failed RDP/SSH transport rows and scanner/noise traffic remain eligible for normal Zeek
+    missingness, preserving collection texture outside successful remote-interactive sessions.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_dispatcher.py -k "rdp_transport or zeek_visible_child_promotes_dropped_conn_parent or ecar_rdp_tuple"`
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "rdp_session or rdp"`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+
+## Loop 20
+
+- Automated eval passed at `94.885679564687` over 92,804 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.95282477449575`
+  - Causality: `88.49221306685368`
+  - Timing: `95.12210052174817`
+- Hard probe `hard_probe_rdp_transport_visibility.json`:
+  - Successful unique endpoint-visible RDP tuples: `30`.
+  - Successful unique endpoint-visible RDP tuples with Zeek conn: `30`.
+  - Missing Zeek conn companions: `0`.
+  - Former failing tuple `10.10.1.35:56156 -> 10.10.2.20:3389`: endpoint-visible and
+    Zeek-visible.
+  - Type 10 login transport-to-auth gaps: `28` measured; min `2519.2ms`, max `3995.3ms`, mean
+    `3338.3ms`, population stdev `496.2ms`.
+- Blind review started against `loop-20/review-data` with `COLLECTION_PROFILE.json` excluded.
+- Blind initial mean synthetic-confidence: `38.0`; deliberation mean: `46.0`.
+- Reviewer scores:
+  - Threat Hunter: Real, confidence `68`, synthetic-confidence `28`; deliberated to
+    Inconclusive, confidence `60`, synthetic-confidence `44`.
+  - Detection Engineer: Inconclusive, confidence `68`, synthetic-confidence `36`; deliberated to
+    Inconclusive, confidence `72`, synthetic-confidence `48`.
+  - Network Forensics: Real, confidence `66`, synthetic-confidence `24`; deliberated to Real,
+    confidence `62`, synthetic-confidence `30`.
+  - Host/EDR: Synthetic, confidence `72`, synthetic-confidence `64`; deliberated to Synthetic,
+    confidence `70`, synthetic-confidence `62`.
+- Deliberation consensus: loop 20 resolved the prior network/RDP contract gap and network
+  evidence now reads strongly realistic. The most convincing remaining synthetic evidence is
+  Host/EDR's `DC-01` Windows process-tree semantics: `services.exe` and `taskhostw.exe` parent
+  wrapper `cmd.exe` processes for service/task creation, plus repeated 1 ms wrapper-child timing.
+- Selected loop 21 target:
+  - P1 Windows remote-admin process-tree semantics and wrapper-child source timing, especially
+    service creation, scheduled-task creation, and high-signal command wrappers on `DC-01`.
+
+## Loop 21 Fix Target
+
+- Selected family: Windows remote-admin process-tree semantics and wrapper-child source timing.
+- Owning abstraction: Windows remote-admin and persistence action bundles, with canonical
+  `ProcessContext` parentage and source timing planning as the renderer contract.
+- Invariant: `services.exe` starts service binaries and SCM-owned service processes; it must not
+  parent the client-side tools used to create services. `taskhostw.exe` runs scheduled task
+  actions; it must not parent ad hoc `schtasks.exe /Create` authoring unless a prior task action
+  explains that context. Wrapper `cmd.exe /c <tool>` children should have source-native,
+  non-mechanical timing, not repeated 1 ms deltas.
+- Entry paths: explicit Windows remote-admin bundles, storyline command/process events,
+  persistence events that create services or scheduled tasks, PsExec/service-control tooling,
+  and generic command execution compatibility paths.
+- Consumers: Windows Security 4688/4689, Sysmon 1/5, eCAR `PROCESS`/`SERVICE` rows, Host/EDR
+  process-tree pivots, Detection Engineering process-parent checks, and future expert reviews.
+- Layer rationale: the process owner and parent relationship are canonical execution facts, not
+  emitter formatting details. Fixing the action bundle/process-construction path prevents Windows
+  Security, Sysmon, and eCAR from faithfully rendering the same wrong parent.
+- Residual sibling risks: service-start events should still be parented by `services.exe`, and
+  legitimate scheduled task execution can still involve `taskhostw.exe`; only authoring/tooling
+  relationships should move to credible caller processes.
+- Implemented changes:
+  - Remote/service-context `sc.exe create` and `schtasks.exe /Create` wrapper shells now parent
+    from WMI/DCOM-style remote command owners instead of `services.exe` or `taskhostw.exe`.
+  - Scheduled task execution paths that are not authoring (`schtasks.exe /Run`) can still use
+    `taskhostw.exe`, preserving the sibling task-action semantics.
+  - eCAR parent/create-order normalization now uses bounded deterministic repair gaps instead of
+    forcing child process creates to exactly parent+1 ms.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_spawn_rules.py -k "system_admin_utility or scheduled_task_execution_can_still_use_taskhostw_owner or remote_execution_wrapper"`
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py -k "close_moves_child_process_create_after_visible_parent or close_moves_child_process_create_after_parent_pid_without_actor_id"`
+  - `uv run pytest --no-cov tests/unit/test_source_timing.py -k "ecar_process_create_normalization_preserves_canonical_order"`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+
+## Loop 21
+
+- Automated eval passed at `94.885679564687` over 92,804 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.95282477449575`
+  - Causality: `88.49221306685368`
+  - Timing: `95.12210052174817`
+- Hard probe `hard_probe_windows_remote_admin_process_tree.json`:
+  - eCAR high-signal wrappers checked: `3`.
+  - eCAR/Security/Sysmon bad authoring wrapper parentage: `0`.
+  - Wrapper-child pairs checked: `3`.
+  - Exact 1 ms wrapper-child deltas: `0`.
+  - Wrapper-child delta range: min `44ms`, max `136ms`, mean `101.333ms`.
+- Blind review started against `loop-21/review-data` with `COLLECTION_PROFILE.json` excluded.
+  The first panel was discarded because one reviewer accidentally overwrote
+  `review-data/WS-MCHEN-01.meridianhcs.local/windows_event_security.xml` with scratch search
+  output. The file was restored from pristine `output/data`, validated as XML, and the review
+  was rerun into `loop-21/review-rerun/`; only rerun reports are canonical for loop 21.
+- Blind initial mean synthetic-confidence: `42.5`; deliberation mean: `51.25`.
+- Reviewer scores:
+  - Threat Hunter: Real, confidence `61`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `58`, synthetic-confidence `48`.
+  - Detection Engineer: Real, confidence `68`, synthetic-confidence `28`; deliberated to
+    Inconclusive, confidence `60`, synthetic-confidence `43`.
+  - Network Forensics: Inconclusive, confidence `62`, synthetic-confidence `46`; deliberated to
+    Inconclusive, confidence `65`, synthetic-confidence `50`.
+  - Host/EDR: Synthetic, confidence `63`, synthetic-confidence `62`; deliberated to Synthetic,
+    confidence `70`, synthetic-confidence `64`.
+- Deliberation consensus: the Windows remote-admin parentage/timing fix held and broad
+  cross-source realism remains strong, but the strongest synthetic evidence is now
+  `WS-LNGUYEN-01` bash-history commands whose exact eCAR process creates occur 23-60 minutes
+  later under the same user and `/bin/bash` parent.
+- Selected loop 22 target:
+  - P1 Linux shell-command timeline contract. Bash-history timestamps and correlated eCAR
+    `PROCESS CREATE` rows for the same external command must share one per-shell foreground
+    schedule, with process start within a small realistic tolerance of the history timestamp.
+
+## Loop 22 Fix Target
+
+- Selected family: Linux bash-history and eCAR process timeline coherence.
+- Owning abstraction: Linux shell command action bundle plus foreground shell availability state in
+  `ActivityGenerator`.
+- Invariant: when a generated bash-history command emits correlated process telemetry, the
+  history timestamp and first eCAR/Linux process-create timestamp for the same command must be
+  near the same scheduled shell command time. Foreground shell serialization may delay both
+  artifacts together, but it must not delay process telemetry while leaving bash history at an
+  earlier requested time.
+- Entry paths: baseline Linux workstation shell command noise, direct `generate_bash_command`
+  calls, storyline process-friction shell commands, Linux process activity that emits bash
+  history, and SSH/local interactive session command bundles.
+- Consumers: bash_history files, eCAR `PROCESS`/`FLOW`/`FILE` rows, syslog session timing,
+  foreground process lifetime tracking, host forensic pivots, and shell-session validation
+  probes.
+- Layer rationale: the shell action bundle owns a single user-entered command occurrence. Bash
+  history and process telemetry are sibling evidence for that occurrence, so separate history and
+  process reservations are the root cause rather than source-native rendering.
+- Residual sibling risks: background or script-owned one-liners that should not appear in bash
+  history still need a separate script/scheduler owner; DNS/PTR realism remains a later
+  network-family target.
+
+## Loop 22
+
+- Implemented changes:
+  - Bash-history scheduling now aligns with the same foreground-shell slot used by process
+    telemetry for generated shell commands.
+  - Foreground shell availability follows source-visible process termination time, not only
+    canonical termination time, so eCAR close-time jitter cannot make the next command visibly
+    overlap.
+  - Foreground shell queue keys use the actual shell process logon ID when available, preventing
+    blank-logon and session-logon callers from maintaining separate queues for the same bash PID.
+  - Bash-history-synchronized Linux process rows carry an internal `bash-history:*`
+    concurrency marker. The eCAR shell foreground normalizer strips the marker but preserves the
+    action-bundle-owned timestamp instead of shifting the row independently.
+  - Synthetic Linux proxy socket-owner helper rows now parent to a non-shell session process
+    (`systemd --user` / terminal / session root) rather than occupying the user's interactive
+    `/bin/bash` foreground timeline.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "bash_history or generate_bash_command or foreground_shell or foreground_termination_uses_source_visible_release_time or linux_proxy_client_process_uses_non_shell_session_parent"`
+  - `uv run pytest --no-cov tests/unit/test_source_timing.py -k "linux_shell_foreground_order"`
+  - `uv run pytest --no-cov tests/unit/test_activity.py tests/unit/test_source_timing.py`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+- Automated eval passed at `95.55644473749022` over 94,597 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.17083728577973`
+  - Causality: `89.67411207926047`
+  - Timing: `95.47603698115087`
+- Hard probe `hard_probe_linux_bash_ecar_timeline.json`:
+  - Bash-history commands scanned: `314`.
+  - Near eCAR process matches checked: `189`.
+  - Late bash-history to eCAR process mismatches: `0`.
+  - Near-match max offset: `2.986s`; p95 offset: `2.666s`.
+  - Linux proxy helper rows parented by `/bin/bash`: `0 / 43`.
+- Additional reviewer-finding probe `reviewer_finding_probes.json`:
+  - Verified sudo timing defect: `124` visible sudo triplets, `101` under 1 second, and `7`
+    interval commands (`vmstat 1 5` / `iostat -xz 1 3`) closing in `0.401-1.048s`.
+  - Verified Host/EDR SSH eCAR lifecycle gaps for the reported APP-INT-01, DB-PROD-01, and
+    MAIL-EDGE-01 tuples: eCAR retained related `sshd`/shell process context but lacked matching
+    inbound FLOW and USER_SESSION LOGIN rows.
+- Blind initial mean synthetic-confidence: `51.75`; deliberation mean: `61.25`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `76`, synthetic-confidence `67`; deliberated to
+    Synthetic, confidence `80`, synthetic-confidence `72`.
+  - Detection Engineer: Synthetic, confidence `68`, synthetic-confidence `64`; deliberated to
+    Synthetic, confidence `74`, synthetic-confidence `69`.
+  - Network Forensics: Real, confidence `72`, synthetic-confidence `24`; deliberated to
+    Inconclusive, confidence `64`, synthetic-confidence `42`.
+  - Host/EDR: Inconclusive, confidence `74`, synthetic-confidence `52`; deliberated to
+    Synthetic, confidence `76`, synthetic-confidence `62`.
+- Deliberation consensus: network protocol realism remains a major strength, but the loop surfaced
+  stronger endpoint/source-contract issues: sudo interval-command runtimes, high-value proxy/C2
+  endpoint ownership mismatch, and SSH eCAR lifecycle-group gaps.
+- Selected loop 23 target:
+  - P1 Linux sudo runtime contract. Sudo PAM open/COMMAND/close triplets should use
+    command-aware runtime modeling so interval commands keep the session open for their implied
+    duration and ordinary sudo lifetimes are varied rather than uniformly sub-second.
+  - P1 follow-up candidates after sudo: endpoint/proxy ownership for high-value proxy/C2
+    transactions, then eCAR SSH lifecycle group visibility.
+
+## Loop 23
+
+- Implemented changes:
+  - Extra Linux sudo syslog triplets now use command-aware session runtime instead of closing
+    within a uniform sub-second window after the `COMMAND=` row.
+  - `vmstat`/`iostat` interval commands parse numeric interval/count arguments and hold PAM
+    session close evidence open for the implied runtime plus source-native jitter.
+  - Longer-running families such as package management, service restart, `journalctl`, `find`,
+    `lsof`, `iptables`, and `systemd-analyze` receive broader runtime envelopes; quick status
+    and inventory commands keep shorter but varied lifetimes.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_baseline_canonical.py -k "sudo or pam" tests/unit/test_systemd_ecar_correlation.py -k "sudo" tests/unit/test_syslog_family_renderer.py -k "sudo"`
+  - `uv run ruff check src/evidenceforge/generation/engine/baseline.py tests/unit/test_baseline_canonical.py`
+  - `uv run ruff format --check src/evidenceforge/generation/engine/baseline.py tests/unit/test_baseline_canonical.py`
+- Automated eval passed at `95.29205091144773` over 95,819 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.29351259983402`
+  - Causality: `89.47668953519369`
+  - Timing: `95.49750188845404`
+- Hard probe `hard_probe_sudo_runtime.json`:
+  - Visible sudo triplets: `138`.
+  - Subsecond command-to-close durations: `1`.
+  - Minimum duration: `0.806s`; maximum duration: `15.750s`; p50 duration: `3.724s`.
+  - Interval commands checked: `6`; interval-command runtime violations: `0`.
+- Blind initial mean synthetic-confidence: `40.75`; deliberation mean: `44.75`.
+- Reviewer scores:
+  - Threat Hunter: Real, confidence `64`, synthetic-confidence `34`; deliberated to Real
+    synthetic-sensitive, realism `80`, synthetic-confidence `41`.
+  - Detection Engineer: Inconclusive, confidence `64`, synthetic-confidence `43`; deliberated to
+    Inconclusive, realism `76`, synthetic-confidence `48`.
+  - Network Forensics: Real, confidence `72`, synthetic-confidence `28`; deliberated to Real,
+    realism `78`, synthetic-confidence `32`.
+  - Host/EDR: Inconclusive leaning Synthetic, confidence `72`, synthetic-confidence `58`;
+    deliberated unchanged, realism `62`, synthetic-confidence `58`.
+- Deliberation consensus:
+  - Network, Windows/Sysmon, RDP, SSH/SCP, and Zeek UID/FUID contracts remain strong.
+  - The strongest synthetic-sensitive finding is eCAR Linux process/thread semantics:
+    `PROCESS/TERMINATE` rows often changed `tid` away from the matching `PROCESS/CREATE` main
+    thread without visible thread lifecycle.
+  - Follow-up families: eCAR FLOW actor attribution coherence, Windows endpoint background
+    templating, proxy source-native profile/identity texture, public web/scanner distributions,
+    and direct-root SSH administration texture.
+- Selected loop 24 target:
+  - P1 eCAR Linux process/thread lifecycle semantics. Linux `PROCESS/CREATE` and
+    `PROCESS/TERMINATE` rows for the same process object should share the main-thread TID, while
+    dependent FLOW/FILE/MODULE rows can still carry source-native thread texture.
+
+## Loop 24
+
+- Implemented changes:
+  - eCAR Linux `_stable_tid(...)` now returns `pid` for both `process_create` and
+    `process_terminate` lifecycle rows.
+  - Linux non-lifecycle eCAR rows still use deterministic source-thread texture so host telemetry
+    does not become flat.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py -k "linux_process_lifecycle_tid or linux_dependent_tids or linux_stable_tid or pid_morphology"`
+  - `uv run ruff check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+  - `uv run ruff format --check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+- Generated loop 24 output successfully.
+- Automated eval passed at `95.29205091144773` over 95,819 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.29351259983402`
+  - Causality: `89.47668953519369`
+  - Timing: `95.49750188845404`
+- Hard probe `hard_probe_ecar_linux_tid.json`:
+  - Linux process terminations: `764`.
+  - Matched Linux create/terminate lifecycles: `753`.
+  - Create/terminate TID mismatches: `0`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-24/review-data`.
+  - Neutral read-only copy: `/private/tmp/eforge-review-dataset-charlie.zmo2OW`.
+  - `COLLECTION_PROFILE.json` excluded from both review copies.
+  - Four-reviewer blind panel completed.
+- Blind initial mean synthetic-confidence: `51.25`; deliberation mean: `59.5`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, realism `68`, confidence `70`, synthetic-confidence `43`;
+    deliberated to Synthetic, realism `60`, synthetic-confidence `56`.
+  - Detection Engineer: Inconclusive, realism `82`, confidence `66`, synthetic-confidence `31`;
+    deliberated to Inconclusive, realism `76`, synthetic-confidence `44`.
+  - Network Forensics: Synthetic, realism `61`, confidence `74`, synthetic-confidence `67`;
+    deliberated to Synthetic, realism `60`, synthetic-confidence `70`.
+  - Host/EDR: Synthetic, realism `58`, confidence `72`, synthetic-confidence `64`;
+    deliberated to Synthetic, realism `57`, synthetic-confidence `68`.
+- Deliberation consensus:
+  - Linux SSH/session lifecycle ordering is the top failure: repeated `/bin/bash -bash`
+    process creates appeared before matching SSH Accepted/PAM/logind/eCAR login rows.
+  - DNS answer-to-destination/proxy-origin binding is the next highest-priority family.
+  - Additional follow-ups: interactive shell/session ownership, staged exfil process ownership,
+    Windows 4648 source-native field names, Linux eCAR `tid == pid` texture, perimeter/proxy
+    distribution texture, and repeated Linux command pools.
+- Selected loop 25 target:
+  - P1 Linux SSH/session lifecycle ordering. In eCAR, interactive Linux login-shell
+    `PROCESS/CREATE` rows must not render before the same-user successful `USER_SESSION/LOGIN`.
+    Parent ordering must then keep child command rows behind the shifted shell.
+
+## Loop 25
+
+- Implemented changes:
+  - Added eCAR host-buffer normalization for interactive Linux login-shell creates. If a
+    `/bin/bash` or `/usr/bin/bash` login shell (`-bash`, `bash`, `/bin/bash`, `/usr/bin/bash`)
+    renders shortly before a same-host/same-user successful `USER_SESSION/LOGIN`, it is shifted
+    after that login with deterministic source-local jitter.
+  - Re-ran eCAR process-parent ordering after the shell shift so command child rows remain after
+    their shell parent.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py -k "linux_login_shell_create_shifted_after_session_login or remote_user_session_login_shifted_after_late_inbound_flow or linux_process_lifecycle_tid"`
+  - `uv run ruff check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+  - `uv run ruff format --check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+- Generated loop 25 output successfully.
+- Automated eval passed at `95.29205091144773` over 95,819 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.29351259983402`
+  - Causality: `89.47668953519369`
+  - Timing: `95.49750188845404`
+- Hard probe `hard_probe_ssh_shell_order.json`:
+  - Interactive shell creates scanned: `74`.
+  - Shell-before-login contradictions: `0`.
+  - Remaining sessionless/orphan shell rows: `11`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-25/review-data`.
+  - Neutral read-only copy: `/private/tmp/eforge-review-dataset-delta.DOpedZ`.
+  - `COLLECTION_PROFILE.json` excluded from both review copies.
+  - Four-reviewer blind panel completed.
+- Blind initial mean synthetic-confidence: `45.5`; deliberation mean: `51.5`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, realism `72`, confidence `68`, synthetic-confidence `58`;
+    deliberated to Synthetic, realism `70`, confidence `72`, synthetic-confidence `60`.
+  - Detection Engineer: Inconclusive, realism `72`, confidence `66`, synthetic-confidence `34`;
+    deliberated unchanged, realism `68`, confidence `70`, synthetic-confidence `42`.
+  - Network Forensics: Real, realism `78`, confidence `72`, synthetic-confidence `22`;
+    deliberated to Inconclusive, realism `74`, confidence `68`, synthetic-confidence `34`.
+  - Host/EDR: Synthetic, realism `56`, confidence `74`, synthetic-confidence `68`;
+    deliberated unchanged, realism `54`, confidence `76`, synthetic-confidence `70`.
+- Deliberation consensus:
+  - The highest-priority synthetic tell is a shared browser/session identity contradiction on the
+    high-value exfil path: endpoint evidence showed Chrome while proxy/Zeek HTTP evidence could
+    collapse to Firefox/generic browser ownership for the same upload.
+  - eCAR endpoint lifecycle/actor ownership remains the broader follow-up family, including thin
+    service actor metadata and missing FLOW actor/process ownership where adjacent evidence has
+    context.
+  - Bulk transfer/staging texture, attacker infrastructure reuse, and tidy collection/profile
+    texture remain lower-priority follow-ups.
+- Selected loop 26 target:
+  - P0 shared endpoint/browser/proxy/network session ownership for staged HTTPS exfiltration.
+    Authored browser UAs and staged-upload browser processes must remain bound so endpoint file
+    reads, eCAR FLOW rows, proxy access rows, and Zeek CONNECT rows agree on the browser family.
+
+## Loop 26
+
+- Implemented changes:
+  - Added a data-driven browser process-to-User-Agent helper backed by
+    `proxy_user_agents.yaml`, so known browser process images can receive a matching full
+    source-native User-Agent.
+  - Storyline staged-upload exfil now selects a Windows browser process that matches an authored
+    browser User-Agent (`Chrome`, `Firefox`, or `Edge`) and infers a process-native User-Agent for
+    blank/generic upload HTTP metadata.
+  - Explicit proxy context building now treats caller-supplied full browser User-Agents as
+    overrides for HTTP-originated requests, preventing non-browser-like API destinations from
+    replacing them with a source-sticky generated browser family.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_storyline_command_networks.py -k "compress_archive_exfil"`
+  - `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "build_proxy_context_preserves_caller_browser_user_agent_for_api_domain or preserves_override_browser_user_agent or collapses_generated_browser_family"`
+  - `uv run ruff check src/evidenceforge/generation/activity/proxy_user_agents.py src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/engine/storyline.py tests/unit/test_storyline_command_networks.py tests/unit/test_explicit_proxy.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/proxy_user_agents.py src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/engine/storyline.py tests/unit/test_storyline_command_networks.py tests/unit/test_explicit_proxy.py`
+- Generated loop 26 output successfully.
+- Automated eval passed at `95.30102273163071` over 94,798 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.46977954516477`
+  - Causality: `89.47668953519369`
+  - Timing: `95.3220273077055`
+- Hard probe `hard_probe_exfil_browser_identity.json`:
+  - Proxy upload rows: `1`; all use `Chrome/121.0.0.0`.
+  - Zeek CONNECT rows for the upload tunnel: `2`; all use `Chrome/121.0.0.0`.
+  - Endpoint Chrome pid: `7184`; staged ZIP read pid: `7184`; eCAR proxy FLOW pid: `7184`;
+    source port: `64794`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-26/review-data`.
+  - Neutral read-only copy: `/private/tmp/eforge-review-dataset-echo.VNfkns`.
+  - `COLLECTION_PROFILE.json` excluded from both review copies.
+  - Four-reviewer blind panel completed.
+- Blind initial mean synthetic-confidence: `51.5`; deliberation mean: `55.75`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, realism `70`, confidence `72`, synthetic-confidence `61`;
+    deliberated to Synthetic, confidence `74`, synthetic-confidence `64`.
+  - Detection Engineer: Inconclusive, realism `76`, confidence `70`, synthetic-confidence `42`;
+    deliberated to Inconclusive synthetic-leaning, confidence `72`, synthetic-confidence `50`.
+  - Network Forensics: Inconclusive, realism `74`, confidence `66`, synthetic-confidence `42`;
+    deliberated unchanged, confidence `68`, synthetic-confidence `45`.
+  - Host/EDR: Synthetic, realism `74`, confidence `70`, synthetic-confidence `61`;
+    deliberated to Synthetic, confidence `73`, synthetic-confidence `64`.
+- Deliberation consensus:
+  - All four reviewers either directly or indirectly pointed to eCAR `FLOW` actor attribution as
+    the highest-leverage realism problem.
+  - The main synthetic tell is no longer the staged browser upload path; it is the patterned
+    absence or contradiction of process/principal attribution on high-confidence service and
+    user-owned flows.
+  - Concrete examples include WEB-EXT MySQL flows, MAIL LDAP flows, DB/server proxy and SMB
+    flows, WS-AJOHNSON SSH flows, and DC/server proxy activity.
+  - Secondary follow-ups are large proxy-mediated transfer durations, public HTTP client
+    diversity, Linux TID texture, direct root SSH, and process-before-login/session edge cases.
+- Selected loop 27 target:
+  - P1 eCAR `FLOW` actor attribution for known-owner and high-confidence flows. The network
+    connection owner should materialize plausible user or service process identity at the
+    canonical event layer so eCAR can render coherent `pid`, `principal`, and `image_path`
+    without source-specific patching.
+
+## Loop 27
+
+- Implemented changes:
+  - Added a high-confidence connection-owner materialization path in the network connection
+    bundle. Existing caller-supplied and inferred PIDs still win; when those are missing, stale,
+    future-dated, or expired, the bundle can now create/reuse canonical source-side process
+    ownership before rendering.
+  - Server/service-owned flows now get source-native daemon/client owners for common high-signal
+    families: web/app to database, mail/app/web to LDAP, server SMB, and server/proxy HTTP(S)
+    traffic.
+  - Workstation SSH/SMB flows now materialize user-mode owners only when a visible interactive
+    user session exists, preserving the collection-window/session contract.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "connection_materializes"`
+  - `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "proxy or build_proxy_context"`
+    (`72` passed after tightening direct proxy listener fallback to use UA-matching tool owners).
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "generate_connection or ssh_process_network_effect or generic_ssh_preauth or connection_materializes"`
+    (`31` passed).
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py tests/unit/test_explicit_proxy.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py tests/unit/test_explicit_proxy.py`
+- Generated loop 27 output successfully.
+- Automated eval passed at `95.092505124442` over 96,786 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.07492337480768`
+  - Causality: `88.80992196209588`
+  - Timing: `95.60646895108057`
+- Hard probe `hard_probe_ecar_flow_attribution.json`:
+  - Total eCAR `FLOW` rows missing identity dropped from loop 26 `2329` to loop 27 `1525`.
+  - Outbound high-value `FLOW` rows missing identity dropped from loop 26 `1309` to loop 27
+    `418`.
+  - Key reviewer buckets improved:
+    - WEB-EXT MySQL missing: `308/310` -> `5/361`.
+    - MAIL-CLIN LDAP missing: `77/77` -> `0/80`.
+    - MAIL-EDGE LDAP missing: `73/73` -> `0/85`.
+    - APP-INT LDAP missing: `23/23` -> `0/31`.
+    - DB-PROD proxy missing: `37/37` -> `0/23`.
+    - DC proxy missing: `45/54` -> `3/66`.
+    - DB-PROD SMB missing: `31/31` -> `0/19`.
+    - WS-AJOHNSON SSH missing: `19/19` -> `0/16`.
+  - Remaining focus gaps:
+    - Workstation SMB remains partially actorless (`WS-OHADDAD-01:445` `20/60`,
+      `WS-LNGUYEN-01:445` `14/38`).
+    - WS-AJOHNSON proxy listener rows remain partially actorless (`24/73`), likely cases without
+      a compatible live browser/tool session.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-27/review-data`.
+  - Neutral read-only copy: `/private/tmp/eforge-review-dataset-foxtrot.lUy9yV`.
+  - `COLLECTION_PROFILE.json`, `GROUND_TRUTH.md`, and `GROUND_TRUTH.json` excluded from both
+    review copies.
+  - Four-reviewer blind panel completed.
+- Blind initial mean synthetic-confidence: `46.0`; deliberation mean: `64.25`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `84`, synthetic-confidence `72`; deliberated to
+    Synthetic, confidence `88`, synthetic-confidence `76`.
+  - Detection Engineer: Inconclusive, confidence `68`, synthetic-confidence `42`; deliberated to
+    Synthetic, confidence `76`, synthetic-confidence `64`.
+  - Network Forensics: Real, confidence `64`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `62`, synthetic-confidence `56`.
+  - Host/EDR: Inconclusive, confidence `66`, synthetic-confidence `36`; deliberated to
+    Synthetic, confidence `72`, synthetic-confidence `61`.
+- Deliberation consensus:
+  - The eCAR actor-omission fix materially improved endpoint ownership, and Host/EDR plus Network
+    initially scored the dataset as mostly realistic.
+  - The consensus-dominant defect is now a harder proxy/eCAR contradiction: same client IP,
+    source port, proxy IP, and proxy port can show one endpoint command-line target while Zeek
+    HTTP/proxy access show a different host and User-Agent for the same socket.
+  - Threat Hunter reported `98` mismatches among `137` joined explicit proxy tuples with exposed
+    command-line targets.
+  - eCAR command lines also leak planning/classification annotations such as
+    `# proxy-check internal-service` and `# smb FILE-SRV-01.meridianhcs.local`.
+  - Secondary findings: DC/server health-check target/account texture, eCAR parent lifecycle
+    orphan for DC scheduled task, workstation event-volume homogeneity, x509 SAN simplification,
+    TXT resolver egress visibility, and proxy 304 byte semantics.
+- Selected loop 28 target:
+  - P0 explicit proxy transaction semantic consistency. The source endpoint `FLOW` owner
+    command line, Zeek HTTP host/URI/User-Agent, proxy access host/User-Agent, source port, and
+    eCAR process context must be generated from the same transaction truth. Rendered endpoint
+    command lines must not contain hidden planning labels or comments.
+
+## Loop 28
+
+- Implemented changes:
+  - Target-bearing connection-owner process keys now include the proxy/origin host so
+    `service-healthcheck`, Java integration workers, `curl`, `wget`, Python requests, and
+    Windows service-health owners are not reused across different destinations.
+  - Existing proxy caller PID validation now rejects same-image processes when their
+    target-bearing command line does not match the current proxy transaction host.
+  - Proxy client process reuse now requires exact command-line matches for target-bearing tools.
+  - Removed hidden planning/comment labels from rendered service-owner command lines, including
+    `# proxy-check`, `# smb`, and `# db-maintenance` variants.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "proxy_service_owner_is_not_reused_across_targets or command_lines_do_not_leak or connection_materializes"`
+    (`4` passed).
+  - `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "proxy or build_proxy_context"`
+    (`72` passed).
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py tests/unit/test_explicit_proxy.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py tests/unit/test_explicit_proxy.py`
+- Generated loop 28 output successfully.
+- Automated eval passed at `95.40020233866719` over 94,318 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.9681362136533`
+  - Causality: `90.27553588475223`
+  - Timing: `95.44642157032901`
+- Hard probe `hard_probe_proxy_tuple_semantics.json`:
+  - Loop 27 target-bearing proxy `FLOW` rows checked: `682`; non-browser mismatches:
+    `96/232`; command-line comment leaks: `219`.
+  - Loop 28 target-bearing proxy `FLOW` rows checked: `640`; non-browser mismatches:
+    `0/237`; command-line comment leaks: `0`.
+  - Remaining raw host mismatch rows are browser-family processes (`firefox`, `chrome.exe`,
+    `google-chrome`, `msedge.exe`) where the launch command line can source-natively preserve
+    an initial URL while later proxy rows represent subsequent browsing.
+- Blind review:
+  - Initial review bundle accidentally included `OBSERVATION_MANIFEST.json`, which Threat Hunter
+    correctly identified as package metadata rather than raw-log evidence. Rebuilt a clean bundle
+    excluding `GROUND_TRUTH.md`, `GROUND_TRUTH.json`, `data/COLLECTION_PROFILE.json`,
+    `OBSERVATION_MANIFEST.json`, `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Corrected review bundle:
+    `scenarios/iteration-test-expanded/blind-test/loop-28/review-data-clean`.
+  - Neutral corrected copy: `/private/tmp/review-dataset-hotel.Bqcr6U`.
+  - Re-ran Threat Hunter only on the corrected bundle; the other three reports did not use the
+    manifest leak and were retained.
+- Corrected blind initial mean synthetic-confidence: `40.5`; deliberation mean: `41.5`.
+- Reviewer scores:
+  - Threat Hunter corrected: Synthetic, confidence `67`, synthetic-confidence `62`;
+    deliberated to Synthetic, confidence `61`, synthetic-confidence `56`.
+  - Detection Engineer: Inconclusive, confidence `64`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `63`, synthetic-confidence `38`.
+  - Network Forensics: Real, confidence `66`, synthetic-confidence `32`; deliberated to Real,
+    confidence `62`, synthetic-confidence `35`.
+  - Host/EDR: Inconclusive, confidence `68`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `66`, synthetic-confidence `37`.
+- Deliberation consensus:
+  - The Loop 28 fix removed the prior hard proxy tuple target mismatch and command-line comment
+    leaks; reviewers now emphasized texture and weaker identity issues rather than impossible
+    ordering.
+  - The strongest synthetic-leaning issue was repeated corpus texture in benign email prose and
+    Linux bash history command pools.
+  - The strongest concrete cross-source issue was DC/server proxy traffic where eCAR attributes a
+    flow to `service-healthcheck.exe` while proxy/Zeek HTTP carries Chrome-like browser identity
+    on the same source port.
+  - Lower-priority follow-ups: Windows 4624 EventData order, forwarded-vs-local Security 1102
+    collection semantics, proxy SSL-inspection/tunnel grammar texture, NTP precision, and Zeek
+    public-mail `local_resp` ambiguity.
+- Selected loop 29 target:
+  - P1 proxy User-Agent/process ownership binding for server/service-owned proxy traffic. When
+    source endpoint ownership is a service or tool process, proxy access and Zeek HTTP must carry
+    a compatible service/tool User-Agent, or the generator must render explicit evidence of
+    deliberate browser-UA spoofing. Prefer binding the canonical `ProxyContext` to the source
+    process family before the proxy transaction bundle renders sibling evidence.
+
+## Loop 29
+
+- Implemented changes:
+  - Added proxy User-Agent normalization inside canonical proxy context construction so
+    server/service-owned proxy transactions cannot silently reuse browser-family User-Agents.
+  - Server-like proxy sources that would otherwise render Chrome/Firefox/Edge/Safari-style
+    User-Agents now receive a compatible service/tool client identity (`Go-http-client/1.1`)
+    before proxy access, Zeek HTTP, and endpoint flow evidence are rendered.
+  - Caller-authored workstation browser activity continues to preserve the browser User-Agent
+    when it is compatible with the source process family.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "server_browser_user_agent or binds_server_proxy_user_agent or preserves_caller_browser_user_agent_for_api_domain or proxy or build_proxy_context"`
+    (`74` passed).
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "proxy_service_owner_is_not_reused_across_targets or command_lines_do_not_leak or connection_materializes"`
+    (`4` passed).
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_explicit_proxy.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_explicit_proxy.py`
+- Generated loop 29 output successfully.
+- Automated eval passed at `95.09772243176974` over 94,627 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.15430840807609`
+  - Causality: `90.27508723160896`
+  - Timing: `94.95186760924241`
+- Hard probe `hard_probe_service_proxy_ua_binding.json`:
+  - Service-healthcheck joined HTTP rows with browser User-Agent mismatches dropped from loop 28
+    `18` to loop 29 `0`.
+  - DC westbridge proxy access browser rows dropped from loop 28 `20` to loop 29 `0`; matching
+    service/tool rows increased from `0` to `20`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-29/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-india.YBaesU`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+- Blind initial mean synthetic-confidence: `53.0`; deliberation mean: `58.5`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `72`, synthetic-confidence `67`; deliberated to
+    Synthetic, confidence `74`, synthetic-confidence `70`.
+  - Detection Engineer: Inconclusive, confidence `63`, synthetic-confidence `34`; deliberated to
+    Inconclusive leaning Synthetic, confidence `60`, synthetic-confidence `46`.
+  - Network Forensics: Synthetic, confidence `68`, synthetic-confidence `64`; deliberated to
+    Synthetic, confidence `70`, synthetic-confidence `66`.
+  - Host/EDR: Inconclusive, confidence `66`, synthetic-confidence `47`; deliberated to
+    Inconclusive leaning Synthetic, confidence `64`, synthetic-confidence `52`.
+- Deliberation consensus:
+  - The service-owned proxy User-Agent contradiction was fixed for the targeted family.
+  - The new highest-confidence hard contradiction is outbound SMTP evidence: external recipient
+    `Received:` headers show RFC1918 internal sender IPs even though ASA evidence for the same
+    sessions shows NAT to `203.14.220.1`.
+  - Reviewers cited examples where external MTAs such as `smtp1.greatplains-mail.net` appear to
+    receive directly from `10.10.2.26`, while perimeter logs show the boundary-translated source.
+  - Secondary follow-ups include missing proxy-origin flows after CONNECT to internal mail
+    targets, endpoint timestamp texture, and public scan/PTR/web texture.
+- Selected loop 30 target:
+  - P0/P1 SMTP delivery boundary identity. The email delivery bundle/artifact construction path
+    should render external-facing `Received:` headers with the peer address seen at the boundary
+    (NAT/public identity for outbound perimeter hops) while preserving RFC1918/private identity
+    on internal relay hops. The fix should live where SMTP hop truth is built, before EML
+    artifacts, Zeek SMTP, Postfix/syslog, ASA, and manifest consumers render sibling evidence.
+
+## Loop 30
+
+- Implemented changes:
+  - Added a canonical SMTP `Received:` peer-identity helper in the email delivery construction
+    path. External-facing server-to-server hops from modeled internal sources now render the
+    receiving MTA's boundary-visible peer IP, using configured outbound NAT source identity
+    without consuming PAT state.
+  - Internal relay and submission headers continue to render the private/source-local peer
+    identity, preserving source-native internal mailbox evidence.
+  - Added a focused mixed internal/external outbound route regression with an outbound PAT
+    firewall sensor. The test asserts external `Received:` headers show `203.14.220.1` while
+    internal relay headers still show RFC1918 source IPs.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_email_evidence.py -k "mixed_internal_external_outbound_hops_scope_recipients or outbound_route_group_override_and_global_isp_relay or email_generation_writes_smtp_artifacts"`
+    (`3` passed).
+  - `uv run pytest --no-cov tests/unit/test_email_evidence.py` (`33` passed).
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_email_evidence.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_email_evidence.py`
+- Generated loop 30 output successfully.
+- Automated eval passed at `95.09772243176974` over 94,627 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.15430840807609`
+  - Causality: `90.27508723160896`
+  - Timing: `94.95186760924241`
+- Hard probe `hard_probe_smtp_received_nat.json`:
+  - Loop 29 external-facing `Received:` headers exposing private sender IPs: `7`.
+  - Loop 30 external-facing `Received:` headers exposing private sender IPs: `0`.
+  - Loop 30 external-facing NAT/public sender headers: `7`.
+  - Loop 30 internal relay headers retaining private peer IPs: `33`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-30/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-juliet.8UdP8o`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was not triggered: all reviewers returned Synthetic, average verdict
+    confidence was above 60, and synthetic-confidence spread was `12`.
+- Blind initial mean synthetic-confidence: `71.5`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `62`, synthetic-confidence `66`.
+  - Detection Engineer: Synthetic, confidence `84`, synthetic-confidence `78`.
+  - Network Forensics: Synthetic, confidence `78`, synthetic-confidence `70`.
+  - Host/EDR: Synthetic, confidence `78`, synthetic-confidence `72`.
+- Panel consensus and prioritized findings:
+  - The loop 30 SMTP NAT/header contradiction was absent from reviewer reports after the fix.
+  - The dominant multi-reviewer hard contradiction is now SSH/eCAR command target and network
+    destination identity binding: Windows `ssh.exe <host>` process identities are reused across
+    flows to different hosts/IPs, and some eCAR `FLOW` rows name one internal host while the
+    tuple reaches another.
+  - Detection reported `84` eCAR command-target versus `dst_ip` mismatches plus a related
+    Windows 4648 target/address mismatch.
+  - Host/EDR cited repeated SSH examples on `WS-AJOHNSON-01`, `WS-MCHEN-01`, and
+    `WS-SMARTINEZ-01` where the same PID/command line owns sessions to multiple unrelated
+    hosts.
+  - Threat Hunter found a sibling process-command ownership gap on FILE-SRV where `net.exe net
+    view \\FILE-SRV-01` is parented by a `cmd.exe /c net.exe` process rather than the sibling
+    `cmd.exe /c net view \\FILE-SRV-01`.
+  - Network Forensics independently found proxy request-target and referer URL fragments in
+    `proxy_access.log`; this is a strong single-reviewer source-native proxy target for a later
+    loop if it persists.
+- Selected loop 31 target:
+  - P0/P1 SSH/eCAR command target and network destination identity binding. Owning abstraction:
+    canonical process/network ownership in `ActivityGenerator` plus SSH action entry paths.
+    Invariant: if a source-visible client process command line names an internal host, that
+    process can own only flows to that host/IP unless explicit tunnel or multiplex evidence is
+    modeled; otherwise allocate or reuse a target-specific process identity. Consumers include
+    eCAR `FLOW`, Sysmon Event 3, process-create/terminate rows, SSH target-side syslog/eCAR
+    sessions, Windows 4648 companion evidence, and blind reviewer host/IP probes.
+
+## Loop 31
+
+- Family contract:
+  - Owning abstraction: canonical process/network ownership in `ActivityGenerator`; this is where
+    source-visible client process reuse is selected before eCAR/Sysmon/source timing renderers
+    consume process identity.
+  - Invariant: target-bearing client command lines (`ssh`, `scp`, `sftp`, SMB browse commands)
+    may only reuse an active process when the command line names the same target host. A process
+    whose command line names one internal host must not own `FLOW` rows to another internal host
+    unless explicit tunnel/multiplex evidence is modeled.
+  - Entry paths: high-confidence process ownership for generated user connections, SSH baseline
+    and storyline paths that materialize source client ownership, SMB browse/network noise, and
+    source-visible endpoint flow rendering.
+  - Consumers: eCAR `FLOW`, process create/terminate lifecycle rows, Sysmon Event 3, Windows 4648
+    companions, SSH target-side syslog/eCAR sessions, and rendered-output probes that compare
+    command-line target host to `dst_ip`.
+  - Sibling risk: direct remote-admin command parent/child grammar (`cmd.exe /c net.exe` vs
+    `cmd.exe /c net view ...`) remains a separate process-tree grammar issue; loop 31 scoped to
+    target-bearing network owner reuse.
+- Implemented changes:
+  - Added target-bearing exact-command matching for `ssh`, `ssh.exe`, `scp`, `scp.exe`, `sftp`,
+    `sftp.exe`, and `gvfsd-smb-browse` process owners.
+  - `_ensure_user_connection_owner_process` now refuses to reuse an active candidate process for
+    target-bearing command lines unless the existing command line exactly matches the requested
+    target-bearing command.
+  - Added focused tests proving Windows `ssh.exe <host>` and Linux `gvfsd-smb-browse
+    smb://<host>/...` allocate target-specific owner processes and reuse only for the same
+    target.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "ssh_owner_is_scoped or smb_browse_owner_is_scoped or workstation_ssh_connection_materializes_user_owner or ssh_process_network_effect"`
+    (`5` passed).
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "connection_materializes or high_confidence or proxy_service_owner_is_not_reused_across_targets or command_lines_do_not_leak or ssh_process_network_effect or workstation_ssh"`
+    (`7` passed).
+  - `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "build_proxy_context or proxy"`
+    (`74` passed).
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+- Generated loop 31 output successfully.
+- Automated eval passed at `95.48137933988775` over 94,935 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.40265788614258`
+  - Causality: `90.32296183444666`
+  - Timing: `96.49987204870217`
+- Hard probe `hard_probe_ecar_target_bearing_owner.json`:
+  - Loop 30 target-bearing eCAR `FLOW` rows checked: `148`.
+  - Loop 30 target/destination mismatches: `80`.
+  - Loop 31 target-bearing eCAR `FLOW` rows checked: `163`.
+  - Loop 31 target/destination mismatches: `0`.
+  - Loop 31 multi-target process reuse count: `0`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-31/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-kilo.0x4qUA`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement.
+- Blind initial mean synthetic-confidence: `39.25`; deliberation mean: `45.0`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `66`, synthetic-confidence `43`; deliberated to
+    Inconclusive, confidence `70`, synthetic-confidence `48`.
+  - Detection Engineer: Real, confidence `57`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `58`, synthetic-confidence `43`.
+  - Network Forensics: Real, confidence `72`, synthetic-confidence `26`; deliberated to Real,
+    confidence `68`, synthetic-confidence `31`.
+  - Host/EDR: Synthetic, confidence `63`, synthetic-confidence `54`; deliberated to Synthetic,
+    confidence `66`, synthetic-confidence `58`.
+- Panel consensus and prioritized findings:
+  - The loop 30 SSH/eCAR target-bearing command mismatch was absent from reviewer reports after
+    the fix. Detection explicitly reported no SSH auth outside visible transport windows, and
+    Host/EDR called Linux SSH evidence source-native.
+  - The strongest new consensus target is Linux reboot lifecycle modeling: `loginctl reboot` or
+    `systemctl reboot` commands plus polkit authorization appear on multiple Linux hosts without
+    shutdown/boot evidence, daemon PID churn, service stops, DHCP reacquisition, or explicit
+    failure/inhibitor text. This is a source-visible lifecycle gap and moved Detection from Real
+    to Inconclusive in deliberation.
+  - Secondary targets:
+    - Windows Sysmon CBS package-state registry writes are repeatedly attributed to `msiexec.exe`
+      across roles; likely should be TrustedInstaller/TiWorker servicing activity or retargeted
+      to MSI/product registry keys.
+    - Linux admin/sudo command pools and SSH auth/PAM timing remain distribution-texture tells.
+    - Detection still found one Windows 4648 `TargetServerName=DC-01` with
+      `NetworkAddress=10.10.1.99`; investigate as a residual explicit credential-use companion
+      source/destination binding issue.
+    - Proxy `304` byte semantics, NTP stratum/ref_id, UDP/88 zero-byte denies, and a single
+      incomplete bash history command are lower-impact weak signals.
+- Selected loop 32 target:
+  - P0/P1 Linux reboot lifecycle semantics. Owning abstraction: Linux command/process/session
+    lifecycle generation plus syslog/eCAR side effects, likely in the ActivityGenerator/Linux
+    baseline command path and any canonical command/network side-effect helpers. Invariant: a
+    visible successful `loginctl reboot`, `systemctl reboot`, or equivalent shutdown command must
+    either produce a coherent reboot lifecycle (session termination, service stop/shutdown,
+    kernel/boot messages, daemon PID churn, DHCP reacquisition, post-boot gap) or be rendered as
+    visibly denied/failed/inhibited with no subsequent boot expectations. Consumers include
+    syslog, eCAR PROCESS lifecycle, bash history, DHCP syslog/Zeek, and blind host lifecycle
+    probes. Sibling risk: package/service restart commands may need a lighter lifecycle contract
+    but can be deferred unless the reboot fix surfaces shared command-outcome modeling.
+
+## Loop 32
+
+- Family contract:
+  - Owning abstraction: Linux polkit/background syslog command-outcome generation in
+    `BaselineMixin`, plus the eCAR companion process materialization it invokes.
+  - Invariant: generic background polkit reboot noise must not claim a successful reboot unless a
+    coherent host reboot lifecycle is modeled. A visible `loginctl reboot`/`systemctl reboot`
+    attempt without boot/session/daemon/DHCP lifecycle evidence must be explicitly failed or
+    unauthorized.
+  - Entry paths: extra syslog `polkitd` workstation entries, polkit action/profile selection,
+    companion CLI process materialization, eCAR process lifecycle, and syslog rendering.
+  - Consumers: Linux syslog, eCAR PROCESS create/terminate, bash-history-adjacent host lifecycle
+    probes, DHCP/syslog daemon continuity checks, and blind Host/EDR review.
+  - Sibling risk: true modeled reboot/shutdown remains future work; this loop fixes generic
+    background noise by preventing accidental successful reboot semantics.
+- Implemented changes:
+  - Added `_polkit_action_message_template` so `org.freedesktop.login1.reboot` generic polkit
+    messages render as explicit failure/not-authorized text rather than successful authorization.
+  - Retained endpoint-visible `loginctl reboot` or `systemctl reboot` process attempts so analysts
+    see a plausible failed attempt instead of a hidden event.
+  - Added a focused regression test forcing the reboot action and asserting no successful
+    authorization text is emitted while the reboot command process remains visible.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_phase5_system_traffic.py -k "polkit_action or polkit_reboot"`
+    (`3` passed).
+  - `uv run pytest --no-cov tests/unit/test_phase5_system_traffic.py` (`62` passed).
+  - `uv run ruff check src/evidenceforge/generation/engine/baseline.py tests/unit/test_phase5_system_traffic.py`
+  - `uv run ruff format --check src/evidenceforge/generation/engine/baseline.py tests/unit/test_phase5_system_traffic.py`
+- Generated loop 32 output successfully.
+- Automated eval passed at `95.0425237961009` over 95,354 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.56367827855763`
+  - Causality: `88.79128058921359`
+  - Timing: `96.01892039579043`
+- Guardrail note:
+  - Causality pillar dipped below 90 because event-presence scoring stayed at `89.1`; causal
+    ordering remained `100.0` and acceptance passed. The reported sample failures are existing
+    scenario traceability gaps rather than a reboot-fix ordering regression.
+- Hard probe `hard_probe_linux_reboot_polkit_outcome.json`:
+  - Loop 31 reboot command processes: `6`.
+  - Loop 31 successful reboot authorizations: `6`.
+  - Loop 32 reboot command processes: `7`.
+  - Loop 32 successful reboot authorizations: `0`.
+  - Loop 32 unsuccessful reboot authorizations: `7`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-32/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-lima.coqi5h`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread over 30.
+- Blind initial mean synthetic-confidence: `44.75`; deliberation mean: `52.25`.
+- Reviewer scores:
+  - Threat Hunter: Real, confidence `68`, synthetic-confidence `36`; deliberated to
+    Inconclusive, confidence `64`, synthetic-confidence `48`.
+  - Detection Engineer: Inconclusive, confidence `72`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `74`, synthetic-confidence `43`.
+  - Network Forensics: Inconclusive, confidence `68`, synthetic-confidence `42`; deliberated to
+    Inconclusive, confidence `70`, synthetic-confidence `50`.
+  - Host/EDR: Synthetic, confidence `72`, synthetic-confidence `67`; deliberated to Synthetic,
+    confidence `74`, synthetic-confidence `68`.
+- Panel consensus and prioritized findings:
+  - The reboot lifecycle issue no longer dominated the panel. Host/EDR specifically reported no
+    visible process/session lifecycle inversions and praised Linux SSH/SCP ordering.
+  - The new strongest source-native contradiction is FILE-SRV-01/10.10.2.20 rendering HTTP
+    health checks as `kube-probe/1.28` while endpoint eCAR and Windows WFP attribute the same
+    tuples/source ports to Windows `svchost.exe -k netsvcs`, with no kubelet/container evidence.
+  - Secondary targets include duplicated core/DMZ sensor timing offsets, endpoint/export window
+    clustering, Linux sysstat/cron regularity, repeated sudo/admin command pool texture, and
+    templated email prose.
+- Selected loop 33 target:
+  - P0/P1 health-check User-Agent/process ownership semantics. Owning abstraction:
+    web-session/profile selection plus canonical HTTP/network process ownership, not a single
+    web emitter. Invariant: source-native HTTP User-Agent families must match the source host and
+    visible owner process. `kube-probe/*` health checks may originate only from modeled Linux
+    Kubernetes/kubelet/container sources with corresponding endpoint evidence; Windows service
+    health-check traffic must use Windows-service-appropriate User-Agents and endpoint process
+    identity. Consumers include web_access, Zeek HTTP, proxy/access when applicable, eCAR FLOW,
+    Windows Security 5156, Sysmon Event 3, and blind host/network probes.
+
+## Loop 33
+
+- Family contract:
+  - Owning abstraction: data-driven inbound web visitor profiles and the shared
+    `pick_web_user_agent` OS-aware selection helper consumed by baseline web traffic generation.
+  - Invariant: generic health-check User-Agent pools must be host/software compatible. A
+    Windows-originated health-check request must not draw a Kubernetes/kubelet User-Agent unless
+    the source host has modeled Kubernetes/container ownership evidence; generic internal health
+    checks should use OS-appropriate service/monitoring User-Agents.
+  - Entry paths: inbound web baseline request profiles, profile source-type/role filtering,
+    source-host OS resolution in `_emit_web_server_access`, sticky User-Agent selection, and any
+    overlay-provided web visitor classes that use `user_agent_pool_by_os`.
+  - Consumers: `web_access.log`, Zeek `http.json`, proxy access rows for routed HTTP activity,
+    eCAR `FLOW`, Windows Security 5156, Sysmon Event 3, and rendered-output probes comparing HTTP
+    User-Agent families with endpoint process ownership.
+  - Sibling risk: true Kubernetes health checks still need a role/software-aware source family
+    with visible kubelet/container evidence; this loop removes the generic cross-platform
+    mismatch rather than adding a full Kubernetes node model.
+- Implemented changes:
+  - Split the generic health-check User-Agent profile into OS-specific pools:
+    `health_check_windows` and `health_check_linux`.
+  - Removed `kube-probe/1.28` from generic health-check selection so ordinary Windows and Linux
+    server health checks cannot masquerade as Kubernetes/kubelet traffic by default.
+  - Added a `validate-config` guard that rejects `kube-probe` in generic health-check pools unless
+    the profile is explicitly scoped to Kubernetes/container roles.
+  - Extended web-session profile and baseline web-access tests to assert OS-scoped health-check
+    User-Agent selection and no Kubernetes User-Agent leakage from server-scoped health checks.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_web_session_profiles.py tests/unit/test_baseline_canonical.py -k "health_check"`
+    (`4` passed).
+  - `uv run pytest --no-cov tests/unit/test_validate_config.py -k "web_session_profile or kube_probe"`
+    (`2` passed).
+  - `uv run pytest --no-cov tests/unit/test_web_session_profiles.py tests/unit/test_validate_config.py`
+    (`90` passed).
+  - `uv run eforge validate-config`
+  - `uv run ruff check src/evidenceforge/cli/validate_config.py tests/unit/test_web_session_profiles.py tests/unit/test_baseline_canonical.py tests/unit/test_validate_config.py`
+  - `uv run ruff format --check src/evidenceforge/cli/validate_config.py tests/unit/test_web_session_profiles.py tests/unit/test_baseline_canonical.py tests/unit/test_validate_config.py`
+- Generated loop 33 output successfully.
+- Automated eval passed at `95.0425237961009` over 95,354 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.56367827855763`
+  - Causality: `88.79128058921359`
+  - Timing: `96.01892039579043`
+- Guardrail note:
+  - Causality stayed below 90 for the same existing event-presence/storyline-linkability issues
+    observed in loop 32; causal ordering remained `100.0` and acceptance passed.
+- Hard probe `hard_probe_health_check_user_agent_binding.json`:
+  - Loop 32 Windows-source `kube-probe` HTTP rows: `15`.
+  - Loop 33 Windows-source `kube-probe` HTTP rows: `0`.
+  - Loop 33 total `kube-probe` HTTP rows: `0`.
+  - Loop 33 Windows service-style health-check rows: `21`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-33/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-mike.vx_ypzgg`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread over 30.
+- Blind initial mean synthetic-confidence: `50.5`; deliberation mean: `59.25`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `64`, synthetic-confidence `42`; deliberated to
+    Inconclusive/synthetic-leaning, confidence `68`, synthetic-confidence `55`.
+  - Detection Engineer: Synthetic, confidence `62`, synthetic-confidence `64`; deliberated to
+    Synthetic, confidence `68`, synthetic-confidence `70`.
+  - Network Forensics: Real, confidence `72`, synthetic-confidence `28`; deliberated to Real
+    with endpoint caveat, confidence `64`, synthetic-confidence `38`.
+  - Host/EDR: Synthetic, confidence `70`, synthetic-confidence `68`; deliberated to Synthetic,
+    confidence `76`, synthetic-confidence `74`.
+- Panel consensus and prioritized findings:
+  - The loop 32 Windows `svchost.exe`/`kube-probe` contradiction disappeared from the loop 33
+    reports after the fix.
+  - The strongest new concrete contract gap is MAIL-EDGE endpoint FLOW viewpoint handling:
+    eCAR renders repeated internal SMTP flows to the public VIP `203.14.220.11` while host-local
+    Postfix syslog shows MAIL-EDGE accepting those sessions locally from internal mail hosts.
+  - A broad timing texture issue recurred across Detection and Host/EDR: MAIL-FIN and
+    WS-EBROOKS Security 4688, Sysmon Event 1, and eCAR process-create timestamps align within
+    sub-millisecond windows across most matched process creates.
+  - Secondary targets: compact/repetitive Zeek SMB file name/size distribution, uneven endpoint
+    collection texture/eCAR vocabulary coverage, templated email prose, Linux admin command pool
+    repetition, and a lower-impact APP-INT SCP receiver PID/session split.
+- Selected loop 34 target:
+  - P0/P1 endpoint NAT/viewpoint contract for inbound MAIL-EDGE SMTP. Owning abstraction:
+    canonical network connection/routing plus endpoint observation/rendering viewpoint, not the
+    Zeek or eCAR renderer alone. Invariant: endpoint host telemetry for inbound flows must render
+    the local socket tuple visible to the host after NAT/VIP translation, while firewall/perimeter
+    and Zeek sensors may render pre-NAT or public-VIP tuples according to sensor viewpoint.
+    Consumers include eCAR `FLOW`, host syslog/Postfix/Dovecot evidence, Zeek SMTP/conn/files,
+    ASA NAT/teardown rows, and blind host/network tuple-correlation probes. Sibling risk:
+    public VIP handling for web and other inbound services must be checked so the fix does not
+    break legitimate perimeter/network viewpoints.
+
+## Loop 34
+
+- Family contract:
+  - Owning abstraction: network visibility/NAT context computation before source observation and
+    endpoint rendering.
+  - Invariant: traffic aimed at a modeled static NAT VIP must carry DNAT context even when the VIP
+    inherits the real host's segment for visibility. Endpoint telemetry may render the host-local
+    post-NAT listener tuple, while firewall/perimeter/network sensors can retain their viewpoint.
+  - Entry paths: `NetworkVisibilityEngine.compute_nat`, dispatcher NAT swaps, eCAR inbound FLOW
+    rendering, and internal mail traffic that resolves MX hostnames to public VIPs.
+  - Consumers: eCAR `FLOW`, Postfix/syslog tuple correlation, Zeek SMTP/conn, ASA NAT/teardown,
+    and blind host/network endpoint-viewpoint probes.
+- Implemented changes:
+  - Added a static-VIP pre-pass in `compute_nat()` so known VIP destinations produce static DNAT
+    context before the same-segment no-NAT guard and before dynamic PAT can win by rule order.
+  - Added unit coverage for internal server-to-public-VIP hairpin SMTP with dynamic PAT listed
+    before the static VIP rule, plus a guard that ordinary same-segment real-IP traffic remains
+    un-NATed.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_network_visibility.py -k "NatComputation"`
+    (`2` passed).
+  - `uv run pytest --no-cov tests/unit/test_log_realism_fixes.py -k "EcarNatAwareIp"`
+    (`1` passed).
+  - `uv run pytest --no-cov tests/unit/test_network_visibility.py` (`30` passed).
+  - `uv run ruff check src/evidenceforge/generation/network_visibility.py tests/unit/test_network_visibility.py`
+  - `uv run ruff format --check src/evidenceforge/generation/network_visibility.py tests/unit/test_network_visibility.py`
+- Generated loop 34 output successfully.
+- Automated eval passed at `95.0425237961009` over 95,354 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.56367827855763`
+  - Causality: `88.79128058921359`
+  - Timing: `96.01892039579043`
+- Hard probe `hard_probe_mail_edge_endpoint_nat_viewpoint.json`:
+  - Loop 33 MAIL-EDGE endpoint inbound SMTP rows from internal sources to public VIP: `7`.
+  - Loop 34 MAIL-EDGE endpoint inbound SMTP rows from internal sources to public VIP: `0`.
+  - Loop 34 matching rows rendered to local real IP `10.10.2.25`: `7`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-34/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-mike.svnh_0_0`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread over 30.
+- Blind initial mean synthetic-confidence: `64.0`; deliberation mean: `67.5`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `76`, synthetic-confidence `78`; deliberated to
+    Synthetic, confidence `76`, synthetic-confidence `74`.
+  - Detection Engineer: Synthetic, confidence `72`, synthetic-confidence `68`; deliberated to
+    Synthetic, confidence `75`, synthetic-confidence `72`.
+  - Network Forensics: Inconclusive, confidence `68`, synthetic-confidence `42`; deliberated to
+    Inconclusive/synthetic-leaning, confidence `64`, synthetic-confidence `52`.
+  - Host/EDR: Synthetic, confidence `74`, synthetic-confidence `68`; deliberated to Synthetic,
+    confidence `76`, synthetic-confidence `72`.
+- Panel consensus and prioritized findings:
+  - The loop 33 MAIL-EDGE public-VIP endpoint FLOW defect disappeared. Network Forensics
+    specifically credited proxy/NAT viewpoint coherence and did not find a hard NAT contradiction.
+  - The strongest remaining cross-source contradiction is external mail infrastructure identity:
+    provider hostnames and EML `Received` chains do not cohere with Zeek SMTP peer IP/provider
+    families or relay paths.
+  - The second strongest source-native issue is daemon-owned Linux endpoint FILE activity:
+    Postfix processes write/read browser caches, downloads, `.ssh/known_hosts`, and desktop
+    metadata paths.
+  - Secondary targets: intent-revealing artifact filenames and repeated EML boilerplate, proxy/web
+    page-resource bundle repetition, overly complete shell-history breadcrumbs, and Windows WFP
+    `\device\harddiskvolume1` uniformity.
+- Selected loop 35 target:
+  - P0/P1 external mail infrastructure identity modeling. Owning abstraction: mail identity
+    planning/provider catalog and canonical SMTP/email contexts before Zeek/EML/syslog rendering,
+    not a single emitter patch. Invariant: external mail provider identity must bind together
+    HELO/EHLO, Received-chain hostnames, MX/relay hostnames, source IP family, Zeek SMTP peers,
+    firewall source tuples, and artifact headers. Google/Mimecast/Zoho/etc. hostnames must not be
+    paired with unrelated provider IP ranges unless the model explicitly represents an upstream
+    relay/forwarding hop. Consumers include EML artifacts, Zeek SMTP/conn, Postfix syslog, ASA,
+    DNS/MX evidence, and blind email-investigation pivots.
+
+## Loop 35
+
+- Family contract:
+  - Owning abstraction: mail provider identity catalog plus external SMTP/source-mail planning
+    before Zeek, EML, syslog, and firewall rendering.
+  - Invariant: external mail provider hostnames must bind to provider-family public IPs across
+    Zeek SMTP peers, EML `Received` headers, HELO/EHLO strings, relay hostnames, and firewall
+    tuples. Google, Microsoft, Proofpoint, Mimecast, SendGrid, Zoho, Fastmail, Mailgun, Amazon
+    SES, and generic hosted-mail identities must not be cross-paired unless an explicit relay hop
+    models that relationship.
+  - Entry paths: `_external_email_hop`, `_external_source_mail_system`,
+    `_external_sender_public_hops`, public mail identity generation, EML header construction,
+    Zeek SMTP/conn rendering, and ASA/firewall rendering.
+  - Consumers: EML artifacts, Zeek SMTP/conn, Postfix syslog, firewall rows, DNS/MX evidence,
+    and blind email-investigation pivots.
+- Implemented changes:
+  - Expanded `mail_public_identities.yaml` with provider hostname patterns, prefixes, PTR
+    templates, and IP pools for Google Workspace, Microsoft 365, Proofpoint, SendGrid, Mimecast,
+    Amazon SES, Fastmail, Mailgun, Zoho, and generic hosted-mail sources.
+  - Added hostname-to-provider matching in `mail_public_identities.py` and made public mail IP
+    generation prefer the provider implied by the forward hostname.
+  - Routed external SMTP hop, source-mail-system, and sender-public-hop generation through the
+    provider-aware public mail identity helper.
+  - Added regression coverage for provider hostname/IP binding and source mail system generation.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_email_evidence.py -k "provider_hostname or source_mail_system or external_sender_received"`
+    (`3` passed).
+  - `uv run pytest --no-cov tests/unit/test_identity_pools.py -k "mail_public or identity"`
+    (`6` passed).
+  - `uv run pytest --no-cov tests/unit/test_email_evidence.py` (`35` passed).
+  - `uv run pytest --no-cov tests/unit/test_identity_pools.py` (`6` passed).
+  - `uv run eforge validate-config`
+  - `uv run ruff check src/evidenceforge/generation/activity/mail_public_identities.py src/evidenceforge/generation/activity/generator.py tests/unit/test_email_evidence.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/mail_public_identities.py src/evidenceforge/generation/activity/generator.py tests/unit/test_email_evidence.py`
+- Generated loop 35 output successfully.
+- Automated eval passed at `95.14267614748574` over 95,349 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.96450921770158`
+  - Causality: `88.79128058921359`
+  - Timing: `96.01864347878478`
+- Hard probe `hard_probe_external_mail_provider_identity_binding.json`:
+  - Loop 34 SMTP provider mismatches: `13`.
+  - Loop 34 EML `Received` provider mismatches: `13`.
+  - Loop 35 SMTP provider mismatches: `0`.
+  - Loop 35 EML `Received` provider mismatches: `0`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-35/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-mike.bspbnp5l`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread over 30.
+- Blind initial mean synthetic-confidence: `70.0`; deliberation mean: `78.25`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `66`, synthetic-confidence `42`; deliberated to
+    Synthetic, confidence `72`, synthetic-confidence `68`.
+  - Detection Engineer: Synthetic, confidence `84`, synthetic-confidence `82`; deliberated to
+    Synthetic, confidence `88`, synthetic-confidence `84`.
+  - Network Forensics: Synthetic, confidence `64`, synthetic-confidence `70`; deliberated to
+    Synthetic, confidence `70`, synthetic-confidence `74`.
+  - Host/EDR: Synthetic, confidence `82`, synthetic-confidence `86`; deliberated to Synthetic,
+    confidence `85`, synthetic-confidence `87`.
+- Panel consensus and prioritized findings:
+  - The external mail provider identity defect disappeared from the loop 35 bounded probe and did
+    not recur as the dominant review finding.
+  - The strongest remaining source-native contradiction is SSH identity correlation: Windows
+    `ssh.exe` endpoint commands owned by one local actor often omit an alternate remote user while
+    the same tuple is accepted by Linux `sshd` as a different user. Detection's bounded check found
+    `23` mismatches among `44` matched flows.
+  - Secondary targets include Linux eCAR package-manager helper parentage, NTP/source-view timing
+    texture, multi-sensor byte mirroring, public-client IP and user-agent realism, and selective
+    observation gaps around high-signal attack paths.
+- Selected loop 36 target:
+  - P0/P1 SSH remote-session identity correlation. Owning abstraction: SSH action bundle and
+    canonical session/transport intent, with Windows client process command rendering adapting to
+    that shared truth. Invariant: the source endpoint `ssh.exe` process owner, command-line remote
+    user/host target, Linux `sshd` accepted user, bash-history owner, eCAR login/logout rows, and
+    Zeek/ASA tuple must agree. If the remote authenticated user differs from the local source
+    actor, the client command must explicitly specify the remote principal (for example
+    `remote.user@host`) or the bundle must align the remote identity to the local actor; the target
+    host must not silently authenticate a different user on the same tuple.
+
+## Loop 36
+
+- Family contract:
+  - Owning abstraction: SSH action bundle, canonical network connection request, and source-side
+    user connection owner process modeling.
+  - Invariant: the source endpoint SSH command line must expose the authenticated remote principal
+    when it differs from the local source actor. A tuple accepted by Linux `sshd` as `remote.user`
+    must have source endpoint evidence such as `ssh.exe remote.user@target` or `/usr/bin/ssh
+    remote.user@target`, not a bare target that implies same-user authentication.
+  - Consumers: eCAR FLOW and PROCESS rows, Sysmon process/network rows, Linux syslog SSH auth,
+    Zeek conn, ASA/firewall rows, shell history, and review pivots that join source endpoint
+    process telemetry to target authentication.
+- Implemented changes:
+  - Propagated `ssh_attempted_username` from the SSH action bundle into the canonical connection
+    generation path.
+  - Updated high-confidence SSH client process command construction to include
+    `remote.user@target` while keeping the local source process owner unchanged.
+  - Added regression coverage for a Windows client owned by one actor authenticating to a Linux
+    SSH server as a different remote user.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "ssh_session_windows_client_command_names_remote_user or workstation_ssh_owner_is_scoped_to_command_target or ssh_process_network_effect_passes_command_username or generic_ssh_preauth_syslog_uses_attempted_username"`
+    (`4` passed).
+  - `uv run pytest --no-cov tests/unit/test_activity.py` (`321` passed).
+  - `uv run ruff check src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+  - `uv run ruff format --check src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+- Generated loop 36 output successfully.
+- Automated eval passed at `95.60105317639982` over 93,590 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.00427236022101`
+  - Causality: `89.6969696969697`
+  - Timing: `95.8787133105107`
+- Hard probe `hard_probe_ssh_remote_identity_correlation.json`:
+  - Loop 35 matched Windows SSH flows: `44`.
+  - Loop 35 remote-user command mismatches: `23`.
+  - Loop 36 matched Windows SSH flows: `49`.
+  - Loop 36 remote-user command mismatches: `0`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-36/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-nova.JuGonM`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement.
+- Blind initial mean synthetic-confidence: `60.0`; deliberation mean: `66.0`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `82`, synthetic-confidence `72`; deliberated to
+    Synthetic, confidence `84`, synthetic-confidence `75`.
+  - Detection Engineer: Synthetic, confidence `61`, synthetic-confidence `58`; deliberated to
+    Synthetic, confidence `66`, synthetic-confidence `62`.
+  - Network Forensics: Inconclusive, confidence `58`, synthetic-confidence `42`; deliberated to
+    Synthetic, confidence `60`, synthetic-confidence `55`.
+  - Host/EDR: Synthetic, confidence `74`, synthetic-confidence `68`; deliberated to Synthetic,
+    confidence `78`, synthetic-confidence `72`.
+- Panel consensus and prioritized findings:
+  - The loop 35 SSH remote-user identity mismatch disappeared from the bounded probe.
+  - The strongest remaining cross-source contradiction is SSH source-process lifecycle: source
+    eCAR shows `ssh.exe` PIDs terminating well before Zeek and target Linux syslog keep the same
+    SSH tuple/session alive.
+  - The second strongest issue is Linux endpoint session ownership, where `systemd --user`, shell,
+    and terminal trees appear for a user before visible successful session establishment for that
+    same user.
+  - Secondary targets include successful Zeek DNS connection rows without DNS companions and
+    unstable byte accounting for repeated static/hash-named web assets.
+- Selected loop 37 target:
+  - P0 SSH client process lifecycle. Owning abstraction: SSH action bundle plus canonical
+    network-connection/source-process lifecycle path. Invariant: for an SSH/RDP-like interactive
+    session, source endpoint client process termination must not precede the correlated network
+    transport close or target session close. If source process identity would otherwise force an
+    impossible lifetime, the lifecycle owner should extend/protect the process through close or
+    omit process identity rather than emitting an early termination.
+
+## Loop 37
+
+- Family contract:
+  - Owning abstraction: canonical network connection and process lifecycle ownership.
+  - Invariant: any process-attributed transport with a concrete close interval should keep the
+    source endpoint process alive through that interval. Process termination may be delayed beyond
+    session logoff clamping if the process already owns a visible transport that closes later.
+  - Consumers: eCAR PROCESS/TERMINATE and FLOW rows, Windows Security/Sysmon process lifecycle and
+    network rows, Zeek connection durations, and target-side SSH/syslog session close evidence.
+- Implemented changes:
+  - Added process connection-hold state keyed by source host/PID.
+  - Recorded process holds from process-attributed network connections with known close times.
+  - Made process termination honor the latest held transport close even after existing
+    session-end clamping.
+  - Added regression coverage for a Windows SSH client whose transport remains open for 30
+    minutes while an early termination request is issued.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_process_lifetimes.py` (`34` passed).
+  - `uv run pytest --no-cov tests/unit/test_zeek_activity_contexts.py` (`85` passed).
+  - `uv run pytest --no-cov tests/unit/test_activity.py` (`321` passed).
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_process_lifetimes.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_process_lifetimes.py`
+- Generated loop 37 output successfully.
+- Automated eval passed at `95.60121230950934` over 93,597 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.00490889265907`
+  - Causality: `89.6969696969697`
+  - Timing: `95.8787133105107`
+- Hard probe `hard_probe_ssh_source_process_lifecycle.json`:
+  - Loop 36 matched SSH source endpoint flows: `70`.
+  - Loop 36 premature source process terminations: `2`.
+  - Loop 37 matched SSH source endpoint flows: `77`.
+  - Loop 37 premature source process terminations: `0`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-37/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-nova.2cWtRJ`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread over 30.
+- Blind initial mean synthetic-confidence: `49.5`; deliberation mean: `67.75`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `78`, synthetic-confidence `70`; deliberated to
+    Synthetic, confidence `82`, synthetic-confidence `76`.
+  - Detection Engineer: Realistic, confidence `76`, synthetic-confidence `32`; deliberated to
+    Synthetic, confidence `68`, synthetic-confidence `62`.
+  - Network Forensics: Realistic, confidence `74`, synthetic-confidence `28`; deliberated to
+    Synthetic, confidence `64`, synthetic-confidence `58`.
+  - Host/EDR: Synthetic, confidence `72`, synthetic-confidence `68`; deliberated to Synthetic,
+    confidence `80`, synthetic-confidence `75`.
+- Panel consensus and prioritized findings:
+  - The SSH client process lifecycle contradiction disappeared from the bounded probe and was not a
+    panel-leading finding.
+  - The strongest remaining hard contradiction is DHCP renewal timing: Linux `dhclient` syslog
+    advertises one renewal interval while the next Zeek/syslog REQUEST appears at a substantially
+    different time.
+  - The next strongest hard host contradiction remains Linux eCAR session ownership: local session
+    login rows can name one user while adjacent `systemd --user`, terminal, and shell processes
+    belong to another.
+  - Secondary targets include Zeek `missed_bytes` history markers, DNS/cache TTL texture, root SSH
+    policy, and thin NTP recurrence.
+- Selected loop 38 target:
+  - P0 DHCP renewal lifecycle. Owning abstraction: DHCP lease action bundle plus baseline DHCP
+    renewal scheduler. Invariant: Linux `dhclient` "renewal in N seconds" messages must match the
+    actual next scheduled DHCP REQUEST/ACK transaction for that host, or the model must represent
+    an explicit link/reset/observation gap explaining an early renewal. Zeek DHCP rows, syslog
+    dhclient lines, lease state, and registry side effects must share one schedule.
+
+## Loop 38
+
+- Family contract:
+  - Owning abstraction: DHCP lease action bundle, DHCP setup/storyline lease state, and baseline
+    DHCP renewal scheduler.
+  - Invariant: every visible `dhclient` "bound -- renewal in N seconds" message must point to the
+    next visible DHCPREQUEST for the same host/IP when that next transaction falls inside the
+    collection window. Explicit storyline DHCP leases own their host's DHCP transaction for that
+    hour and suppress conflicting ambient renewals.
+  - Consumers: Linux syslog `dhclient`, Zeek DHCP, Zeek conn, DHCP lease state, registry lease side
+    effects, and blind-review pivots joining syslog to Zeek DHCP rows.
+- Implemented changes:
+  - Added `renewal_interval` to the DHCP lease action request and source-native syslog rendering.
+  - Added a shared `dhcp_renewal_interval_seconds()` helper and stored `next_renewal` in setup,
+    storyline, and baseline lease state.
+  - Made baseline DHCP scheduling advertise the next visible/cross-hour renewal rather than a
+    generic T1 interval.
+  - Made baseline DHCP renewals defer to explicit storyline DHCP events in the same host/hour.
+  - Adjusted dhclient syslog renewal display to count from the visible `bound` message timestamp,
+    not the request timestamp.
+  - Added focused tests for DHCP renewal scheduling, bundle rendering, setup lease state, and
+    explicit storyline DHCP lease state.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_baseline_canonical.py -k dhcp` (`12` passed).
+  - `uv run pytest --no-cov tests/unit/test_dhcp_setup.py tests/unit/test_storyline_command_networks.py -k dhcp` (`6` passed).
+  - `uv run ruff check src/evidenceforge/generation/actions/__init__.py src/evidenceforge/generation/actions/dhcp_lease.py src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/engine/baseline.py src/evidenceforge/generation/engine/emitter_setup.py src/evidenceforge/generation/engine/storyline.py tests/unit/test_baseline_canonical.py tests/unit/test_dhcp_setup.py tests/unit/test_storyline_command_networks.py`
+  - `uv run ruff format --check src/evidenceforge/generation/actions/__init__.py src/evidenceforge/generation/actions/dhcp_lease.py src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/engine/baseline.py src/evidenceforge/generation/engine/emitter_setup.py src/evidenceforge/generation/engine/storyline.py tests/unit/test_baseline_canonical.py tests/unit/test_dhcp_setup.py tests/unit/test_storyline_command_networks.py`
+  - Full `tests/unit/test_baseline_canonical.py` still has an unrelated pre-existing failure in
+    `TestWebAccessCorrelation::test_server_like_auto_http_uses_service_user_agent`.
+- Generated loop 38 output successfully after the sibling-path correction.
+- Automated eval passed at `95.34043175969583` over 95,141 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.96486993652913`
+  - Causality: `89.3091433426466`
+  - Timing: `95.10964219950945`
+- Hard probe `hard_probe_dhcp_renewal_schedule.json`:
+  - Loop 37 renewal mismatches: `16`.
+  - Loop 38 checked bound messages with visible next request: `33`.
+  - Loop 38 renewal mismatches: `0`.
+  - Loop 38 Zeek request rows unmatched to syslog: `0`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-38/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-nova.KEtACA`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement.
+- Blind initial mean synthetic-confidence: `49.75`; deliberation mean: `54.75`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `62`, synthetic-confidence `57`; deliberated to
+    Synthetic, confidence `68`, synthetic-confidence `64`.
+  - Detection Engineer: Inconclusive, confidence `68`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `70`, synthetic-confidence `40`.
+  - Network Forensics: Inconclusive, confidence `63`, synthetic-confidence `46`; deliberated to
+    Inconclusive, confidence `66`, synthetic-confidence `50`.
+  - Host/EDR: Synthetic, confidence `66`, synthetic-confidence `62`; deliberated to Synthetic,
+    confidence `70`, synthetic-confidence `65`.
+- Panel consensus and prioritized findings:
+  - The DHCP renewal timing contradiction disappeared from the bounded probe and Detection called
+    DHCP renewal alignment production-like.
+  - The strongest remaining concrete synthetic indicator is eCAR FILE ownership for protected
+    Windows event logs: repeated `C:\Windows\System32\winevt\Logs\Security.evtx` CREATE/WRITE/READ
+    rows attributed to unrelated processes such as `explorer.exe`, `dns.exe`, `userinit.exe`,
+    `SearchIndexer.exe`, and `service-healthcheck.exe`.
+  - Other recurring targets include RDP target eCAR FLOW timing after Type 10 authentication,
+    proxy cache/origin timing texture, Zeek TLS/OCSP source shape, and smooth endpoint collection
+    texture.
+- Selected loop 39 target:
+  - P0 eCAR protected event-log FILE ownership. Owning abstraction: data-driven EDR file path
+    pools and ambient eCAR FILE churn selection. Invariant: generic ambient Windows FILE churn must
+    not emit `C:\Windows\System32\winevt\Logs\*.evtx` rows under arbitrary process ownership.
+    Protected event-log activity, if modeled, should be owned by source-native Windows Event Log
+    service semantics, not browsers, explorers, DNS service, userinit, search indexers, or generic
+    service-health jobs.
+
+## Loop 39
+
+- Family contract:
+  - Owning abstraction: data-driven EDR file path pools and ambient eCAR FILE churn selection.
+  - Invariant: generic ambient Windows FILE churn must not emit
+    `C:\Windows\System32\winevt\Logs\*.evtx` rows under arbitrary process ownership. Protected
+    event-log activity, if modeled later, should be owned by Windows Event Log service semantics.
+- Implemented changes:
+  - Removed `Security.evtx` from the default Windows ambient eCAR file path pool.
+  - Added a Windows protected-event-log filter in ambient FILE churn selection so overlays or
+    future pools cannot reintroduce `winevt\Logs\*.evtx` as generic churn.
+  - Added focused tests for default pools and ambient selection filtering.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_edr_pools.py -k "protected_event_logs or default_windows_file_paths or ambient_file_churn_filters_windows"`
+  - `uv run eforge validate-config`
+  - `uv run pytest --no-cov tests/unit/test_edr_pools.py`
+  - `uv run ruff check src/evidenceforge/generation/activity/edr_pools.py tests/unit/test_edr_pools.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/edr_pools.py tests/unit/test_edr_pools.py`
+- Generated loop 39 output successfully.
+- Automated eval passed at `95.2619512034567` over 91,972 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.80454827032506`
+  - Causality: `88.63321129007949`
+  - Timing: `95.76255656677782`
+- Hard probe `hard_probe_ecar_protected_event_log_file_ownership.json`:
+  - Loop 38 protected event-log eCAR FILE rows: `61`.
+  - Loop 39 protected event-log eCAR FILE rows: `0`.
+  - Overall probe result: `passed`.
+- Additional reviewer-finding probe `hard_probe_windows_process_before_logon.json`:
+  - Loop 38 Security process-before-logon rows: `0`; Sysmon process-before-security-logon rows:
+    `0`.
+  - Loop 39 Security process-before-logon rows: `1`; Sysmon process-before-security-logon rows:
+    `1`.
+  - The defect matches the Host/EDR FILE-SRV-01 sample for LogonId `0xf88578c`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-39/review-data`.
+  - Neutral read-only copy: `/private/tmp/review-dataset-nova.QdQAOK`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement.
+- Blind initial mean synthetic-confidence: `42.0`; deliberation mean: `48.75`.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `64`, synthetic-confidence `39`; deliberated to
+    Inconclusive, confidence `68`, synthetic-confidence `50`.
+  - Detection Engineer: Real, confidence `62`, synthetic-confidence `31`; deliberated to
+    Inconclusive, confidence `64`, synthetic-confidence `43`.
+  - Network Forensics: Inconclusive, confidence `66`, synthetic-confidence `42`; deliberated to
+    Inconclusive, confidence `65`, synthetic-confidence `44`.
+  - Host/EDR: Synthetic, confidence `68`, synthetic-confidence `56`; deliberated to Synthetic,
+    confidence `72`, synthetic-confidence `58`.
+- Panel consensus and prioritized findings:
+  - The loop 38 protected event-log FILE ownership issue disappeared from the bounded probe and
+    did not recur as a panel-leading finding.
+  - The strongest remaining issue is a hard same-session causality contradiction on FILE-SRV-01:
+    Windows Security 4688, Sysmon Event 1, and eCAR process evidence for `svc_mhsync` and LogonId
+    `0xf88578c` visibly precede the same LogonId's 4624/eCAR session login.
+  - Secondary targets include DNS TTL/cache texture, tidy dual-sensor Zeek overlap, unsupported
+    high rsyslog queue-backlog messages, endpoint volume symmetry, SearchIndexer token semantics,
+    and one SSH publickey format outlier.
+- Selected loop 40 target:
+  - P0 same-session causality for Windows remote-admin dependent evidence. Owning abstraction:
+    Windows remote-admin/storyline command action bundles plus canonical session/bootstrap timing
+    and source timing planning. Invariant: for a host and concrete LogonId, Security/Sysmon/eCAR
+    process, file, module, and EDR activity must not appear before visible logon/session creation
+    for that same LogonId. When remote-execution process materialization needs the session
+    identity, the bundle/planner must place or delay the logon before dependent process evidence
+    rather than relying on renderer order.
+
+## Loop 40
+
+- Family contract:
+  - Owning abstraction: Windows remote logon/session source readiness, shared process source-time
+    pre-planning, Windows Security flush ordering, and eCAR final lifecycle normalization.
+  - Invariant: for a host and concrete non-service LogonId, Security 4688, Sysmon Event 1, and
+    eCAR process/file/module/registry/service evidence must not render before the same session's
+    visible 4624 or `USER_SESSION LOGIN`.
+- Implemented changes:
+  - Added a data-driven `windows.remote_logon_source_ready` timing profile.
+  - Marked Windows Type 3 sessions with a deterministic source-ready floor after remote logon.
+  - Made process source pre-planning clamp Windows Sysmon, Security, and eCAR process-create
+    source times after a session's source-ready floor when a process carries that LogonId.
+  - Reordered Windows Security final flush fixups so remote 4624-after-transport repair happens
+    before same-session 4688/special-privilege/dependent/logoff repairs.
+  - Added eCAR `logon_id` propagation to process-owned endpoint rows and a final eCAR
+    same-session dependent-after-login normalizer.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_emitters.py -k "transport_shifted_logon_before_process_create or network_logon_shifted_after_matching_wfp_transport or process_create_shifted_after_visible_logon"`
+  - `uv run pytest --no-cov tests/unit/test_source_timing.py -k "ecar_session_dependents_shift_after_visible_login or ecar_dependent_timestamp_follows_process_create or windows_security_process_create_tracks_sysmon_source_time"`
+  - `uv run pytest --no-cov tests/unit/test_storyline_command_networks.py -k "process_preplan_waits_for_session_source_ready_time or activity_generator_preplans_process_create_time_before_threaded_dispatch"`
+  - `uv run pytest --no-cov tests/unit/test_timing_profiles.py -k "timing_profiles_load_default_relationship"`
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/emitters/windows.py src/evidenceforge/generation/emitters/ecar.py tests/unit/test_emitters.py tests/unit/test_storyline_command_networks.py tests/unit/test_source_timing.py tests/unit/test_timing_profiles.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/emitters/windows.py src/evidenceforge/generation/emitters/ecar.py tests/unit/test_emitters.py tests/unit/test_storyline_command_networks.py tests/unit/test_source_timing.py tests/unit/test_timing_profiles.py`
+  - `uv run eforge validate-config`
+- Generated loop 40 output successfully.
+- Automated eval passed at `95.21246194955461` over 91,972 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.60454827032505`
+  - Causality: `88.6352542744711`
+  - Timing: `95.76255656677782`
+- Hard probe `hard_probe_windows_same_session_causality.json`:
+  - Loop 39 Security process-before-logon rows: `1`; Sysmon process-before-security-logon rows:
+    `1`; eCAR strict same-session dependent-before-login rows: `0` because loop 39 eCAR
+    dependent rows did not carry source-native LogonIds.
+  - Loop 40 Security process-before-logon rows: `0`; Sysmon process-before-security-logon rows:
+    `0`; eCAR same-session dependent-before-login rows: `0`.
+  - Loop 40 eCAR now includes `1,830` session-keyed dependent rows in the probe scope, making the
+    invariant directly checkable.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-40/review-data`.
+  - Neutral copy: `/private/tmp/review-dataset-nova.RoeXao`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+- Blind initial mean synthetic-confidence: `43.75`; deliberation was not triggered.
+- Reviewer scores:
+  - Threat Hunter: Inconclusive, confidence `68`, synthetic-confidence `52`.
+  - Detection Engineer: Inconclusive, confidence `76`, synthetic-confidence `42`.
+  - Network Forensics: Inconclusive, confidence `70`, synthetic-confidence `43`.
+  - Host/EDR: Inconclusive, confidence `72`, synthetic-confidence `38`.
+- Panel consensus and prioritized findings:
+  - The Windows same-session causality contradiction disappeared from the bounded probe and was
+    no longer a panel-leading issue.
+  - The strongest remaining concrete issue is host-role/persona blur in ordinary SSH/admin
+    activity: successful SSH sessions include broad user/source combinations, `root`/`admin`
+    fallbacks, repeated service-health maintenance texture, and workstation/server source choices
+    that make routine Linux administration look generator-selected rather than environment-owned.
+  - Secondary targets include dual-sensor Zeek timestamp texture, eCAR FLOW actor/close semantics,
+    proxy/web response-size texture, templated email text, and bash-history command texture.
+- Selected loop 41 target:
+  - P1 host-role/persona binding for baseline SSH/admin activity. Owning abstraction: world-model
+    remote-admin user eligibility plus baseline SSH source selection. Invariant: successful
+    ordinary baseline SSH sessions use scenario users whose persona, effective groups, and target
+    role plausibly grant Linux admin access, and source from that user's own remote source host.
+    Explicit storyline SSH and suspicious attacker activity remain out of scope for this baseline
+    contract.
+
+## Loop 41 Fix Target
+
+- Selected family: host-role/persona binding for baseline SSH/admin activity.
+- Owning abstraction: `WorldModel` SSH-admin roster plus the baseline SSH identity adapter.
+- Invariant: ordinary baseline SSH sessions should not invent successful `root`/`admin` users or
+  pair named admin users with unrelated sales/finance/executive workstations. The selected
+  username and source host must come from one scenario user whose persona/groups and target role
+  make Linux SSH administration plausible.
+- Entry paths: baseline Linux remote-admin shell sessions and ambient baseline SSH session noise
+  (`source="baseline_ssh_noise"`). Persona traffic already skips bare SSH/RDP and explicit
+  storyline SSH remains owned by scenario intent and the SSH action bundle.
+- Consumers: Linux `sshd` syslog, eCAR source-host `PROCESS`/`FLOW`, Zeek SSH connections,
+  bash-history/session evidence, threat-hunting pivots, and host-role/source-family blind review.
+- Layer rationale: the world model owns host roles, persona/group placement, and remote source
+  systems before the SSH bundle renders source-native evidence. Emitter-side filtering would only
+  hide symptoms and could leave syslog, eCAR, and Zeek disagreeing.
+- Residual sibling risks: routine Linux administration still needs richer bastion/sudo/service
+  automation modeling and maintenance command-palette diversity; this loop narrows successful
+  baseline SSH identity/source selection first.
+- Implemented changes:
+  - Added `WorldModel.get_ssh_admin_users()` with persona, target-role, and effective group
+    scoping for ordinary Linux SSH administration.
+  - Added a baseline SSH identity adapter that returns a matched `(user, source_system)` pair and
+    rejects unrelated workstation fallbacks.
+  - Routed both modeled Linux remote-admin sessions and ambient `baseline_ssh_noise` through the
+    shared identity adapter.
+  - Removed successful ambient SSH `root`/`admin` fallback users from baseline noise.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_world_model.py tests/unit/test_baseline_canonical.py -k "ssh_admin_roster or plan_session_selects or baseline_ssh_identity or syslog_ssh_noise_is_server_scoped or disconnect_uses_same_duration"`
+  - `uv run ruff check src/evidenceforge/generation/world_model.py src/evidenceforge/generation/engine/baseline.py tests/unit/test_world_model.py tests/unit/test_baseline_canonical.py`
+  - `uv run ruff format --check src/evidenceforge/generation/world_model.py src/evidenceforge/generation/engine/baseline.py tests/unit/test_world_model.py tests/unit/test_baseline_canonical.py`
+- Generated loop 41 output successfully.
+- Automated eval passed at `95.33415700770531` over 89,132 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.99732224519799`
+  - Causality: `89.49234376024657`
+  - Timing: `96.05870253172087`
+- Hard probe `hard_probe_baseline_ssh_role_source_binding.json`:
+  - Loop 40 accepted SSH sessions: `121`; generic privileged users: `15`; ordinary named
+    successful users: `4`; named-user unowned workstation sources: `25`.
+  - Loop 41 accepted SSH sessions: `102`; generic privileged users: `6`; ordinary named
+    successful users: `0`; named-user unowned workstation sources: `0`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-41/review-data`.
+  - Neutral copy: `/private/tmp/review-dataset-nova.6KwWMh`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement.
+- Blind initial mean synthetic-confidence: `61.5`; deliberation mean: `70.0`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `82`, synthetic-confidence `72`; deliberated to
+    Synthetic, confidence `86`, synthetic-confidence `76`.
+  - Detection Engineer: Inconclusive, confidence `62`, synthetic-confidence `44`; deliberated to
+    Synthetic, confidence `70`, synthetic-confidence `64`.
+  - Network Forensics: Synthetic, confidence `72`, synthetic-confidence `68`; deliberated to
+    Synthetic, confidence `76`, synthetic-confidence `70`.
+  - Host/EDR: Synthetic, confidence `64`, synthetic-confidence `62`; deliberated to Synthetic,
+    confidence `72`, synthetic-confidence `70`.
+- Panel consensus and prioritized findings:
+  - The loop 40 SSH identity/source issue improved in the bounded probe and did not recur as the
+    leading host-role finding.
+  - The strongest remaining hard contradiction is Linux eCAR process/session lifecycle: apt and
+    service-health helper processes can inherit stale SSH `logon_id`/`session_id` or `sshd` parent
+    state after the visible SSH logout.
+  - Network also found a proxy CONNECT contract gap: successful CONNECT rows for an internal mail
+    host can lack the corresponding proxy-origin flow and have DNS ordering after the 200 response.
+- Selected loop 42 target:
+  - P0 Linux eCAR post-logout process/session parentage. Owning abstraction: canonical Linux
+    process/session ownership and explicit-proxy package/server helper process selection.
+    Invariant: Linux endpoint PROCESS/FLOW rows for background package-manager or service-health
+    helper activity must not carry a human SSH session after that session's visible logout, and
+    must not use a stale session-bound `sshd`/shell process as parent. Workstation browser/proxy
+    traffic remains user-session-owned.
+
+## Loop 42 Fix Target
+
+- Selected family: Linux eCAR post-logout process/session parentage for package-manager and
+  service-health proxy helpers.
+- Owning abstraction: process execution bundle compatibility path plus explicit proxy client
+  owner selection and Linux parent repair.
+- Invariant: Linux background proxy/package helper processes must be system/service-owned when
+  they run outside a live human session. If a caller passes a stale SSH session ID or parent PID,
+  process state must drop the ended human session and choose a live system/service parent before
+  eCAR PROCESS/FLOW contexts are built.
+- Entry paths: explicit proxy client-to-proxy attribution for apt/dnf/server service-health user
+  agents; direct `generate_process()` callers for apt method helpers; parent selection/history and
+  Linux fallback parent repair.
+- Consumers: eCAR PROCESS and FLOW rows, syslog SSH session timelines, Zeek/proxy correlation,
+  Host/EDR and Network blind review.
+- Layer rationale: the generator owns the canonical process owner, logon ID, parent PID, and
+  source process context before renderers see the event. Fixing only eCAR output would still leave
+  connection attribution and sibling process state inconsistent.
+- Implemented changes:
+  - Routed Linux apt/dnf package-manager helpers and server-like service-health/integration-worker
+    proxy helpers through the existing system-owned connection process path before selecting a
+    user session.
+  - Added Linux background-helper identity coercion for direct process creation after a session
+    has ended, mapping apt/service-health helpers to `root` or service ownership.
+  - Hardened Linux parent repair/history/fallback so ended-session `sshd`/shell PIDs are not
+    reused as child parents after visible logout; system fallbacks now prefer `systemd`/`init`
+    rather than stale `sshd` or `bash`.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "linux_package_proxy or background_helper_process"`
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_explicit_proxy.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_explicit_proxy.py`
+- First loop 42 generation attempt exposed a Linux fallback bug introduced by this loop:
+  `_select_parent_pid()` referenced `effective_time` from the Windows-only branch. Fixed by
+  hoisting `effective_time` before OS-specific parent selection and reran focused verification.
+- Generated loop 42 output successfully after the fallback fix.
+- Automated eval passed at `95.18501294378603` over 91,495 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.23485831323002`
+  - Causality: `89.83907909805315`
+  - Timing: `95.83264295482621`
+- Hard probe `hard_probe_linux_ecar_post_logout_process_ownership.json`:
+  - Loop 41 Linux helper PROCESS rows: `62`; human-session-bound helpers: `62`; post-logout
+    helpers: `30`; stale `sshd`/shell parent helpers: `44`.
+  - Loop 42 Linux helper PROCESS rows: `94`; human-session-bound helpers: `0`; post-logout
+    helpers: `0`; stale `sshd`/shell parent helpers: `0`.
+  - Overall probe result: `passed`.
+- Blind review:
+  - Review bundle: `scenarios/iteration-test-expanded/blind-test/loop-42/review-data`.
+  - Neutral copy: `/private/tmp/review-dataset-nova.ldYEPk`.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+  - Deliberation was triggered by verdict disagreement.
+- Blind initial mean synthetic-confidence: `42.0`; deliberation mean: `43.5`.
+- Reviewer scores:
+  - Threat Hunter: Synthetic, confidence `62`, synthetic-confidence `52`; deliberated to
+    Synthetic, confidence `60`, synthetic-confidence `50`.
+  - Detection Engineer: Inconclusive, confidence `64`, synthetic-confidence `44`; deliberated to
+    Inconclusive, confidence `66`, synthetic-confidence `46`.
+  - Network Forensics: Inconclusive, confidence `68`, synthetic-confidence `38`; deliberated to
+    Inconclusive, confidence `69`, synthetic-confidence `40`.
+  - Host/EDR: Inconclusive, confidence `62`, synthetic-confidence `34`; deliberated to
+    Inconclusive, confidence `64`, synthetic-confidence `38`.
+- Panel consensus and prioritized findings:
+  - The Linux eCAR helper post-logout/session-parent defect disappeared from the bounded probe
+    and from the panel-leading findings.
+  - The strongest remaining hard contract gap is Kerberos lifecycle completeness for newly-created
+    account `svc_mhsync`: visible account creation and Domain Admins membership precede a later
+    CIFS `4769`, but no visible `4768` AS/TGT event or matching client-to-DC Kerberos flow
+    supports the service ticket.
+  - Secondary targets include eCAR/Sysmon Windows session ID mismatches, eCAR FLOW `tid` without
+    `pid`, one RDP endpoint correlation gap, external IP distribution texture, sparse NTP, and
+    parser companion texture.
+- Selected loop 43 target:
+  - P0 Kerberos lifecycle completeness for newly-created domain accounts. Owning abstraction:
+    account lifecycle action bundles plus Kerberos authentication/ticket causal expansion and
+    network-connection evidence. Invariant: when a domain account is created during the visible
+    window and later receives a visible service ticket, generation must emit source-native TGT/AS
+    evidence and matching Kerberos transport evidence before the TGS event, using the same
+    client/DC tuple where visibility implies it should exist.
+
+### Loop 43 implementation notes
+
+- Root cause: `_should_emit_visible_kerberos_tgt()` allowed probabilistic "pre-window cached TGT"
+  suppression for principals that had been visibly created by an `account_created` bundle earlier
+  in the dataset. Direct service-ticket paths could therefore emit a 4769 for a newly-created
+  account without a visible 4768 or matching KDC transport flow.
+- Implemented changes:
+  - Track visible account creation times by normalized Kerberos principal in
+    `ActivityGenerator`.
+  - Invalidate any impossible pre-create TGT cache entries when an account is visibly created.
+  - Force a visible fresh TGT decision when a no-cache principal was created inside the visible
+    window.
+  - Teach the Kerberos service-ticket bundle to create the first matching client-to-DC KDC flow
+    for visible-created accounts, reusing the same source IP/DC/source-port tuple as the 4769 and
+    suppressing duplicate connection-driven machine-account audit repair via the existing recent
+    audit cache.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "newly_created_account_service_ticket or generate_connection_can_use_cached_tgt or generate_connection_reuses_recent_kdc_audit"`
+  - `uv run pytest --no-cov tests/unit/test_dc_kerberos_logon.py tests/unit/test_phase5_system_traffic.py -k "kerberos"`
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+- Generated loop 43 output successfully.
+- Automated eval passed at `95.38307498053253` over 91,467 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.03540940150783`
+  - Causality: `89.83907909805315`
+  - Timing: `95.8222642782114`
+- Hard probe `hard_probe_new_account_kerberos_lifecycle.json`:
+  - Loop 42: account creation count `1`, TGT count `0`, TGS count `1`, matching
+    client-to-DC KDC flow before TGS count `0`; result `failed` as expected.
+  - Loop 43: account creation count `1`, TGT count `1`, TGS count `1`, matching
+    client-to-DC KDC flow before TGS count `1`; result `passed`.
+  - Evidence: loop 43 has `svc_mhsync` 4768 at `2024-03-18T17:01:29.2107747Z`
+    and 4769 at `2024-03-18T17:01:29.3354210Z`, both from `10.10.1.35:55466`;
+    Zeek `conn.json` includes `10.10.1.35:55466 -> 10.10.2.10:88` at
+    `1710781288.405664`, before the 4769.
+- Blind review bundle:
+  - Durable bundle: `scenarios/iteration-test-expanded/blind-test/loop-43/review-data`
+    with 116 files.
+  - Neutral copy: `/private/tmp/review-dataset-aurora.qBAdAp` with 116 files.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+
+## Loop 44 Fix Target
+
+- Selected family: eCAR session lifecycle timing for visible workstation sessions.
+- Owning abstraction: eCAR source-observation lifecycle normalization, after process/file/flow
+  source-native timestamp repair has produced the final visible endpoint rows.
+- Invariant: after an eCAR `USER_SESSION LOGOUT` for a host/logon ID, no later eCAR endpoint row
+  should carry that same visible session identity. The logout row is the source-visible boundary
+  for the endpoint session, so it must clear same-logon `PROCESS`, `FILE`, `MODULE`, `REGISTRY`,
+  `SERVICE`, `THREAD`, and `FLOW` observations that remain visible for that session.
+- Entry paths: interactive workstation logoffs, source-timed process/file/module/process-terminate
+  evidence, and final eCAR writer flush normalization.
+- Consumers: eCAR `USER_SESSION` lifecycle, Windows Security/Sysmon correlation pivots, blind
+  Host/EDR and Threat Hunter review, and temporal/casual eval checks.
+- Layer rationale: Windows Security already performs a final render-time 4634 delay after
+  same-session rendered dependents. eCAR needs the equivalent source-local lifecycle contract
+  because its own source timing and process termination repair can move dependent rows after the
+  canonical logoff request. Fixing only one generating call path would leave other visible eCAR
+  dependents able to cross the logout boundary.
+- Implemented changes:
+  - Added final eCAR writer normalization that shifts `USER_SESSION/LOGOUT` after same-logon
+    visible endpoint dependents (`PROCESS`, `FILE`, `MODULE`, `REGISTRY`, `SERVICE`, `THREAD`,
+    and `FLOW`) after the existing process/reference/termination ordering repairs.
+  - Split eCAR logout timing from generic eCAR session timing via `source.ecar_session_logout`
+    and `source.ecar_session_logout_after_dependents` timing profiles so endpoint logout
+    observations trail Windows Security's rendered 4634 jitter instead of racing it.
+  - Added a focused eCAR chronology regression covering a logout before same-session
+    process/file/flow dependents.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py -k "logout_shifted_after"`
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py tests/unit/test_source_timing.py -k "ecar or USER_SESSION or user_session or logout or logoff"`
+  - `uv run pytest --no-cov tests/unit/test_timing_profiles.py tests/unit/test_validate_config.py -k "timing_profiles or timing"`
+  - `uv run ruff check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+  - `uv run ruff format --check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+- Generated loop 44 output successfully.
+- Automated eval passed at `95.38307498053253` over 91,467 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.03540940150783`
+  - Causality: `89.83907909805315`
+  - Timing: `95.8222642782114`
+- Hard probe `hard_probe_ecar_logout_before_windows_session_activity.json`:
+  - Loop 43: failed for two sampled workstation sessions (`WS-AJOHNSON-01` and `WS-MCHEN-01`)
+    with later eCAR and Windows Security activity after eCAR logout.
+  - Loop 44 before the widened logout timing: same-logon eCAR crossings were eliminated, but
+    thirteen narrow Windows-4634-only crossings remained (27-355 ms after eCAR logout).
+  - Final loop 44: `passed` with zero later eCAR, Windows Security, or Sysmon records after the
+    first eCAR logout for the same host/logon ID.
+- Blind review bundle:
+  - Durable bundle: `scenarios/iteration-test-expanded/blind-test/loop-44/review-data`
+    with 116 files.
+  - Neutral copy: `/private/tmp/review-dataset-aurora.o5203X` with 116 files.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+- Blind review:
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread.
+  - Initial mean synthetic-confidence: `44.25`; deliberated mean: `51.75`.
+  - Reviewer scores:
+    - Threat Hunter: Inconclusive, confidence `64`, synthetic-confidence `34`; deliberated to
+      Inconclusive, confidence `66`, synthetic-confidence `44`.
+    - Detection Engineer: Inconclusive, confidence `66`, synthetic-confidence `32`; deliberated
+      to Inconclusive, confidence `70`, synthetic-confidence `48`.
+    - Network Forensics: Inconclusive, confidence `64`, synthetic-confidence `43`; deliberated
+      to Inconclusive, confidence `64`, synthetic-confidence `45`.
+    - Host/EDR: Synthetic, confidence `72`, synthetic-confidence `68`; deliberated to Synthetic,
+      confidence `76`, synthetic-confidence `70`.
+  - Panel consensus and prioritized findings:
+    - The eCAR logout/session-lifecycle contradiction from loop 43 disappeared from the hard
+      probe and did not recur as a leading finding.
+    - The strongest remaining hard contract gap is eCAR remote-thread prerequisite ordering:
+      `WS-AJOHNSON-01` renders `THREAD/REMOTE_CREATE` into `lsass.exe` before the same actor's
+      `PROCESS/OPEN` of that same target, while Sysmon orders process-open before remote-thread
+      creation.
+    - Secondary targets include Windows source-side SSH process identity reuse across many TCP/22
+      transports, tight dual-sensor Zeek timestamp deltas, narrow IDS variety, sparse NTP, and
+      repeated web/proxy asset texture.
+- Hard probe `hard_probe_ecar_remote_thread_before_process_open.json`:
+  - Loop 44: failed with one result. eCAR on `WS-AJOHNSON-01` records
+    `THREAD/REMOTE_CREATE` at `2024-03-18T15:45:34.363Z` before `PROCESS/OPEN` of the same
+    `lsass.exe` target at `2024-03-18T15:45:35.004Z`.
+- Selected loop 45 target:
+  - P0 eCAR remote-thread prerequisite ordering. Owning abstraction: eCAR endpoint source-order
+    normalization / canonical process-access and remote-thread rendering. Invariant: for the same
+    source process and target process, eCAR `PROCESS/OPEN` must render before
+    `THREAD/REMOTE_CREATE`, and final eCAR normalization must preserve the order.
+
+## Loop 45 Fix Target
+
+- Selected family: eCAR remote-thread prerequisite ordering.
+- Owning abstraction: final eCAR endpoint source-order normalization for process-access and
+  remote-thread evidence, with canonical process-access/remote-thread contexts as the source of
+  target identity.
+- Invariant: for a same source process and target process, eCAR `PROCESS/OPEN` must render before
+  `THREAD/REMOTE_CREATE`. If source-native timestamp jitter or final writer repairs would invert
+  the relationship, eCAR must move the remote-thread row after the matching process-open row, not
+  leave the prerequisite inverted.
+- Entry paths: remote thread injection/LSASS access storyline activity, eCAR `PROCESS/OPEN`,
+  eCAR `THREAD/REMOTE_CREATE`, and final writer ordering repairs.
+- Consumers: Host/EDR blind review, eCAR source-native process graph, Sysmon/eCAR cross-source
+  correlation, and attack-path reconstruction.
+- Layer rationale: Sysmon already shows the canonical prerequisite order correctly. The defect is
+  introduced by eCAR source timing/final ordering, so patching a single attack generator call would
+  leave other remote-thread rows vulnerable to the same inversion.
+
+### Loop 45 implementation notes
+
+- Initial root cause: eCAR final sort priority placed `THREAD/REMOTE_CREATE` ahead of
+  `PROCESS/OPEN`, and the existing final normalizer only ensured both rows occurred after
+  `PROCESS/CREATE`. Source-native eCAR jitter could therefore invert the process-open prerequisite
+  even when Sysmon rendered Event ID 10 before Event ID 8.
+- Sibling root cause discovered by hard probe: baseline CreateRemoteThread noise bypassed the
+  storyline-only LSASS causal expansion path, so one Defender-style `THREAD/REMOTE_CREATE` had no
+  matching eCAR `PROCESS/OPEN` at all.
+- Implemented changes:
+  - Added final eCAR normalization that matches `PROCESS/OPEN` and `THREAD/REMOTE_CREATE` by
+    host, source actor/process, and target process UUID/PID, then shifts the remote-thread row
+    after the matching process-open prerequisite when final eCAR timing is inverted.
+  - Changed eCAR sort priority so same-timestamp `PROCESS/OPEN` rows order before
+    `THREAD/REMOTE_CREATE`.
+  - Added `source.ecar_remote_thread_after_process_open` timing profile for deterministic repair
+    gaps.
+  - Generalized `ProcessAccessAfterRemoteThread` causal expansion from LSASS-only to all
+    remote-thread activity with known source/target PID and target image. LSASS keeps the stronger
+    `0x1FFFFF` access mask; non-LSASS targets use lower-friction `0x1010`.
+  - Moved CreateRemoteThread prerequisite expansion to the public
+    `ActivityGenerator.generate_create_remote_thread()` entrypoint so storyline and baseline
+    callers share the same process-open prerequisite contract.
+  - Removed the old storyline-only post-remote-thread LSASS expansion to avoid duplicate
+    process-access companions.
+  - Added `process.remote_thread_process_access` timing profile and gave remote-thread creation a
+    slightly later near-start process clamp than its process-access prerequisite.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py -k "remote_thread or process_open"`
+  - `uv run pytest --no-cov tests/unit/test_ecar_thread_process_access.py`
+  - `uv run pytest --no-cov tests/unit/test_causal_engine.py::TestProcessAccessAfterRemoteThread`
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "create_remote_thread or process_access"`
+  - `uv run pytest --no-cov tests/unit/test_logonid_scoping.py -k "create_remote_thread"`
+  - `uv run pytest --no-cov tests/unit/test_timing_profiles.py tests/unit/test_validate_config.py -k "timing_profiles or timing"`
+  - `uv run ruff check src/evidenceforge/generation/emitters/ecar.py src/evidenceforge/generation/causal/rules.py src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/engine/storyline.py tests/unit/test_ecar_spec_compliance.py tests/unit/test_timing_profiles.py tests/unit/test_causal_engine.py tests/unit/test_activity.py tests/unit/test_logonid_scoping.py`
+  - `uv run ruff format --check src/evidenceforge/generation/emitters/ecar.py src/evidenceforge/generation/causal/rules.py src/evidenceforge/generation/activity/generator.py src/evidenceforge/generation/engine/storyline.py tests/unit/test_ecar_spec_compliance.py tests/unit/test_timing_profiles.py tests/unit/test_causal_engine.py tests/unit/test_activity.py tests/unit/test_logonid_scoping.py`
+- Generated loop 45 output successfully.
+- Automated eval passed at `95.12991448713123` over 94,588 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `93.76561452875072`
+  - Causality: `90.58055274688238`
+  - Timing: `95.21686334111476`
+- Hard probe `hard_probe_ecar_remote_thread_before_process_open.json`:
+  - Loop 44: failed with one eCAR inversion for the `lsass.exe` target.
+  - Loop 45 pre-generalized-prerequisite check exposed one sibling missing process-open companion
+    for Defender-style remote-thread activity targeting `RuntimeBroker.exe`.
+  - Final loop 45: `passed` with `7` `THREAD/REMOTE_CREATE` rows, `577` `PROCESS/OPEN` rows,
+    and zero missing or inverted same-source/same-target process-open prerequisites.
+- Blind review bundle:
+  - Durable bundle: `scenarios/iteration-test-expanded/blind-test/loop-45/review-data`
+    with 116 files.
+  - Neutral copy: `/private/tmp/review-dataset-cypress.UzE4v4` with 116 files.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+- Blind review:
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread.
+  - Initial mean synthetic-confidence: `54.75`; deliberated mean: `65.75`.
+  - Reviewer scores:
+    - Threat Hunter: Inconclusive, confidence `64`, synthetic-confidence `43`; deliberated to
+      Synthetic, confidence `70`, synthetic-confidence `62`.
+    - Detection Engineer: Inconclusive, confidence `60`, synthetic-confidence `40`; deliberated
+      to Synthetic, confidence `68`, synthetic-confidence `60`.
+    - Network Forensics: Synthetic, confidence `76`, synthetic-confidence `72`; deliberated to
+      Synthetic, confidence `78`, synthetic-confidence `74`.
+    - Host/EDR: Synthetic, confidence `68`, synthetic-confidence `64`; deliberated to Synthetic,
+      confidence `72`, synthetic-confidence `67`.
+  - Panel consensus and prioritized findings:
+    - The loop 44 eCAR remote-thread issue was fixed by hard probe and did not recur.
+    - Highest-impact next target: large proxied-flow byte accounting. ASA and Zeek core agree
+      closely, while Zeek DMZ diverges from the same 5-tuples by hundreds of KB to nearly 5 MB
+      beyond `missed_bytes`.
+    - Secondary targets include Sysmon Event ID 7 module metadata version mismatches, one missing
+      Zeek NTP companion row, tight SSH auth timing, Linux local desktop session companion gaps,
+      proxy host/path texture, and email/DNS tunnel texture.
+- Hard probe `hard_probe_large_proxy_flow_byte_accounting.json`:
+  - Loop 45: failed with `3` large inside-to-proxy byte-accounting mismatches.
+  - Sibling examples:
+    - `10.10.2.10:51008 -> 10.10.3.20:8080`: ASA `155898680`, Zeek core IP bytes
+      `155898598`, Zeek DMZ IP bytes `156689946`, allowed delta `70092`.
+    - `10.10.2.10:53062 -> 10.10.3.20:8080`: ASA `112177742`, Zeek core IP bytes
+      `112177677`, Zeek DMZ IP bytes `112298201`, allowed delta `65536`.
+    - `10.10.1.35:50872 -> 10.10.3.20:8080`: ASA `328858087`, Zeek core IP bytes
+      `328858022`, Zeek DMZ IP bytes `333832406`, allowed delta `65536`.
+
+## Loop 46 Fix Target
+
+- Selected family: large proxy flow byte accounting across ASA, Zeek core, Zeek DMZ, and proxy.
+- Owning abstraction: canonical network/proxy connection accounting and sensor-specific
+  observation rendering.
+- Invariant: for the same visible client-to-proxy 5-tuple, ASA teardown bytes, Zeek core IP-byte
+  totals, Zeek DMZ IP-byte totals, and proxy payload byte fields must derive from one accounting
+  model. Any sensor differences must be explained by modeled `missed_bytes`, packet counts, or
+  source-specific framing.
+- Entry paths: explicit-proxy transaction bundle, network-connection action bundle, large HTTP
+  downloads/uploads, Zeek core and DMZ sensor rendering, ASA teardown rendering, and proxy access
+  logging.
+- Consumers: Network Forensics review, large-transfer hard probes, proxy/Zeek/ASA pivots, and
+  future ingestion validation.
+- Layer rationale: the contradiction appears across multiple rendered sources for the same
+  connection tuple. Fixing one emitter would leave sibling sources disagreeing; the shared
+  canonical accounting or observation metadata must own the payload/IP/packet relationship before
+  renderers serialize it.
+
+### Loop 46 implementation notes
+
+- Root cause: Zeek multi-sensor rendering applied percentage-based lossy observation jitter to
+  secondary sensor `orig_bytes`, `resp_bytes`, `orig_ip_bytes`, and `resp_ip_bytes`. For small
+  rows this looked like plausible tap texture, but for 100 MB+ client-to-proxy transfers it scaled
+  into hundreds of KB or MB while `missed_bytes` only claimed tens of KB or less.
+- Implemented changes:
+  - Added bounded bulk-TCP accounting detection in `zeek_base.py` for TCP flows with at least
+    10 MB of payload/IP-byte accounting and no more than 65,536 declared missed bytes.
+  - Routed those rows through bounded sensor texture: preserve canonical payload bytes, apply only
+    tiny packetization/IP-byte deltas plus bounded duration jitter, then re-enforce HTTP body and
+    IP-byte invariants.
+  - Left ordinary small lossy rows on the existing per-sensor jitter path so low-volume capture
+    texture still varies across taps.
+  - Added a regression test that models a large inside-to-proxy TCP transfer and asserts secondary
+    Zeek sensor totals remain within the same missed-byte/framing budget used by the hard probe.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_zeek_multiplex.py -k "bulk_proxy_flow or lossy_conn_observation or lossless_conn_observation or sensor_conn_metrics"`
+  - `uv run pytest --no-cov tests/unit/test_zeek_multiplex.py`
+  - `uv run ruff check src/evidenceforge/generation/emitters/zeek_base.py tests/unit/test_zeek_multiplex.py`
+  - `uv run ruff format --check src/evidenceforge/generation/emitters/zeek_base.py tests/unit/test_zeek_multiplex.py`
+- Generated loop 46 output successfully.
+- Automated eval passed at `95.12991448713123` over 94,588 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `93.76561452875072`
+  - Causality: `90.58055274688238`
+  - Timing: `95.21686334111476`
+- Hard probe `hard_probe_large_proxy_flow_byte_accounting.json`:
+  - Loop 45: failed with `3` large inside-to-proxy byte-accounting mismatches.
+  - Loop 46: `passed` with `854` inside-to-proxy teardowns checked, `3` large transfers checked,
+    and zero ASA/Zeek core/Zeek DMZ byte-accounting mismatches.
+- Blind review bundle:
+  - Durable bundle: `scenarios/iteration-test-expanded/blind-test/loop-46/review-data`
+    with 116 files.
+  - Neutral copy: `/private/tmp/review-dataset-cypress.JoAlV1` with 116 files.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+- Blind review:
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread.
+  - Initial mean synthetic-confidence: `50.25`; deliberated mean: `58.0`.
+  - Reviewer scores:
+    - Threat Hunter: Inconclusive, confidence `63`, synthetic-confidence `34`; deliberated to
+      Inconclusive, confidence `64`, synthetic-confidence `45`.
+    - Detection Engineer: Inconclusive, confidence `61`, synthetic-confidence `43`; deliberated to
+      Inconclusive, confidence `63`, synthetic-confidence `52`.
+    - Network Forensics: Inconclusive, confidence `60`, synthetic-confidence `56`; deliberated to
+      Synthetic, confidence `66`, synthetic-confidence `65`.
+    - Host/EDR: Synthetic, confidence `73`, synthetic-confidence `68`; deliberated to Synthetic,
+      confidence `75`, synthetic-confidence `70`.
+  - Panel consensus and prioritized findings:
+    - The loop 45 large proxy flow byte-accounting issue was fixed; the 17:24 large transfer now
+      pivots consistently across proxy, Zeek, and ASA.
+    - Highest-impact next target: Linux SSH `systemd-logind` removal lifecycle. Host/EDR found 106
+      SSH sessions where PAM opened, `systemd-logind` created a session ID, and PAM closed, but no
+      matching `Removed session <same_id>` appeared.
+    - Secondary targets include proxy DNS/SNI/origin consistency for `mail-fin.meridianhcs.com`,
+      Zeek NTP conn-to-parser fan-out and stratum/ref_id semantics, email/SSH-noise texture, and
+      eCAR field texture.
+
+## Loop 47 Fix Target
+
+- Selected family: Linux SSH `systemd-logind` removal lifecycle.
+- Owning abstraction: SSH action bundle source-native session lifecycle.
+- Invariant: every modeled in-window SSH session that emits `systemd-logind New session <id>` and
+  later emits `pam_unix(sshd:session): session closed` must also emit
+  `systemd-logind Removed session <same_id>` after the PAM close. If source observation drops the
+  lifecycle, it should drop the same-source lifecycle coherently rather than orphaning the removal.
+- Entry paths: storyline SSH sessions, baseline remote-admin SSH sessions, SCP-backed receiver SSH
+  sessions routed through the SSH bundle, Linux syslog rendering, and final syslog logind ID
+  normalization.
+- Consumers: Host/EDR blind review, Linux syslog session reconstruction, bash-history/session
+  correlation, eCAR login/logout pairing, and SSH hard probes.
+- Layer rationale: the SSH bundle already owns connection, accepted auth, PAM open, logind New
+  session, PAM close, and session close timing. Emitting removal in a renderer or broad syslog
+  repair would infer lifecycle facts from strings after the source of truth was available.
+
+### Loop 47 implementation notes
+
+- Root cause: `SshSessionActionBundle._dispatch_linux_session_close_lifecycle()` emitted the SSH
+  PAM close and endpoint logout, then terminated the tuple-scoped `sshd` process, but never emitted
+  the matching `systemd-logind Removed session <same_id>` row. Ambient baseline logind noise did
+  emit unrelated remove rows, making the modeled SSH session IDs look orphaned. After the bundle
+  fix, a hard-probe run found the compatibility `generate_logoff()` path still orphaned some
+  Linux SSH session IDs, and one regenerated row had the removal rendered 81 ms before the PAM
+  close because `sshd` and `systemd-logind` syslog rows had independent observation-delay
+  identities.
+- Implemented changes:
+  - Added a deterministic source-native logind removal timestamp after PAM close.
+  - Emitted a separate `systemd-logind` syslog row using the same logind PID lookup and the same
+    `auth_state.logind_session_id` allocated for the New-session row.
+  - Added the same removal emission to the compatibility `ActivityGenerator.generate_logoff()`
+    path for Linux SSH sessions.
+  - Added a syslog observation-group key for SSH PAM/logind rows carrying the same auth/session
+    identity, then attached that auth context to logind New/Removed rows so collection delay cannot
+    invert source-local session lifecycle order.
+  - Extended the SSH action-bundle close regression test to require `Removed session <same_id>`
+    after the PAM close.
+  - Added an observation-policy regression test proving SSH PAM close and logind removal rows for
+    the same session receive the same syslog delay decision.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_dispatcher.py -k "ssh_success_syslog_lifecycle_rows_share_observation_delay"`
+  - `uv run pytest --no-cov tests/unit/test_zeek_activity_contexts.py -k "ssh_session_bundle_renders_publickey_and_optional_close or records_logind_session_id or logind_uses_seeded"`
+  - `uv run pytest --no-cov tests/unit/test_phase5_logoff.py -k "ssh_logoff or linux_type10"`
+  - `uv run ruff check src/evidenceforge/events/observation.py src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_dispatcher.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_phase5_logoff.py`
+  - `uv run ruff format --check src/evidenceforge/events/observation.py src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_dispatcher.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_phase5_logoff.py`
+
+## Loop 49 Fix Target
+
+- Selected family: canonical endpoint lifecycle/session ownership for process termination.
+- Owning abstraction: canonical process/session state plus Linux parent validity.
+- Invariant: process termination evidence must preserve the original process principal/logon
+  identity from `RunningProcess`; it must not inherit a newer active session at termination time.
+  Linux SSH login shell creation must treat a tuple-scoped privileged `sshd: <user> [priv]`
+  process as a valid native parent even when that parent is root/system-owned.
+- Entry paths: baseline system processes, connection-owned foreground terminations, stale
+  process cleanup, storyline process termination, SSH session bootstrap, eCAR rendering, and
+  process/source timing repair.
+- Consumers: eCAR process lifecycle rows, host/EDR review, threat-hunter process/session pivots,
+  process object graph tests, and process lifecycle hard probes.
+- Layer rationale: the loop 48 finding came from a state/rendering mismatch. Linux system process
+  create rows rendered `0x3e7`, but the stored `RunningProcess` lacked that logon ID. Later generic
+  termination resolved `root` against the current SSH session and rendered a different logon/session.
+
+### Loop 49 implementation notes
+
+- Root cause: `generate_system_process()` rendered system logon IDs but called
+  `StateManager.create_process()` without `logon_id`, leaving root-owned Linux system processes
+  with empty canonical process ownership. Generic termination then used the caller/current session
+  context. A first regeneration also exposed a sibling parent-selection issue: a root-owned
+  privileged SSH child process was rejected as the parent of the user login shell, causing recursive
+  `ensure_linux_session_shell()` calls during SSH bootstrap.
+- Implemented changes:
+  - Passed the system logon ID into canonical process state for system-generated processes.
+  - Allowed live `/usr/sbin/sshd` privileged children with `sshd: <user> [priv]` command lines to
+    parent Linux SSH user shells despite the root/system logon ID.
+  - Added regression coverage for Linux root system process termination during a later root SSH
+    session and for SSH login-shell parent selection.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_edr_object_graph.py -k "linux_system_process_termination_preserves_original_logon or process_create_terminate_share_object_id or late_termination"`
+  - `uv run pytest --no-cov tests/unit/test_spawn_rules.py -k "ssh_login_shell_keeps_privileged_sshd_parent or ssh_user_process_prefers_matching_session_shell or linux_generate_process_replaces_untracked_parent_pid"`
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_edr_object_graph.py tests/unit/test_spawn_rules.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_edr_object_graph.py tests/unit/test_spawn_rules.py`
+- Generated loop 49 output successfully after the SSH parent-validity fix.
+- Automated eval passed at `95.17991535282289` over 94,702 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `93.9656145287507`
+  - Causality: `90.58055274688238`
+  - Timing: `95.21686766957305`
+- Hard probe `hard_probe_process_termination_ownership.json`:
+  - Loop 48 comparison: failed with `257` process termination ownership mismatches across `1,324`
+    matched terminations.
+  - Loop 49: `passed` with `1,324` matched terminations checked and `0` ownership mismatches.
+  - Probe semantics: principal/logon ID drift always fails; session ID conflicts fail when both
+    create and terminate rows carry non-empty session IDs. Termination-side session ID enrichment
+    is not counted as ownership drift when the create row lacks `session_id` and both rows share
+    the same logon ID.
+- Blind review bundle:
+  - Durable bundle: `scenarios/iteration-test-expanded/blind-test/loop-49/review-data`
+    with 86 log evidence files.
+  - Neutral copy: `/private/tmp/review-dataset-cypress.eNJQ6J` with 86 log evidence files.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`, `ARTIFACTS_MANIFEST.json`, and
+    `OUTPUT_TARGET.txt`.
+- Blind review:
+  - Deliberation was triggered by verdict disagreement and a synthetic-confidence spread above 30.
+  - Initial mean synthetic-confidence: `43.5`; deliberated mean: `49.5`
+    (`Mixed/Inconclusive`).
+  - Reviewer scores:
+    - Threat Hunter: Real, confidence `68`, synthetic-confidence `28`; deliberated to
+      Inconclusive, confidence `66`, synthetic-confidence `38`.
+    - Detection Engineer: Inconclusive, confidence `76`, synthetic-confidence `44`; deliberated
+      to Inconclusive, confidence `78`, synthetic-confidence `52`.
+    - Network Forensics: Inconclusive, confidence `64`, synthetic-confidence `34`; deliberated
+      to Inconclusive, confidence `66`, synthetic-confidence `38`.
+    - Host/EDR: Synthetic, confidence `74`, synthetic-confidence `68`; deliberated to Synthetic,
+      confidence `76`, synthetic-confidence `70`.
+  - Panel consensus and prioritized findings:
+    - Loop 48's process-termination ownership defect is fixed by hard probe; the blind panel did
+      not re-identify that family as the top issue.
+    - Highest-impact future target: singleton lifecycle constraints for long-running Windows
+      service agents such as `PanGPS.exe` and `ZSAService.exe`, which overlapped on multiple hosts
+      without prior visible termination.
+    - Secondary targets: stable Sysmon `LogonGuid` per `(host, LogonId)`, source-native Windows
+      4672 privilege lists, Linux local session-open anchoring, static web/proxy object byte
+      stability, proxy CONNECT visibility contracts, and host-specific WFP device-volume mappings.
+- Generated loop 48 output successfully.
+- Automated eval passed at `95.17991488181465` over 94,702 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `93.9656145287507`
+  - Causality: `90.58055274688238`
+  - Timing: `95.21686531453192`
+- Hard probe `hard_probe_ssh_auth_lifecycle_order.json`:
+  - Loop 47 comparison: failed with `19` ordering inversions across `116` complete successful
+    SSH sessions.
+  - Loop 48: `passed` with `116` attempts containing Accepted+PAM checked, `116` complete
+    successful SSH sessions checked, and zero source-native ordering inversions.
+- Regression hard probe `hard_probe_ssh_logind_removed_session.json`:
+  - Loop 48: `passed` with `109` closed SSH sessions checked, `116` sessions with logind New
+    rows checked, and zero missing or inverted `Removed session <same_id>` rows.
+- Blind review bundle:
+  - Durable bundle: `scenarios/iteration-test-expanded/blind-test/loop-48/review-data`
+    with 116 files.
+  - Neutral copy: `/private/tmp/review-dataset-cypress.XviGSg` with 116 files.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+- Blind review:
+  - Deliberation was triggered by verdict disagreement and cross-review endpoint/session lifecycle
+    overlap.
+  - Initial mean synthetic-confidence: `57.5`; deliberated mean: `59.0`.
+  - Reviewer scores:
+    - Threat Hunter: Inconclusive, confidence `74`, synthetic-confidence `62`; deliberated to
+      Inconclusive, confidence `76`, synthetic-confidence `64`.
+    - Detection Engineer: Inconclusive, confidence `72`, synthetic-confidence `42`; deliberated to
+      Inconclusive, confidence `73`, synthetic-confidence `46`.
+    - Network Forensics: Inconclusive, confidence `72`, synthetic-confidence `58`; deliberated to
+      Inconclusive, confidence `72`, synthetic-confidence `56`.
+    - Host/EDR: Synthetic, confidence `62`, synthetic-confidence `68`; deliberated to Synthetic,
+      confidence `65`, synthetic-confidence `70`.
+  - Panel consensus and prioritized findings:
+    - The loop 47 SSH Accepted-before-PAM ordering issue was fixed; reviewers described SSH syslog
+      ordering as plausible/believable.
+    - Highest-impact future target: canonical endpoint lifecycle/session ownership for process
+      termination. Threat Hunter and Host/EDR independently found DB-PROD `wget` processes created
+      under system/service context but terminated under a later root SSH logon/session.
+    - Secondary targets include Windows/eCAR USER_SESSION normalization, proxy-origin DNS/SNI
+      consistency, NTP protocol fan-out, duplicate shell creation, repeated root SSH/password
+      texture, benign command-palette diversity, and IDS alert texture.
+- Generated loop 47 output successfully after the final observation-grouping fix.
+- Automated eval passed at `95.17991448713123` over 94,702 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `93.9656145287507`
+  - Causality: `90.58055274688238`
+  - Timing: `95.21686334111476`
+- Hard probe `hard_probe_ssh_logind_removed_session.json`:
+  - Loop 47: `passed` with `109` closed SSH sessions checked, `116` sessions with logind New
+    rows checked, and zero missing or inverted `Removed session <same_id>` rows.
+- Blind review bundle:
+  - Durable bundle: `scenarios/iteration-test-expanded/blind-test/loop-47/review-data`
+    with 116 files.
+  - Neutral copy: `/private/tmp/review-dataset-cypress.jOw4kS` with 116 files.
+  - Verified both bundles excluded `GROUND_TRUTH.md`, `GROUND_TRUTH.json`,
+    `data/COLLECTION_PROFILE.json`, `OBSERVATION_MANIFEST.json`,
+    `ARTIFACTS_MANIFEST.json`, and `OUTPUT_TARGET.txt`.
+- Blind review:
+  - Deliberation was triggered by verdict disagreement and synthetic-confidence spread.
+  - Initial mean synthetic-confidence: `55.5`; deliberated mean: `63.5`.
+  - Reviewer scores:
+    - Threat Hunter: Realistic, confidence `78`, synthetic-confidence `22`; deliberated to
+      Inconclusive, confidence `76`, synthetic-confidence `38`.
+    - Detection Engineer: Inconclusive, confidence `76`, synthetic-confidence `46`; deliberated
+      to Synthetic, confidence `78`, synthetic-confidence `62`.
+    - Network Forensics: Synthetic, confidence `76`, synthetic-confidence `78`; deliberated to
+      Synthetic, confidence `76`, synthetic-confidence `76`.
+    - Host/EDR: Synthetic, confidence `78`, synthetic-confidence `76`; deliberated to Synthetic,
+      confidence `79`, synthetic-confidence `78`.
+  - Panel consensus and prioritized findings:
+    - The loop 46/47 SSH logind-removal issue was fixed by hard probe and reviewers observed many
+      richer SSH session chains.
+    - Highest-impact next target: successful SSH syslog source-native ordering. Detection and
+      Host/EDR independently found repeated cases where PAM session-open rows render before
+      `Accepted password/publickey` for the same `sshd` PID/source tuple.
+    - Secondary targets include `mail-fin.meridianhcs.com` DNS/SNI/origin ownership,
+      eCAR session ownership/reuse around logout and unlock, proxy/file transfer
+      missed-byte consistency, Linux command-line rendering, email text texture, and sparse NTP.
+
+## Loop 48 Fix Target
+
+- Selected family: Linux SSH successful-auth syslog lifecycle ordering.
+- Owning abstraction: SSH action bundle plus source-observation grouping for successful SSH
+  session syslog rows.
+- Invariant: every complete successful SSH session must render source-native syslog order for one
+  PID/source tuple:
+  `Connection from` -> `Accepted password/publickey` -> `pam_unix session opened` ->
+  `systemd-logind New session`, with close/removal after session activity. Source-observation
+  delay must be coherent across the successful-auth lifecycle so it cannot invert the already
+  planned canonical order.
+- Entry paths: storyline SSH sessions, baseline remote-admin SSH sessions, SCP-backed receiver SSH
+  sessions routed through the SSH bundle, Linux syslog rendering, source-observation delay, and
+  compatibility Linux type-10 logon syslog.
+- Consumers: Detection Engineering, Host/EDR review, Linux syslog session reconstruction, eCAR
+  session correlation, SSH hard probes, and downstream SIEM auth-session rules.
+- Layer rationale: the SSH bundle owns successful SSH auth lifecycle timing, but source-observation
+  delay is applied after canonical events are built. Fixing only the rendered timestamps or one
+  syslog emitter would leave source-local rows vulnerable to observation-delay inversions.
+
+### Loop 48 implementation notes
+
+- Root cause: loop 47 grouped PAM/logind rows to prevent close/removal inversion, but successful
+  `Connection from` and `Accepted password/publickey` rows still used a different syslog
+  observation identity from PAM/logind. The canonical gap between Accepted and PAM open is often
+  tens to hundreds of milliseconds, while messy syslog collection delay can be up to 1000 ms, so
+  independent delays could render PAM open before Accepted.
+- Implemented changes:
+  - Extended the syslog SSH session observation group to include successful `Connection from` and
+    `Accepted` rows when they carry the same auth/session identity.
+  - Attached the SSH session `AuthContext` to the SSH bundle's pre-auth connection and accepted
+    authentication syslog rows, matching the auth context already attached to PAM/logind rows.
+  - Broadened the observation-policy regression test to require one shared delay decision across
+    `Connection`, `Accepted`, PAM open, logind New, PAM close, and logind Removed.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_dispatcher.py -k "ssh_success_syslog_lifecycle_rows_share_observation_delay"`
+  - `uv run pytest --no-cov tests/unit/test_zeek_activity_contexts.py -k "ssh_session_bundle_renders_publickey_and_optional_close or records_logind_session_id or logind_uses_seeded"`
+  - `uv run pytest --no-cov tests/unit/test_phase5_logoff.py -k "ssh_logoff or linux_type10"`
+  - `uv run ruff check src/evidenceforge/events/observation.py src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_dispatcher.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_phase5_logoff.py`
+  - `uv run ruff format --check src/evidenceforge/events/observation.py src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_dispatcher.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_phase5_logoff.py`

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -1640,6 +1640,7 @@ def validate_config() -> ValidationResult:
                         f'Visitor class "{class_name}" references missing user_agent_pool "{pool_name}"',
                     )
                 )
+            referenced_pool_names = {pool_name} if isinstance(pool_name, str) else set()
             by_os = class_data.get("user_agent_pool_by_os")
             if by_os is not None and not isinstance(by_os, dict):
                 result.issues.append(
@@ -1668,6 +1669,30 @@ def validate_config() -> ValidationResult:
                                 f'Visitor class "{class_name}" references missing OS user_agent_pool "{os_pool}"',
                             )
                         )
+                    else:
+                        referenced_pool_names.add(os_pool)
+            role_values = class_data.get("source_role_any")
+            source_roles = (
+                {str(role).lower() for role in role_values}
+                if isinstance(role_values, list)
+                else set()
+            )
+            kube_roles = {"kubernetes", "k8s", "kubelet", "container", "container_runtime"}
+            if class_name == "health_check" and not source_roles & kube_roles:
+                for referenced_pool_name in sorted(referenced_pool_names):
+                    user_agents = web_ua_pools.get(referenced_pool_name)
+                    if not isinstance(user_agents, list):
+                        continue
+                    for user_agent in user_agents:
+                        if isinstance(user_agent, str) and "kube-probe" in user_agent.lower():
+                            result.issues.append(
+                                Issue(
+                                    "ERROR",
+                                    "web_session_profiles.yaml",
+                                    'Visitor class "health_check" may use kube-probe only with '
+                                    "a Kubernetes-scoped source_role_any",
+                                )
+                            )
             if class_data.get("kind") == "requests":
                 request_count = class_data.get("request_count")
                 if (

--- a/src/evidenceforge/config/activity/edr_pools.yaml
+++ b/src/evidenceforge/config/activity/edr_pools.yaml
@@ -237,7 +237,6 @@ file_paths_windows:
   - "C:\\ProgramData\\Microsoft\\Windows\\WER\\ReportQueue\\{rand}\\Report.wer"
   - "C:\\Windows\\Temp\\{rand}.tmp"
   - "C:\\ProgramData\\Microsoft\\Windows Defender\\Scans\\History\\Service\\DetectionHistory\\{rand}"
-  - "C:\\Windows\\System32\\winevt\\Logs\\Security.evtx"
   - "C:\\Windows\\SoftwareDistribution\\Download\\{rand}\\update.cab"
 
 file_paths_linux:

--- a/src/evidenceforge/config/activity/mail_public_identities.yaml
+++ b/src/evidenceforge/config/activity/mail_public_identities.yaml
@@ -10,8 +10,44 @@ reserved_replacement_domains:
   - edgepostmail.com
 
 providers:
+  - name: google_workspace
+    weight: 4
+    hostname_patterns:
+      - google.com
+      - googlemail.com
+      - aspmx.l.google.com
+    prefixes:
+      - [64, 233, 160, 191]
+      - [66, 102, 0, 15]
+      - [74, 125, 0, 255]
+      - [142, 250, 0, 255]
+      - [173, 194, 0, 255]
+      - [209, 85, 128, 255]
+    ptr_templates:
+      - "mail-{third}-{fourth}.google.com"
+      - "mx.google.com"
+      - "aspmx.l.google.com"
+  - name: microsoft_365
+    weight: 4
+    hostname_patterns:
+      - protection.outlook.com
+      - mail.protection.outlook.com
+      - outlook.com
+      - office365.com
+    prefixes:
+      - [40, 92, 0, 255]
+      - [40, 107, 0, 255]
+      - [52, 100, 0, 255]
+      - [104, 47, 0, 255]
+    ptr_templates:
+      - "mail-{third}-{fourth}.outbound.protection.outlook.com"
+      - "{third}-{fourth}.mail.protection.outlook.com"
+      - "mx.microsoft.com"
   - name: proofpoint
     weight: 4
+    hostname_patterns:
+      - pphosted.com
+      - pphostedmail.net
     prefixes:
       - [148, 163, 128, 191]
       - [199, 255, 192, 195]
@@ -21,6 +57,9 @@ providers:
       - "mta-{third}-{fourth}.pphostedmail.net"
   - name: sendgrid
     weight: 3
+    hostname_patterns:
+      - sendgrid.net
+      - outbound-mail
     prefixes:
       - [167, 89, 0, 127]
       - [198, 37, 144, 159]
@@ -28,8 +67,76 @@ providers:
       - "o{third}.outbound-mail.{domain}"
       - "mta-{third}-{fourth}.sendgrid.net"
       - "smtp{slot}.{domain}"
+  - name: mimecast
+    weight: 3
+    hostname_patterns:
+      - mimecast.com
+      - mimecast.net
+    prefixes:
+      - [103, 13, 68, 70]
+      - [185, 58, 84, 85]
+      - [207, 211, 30, 31]
+      - [216, 205, 24, 25]
+    ptr_templates:
+      - "us-smtp-inbound-{slot}.mimecast.com"
+      - "eu-smtp-inbound-{slot}.mimecast.com"
+      - "mx{slot}.mimecast.com"
+  - name: amazon_ses
+    weight: 2
+    hostname_patterns:
+      - amazonses.com
+      - amazonaws.com
+      - feedback-smtp
+      - inbound-smtp
+    prefixes:
+      - [23, 251, 224, 255]
+      - [54, 240, 0, 127]
+      - [69, 169, 224, 255]
+    ptr_templates:
+      - "a{third}-{fourth}.smtp-out.amazonses.com"
+      - "inbound-smtp.us-east-1.amazonaws.com"
+      - "feedback-smtp.us-west-2.amazonses.com"
+  - name: fastmail
+    weight: 2
+    hostname_patterns:
+      - messagingengine.com
+      - fastmail.com
+    prefixes:
+      - [66, 111, 4, 7]
+      - [103, 168, 172, 175]
+    ptr_templates:
+      - "in{slot}-smtp.messagingengine.com"
+      - "out{slot}-smtp.messagingengine.com"
+  - name: mailgun
+    weight: 2
+    hostname_patterns:
+      - mailgun.org
+      - mailgun.net
+    prefixes:
+      - [198, 61, 254, 255]
+      - [209, 61, 151, 151]
+    ptr_templates:
+      - "mxa.mailgun.org"
+      - "mxb.mailgun.org"
+      - "smtp-out-{third}-{fourth}.mailgun.org"
+  - name: zoho
+    weight: 2
+    hostname_patterns:
+      - zoho.com
+      - zoho.eu
+    prefixes:
+      - [136, 143, 176, 191]
+      - [204, 141, 32, 63]
+    ptr_templates:
+      - "mx.zoho.com"
+      - "mx{slot}.zoho.com"
+      - "smtp-{third}-{fourth}.zoho.com"
   - name: hosted-mail
     weight: 3
+    hostname_patterns:
+      - ionos.com
+      - secureserver.net
+      - emailsrvr.com
     prefixes:
       - [66, 96, 128, 191]
       - [74, 208, 0, 255]

--- a/src/evidenceforge/config/activity/proxy_user_agents.yaml
+++ b/src/evidenceforge/config/activity/proxy_user_agents.yaml
@@ -139,7 +139,6 @@ workstation:
     - "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
     - "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0"
     - "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
-    - "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
 
   linux:
     - "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"

--- a/src/evidenceforge/config/activity/site_maps.yaml
+++ b/src/evidenceforge/config/activity/site_maps.yaml
@@ -211,7 +211,7 @@ domains:
         nav_targets: ["/render", "/r/week", "/r/eventedit"]
         subresources:
           - {host: "www.gstatic.com", path: "/calendar/{hex8}/js/month-view.js", type: "application/javascript"}
-          - {path: "/calendar/v3/calendars/primary/events?timeMin=2026-01-01T00:00:00Z", type: "application/json"}
+          - {path: "/calendar/v3/calendars/primary/events?timeMin={calendar_time_min}", type: "application/json"}
 
   www.google.com:
     cdn_domains: ["www.gstatic.com", "encrypted-tbn0.gstatic.com", "fonts.gstatic.com"]

--- a/src/evidenceforge/config/activity/timing_profiles.yaml
+++ b/src/evidenceforge/config/activity/timing_profiles.yaml
@@ -26,6 +26,11 @@ relationships:
     position: before
     min_ms: 1
     max_ms: 75
+  process.remote_thread_process_access:
+    class: source_latency
+    position: before
+    min_ms: 8
+    max_ms: 180
   windows.audit_from_admin_command:
     class: source_latency
     position: after
@@ -86,6 +91,11 @@ relationships:
     position: after
     min_ms: 2
     max_ms: 45
+  windows.remote_logon_source_ready:
+    class: source_latency
+    position: after
+    min_ms: 850
+    max_ms: 1450
   source.sysmon_network_connection:
     class: source_latency
     position: after
@@ -156,6 +166,16 @@ relationships:
     position: after
     min_ms: 1
     max_ms: 11
+  source.ecar_session_logout:
+    class: teardown
+    position: after
+    min_ms: 1800
+    max_ms: 2800
+  source.ecar_session_logout_after_dependents:
+    class: teardown
+    position: after
+    min_ms: 1800
+    max_ms: 2800
   source.ecar_ssh_session_after_accept:
     class: source_latency
     position: after
@@ -166,6 +186,11 @@ relationships:
     position: after
     min_ms: 35
     max_ms: 250
+  source.ecar_remote_thread_after_process_open:
+    class: source_latency
+    position: after
+    min_ms: 25
+    max_ms: 240
   source.zeek_conn_start:
     class: same_observation
     position: after

--- a/src/evidenceforge/config/activity/web_session_profiles.yaml
+++ b/src/evidenceforge/config/activity/web_session_profiles.yaml
@@ -42,6 +42,9 @@ visitor_classes:
     source_role_any: ["monitoring", "load_balancer", "forward_proxy", "app_server"]
     request_count: [1, 2]
     user_agent_pool: health_check
+    user_agent_pool_by_os:
+      windows: health_check_windows
+      linux: health_check_linux
     referrer_mode: none
     requests:
       - {path: "/health", method: "GET", status: 200, type: "application/json", weight: 40}
@@ -99,8 +102,16 @@ user_agent_pools:
     - "Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)"
   health_check:
     - "ELB-HealthChecker/2.0"
-    - "kube-probe/1.28"
     - "Prometheus/2.47.0"
+    - "Nagios-CheckHTTP/4.4.6"
+  health_check_windows:
+    - "Microsoft-Delivery-Optimization/10.0"
+    - "Windows-HealthCheck/10.0"
+    - "Meridian-ServiceHealth/2.4"
+  health_check_linux:
+    - "Prometheus/2.47.0"
+    - "curl/7.88.1"
+    - "Nagios-CheckHTTP/4.4.6"
   api_client:
     - "python-requests/2.31.0"
     - "Go-http-client/1.1"

--- a/src/evidenceforge/config/formats/windows_event_sysmon.yaml
+++ b/src/evidenceforge/config/formats/windows_event_sysmon.yaml
@@ -130,6 +130,9 @@ variants:
       - name: ParentCommandLine
         type: string
         required: false
+      - name: ParentUser
+        type: string
+        required: false
 
   # Sysmon EventID 5: Process Terminated
   - name: sysmon_process_terminate
@@ -530,6 +533,7 @@ output:
         <Data Name="ParentProcessId">{{ ParentProcessId | default(0) }}</Data>
         <Data Name="ParentImage">{{ ParentImage | default('-') }}</Data>
         <Data Name="ParentCommandLine">{{ ParentCommandLine | default('-') }}</Data>
+        <Data Name="ParentUser">{{ ParentUser | default('-') }}</Data>
         {% elif EventID == 5 %}
         <Data Name="RuleName">{{ RuleName | default('-') }}</Data>
         <Data Name="UtcTime">{{ UtcTime }}</Data>

--- a/src/evidenceforge/evaluation/parsers/proxy.py
+++ b/src/evidenceforge/evaluation/parsers/proxy.py
@@ -72,6 +72,11 @@ def _parse_proxy_metadata(metadata: str) -> dict[str, str]:
             fields["proxy_action"] = value
         elif key == "ssl_bump":
             fields["ssl_bump_action"] = value
+        elif key in {"cs_bytes", "sc_bytes"}:
+            try:
+                fields[key] = int(value)
+            except ValueError:
+                fields[key] = value
     return fields
 
 

--- a/src/evidenceforge/events/dispatcher.py
+++ b/src/evidenceforge/events/dispatcher.py
@@ -92,6 +92,25 @@ def expand_formats(formats: list[str] | set[str]) -> set[str]:
     return expanded
 
 
+def _is_successful_remote_interactive_transport(event: SecurityEvent) -> bool:
+    """Return whether a network event is an established SSH/RDP session transport."""
+
+    network = event.network
+    if network is None:
+        return False
+    if str(network.protocol or "").lower() != "tcp" or network.dst_port not in {22, 3389}:
+        return False
+    state = str(network.conn_state or "").upper()
+    if state and state != "SF":
+        return False
+    if event.firewall is not None and event.firewall.action == "deny":
+        return False
+    service = str(network.service or "").lower()
+    if service and service not in {"ssh", "rdp"}:
+        return False
+    return True
+
+
 class EventDispatcher:
     """Routes SecurityEvents to StateManager and matching emitters."""
 
@@ -214,6 +233,24 @@ class EventDispatcher:
         self._promote_zeek_parent(decisions, "zeek_files", _ZEEK_FILES_DEPENDENTS)
         self._promote_zeek_parent(decisions, "zeek_conn", {"zeek_files"})
         self._preserve_zeek_tls_certificate_companions(event, decisions)
+        self._preserve_remote_interactive_transport_companions(event, decisions)
+
+    @staticmethod
+    def _preserve_remote_interactive_transport_companions(
+        event: SecurityEvent,
+        decisions: dict[str, ObservationDecision],
+    ) -> None:
+        """Keep successful SSH/RDP network rows when endpoint transport telemetry survives."""
+
+        if not _is_successful_remote_interactive_transport(event):
+            return
+        endpoint_decision = decisions.get("ecar")
+        if endpoint_decision is None or endpoint_decision.status == "dropped":
+            return
+        for format_name in ("zeek_conn", "cisco_asa"):
+            decision = decisions.get(format_name)
+            if decision is not None and decision.status == "dropped":
+                decisions[format_name] = ObservationDecision(status="visible")
 
     @staticmethod
     def _preserve_zeek_tls_certificate_companions(

--- a/src/evidenceforge/events/observation.py
+++ b/src/evidenceforge/events/observation.py
@@ -161,6 +161,8 @@ class ObservationPolicy:
     ) -> float:
         if self._preserve_ssh_session_lifecycle(source, event):
             return 0.0
+        if self._preserve_logind_session_lifecycle(source, event):
+            return 0.0
         if self._preserve_ecar_cron_process_lifecycle(source, event):
             return 0.0
         host = self._host_key_for_event(event)
@@ -259,6 +261,10 @@ class ObservationPolicy:
         )
 
     def _coherent_group_key(self, source: str, event: SecurityEvent) -> str:
+        if source == "ecar":
+            remote_session_group = self._ecar_remote_session_group_key(event)
+            if remote_session_group:
+                return remote_session_group
         if (
             source == "ecar"
             and event.storyline_cluster_id
@@ -273,6 +279,10 @@ class ObservationPolicy:
             )
         if source == "ecar" and event.process and event.process.concurrency_group_id:
             return f"process-group:{event.process.concurrency_group_id}"
+        if source == "syslog":
+            ssh_session_group = self._syslog_ssh_session_group_key(event)
+            if ssh_session_group:
+                return ssh_session_group
         if source == "syslog" and event.syslog and event.syslog.app_name == "sshd":
             pid = event.syslog.pid if event.syslog.pid not in (None, "") else ""
             if pid:
@@ -300,8 +310,41 @@ class ObservationPolicy:
         return "event"
 
     @staticmethod
+    def _ecar_remote_session_group_key(event: SecurityEvent) -> str:
+        """Return tuple-scoped eCAR grouping for remote session transport and login."""
+        host = event.dst_host
+        if host is None:
+            return ""
+        dst_port = 0
+        src_ip = ""
+        src_port = 0
+        dst_ip = host.ip
+        if event.network is not None:
+            protocol = str(event.network.protocol or "").lower()
+            if protocol != "tcp" or event.network.dst_port not in {22, 3389}:
+                return ""
+            dst_port = int(event.network.dst_port or 0)
+            src_ip = str(event.network.src_ip or "")
+            src_port = int(event.network.src_port or 0)
+            dst_ip = dst_ip or str(event.network.dst_ip or "")
+        elif event.auth is not None and event.auth.source_ip and event.auth.source_port:
+            if event.event_type == "ssh_session":
+                dst_port = 22
+            elif event.event_type == "logon" and event.auth.logon_type == 10:
+                dst_port = 3389
+            else:
+                return ""
+            src_ip = str(event.auth.source_ip or "")
+            src_port = int(event.auth.source_port or 0)
+        if not src_ip or src_port <= 0 or dst_port <= 0:
+            return ""
+        return f"remote-session:{dst_port}:{host.hostname}:{src_ip}:{src_port}:{dst_ip}"
+
+    @staticmethod
     def _uses_coherent_source_identity(source: str, group: str) -> bool:
         """Return whether observation delay/drop should be shared within a source group."""
+        if source == "ecar" and group.startswith("remote-session:"):
+            return True
         if group.startswith("process:") and source in {"windows_security", "sysmon", "ecar"}:
             return True
         if group.startswith("session:") and source in {"windows_security", "ecar", "syslog"}:
@@ -318,6 +361,8 @@ class ObservationPolicy:
             return True
         if source == "syslog" and group.startswith("sshd:"):
             return True
+        if source == "syslog" and group.startswith("linux-ssh-session:"):
+            return True
         if source == "ecar" and group.startswith("storyline-process:"):
             return True
         if source == "ecar" and group.startswith("process-group:"):
@@ -325,6 +370,31 @@ class ObservationPolicy:
         if source == "zeek" and (group.startswith("uid:") or group.startswith("dns:")):
             return True
         return False
+
+    @staticmethod
+    def _syslog_ssh_session_group_key(event: SecurityEvent) -> str:
+        """Return a shared syslog observation key for one SSH session lifecycle."""
+        if event.syslog is None or event.auth is None:
+            return ""
+        app_name = event.syslog.app_name
+        message = event.syslog.message
+        if app_name == "sshd":
+            if not (
+                message.startswith("Connection from ")
+                or message.startswith("Accepted ")
+                or "pam_unix(sshd:session): session " in message
+            ):
+                return ""
+        elif app_name == "systemd-logind":
+            if not (message.startswith("New session ") or message.startswith("Removed session ")):
+                return ""
+        else:
+            return ""
+        if not event.auth.username or not event.auth.logon_id or not event.auth.session_id:
+            return ""
+        return (
+            f"linux-ssh-session:{event.auth.username}:{event.auth.logon_id}:{event.auth.session_id}"
+        )
 
     @staticmethod
     def _preserve_ssh_session_lifecycle(source: str, event: SecurityEvent) -> bool:
@@ -342,6 +412,16 @@ class ObservationPolicy:
             or message.startswith("Connection closed by ")
             or "pam_unix(sshd:session): session " in message
         )
+
+    @staticmethod
+    def _preserve_logind_session_lifecycle(source: str, event: SecurityEvent) -> bool:
+        """Preserve logind session rows that correlate with endpoint session rows."""
+        if source != "syslog" or event.syslog is None:
+            return False
+        if event.syslog.app_name != "systemd-logind":
+            return False
+        message = event.syslog.message
+        return message.startswith("New session ") or message.startswith("Removed session ")
 
     @staticmethod
     def _preserve_ecar_cron_process_lifecycle(source: str, event: SecurityEvent) -> bool:

--- a/src/evidenceforge/generation/actions/__init__.py
+++ b/src/evidenceforge/generation/actions/__init__.py
@@ -51,6 +51,7 @@ from evidenceforge.generation.actions.browser_session import (
 from evidenceforge.generation.actions.dhcp_lease import (
     DhcpLeaseActionBundle,
     DhcpLeaseRequest,
+    dhcp_renewal_interval_seconds,
 )
 from evidenceforge.generation.actions.dns_lookup import (
     DnsLookupActionBundle,
@@ -180,6 +181,7 @@ __all__ = [
     "CreateRemoteThreadRequest",
     "DhcpLeaseActionBundle",
     "DhcpLeaseRequest",
+    "dhcp_renewal_interval_seconds",
     "DnsLookupActionBundle",
     "DnsLookupRequest",
     "EmailAccessActionBundle",

--- a/src/evidenceforge/generation/actions/browser_session.py
+++ b/src/evidenceforge/generation/actions/browser_session.py
@@ -156,6 +156,7 @@ class BrowserSessionActionBundle:
                 port=request.dst_port,
                 require_browser_like_domain=request.require_browser_like_domain,
                 transfer_variant_key=request.transfer_variant_key,
+                request_time=request.time,
             )
         visible_requests, page_load_count = self._visible_requests(session_requests)
         visible_requests = self._requests_before_deadline(visible_requests)
@@ -239,6 +240,7 @@ class BrowserSessionActionBundle:
                 port=self.request.dst_port,
                 require_browser_like_domain=self.request.require_browser_like_domain,
                 transfer_variant_key=self.request.transfer_variant_key,
+                request_time=self.request.time,
             )
 
         page_bounds = {

--- a/src/evidenceforge/generation/actions/dhcp_lease.py
+++ b/src/evidenceforge/generation/actions/dhcp_lease.py
@@ -26,11 +26,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from random import Random
 from typing import Protocol
 
 from evidenceforge.generation.actions.base import ActionAnchor
 from evidenceforge.models.scenario import System
 from evidenceforge.utils.rng import _stable_seed
+
+
+def dhcp_renewal_interval_seconds(lease_time: float, rng: Random) -> float:
+    """Return a jittered DHCP T1-style renewal interval."""
+
+    base_renewal = max(60.0, lease_time / 2)
+    return base_renewal * (1.0 + rng.uniform(-0.10, 0.10))
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +53,7 @@ class DhcpLeaseRequest:
     uid: str = ""
     msg_types: list[str] | None = None
     domain: str | None = None
+    renewal_interval: float | None = None
     source: str = "activity_generator"
 
     @property
@@ -56,7 +65,7 @@ class DhcpLeaseRequest:
             "action_bundle:dhcp_lease:"
             f"{self.system.hostname}:{self.system.ip}:{self.time.isoformat()}:"
             f"{self.mac}:{self.server_addr}:{self.lease_time}:{self.uid}:"
-            f"{msg_types}:{self.domain or ''}:{self.source}"
+            f"{msg_types}:{self.domain or ''}:{self.renewal_interval or ''}:{self.source}"
         )
         return f"dhcp-lease-{seed:016x}"
 

--- a/src/evidenceforge/generation/actions/file_transfer.py
+++ b/src/evidenceforge/generation/actions/file_transfer.py
@@ -576,6 +576,11 @@ class StagedArchiveSmbReadRequest:
     source_pid: int = -1
     source_process: str = ""
     source_command: str = ""
+    source_logon_id: str = ""
+    terminate_source_process: bool = False
+    reader_pid: int = -1
+    reader_process: str = ""
+    reader_command: str = ""
     source_file_read_path: str = ""
     source: str = "storyline_staged_archive"
 
@@ -588,7 +593,8 @@ class StagedArchiveSmbReadRequest:
             f"{self.actor.username}:{self.source_ip}:{self.staging_ip}:"
             f"{self.archive_path}:{self.smb_filename}:{self.staged_at.isoformat()}:"
             f"{self.exfil_time.isoformat()}:{self.upload_bytes}:"
-            f"{self.source_pid}:{self.source_file_read_path}:{self.source}"
+            f"{self.source_pid}:{self.reader_pid}:{self.source_file_read_path}:"
+            f"{self.source}"
         )
         return f"staged-archive-smb-read-{seed:016x}"
 
@@ -680,7 +686,10 @@ class StagedArchiveSmbReadActionBundle:
                 **hashes,
             ),
         )
-        self._emit_source_file_read(transfer_time)
+        ready_time = transfer_time + timedelta(seconds=duration)
+        local_create_time = self._emit_source_local_staging_create(ready_time)
+        self._terminate_source_process(ready_time, not_before=local_create_time)
+        self._emit_source_file_read(ready_time, not_before=local_create_time)
         smb_source_port = self._last_smb_connection_source_port()
         if self._target_is_file_server() and self._emit_smb_logon_pair is not None:
             self._emit_smb_logon_pair(
@@ -723,18 +732,23 @@ class StagedArchiveSmbReadActionBundle:
             return None
         return candidate
 
-    def _emit_source_file_read(self, transfer_time: datetime) -> None:
-        """Emit upload-host FILE/READ evidence for the staged archive."""
+    def _source_file_read_path(self) -> str:
+        """Return the upload-host path read by the source process."""
+
+        return self._request.source_file_read_path or self._request.smb_filename
+
+    def _emit_source_local_staging_create(self, transfer_time: datetime) -> datetime | None:
+        """Emit local staging evidence when the upload host reads a copied archive."""
 
         if (
             self._request.source_system is None
             or self._request.source_pid <= 0
             or not self._request.source_process
         ):
-            return
-        source_path = self._request.source_file_read_path or self._request.smb_filename
-        if not source_path:
-            return
+            return None
+        source_path = self._source_file_read_path()
+        if not source_path or source_path == self._request.smb_filename:
+            return None
         running_source = self._executor.state_manager.get_process(
             self._request.source_system.hostname,
             self._request.source_pid,
@@ -744,7 +758,7 @@ class StagedArchiveSmbReadActionBundle:
             self._request.source_system.hostname,
             self._request.source_pid,
         )
-        file_time = transfer_time + timedelta(milliseconds=self._rng.randint(220, 1200))
+        file_time = transfer_time + timedelta(milliseconds=self._rng.randint(80, 240))
         source_time_getter = getattr(
             self._executor.activity_generator,
             "process_source_create_time",
@@ -757,15 +771,15 @@ class StagedArchiveSmbReadActionBundle:
             )
             if isinstance(source_process_time, datetime) and file_time <= source_process_time:
                 file_time = source_process_time + timedelta(
-                    milliseconds=self._rng.randint(250, 950)
+                    milliseconds=self._rng.randint(180, 500)
                 )
         if file_time >= self._request.exfil_time:
-            return
+            return None
 
         self._executor.dispatcher.dispatch(
             SecurityEvent(
                 timestamp=file_time,
-                event_type="file_read",
+                event_type="file_create",
                 src_host=self._executor.activity_generator._build_host_context(
                     self._request.source_system
                 ),
@@ -779,12 +793,12 @@ class StagedArchiveSmbReadActionBundle:
                 ),
                 file=FileContext(
                     path=source_path,
-                    action="read",
+                    action="create",
                     pid=self._request.source_pid,
                 ),
                 edr=EdrContext(
                     object_id=stable_uuid(
-                        "staged-archive-source-file-read-edr",
+                        "staged-archive-local-create-edr",
                         self._request.source_system.hostname,
                         self._request.source_pid,
                         source_path,
@@ -795,6 +809,138 @@ class StagedArchiveSmbReadActionBundle:
                 storyline_origin=True,
             )
         )
+        return file_time
+
+    def _terminate_source_process(
+        self,
+        ready_time: datetime,
+        *,
+        not_before: datetime | None = None,
+    ) -> None:
+        """Close a short-lived staging copy process when this bundle created one."""
+
+        if (
+            not self._request.terminate_source_process
+            or self._request.source_system is None
+            or self._request.source_pid <= 0
+            or not self._request.source_process
+            or not self._request.source_logon_id
+        ):
+            return
+        termination_time = ready_time + timedelta(milliseconds=self._rng.randint(650, 2100))
+        if not_before is not None and termination_time <= not_before:
+            termination_time = not_before + timedelta(milliseconds=self._rng.randint(300, 900))
+        if termination_time >= self._request.exfil_time:
+            return
+        terminate = getattr(self._executor.activity_generator, "generate_process_termination", None)
+        if not callable(terminate):
+            return
+        terminate(
+            user=self._request.actor,
+            system=self._request.source_system,
+            time=termination_time,
+            pid=self._request.source_pid,
+            process_name=self._request.source_process,
+            logon_id=self._request.source_logon_id,
+            from_storyline=True,
+        )
+
+    def _emit_source_file_read(
+        self,
+        transfer_time: datetime,
+        *,
+        not_before: datetime | None = None,
+    ) -> None:
+        """Emit upload-host FILE/READ evidence for the staged archive."""
+
+        if (
+            self._request.source_system is None
+            or self._reader_pid() <= 0
+            or not self._reader_process()
+        ):
+            return
+        source_path = self._source_file_read_path()
+        if not source_path:
+            return
+        running_source = self._executor.state_manager.get_process(
+            self._request.source_system.hostname,
+            self._reader_pid(),
+        )
+        parent_pid = running_source.parent_pid if running_source is not None else 0
+        source_actor_id = self._executor.state_manager.get_process_object_id(
+            self._request.source_system.hostname,
+            self._reader_pid(),
+        )
+        file_time = transfer_time + timedelta(milliseconds=self._rng.randint(420, 1400))
+        source_time_getter = getattr(
+            self._executor.activity_generator,
+            "process_source_create_time",
+            None,
+        )
+        if callable(source_time_getter):
+            source_process_time = source_time_getter(
+                self._request.source_system.hostname,
+                self._reader_pid(),
+            )
+            if isinstance(source_process_time, datetime) and file_time <= source_process_time:
+                file_time = source_process_time + timedelta(
+                    milliseconds=self._rng.randint(250, 950)
+                )
+        if not_before is not None and file_time <= not_before:
+            file_time = not_before + timedelta(milliseconds=self._rng.randint(120, 620))
+        if file_time >= self._request.exfil_time:
+            return
+
+        self._executor.dispatcher.dispatch(
+            SecurityEvent(
+                timestamp=file_time,
+                event_type="file_read",
+                src_host=self._executor.activity_generator._build_host_context(
+                    self._request.source_system
+                ),
+                auth=AuthContext(username=self._request.actor.username),
+                process=ProcessContext(
+                    pid=self._reader_pid(),
+                    parent_pid=parent_pid,
+                    image=self._reader_process(),
+                    command_line=self._reader_command() or self._reader_process(),
+                    username=self._request.actor.username,
+                ),
+                file=FileContext(
+                    path=source_path,
+                    action="read",
+                    pid=self._reader_pid(),
+                ),
+                edr=EdrContext(
+                    object_id=stable_uuid(
+                        "staged-archive-source-file-read-edr",
+                        self._request.source_system.hostname,
+                        self._reader_pid(),
+                        source_path,
+                        self._request.exfil_time.isoformat(),
+                    ),
+                    actor_id=source_actor_id,
+                ),
+                storyline_origin=True,
+            )
+        )
+
+    def _reader_pid(self) -> int:
+        """Return the process that reads the local staged file for upload."""
+
+        return (
+            self._request.reader_pid if self._request.reader_pid > 0 else self._request.source_pid
+        )
+
+    def _reader_process(self) -> str:
+        """Return the image that reads the local staged file for upload."""
+
+        return self._request.reader_process or self._request.source_process
+
+    def _reader_command(self) -> str:
+        """Return the command line that reads the local staged file for upload."""
+
+        return self._request.reader_command or self._request.source_command
 
     def _last_smb_connection_source_port(self) -> int | None:
         """Return the just-emitted SMB transfer source port when available."""

--- a/src/evidenceforge/generation/actions/rdp_session.py
+++ b/src/evidenceforge/generation/actions/rdp_session.py
@@ -37,7 +37,7 @@ from typing import Any, Protocol
 
 from evidenceforge.generation.actions.base import ActionAnchor
 from evidenceforge.generation.activity.helpers import _get_os_category, _get_rng
-from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
+from evidenceforge.generation.activity.timing_profiles import get_timing_window, sample_timing_delta
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.timing import TemporalConstraintGraph
 from evidenceforge.models.scenario import System, User
@@ -421,11 +421,31 @@ class RdpSessionActionBundle:
         )
         graph.add_node(
             "target_logon",
-            observed_connection_time + timedelta(milliseconds=rng.randint(900, 1600)),
+            observed_connection_time
+            + timedelta(milliseconds=self._target_logon_gap_after_transport(rng)),
         )
         graph.constrain_after(
             "target_logon",
             "transport_observed",
-            min_gap=timedelta(milliseconds=900),
+            min_gap=timedelta(milliseconds=self._endpoint_flow_visible_gap_ms() + 25),
         )
         return graph.resolved_time("target_logon")
+
+    @staticmethod
+    def _endpoint_flow_visible_gap_ms() -> int:
+        """Return the latest expected same-tuple endpoint FLOW observation delay."""
+        flow_window = get_timing_window(
+            "source.ecar_flow",
+            default_min_ms=40,
+            default_max_ms=300,
+            default_position="after",
+            default_class="source_latency",
+        )
+        return flow_window.max_ms
+
+    def _target_logon_gap_after_transport(self, rng: random.Random) -> int:
+        """Choose an RDP target logon gap after endpoint transport visibility."""
+        return max(
+            rng.randint(900, 1600),
+            self._endpoint_flow_visible_gap_ms() + rng.randint(75, 260),
+        )

--- a/src/evidenceforge/generation/actions/ssh_session.py
+++ b/src/evidenceforge/generation/actions/ssh_session.py
@@ -425,6 +425,18 @@ class SshSessionActionBundle:
             duration = rng.uniform(30.0, 3600.0)
         if request.min_duration is not None and request.duration is None:
             duration = max(duration, request.min_duration)
+        transport_open_time = request.time + sample_packet_timing_delta(
+            "network.connection_start_jitter",
+            seed_parts=(
+                request.source_ip,
+                src_port,
+                request.target_system.ip,
+                22,
+                "tcp",
+                "ssh",
+                request.time,
+            ),
+        )
         orig_bytes = (
             request.orig_bytes if request.orig_bytes is not None else rng.randint(2000, 50000)
         )
@@ -435,14 +447,14 @@ class SshSessionActionBundle:
             rng=rng,
             source_port=src_port,
             duration=duration,
-            close_time=request.time + timedelta(seconds=duration),
+            close_time=transport_open_time + timedelta(seconds=duration),
             orig_bytes=max(0, orig_bytes),
             resp_bytes=max(0, resp_bytes),
             network_visible=self._is_network_visible(),
             dst_host=self.executor._build_host_context(request.target_system),
             session_obj_id=request.session_obj_id,
             src_host=self._source_host_context(),
-            open_time=request.time,
+            open_time=transport_open_time,
             logon_id=request.logon_id,
             execution_anchor=ActionAnchor(
                 family="ssh_session",
@@ -514,6 +526,7 @@ class SshSessionActionBundle:
             process_image=source_process_image,
             preserve_dst_ip=True,
             responding_pid=responding_pid or -1,
+            ssh_attempted_username=request.user.username,
         )
         state.uid = network_uid
         state.network_visible = bool(network_uid)
@@ -743,8 +756,8 @@ class SshSessionActionBundle:
             default_position="after",
             default_class="source_latency",
         )
-        canonical_event_time = ensure_utc(event.timestamp)
         canonical_transport_open_time = ensure_utc(transport_open_time)
+        canonical_event_time = ensure_utc(event.timestamp)
         canonical_offset_ms = max(
             0,
             math.ceil(
@@ -915,6 +928,14 @@ class SshSessionActionBundle:
                 timestamp=auth_state.connection_time,
                 event_type="syslog",
                 src_host=event.dst_host,
+                auth=AuthContext(
+                    username=request.user.username,
+                    source_ip=request.source_ip,
+                    source_port=state.source_port,
+                    logon_id=state.logon_id,
+                    session_id=auth_state.logind_session_id,
+                    logon_type=10,
+                ),
                 syslog=SyslogContext(
                     app_name="sshd",
                     pid=auth_state.sshd_pid,
@@ -1011,6 +1032,14 @@ class SshSessionActionBundle:
                 timestamp=auth_state.accepted_time,
                 event_type="syslog",
                 src_host=event.dst_host,
+                auth=AuthContext(
+                    username=request.user.username,
+                    source_ip=request.source_ip,
+                    source_port=state.source_port,
+                    logon_id=state.logon_id,
+                    session_id=auth_state.logind_session_id,
+                    logon_type=10,
+                ),
                 syslog=SyslogContext(
                     app_name="sshd",
                     pid=auth_state.sshd_pid,
@@ -1025,6 +1054,14 @@ class SshSessionActionBundle:
                 timestamp=auth_state.pam_time,
                 event_type="syslog",
                 src_host=event.dst_host,
+                auth=AuthContext(
+                    username=request.user.username,
+                    source_ip=request.source_ip,
+                    source_port=state.source_port,
+                    logon_id=state.logon_id,
+                    session_id=auth_state.logind_session_id,
+                    logon_type=10,
+                ),
                 syslog=SyslogContext(
                     app_name="sshd",
                     pid=auth_state.sshd_pid,
@@ -1045,6 +1082,14 @@ class SshSessionActionBundle:
                 timestamp=auth_state.logind_time,
                 event_type="syslog",
                 src_host=event.dst_host,
+                auth=AuthContext(
+                    username=request.user.username,
+                    source_ip=request.source_ip,
+                    source_port=state.source_port,
+                    logon_id=state.logon_id,
+                    session_id=session_id,
+                    logon_type=10,
+                ),
                 syslog=SyslogContext(
                     app_name="systemd-logind",
                     pid=executor._get_system_pid(hostname, "logind", 456),
@@ -1109,6 +1154,32 @@ class SshSessionActionBundle:
                 ),
             )
         )
+        self.executor.dispatcher.dispatch(
+            SecurityEvent(
+                timestamp=self._source_native_logind_removed_time(state, auth_state, close_time),
+                event_type="syslog",
+                src_host=event.dst_host,
+                auth=AuthContext(
+                    username=request.user.username,
+                    source_ip=request.source_ip,
+                    source_port=state.source_port,
+                    logon_id=state.logon_id,
+                    session_id=auth_state.logind_session_id,
+                    logon_type=10,
+                ),
+                syslog=SyslogContext(
+                    app_name="systemd-logind",
+                    pid=self.executor._get_system_pid(
+                        request.target_system.hostname,
+                        "logind",
+                        456,
+                    ),
+                    facility=10,
+                    severity=6,
+                    message=f"Removed session {auth_state.logind_session_id}.",
+                ),
+            )
+        )
         self._terminate_receiver_sshd_process(state, auth_state, close_time)
 
     def _terminate_receiver_sshd_process(
@@ -1164,4 +1235,23 @@ class SshSessionActionBundle:
         return state.close_time + timedelta(
             milliseconds=120 + (seed % 2380),
             microseconds=211 + (seed % 613),
+        )
+
+    def _source_native_logind_removed_time(
+        self,
+        state: _SshTransportState,
+        auth_state: _SshLinuxAuthState,
+        close_time: datetime,
+    ) -> datetime:
+        """Return systemd-logind removal time for the same visible SSH session ID."""
+
+        request = self.request
+        seed = _stable_seed(
+            "ssh_session_logind_removed:"
+            f"{request.target_system.hostname}:{request.user.username}:{request.source_ip}:"
+            f"{state.source_port}:{auth_state.logind_session_id}:{close_time.isoformat()}"
+        )
+        return close_time + timedelta(
+            milliseconds=120 + (seed % 880),
+            microseconds=701 + (seed % 173),
         )

--- a/src/evidenceforge/generation/activity/browsing_session.py
+++ b/src/evidenceforge/generation/activity/browsing_session.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
+from datetime import datetime
 
 from evidenceforge.generation.activity.http_content import (
     apply_transfer_size_variance,
@@ -312,6 +313,7 @@ def generate_browsing_session(
     port: int = 443,
     require_browser_like_domain: bool = True,
     transfer_variant_key: str | None = None,
+    request_time: datetime | None = None,
 ) -> list[BrowsingRequest]:
     """Generate a complete browsing session as a list of HTTP requests.
 
@@ -332,6 +334,8 @@ def generate_browsing_session(
         transfer_variant_key: Optional client/session key used to vary
             source-visible bytes for cacheable resources while keeping origin
             content stable.
+        request_time: Optional modeled session start time for time-relative API
+            path templates.
 
     Returns:
         List of BrowsingRequest objects sorted by time_offset_ms.
@@ -342,7 +346,7 @@ def generate_browsing_session(
     ):
         return []
 
-    site_map = get_site_map(hostname, domain_tags, rng)
+    site_map = get_site_map(hostname, domain_tags, rng, request_time=request_time)
     params = _INTENSITY_PARAMS.get(browsing_intensity, _INTENSITY_PARAMS["normal"])
 
     if not site_map.pages:

--- a/src/evidenceforge/generation/activity/edr_pools.py
+++ b/src/evidenceforge/generation/activity/edr_pools.py
@@ -108,6 +108,7 @@ _LINUX_ROOT_ONLY_FILE_PREFIXES = (
     "/var/lib/dpkg/",
     "/var/log/apt/",
 )
+_WINDOWS_PROTECTED_EVENT_LOG_PREFIX = "c:\\windows\\system32\\winevt\\logs\\"
 _GUID_RE = re.compile(
     r"^\{?[0-9A-Fa-f]{8}-"
     r"[0-9A-Fa-f]{4}-"
@@ -449,6 +450,15 @@ def _is_windows_prefetch_template(template: str) -> bool:
     return "\\windows\\prefetch\\" in normalized
 
 
+def _is_windows_protected_event_log_template(template: str) -> bool:
+    """Return whether a file template points at protected Windows event logs."""
+
+    normalized = template.replace("/", "\\").lower()
+    return normalized.startswith(_WINDOWS_PROTECTED_EVENT_LOG_PREFIX) and normalized.endswith(
+        ".evtx"
+    )
+
+
 def _runmru_value_name(rng: random.Random) -> str:
     """Return a plausible RunMRU value slot."""
     return chr(ord("a") + rng.randint(0, 15))
@@ -732,7 +742,10 @@ def select_ambient_file_churn_effect(
     candidates = file_path_templates_for_user(path_templates, os_category, user)
     if os_category == "windows":
         candidates = [
-            candidate for candidate in candidates if not _is_windows_prefetch_template(candidate)
+            candidate
+            for candidate in candidates
+            if not _is_windows_prefetch_template(candidate)
+            and not _is_windows_protected_event_log_template(candidate)
         ]
     if not candidates:
         return None

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -918,6 +918,14 @@ def _linux_ssh_client_command_line(
     return rng.choice(variants)
 
 
+def _ssh_command_target(target_host: str, attempted_username: str | None) -> str:
+    """Return a source-native SSH target token with the remote user when known."""
+    username = (attempted_username or "").strip()
+    if username:
+        return f"{username}@{target_host}"
+    return target_host
+
+
 def _http_response_requires_file_transfer(http: HttpContext) -> bool:
     """Return whether Zeek should always analyze this HTTP response body as a file."""
 
@@ -4151,6 +4159,8 @@ class ActivityGenerator:
         self._kerberos_source_port_reservations: dict[tuple[str, str], list[tuple[float, int]]] = {}
         self._kerberos_audit_tuple_times: dict[tuple[str, str, int], list[float]] = {}
         self._kerberos_tgt_cache_until: dict[tuple[str, str, str], datetime] = {}
+        self._visible_account_created_at: dict[str, datetime] = {}
+        self._visible_account_kerberos_transport_emitted: set[tuple[str, str, str]] = set()
         self._next_icmp_observation_ts_us: dict[tuple[str, int, str, int], int] = {}
         self._ssh_source_ports: set[tuple[str, str, int]] = set()
         self._terminated_process_keys: set[tuple[str, int, datetime | None]] = set()
@@ -4190,6 +4200,7 @@ class ActivityGenerator:
         self._last_browser_launch_by_session: dict[tuple[str, str, str], datetime] = {}
         self._process_source_create_times: dict[tuple[str, int], datetime] = {}
         self._process_source_terminate_times: dict[tuple[str, int], datetime] = {}
+        self._process_connection_hold_until: dict[tuple[str, int], datetime] = {}
         self._source_timing_planner = SourceTimingPlanner(clock_profile_name=source_timing_profile)
 
         # Causal expansion engine (auto-created if not provided) and recursion guard
@@ -4212,6 +4223,49 @@ class ActivityGenerator:
                 for terminated_host, terminated_pid, _ in self._terminated_process_keys
             )
         return (hostname, pid, start_time) in self._terminated_process_keys
+
+    def _remember_process_connection_hold(
+        self,
+        *,
+        system: System,
+        pid: int,
+        close_time: datetime | None,
+    ) -> None:
+        """Keep process lifecycle compatible with a process-owned transport interval."""
+        if pid <= 0 or close_time is None:
+            return
+        close_time = ensure_utc(close_time)
+        key = (system.hostname, pid)
+        previous = self._process_connection_hold_until.get(key)
+        if previous is None or close_time > previous:
+            self._process_connection_hold_until[key] = close_time
+        self.state_manager.update_process_activity_time(system.hostname, pid, close_time)
+        running = self.state_manager.get_process(system.hostname, pid)
+        if running is not None and running.logon_id:
+            self.state_manager.update_session_activity_time(running.logon_id, close_time)
+
+    def _held_process_termination_time(
+        self,
+        *,
+        system: System,
+        pid: int,
+        requested_time: datetime,
+    ) -> datetime:
+        """Move process termination after any active process-owned transport hold."""
+        hold_until = self._process_connection_hold_until.get((system.hostname, pid))
+        if hold_until is None:
+            return requested_time
+        hold_until = ensure_utc(hold_until)
+        requested_time = ensure_utc(requested_time)
+        if requested_time > hold_until:
+            return requested_time
+        delay_rng = random.Random(
+            _stable_seed(
+                "process_terminate_after_connection_hold:"
+                f"{system.hostname}:{pid}:{hold_until.isoformat()}"
+            )
+        )
+        return hold_until + timedelta(seconds=delay_rng.uniform(1.0, 12.0))
 
     def _remember_foreground_process_finalizer(
         self,
@@ -4301,6 +4355,9 @@ class ActivityGenerator:
                 process_name=process_name,
                 logon_id=logon_id,
             )
+            source_termination_time = self.process_source_terminate_time(system.hostname, pid)
+            if source_termination_time is not None:
+                return max(termination_time, source_termination_time)
         return termination_time
 
     def _is_within_scenario_window(self, event_time: datetime) -> bool:
@@ -4325,7 +4382,8 @@ class ActivityGenerator:
         image = (proc.image or "").rsplit("/", 1)[-1].lower()
         if image not in {"bash", "sh", "zsh"}:
             return None
-        return (system.hostname, username, logon_id, parent_pid)
+        shell_logon_id = proc.logon_id or logon_id
+        return (system.hostname, username, shell_logon_id, parent_pid)
 
     def _reserve_foreground_shell_time(
         self,
@@ -5296,14 +5354,42 @@ class ActivityGenerator:
         return (source_ip.removeprefix("::ffff:"), dc_hostname.lower().rstrip("."))
 
     @staticmethod
+    def _kerberos_principal_key(username: str) -> str:
+        """Return the stable account principal key used for Kerberos/account lifecycle state."""
+        principal = username.strip().rsplit("\\", 1)[-1].split("@", 1)[0]
+        return principal.upper()
+
+    @staticmethod
     def _kerberos_tgt_cache_key(
         username: str,
         source_ip: str,
         dc_hostname: str,
     ) -> tuple[str, str, str]:
         """Return the source-native TGT cache identity for one client/DC account."""
-        principal = username.split("@", 1)[0].upper()
+        principal = ActivityGenerator._kerberos_principal_key(username)
         return (principal, source_ip.removeprefix("::ffff:"), dc_hostname.lower().rstrip("."))
+
+    def _remember_visible_account_created(self, username: str, time: datetime) -> None:
+        """Remember a visible account creation and invalidate impossible pre-create TGT cache."""
+        principal = self._kerberos_principal_key(username)
+        if not principal:
+            return
+        created_at = ensure_utc(time)
+        existing = self._visible_account_created_at.get(principal)
+        if existing is None or created_at < existing:
+            self._visible_account_created_at[principal] = created_at
+        for key in list(self._kerberos_tgt_cache_until):
+            if key[0] == principal:
+                self._kerberos_tgt_cache_until.pop(key, None)
+        self._visible_account_kerberos_transport_emitted = {
+            key for key in self._visible_account_kerberos_transport_emitted if key[0] != principal
+        }
+
+    def _visible_account_created_before(self, username: str, time: datetime) -> bool:
+        """Return whether an account principal was created during the visible window."""
+        principal = self._kerberos_principal_key(username)
+        created_at = self._visible_account_created_at.get(principal)
+        return created_at is not None and created_at <= ensure_utc(time)
 
     @staticmethod
     def _kerberos_source_time(
@@ -5380,6 +5466,9 @@ class ActivityGenerator:
         if cached_until is not None and cached_until > current_time:
             return rng.random() < 0.08
 
+        if self._visible_account_created_before(username, current_time):
+            return True
+
         pre_window_cache_probability = 0.55 if username.endswith("$") else 0.35
         if rng.random() < pre_window_cache_probability:
             self._remember_kerberos_tgt_cache(username, source_ip, dc_hostname, time, rng)
@@ -5409,6 +5498,83 @@ class ActivityGenerator:
             source_port=source_port,
         )
         return True
+
+    def _ensure_visible_created_account_kerberos_exchange(
+        self,
+        *,
+        username: str,
+        source_ip: str,
+        dc_hostname: str,
+        time: datetime,
+        source_port: int,
+        domain: str,
+    ) -> None:
+        """Ensure first visible TGS for a newly-created account has TGT and KDC flow."""
+        service_time = ensure_utc(time)
+        if not self._visible_account_created_before(username, service_time):
+            return
+
+        principal = self._kerberos_principal_key(username)
+        source_ip_key = source_ip.removeprefix("::ffff:")
+        dc_key = dc_hostname.lower().rstrip(".")
+        cache_key = self._kerberos_tgt_cache_key(username, source_ip, dc_hostname)
+        transport_key = (principal, source_ip_key, dc_key)
+        rng = random.Random(
+            _stable_seed(
+                "visible_created_account_kerberos_exchange:"
+                f"{principal}:{source_ip_key}:{dc_key}:{service_time.isoformat()}"
+            )
+        )
+
+        cached_until = self._kerberos_tgt_cache_until.get(cache_key)
+        if cached_until is None or cached_until <= service_time:
+            tgt_time = service_time - timedelta(
+                milliseconds=rng.randint(45, 260),
+                microseconds=rng.randint(103, 941),
+            )
+            self._maybe_generate_kerberos_tgt(
+                username=username,
+                source_ip=source_ip,
+                dc_hostname=dc_hostname,
+                time=tgt_time,
+                rng=rng,
+                source_port=source_port,
+                domain=domain,
+            )
+
+        if transport_key in self._visible_account_kerberos_transport_emitted:
+            return
+
+        dc_system = self._dc_system_for_hostname(dc_hostname)
+        source_system = self._ip_to_system.get(source_ip_key) or self._ip_to_system.get(source_ip)
+        if dc_system is None or source_system is None:
+            return
+        dc_ip = str(getattr(dc_system, "ip", "") or "")
+        if not dc_ip:
+            return
+
+        conn_time = service_time - timedelta(
+            milliseconds=rng.randint(1200, 1850),
+            microseconds=rng.randint(43, 937),
+        )
+        if conn_time >= service_time:
+            conn_time = service_time - timedelta(microseconds=733)
+        self.generate_connection(
+            src_ip=source_ip_key,
+            dst_ip=dc_ip,
+            time=conn_time,
+            dst_port=88,
+            proto="tcp",
+            service="kerberos",
+            duration=rng.uniform(1.25, 2.1),
+            orig_bytes=rng.randint(520, 1600),
+            resp_bytes=rng.randint(1800, 5200),
+            src_port=source_port,
+            source_system=source_system,
+            conn_state="SF",
+            suppress_prereq_dns=True,
+        )
+        self._visible_account_kerberos_transport_emitted.add(transport_key)
 
     @staticmethod
     def _is_domain_controller_system(system: Any | None) -> bool:
@@ -5658,6 +5824,572 @@ class ActivityGenerator:
                 return pid
         return -1
 
+    def _ensure_high_confidence_connection_owner(
+        self,
+        *,
+        source_system: System | None,
+        time: datetime,
+        service: str | None,
+        dst_port: int,
+        proto: str,
+        hostname: str | None,
+        http: HttpContext | None,
+        ssh_attempted_username: str | None = None,
+    ) -> tuple[int, str | None]:
+        """Create or reuse canonical process ownership for high-signal outbound flows."""
+        if source_system is None or proto != "tcp":
+            return -1, None
+
+        if self._high_confidence_connection_should_remain_unattributed(
+            service=service,
+            dst_port=dst_port,
+            http=http,
+        ):
+            return -1, None
+
+        os_category = _get_os_category(source_system.os)
+        if self._source_should_use_service_connection_owner(source_system, dst_port):
+            return self._ensure_service_connection_owner_process(
+                source_system=source_system,
+                time=time,
+                service=service,
+                dst_port=dst_port,
+                os_category=os_category,
+                hostname=hostname,
+                http=http,
+            )
+
+        return self._ensure_user_connection_owner_process(
+            source_system=source_system,
+            time=time,
+            service=service,
+            dst_port=dst_port,
+            os_category=os_category,
+            hostname=hostname,
+            ssh_attempted_username=ssh_attempted_username,
+        )
+
+    @staticmethod
+    def _high_confidence_connection_should_remain_unattributed(
+        *,
+        service: str | None,
+        dst_port: int,
+        http: HttpContext | None,
+    ) -> bool:
+        """Return whether a flow is too low-confidence to synthesize process ownership."""
+        service_name = (service or "").lower()
+        high_signal_services = {"http", "https", "ssl", "ssh", "smb", "ldap", "kerberos", "mysql"}
+        high_signal_ports = {22, 80, 88, 389, 443, 445, 8080, 8443, 3306, 5432}
+        if service_name in high_signal_services or dst_port in high_signal_ports:
+            return False
+        return http is None
+
+    @staticmethod
+    def _source_should_use_service_connection_owner(
+        source_system: System,
+        dst_port: int,
+    ) -> bool:
+        """Return whether a source host should model daemon/service ownership."""
+        roles = {str(role).lower() for role in (getattr(source_system, "roles", []) or [])}
+        server_roles = {
+            "app_server",
+            "database",
+            "dns_server",
+            "domain_controller",
+            "file_server",
+            "forward_proxy",
+            "log_server",
+            "mail_server",
+            "monitoring",
+            "web_server",
+        }
+        if roles & server_roles:
+            return True
+        system_type = (getattr(source_system, "type", "") or "").lower()
+        if system_type in {"server", "domain_controller"}:
+            return True
+        return dst_port in {88, 389}
+
+    def _ensure_service_connection_owner_process(
+        self,
+        *,
+        source_system: System,
+        time: datetime,
+        service: str | None,
+        dst_port: int,
+        os_category: str,
+        hostname: str | None,
+        http: HttpContext | None,
+    ) -> tuple[int, str | None]:
+        """Create or reuse a daemon/client process for server-originated flows."""
+        spec = self._service_connection_owner_spec(
+            source_system=source_system,
+            service=service,
+            dst_port=dst_port,
+            os_category=os_category,
+            hostname=hostname,
+            http=http,
+        )
+        if spec is None:
+            return -1, None
+        key, image, command_line, username = spec
+        return self._ensure_system_connection_owner_process(
+            source_system=source_system,
+            time=time,
+            key=key,
+            image=image,
+            command_line=command_line,
+            username=username,
+        )
+
+    def _service_connection_owner_spec(
+        self,
+        *,
+        source_system: System,
+        service: str | None,
+        dst_port: int,
+        os_category: str,
+        hostname: str | None,
+        http: HttpContext | None,
+    ) -> tuple[str, str, str, str] | None:
+        """Return source-native process metadata for a service-owned connection."""
+        service_name = (service or "").lower()
+        roles = {str(role).lower() for role in (getattr(source_system, "roles", []) or [])}
+        target = hostname or "internal-service"
+
+        if os_category == "windows":
+            if service_name in {"kerberos", "ldap"} or dst_port in {88, 389}:
+                return (
+                    "lsass",
+                    r"C:\Windows\System32\lsass.exe",
+                    "lsass.exe",
+                    "SYSTEM",
+                )
+            if dst_port in {80, 443, 8080, 8443} or service_name in {"http", "ssl", "https"}:
+                return (
+                    f"service_healthcheck:{target}",
+                    r"C:\Program Files\Meridian\ServiceHealth\service-healthcheck.exe",
+                    rf'"C:\Program Files\Meridian\ServiceHealth\service-healthcheck.exe" '
+                    rf'--target "{target}"',
+                    "SYSTEM",
+                )
+            if dst_port == 445 or service_name == "smb":
+                return (
+                    "lanmanworkstation",
+                    r"C:\Windows\System32\svchost.exe",
+                    "svchost.exe -k NetworkService -p -s LanmanWorkstation",
+                    "NETWORK SERVICE",
+                )
+            return None
+
+        if os_category != "linux":
+            return None
+
+        if dst_port in {3306, 5432} or service_name in {"mysql", "postgres", "postgresql"}:
+            if "app_server" in roles:
+                return (
+                    "gunicorn",
+                    "/opt/meridian/venv/bin/gunicorn",
+                    "gunicorn meridian.wsgi:application --bind 0.0.0.0:8080",
+                    "www-data",
+                )
+            if "web_server" in roles:
+                return (
+                    "apache2",
+                    "/usr/sbin/apache2",
+                    "/usr/sbin/apache2 -DFOREGROUND",
+                    "www-data",
+                )
+            return (
+                f"db_client_service:{target}:{dst_port}",
+                "/usr/bin/mysqladmin",
+                f"mysqladmin --host={target} --port={dst_port} ping",
+                "root",
+            )
+
+        if service_name == "ldap" or dst_port == 389:
+            if "mail_server" in roles:
+                return (
+                    "postfix",
+                    "/usr/lib/postfix/sbin/smtpd",
+                    "smtpd -n smtp -t inet -u",
+                    "postfix",
+                )
+            if "app_server" in roles or "web_server" in roles:
+                return (
+                    "gunicorn",
+                    "/opt/meridian/venv/bin/gunicorn",
+                    "gunicorn meridian.wsgi:application --bind 0.0.0.0:8080",
+                    "www-data",
+                )
+            return (
+                "sssd",
+                "/usr/sbin/sssd",
+                "/usr/sbin/sssd -i --logger=files",
+                "root",
+            )
+
+        if service_name == "smb" or dst_port == 445:
+            return (
+                "backup_agent",
+                "/usr/sbin/rsyncd",
+                "/usr/sbin/rsyncd --daemon --config=/etc/rsyncd.conf",
+                "root",
+            )
+
+        if dst_port in {80, 443, 8080, 8443} or service_name in {"http", "ssl", "https"}:
+            user_agent = (http.user_agent if http is not None else "") or ""
+            user_agent_lower = user_agent.lower()
+            if "mail_server" in roles:
+                return (
+                    "postfix",
+                    "/usr/lib/postfix/sbin/smtp",
+                    "smtp -n smtp -t unix -u",
+                    "postfix",
+                )
+            if "forward_proxy" in roles:
+                return (
+                    "squid",
+                    "/usr/sbin/squid",
+                    "/usr/sbin/squid -N -f /etc/squid/squid.conf",
+                    "proxy",
+                )
+            if "curl/" in user_agent_lower:
+                return (
+                    f"curl_proxy_client:{target}",
+                    "/usr/bin/curl",
+                    f"curl -fsS --proxy http://proxy:8080 https://{target}/",
+                    "root",
+                )
+            if "wget/" in user_agent_lower:
+                return (
+                    f"wget_proxy_client:{target}",
+                    "/usr/bin/wget",
+                    f"wget -q -e use_proxy=yes -O - https://{target}/",
+                    "root",
+                )
+            if "python-requests/" in user_agent_lower:
+                return (
+                    f"python_requests_proxy_client:{target}",
+                    "/usr/bin/python3",
+                    f"/usr/bin/python3 /opt/meridian/bin/proxy_healthcheck.py --target {target}",
+                    "root",
+                )
+            if "apache-httpclient" in user_agent_lower:
+                return (
+                    f"integration_worker:{target}",
+                    "/usr/bin/java",
+                    f"/usr/bin/java -jar /opt/meridian/integration-worker.jar --check-url https://{target}/",
+                    "www-data",
+                )
+            return (
+                f"service_healthcheck:{target}",
+                "/usr/bin/java",
+                f"/usr/bin/java -jar /opt/meridian/service-healthcheck.jar --target {target}",
+                "root",
+            )
+
+        return None
+
+    def _ensure_system_connection_owner_process(
+        self,
+        *,
+        source_system: System,
+        time: datetime,
+        key: str,
+        image: str,
+        command_line: str,
+        username: str,
+    ) -> tuple[int, str | None]:
+        """Reuse or create a source-native system process for connection attribution."""
+        sys_pids = getattr(self, "_system_pids", {}).setdefault(source_system.hostname, {})
+        pid = self._active_matching_process_pid(
+            source_system=source_system,
+            time=time,
+            key=key,
+            image=image,
+            username=username,
+            command_line=command_line,
+        )
+        if pid > 0:
+            self.state_manager.update_process_activity_time(source_system.hostname, pid, time)
+            return pid, image
+
+        process_rng = random.Random(
+            _stable_seed(
+                "high_confidence_connection_owner:"
+                f"{source_system.hostname}:{key}:{image}:{username}:{time.isoformat()}"
+            )
+        )
+        lead_seconds = process_rng.uniform(45.0, 420.0)
+        process_time = time - timedelta(seconds=lead_seconds)
+        scenario_start = getattr(self, "_scenario_start_time", None)
+        if scenario_start is not None:
+            visible_start = ensure_utc(scenario_start) + timedelta(
+                seconds=15 + (process_rng.randint(0, 75))
+            )
+            if process_time < visible_start < time:
+                process_time = visible_start
+        if process_time >= time:
+            process_time = time - timedelta(milliseconds=120)
+
+        if _get_os_category(source_system.os) == "windows":
+            parent_pid = self._windows_system_parent_fallback(source_system, process_time)
+        else:
+            parent_pid = self._linux_system_parent_fallback(source_system, process_time)
+        pid = self.generate_system_process(
+            source_system,
+            process_time,
+            image,
+            command_line,
+            parent_pid=parent_pid,
+            username=username,
+            emit_linux_syslog=False,
+        )
+        if pid > 0:
+            sys_pids[key] = pid
+            self.state_manager.update_process_activity_time(source_system.hostname, pid, time)
+            self.state_manager.set_current_time(time)
+            running = self.state_manager.get_process(source_system.hostname, pid)
+            return pid, running.image if running is not None else image
+        self.state_manager.set_current_time(time)
+        return -1, None
+
+    def _active_matching_process_pid(
+        self,
+        *,
+        source_system: System,
+        time: datetime,
+        key: str,
+        image: str,
+        username: str,
+        command_line: str,
+    ) -> int:
+        """Return an active process matching a role key or exact image/user owner."""
+        sys_pids = getattr(self, "_system_pids", {}).get(source_system.hostname, {})
+        candidate_pids = [pid for pid in (sys_pids.get(key),) if pid]
+        image_lower = image.lower()
+        require_exact_command = self._connection_owner_requires_exact_command_line(
+            image,
+            command_line,
+        )
+        for proc in self.state_manager.get_processes_on_system(source_system.hostname):
+            if proc.image.lower() == image_lower and proc.username == username:
+                if require_exact_command and proc.command_line != command_line:
+                    continue
+                candidate_pids.append(proc.pid)
+
+        for candidate_pid in candidate_pids:
+            proc = self.state_manager.get_process(source_system.hostname, candidate_pid)
+            if proc is None:
+                continue
+            if require_exact_command and proc.command_line != command_line:
+                continue
+            if proc.start_time is not None and ensure_utc(proc.start_time) > ensure_utc(time):
+                continue
+            if self._process_termination_recorded(
+                source_system.hostname,
+                candidate_pid,
+                proc.start_time,
+            ):
+                continue
+            if self._foreground_process_expired_for_attribution(source_system, proc, time):
+                continue
+            return candidate_pid
+        return -1
+
+    @staticmethod
+    def _connection_owner_requires_exact_command_line(
+        image: str,
+        command_line: str,
+    ) -> bool:
+        """Return whether a process command line carries per-target network semantics."""
+        image_lower = image.lower()
+        command_lower = command_line.lower()
+        target_bearing_images = {
+            "curl",
+            "curl.exe",
+            "wget",
+            "wget.exe",
+            "python",
+            "python.exe",
+            "python3",
+            "python3.exe",
+            "service-healthcheck",
+            "service-healthcheck.exe",
+            "ssh",
+            "ssh.exe",
+            "scp",
+            "scp.exe",
+            "sftp",
+            "sftp.exe",
+            "gvfsd-smb-browse",
+            "java",
+            "java.exe",
+            "mysqladmin",
+        }
+        exe = image_lower.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+        if exe in target_bearing_images:
+            return any(
+                token in command_lower
+                for token in (
+                    "--target",
+                    "--url",
+                    "--check-url",
+                    "http://",
+                    "https://",
+                    "requests.get",
+                    "mysqladmin",
+                    "ssh ",
+                    "ssh.exe ",
+                    "scp ",
+                    "scp.exe ",
+                    "sftp ",
+                    "sftp.exe ",
+                    "smb://",
+                )
+            )
+        return False
+
+    def _ensure_user_connection_owner_process(
+        self,
+        *,
+        source_system: System,
+        time: datetime,
+        service: str | None,
+        dst_port: int,
+        os_category: str,
+        hostname: str | None,
+        ssh_attempted_username: str | None,
+    ) -> tuple[int, str | None]:
+        """Create or reuse a user process for high-confidence workstation flows."""
+        spec = self._user_connection_owner_spec(
+            service=service,
+            dst_port=dst_port,
+            os_category=os_category,
+            hostname=hostname,
+            ssh_attempted_username=ssh_attempted_username,
+        )
+        if spec is None:
+            return -1, None
+        image, command_line = spec
+        session_info = self._select_explicit_proxy_client_session(source_system, time)
+        if session_info is None:
+            return -1, None
+        user, session = session_info
+
+        image_lower = image.lower()
+        require_exact_command = self._connection_owner_requires_exact_command_line(
+            image,
+            command_line,
+        )
+        running_candidates = [
+            proc
+            for proc in self.state_manager.get_processes_on_system(source_system.hostname)
+            if proc.username == user.username
+            and proc.image.lower() == image_lower
+            and (not require_exact_command or proc.command_line == command_line)
+            and proc.start_time is not None
+            and ensure_utc(proc.start_time) <= ensure_utc(time)
+            and not self._foreground_process_expired_for_attribution(source_system, proc, time)
+        ]
+        if running_candidates:
+            proc = max(running_candidates, key=lambda candidate: candidate.start_time)
+            self.state_manager.update_process_activity_time(
+                source_system.hostname,
+                proc.pid,
+                time,
+            )
+            return proc.pid, proc.image
+
+        process_rng = random.Random(
+            _stable_seed(
+                "high_confidence_user_connection_owner:"
+                f"{source_system.hostname}:{user.username}:{image}:{time.isoformat()}"
+            )
+        )
+        process_lifetime = (
+            _windows_foreground_lifetime(image, command_line)
+            if os_category == "windows"
+            else _linux_foreground_lifetime(image, command_line)
+        )
+        if process_lifetime is None:
+            lead_seconds = process_rng.uniform(3.0, 30.0)
+        else:
+            lead_seconds = process_rng.uniform(0.4, min(8.0, process_lifetime[1]))
+        process_time = time - timedelta(seconds=lead_seconds)
+        min_process_time = ensure_utc(session.start_time) + timedelta(milliseconds=500)
+        if process_time < min_process_time:
+            process_time = min_process_time
+        if process_time >= time:
+            process_time = time - timedelta(milliseconds=100)
+
+        parent_pid = self._select_parent_pid(
+            source_system,
+            user,
+            image,
+            time=process_time,
+            logon_id=session.logon_id,
+        )
+        if os_category == "linux":
+            parent_pid = (
+                self._linux_non_shell_session_parent_pid(
+                    system=source_system,
+                    time=process_time,
+                    logon_id=session.logon_id,
+                )
+                or parent_pid
+            )
+        pid = self.generate_process(
+            user=user,
+            system=source_system,
+            time=process_time,
+            logon_id=session.logon_id,
+            process_name=image,
+            command_line=command_line,
+            parent_pid=parent_pid,
+            suppress_command_file_effect=True,
+            allow_existing_browser_reuse=False,
+            allow_browser_launch_spacing=False,
+        )
+        self._record_user_process(source_system, user, pid, image)
+        self.state_manager.update_process_activity_time(source_system.hostname, pid, time)
+        self.state_manager.set_current_time(time)
+        running = self.state_manager.get_process(source_system.hostname, pid)
+        if running is not None:
+            return pid, running.image
+        return pid, image
+
+    @staticmethod
+    def _user_connection_owner_spec(
+        *,
+        service: str | None,
+        dst_port: int,
+        os_category: str,
+        hostname: str | None,
+        ssh_attempted_username: str | None = None,
+    ) -> tuple[str, str] | None:
+        """Return user-process metadata for source-owned workstation connections."""
+        service_name = (service or "").lower()
+        target = hostname or "internal-host"
+        if os_category == "windows":
+            if service_name == "ssh" or dst_port == 22:
+                image = r"C:\Windows\System32\OpenSSH\ssh.exe"
+                return image, f"ssh.exe {_ssh_command_target(target, ssh_attempted_username)}"
+            if service_name == "smb" or dst_port == 445:
+                image = r"C:\Windows\explorer.exe"
+                return image, rf"explorer.exe \\{target}\shared"
+            return None
+        if os_category == "linux":
+            if service_name == "ssh" or dst_port == 22:
+                image = "/usr/bin/ssh"
+                return image, f"ssh {_ssh_command_target(target, ssh_attempted_username)}"
+            if service_name == "smb" or dst_port == 445:
+                image = "/usr/bin/gvfsd-smb-browse"
+                return image, f"gvfsd-smb-browse smb://{target}/shared"
+            return None
+        return None
+
     def _build_dc_host_context(self, dc_hostname: str) -> HostContext:
         """Build a HostContext for a domain controller from raw hostname string.
 
@@ -5822,6 +6554,29 @@ class ActivityGenerator:
     ) -> str:
         """Return a source-sticky proxy User-Agent for one logical client context."""
 
+        def normalize_selected_user_agent(
+            selected_user_agent: str,
+            normalizer_rng: random.Random = rng,
+        ) -> str:
+            normalized = normalize_proxy_user_agent_for_os(
+                normalizer_rng,
+                source_system,
+                selected_user_agent,
+                hostname=hostname,
+                domain_tags=domain_tags,
+            )
+            if self._is_proxy_server_like_source(
+                source_system
+            ) and _is_browser_family_http_user_agent(normalized):
+                return normalize_proxy_user_agent_for_os(
+                    normalizer_rng,
+                    source_system,
+                    "Go-http-client/1.1",
+                    hostname=hostname,
+                    domain_tags=domain_tags,
+                )
+            return normalized
+
         host = hostname or ""
         host_is_browser_like = is_browser_like_proxy_domain(host, domain_tags=domain_tags)
         existing_is_browser_family = _is_browser_family_http_user_agent(existing_user_agent)
@@ -5833,40 +6588,16 @@ class ActivityGenerator:
                 hostname=hostname,
             )
             if domain_user_agent:
-                return normalize_proxy_user_agent_for_os(
-                    rng,
-                    source_system,
-                    domain_user_agent,
-                    hostname=hostname,
-                    domain_tags=domain_tags,
-                )
+                return normalize_selected_user_agent(domain_user_agent)
 
         if override_user_agent:
-            return normalize_proxy_user_agent_for_os(
-                rng,
-                source_system,
-                override_user_agent,
-                hostname=hostname,
-                domain_tags=domain_tags,
-            )
+            return normalize_selected_user_agent(override_user_agent)
 
         if existing_user_agent and existing_is_browser_family and source_system is None:
-            return normalize_proxy_user_agent_for_os(
-                rng,
-                source_system,
-                existing_user_agent,
-                hostname=hostname,
-                domain_tags=domain_tags,
-            )
+            return normalize_selected_user_agent(existing_user_agent)
 
         if existing_user_agent and not existing_is_browser_family:
-            return normalize_proxy_user_agent_for_os(
-                rng,
-                source_system,
-                existing_user_agent,
-                hostname=hostname,
-                domain_tags=domain_tags,
-            )
+            return normalize_selected_user_agent(existing_user_agent)
 
         domain_class = get_proxy_domain_class(host) or ""
         source_key = "unknown"
@@ -5911,13 +6642,7 @@ class ActivityGenerator:
                     hostname=host,
                     domain_tags=domain_tags,
                 )
-        return normalize_proxy_user_agent_for_os(
-            stable_rng,
-            source_system,
-            user_agent,
-            hostname=host,
-            domain_tags=domain_tags,
-        )
+        return normalize_selected_user_agent(user_agent, stable_rng)
 
     def _build_proxy_context(
         self,
@@ -5971,6 +6696,8 @@ class ActivityGenerator:
                 proxy_content_type = "text/html"
             user_agent = http.user_agent
             proxy_referrer = http.referrer
+            if _is_browser_family_http_user_agent(user_agent):
+                proxy_ua_override = user_agent
         elif explicit_mode and dst_port == 443:
             proxy_method = "CONNECT"
             url = f"{proxy_hostname}:443"
@@ -6011,7 +6738,8 @@ class ActivityGenerator:
             proxy_content_type = "text/html"
 
         apply_domain_user_agent = http is None or (
-            not _is_tool_http_user_agent(http.user_agent)
+            proxy_ua_override is None
+            and not _is_tool_http_user_agent(http.user_agent)
             and not is_browser_like_proxy_domain(proxy_hostname, domain_tags=domain_tags)
         )
         user_agent = self._proxy_user_agent_for_context(
@@ -6345,6 +7073,57 @@ class ActivityGenerator:
             return "/usr/bin/dnf", "dnf makecache --timer"
         return None
 
+    def _linux_proxy_helper_system_owner_spec(
+        self,
+        *,
+        source_system: System,
+        image: str,
+        command_line: str,
+    ) -> tuple[str, str, str, str] | None:
+        """Return system-owned process metadata for Linux proxy helper traffic."""
+        if _get_os_category(source_system.os) != "linux":
+            return None
+
+        image_lower = image.lower()
+        command_lower = command_line.lower()
+        exe_name = image_lower.rsplit("/", 1)[-1]
+
+        if image_lower.startswith("/usr/lib/apt/methods/"):
+            method = exe_name or "http"
+            return (
+                f"apt_proxy_method:{method}:{command_line}",
+                image,
+                command_line,
+                "root",
+            )
+        if exe_name in {"dnf", "yum"} and any(
+            token in command_lower for token in ("makecache", "check-update", "update")
+        ):
+            return (
+                f"{exe_name}_proxy_refresh:{command_line}",
+                image,
+                command_line,
+                "root",
+            )
+
+        if not self._is_proxy_server_like_source(source_system):
+            return None
+        if exe_name == "service-healthcheck":
+            return (
+                f"service_healthcheck_proxy:{command_line}",
+                image,
+                command_line,
+                "root",
+            )
+        if exe_name == "java" and "integration-worker" in command_lower:
+            return (
+                f"integration_worker_proxy:{command_line}",
+                image,
+                command_line,
+                "www-data",
+            )
+        return None
+
     @staticmethod
     def _http_target_url(*, hostname: str, uri: str, dst_port: int) -> str:
         """Build the URL used in source-native client process command lines."""
@@ -6607,6 +7386,27 @@ class ActivityGenerator:
             return -1, None
 
         image, command_line = hint
+        os_category = _get_os_category(source_system.os)
+        system_owner_spec = self._linux_proxy_helper_system_owner_spec(
+            source_system=source_system,
+            image=image,
+            command_line=command_line,
+        )
+        if system_owner_spec is not None:
+            key, owner_image, owner_command_line, owner_username = system_owner_spec
+            return self._ensure_system_connection_owner_process(
+                source_system=source_system,
+                time=time,
+                key=key,
+                image=owner_image,
+                command_line=owner_command_line,
+                username=owner_username,
+            )
+
+        require_exact_command = self._connection_owner_requires_exact_command_line(
+            image,
+            command_line,
+        )
         session_info = self._select_explicit_proxy_client_session(source_system, time)
         if session_info is None:
             return -1, None
@@ -6618,6 +7418,7 @@ class ActivityGenerator:
             for proc in self.state_manager.get_processes_on_system(source_system.hostname)
             if proc.username == user.username
             and proc.image.lower() == image_lower
+            and (not require_exact_command or proc.command_line == command_line)
             and proc.start_time is not None
             and proc.start_time <= time
             and not self._foreground_process_expired_for_attribution(source_system, proc, time)
@@ -6631,7 +7432,6 @@ class ActivityGenerator:
             )
             return proc.pid, proc.image
 
-        os_category = _get_os_category(source_system.os)
         if os_category == "windows" and image_lower.endswith(tuple(_WINDOWS_BROWSER_EXES)):
             parsed_url = urlsplit(proxy_context.url or "")
             proxy_uri = parsed_url.path or "/"
@@ -6675,6 +7475,15 @@ class ActivityGenerator:
             time=process_time,
             logon_id=session.logon_id,
         )
+        if os_category == "linux":
+            parent_pid = (
+                self._linux_non_shell_session_parent_pid(
+                    system=source_system,
+                    time=process_time,
+                    logon_id=session.logon_id,
+                )
+                or parent_pid
+            )
         pid = self.generate_process(
             user=user,
             system=source_system,
@@ -6690,6 +7499,69 @@ class ActivityGenerator:
         self.state_manager.update_process_activity_time(source_system.hostname, pid, time)
         self.state_manager.set_current_time(time)
         return pid, image
+
+    def _linux_non_shell_session_parent_pid(
+        self,
+        *,
+        system: System,
+        time: datetime,
+        logon_id: str,
+    ) -> int | None:
+        """Return a live non-shell parent for Linux session-bound helper processes."""
+        if _get_os_category(system.os) != "linux" or not logon_id:
+            return None
+
+        def live_non_shell(candidate: int | None) -> int | None:
+            if not candidate:
+                return None
+            proc = self.state_manager.get_process(system.hostname, candidate)
+            if proc is None or not self._linux_parent_usable_for_child_at(
+                system=system,
+                parent_pid=candidate,
+                time=time,
+                logon_id=logon_id,
+            ):
+                return None
+            exe = proc.image.rsplit("/", 1)[-1].lower()
+            if exe in {"bash", "sh", "zsh"}:
+                return None
+            return candidate
+
+        session = self.state_manager.get_session(logon_id)
+        if session is not None:
+            for candidate in (session.process_tree_root, session.transport_pid):
+                parent_pid = live_non_shell(candidate)
+                if parent_pid is not None:
+                    return parent_pid
+
+        session_user = session.username if session is not None else ""
+        preferred_images = {
+            "systemd",
+            "gnome-terminal-server",
+            "login",
+            "sshd",
+        }
+        candidates = []
+        for proc in self.state_manager.get_processes_on_system(system.hostname):
+            if session_user and proc.username not in {session_user, "root"}:
+                continue
+            if proc.logon_id and proc.logon_id != logon_id:
+                continue
+            exe = proc.image.rsplit("/", 1)[-1].lower()
+            if exe not in preferred_images:
+                continue
+            parent_pid = live_non_shell(proc.pid)
+            if parent_pid is not None:
+                candidates.append(proc)
+        if candidates:
+            return max(candidates, key=lambda candidate: candidate.start_time or time).pid
+
+        sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
+        for role in ("systemd", "init", "sshd"):
+            parent_pid = live_non_shell(sys_pids.get(role))
+            if parent_pid is not None:
+                return parent_pid
+        return None
 
     def _ensure_browser_http_client_process(
         self,
@@ -7000,6 +7872,24 @@ class ActivityGenerator:
             )
             return
 
+        fallback_pid, fallback_image = self._ensure_high_confidence_connection_owner(
+            source_system=source_system,
+            time=time,
+            service=event.network.service,
+            dst_port=event.network.dst_port,
+            proto=event.network.protocol,
+            hostname=proxy_context.host,
+            http=event.http,
+        )
+        if fallback_pid > 0:
+            self._set_connection_process_context(
+                event,
+                source_system=source_system,
+                pid=fallback_pid,
+                image=fallback_image,
+            )
+            return
+
         self._set_connection_process_context(
             event,
             source_system=source_system,
@@ -7053,7 +7943,14 @@ class ActivityGenerator:
             return candidate_image
 
         expected_image = hint[0]
+        expected_command_line = hint[1]
+        require_exact_command = self._connection_owner_requires_exact_command_line(
+            expected_image,
+            expected_command_line,
+        )
         if candidate_image.lower() == expected_image.lower():
+            if require_exact_command and running.command_line != expected_command_line:
+                return None
             return candidate_image
         expected_exe = ntpath.basename(expected_image).lower()
         candidate_exe = ntpath.basename(candidate_image).lower()
@@ -8028,6 +8925,9 @@ class ActivityGenerator:
         if logon_type == 10 and os_cat == "windows" and source_ip in (None, "", "-", system.ip):
             logon_type = 2
             source_ip = None
+        if logon_type == 3 and os_cat == "linux" and source_ip in (None, "", "-", system.ip):
+            logon_type = 2
+            source_ip = None
         if (
             logon_type == 3
             and os_cat == "windows"
@@ -8352,6 +9252,26 @@ class ActivityGenerator:
                 auth_package=auth_package_name,
             )
 
+        if os_cat == "windows" and logon_type == 3 and auth_source_ip not in {"", "-", system.ip}:
+            ready_time = ensure_utc(time) + sample_timing_delta(
+                "windows.remote_logon_source_ready",
+                seed_parts=(
+                    system.hostname,
+                    user.username,
+                    logon_id,
+                    auth_source_ip,
+                    source_port or 0,
+                    time,
+                ),
+            )
+            session = self.state_manager.get_session(logon_id)
+            existing_ready_time = _session_source_ready_time(session) if session else None
+            if existing_ready_time is None or existing_ready_time < ready_time:
+                self.state_manager.update_session_metadata(
+                    logon_id,
+                    source_ready_time=ready_time,
+                )
+
         # Phase 3: Dispatch to matching emitters
         self.dispatcher.dispatch(event)
 
@@ -8424,7 +9344,8 @@ class ActivityGenerator:
         if (
             session is None
             or session.logon_type not in _LINUX_LOCAL_SESSION_LOGON_TYPES
-            or session.session_kind in _LINUX_REMOTE_SESSION_KINDS
+            or session.session_kind in {"network", "service"}
+            or (session.session_kind == "ssh" and session.source_ip not in {"", "-", system.ip})
         ):
             return
 
@@ -8446,6 +9367,14 @@ class ActivityGenerator:
             message=f"New session {session_id} of user {user.username}.",
             pid=self._get_system_pid(system.hostname, "logind", 456),
             facility=10,
+            auth=AuthContext(
+                username=user.username,
+                user_sid=self._get_sid(user.username),
+                logon_id=logon_id,
+                session_id=session_id,
+                logon_type=session.logon_type,
+                source_ip="-",
+            ),
         )
         self._linux_local_logon_syslog_sessions.add(logon_id)
 
@@ -9366,6 +10295,40 @@ class ActivityGenerator:
 
         # Phase 3: Dispatch to matching emitters
         self.dispatcher.dispatch(event)
+        if event.syslog is not None and event.dst_host and event.dst_host.os_category == "linux":
+            if is_ssh_session and session_id:
+                remove_seed = _stable_seed(
+                    "linux_ssh_logoff_logind_removed:"
+                    f"{system.hostname}:{user.username}:{logon_id}:{session_id}:"
+                    f"{time.isoformat()}"
+                )
+                self.dispatcher.dispatch(
+                    SecurityEvent(
+                        timestamp=time
+                        + timedelta(
+                            milliseconds=120 + (remove_seed % 880),
+                            microseconds=701 + (remove_seed % 173),
+                        ),
+                        event_type="syslog",
+                        src_host=event.dst_host,
+                        auth=AuthContext(
+                            username=user.username,
+                            user_sid=self._get_sid(user.username),
+                            logon_id=logon_id,
+                            session_id=session_id,
+                            logon_type=logon_type,
+                            source_ip=session_source_ip,
+                            source_port=session_source_port,
+                        ),
+                        syslog=SyslogContext(
+                            app_name="systemd-logind",
+                            pid=self._get_system_pid(system.hostname, "logind", 456),
+                            facility=10,
+                            severity=6,
+                            message=f"Removed session {session_id}.",
+                        ),
+                    )
+                )
 
         logger.debug(
             f"Generated logoff: {user.username} on {system.hostname} (LogonID: {logon_id})"
@@ -9731,6 +10694,30 @@ class ActivityGenerator:
         self._last_browser_launch_by_session[key] = adjusted_time
         return adjusted_time
 
+    @staticmethod
+    def _linux_process_is_system_background_helper(process_name: str, command_line: str) -> bool:
+        """Return whether a Linux helper should be modeled as daemon/timer-owned."""
+        image_lower = process_name.lower()
+        command_lower = command_line.lower()
+        exe_name = image_lower.rsplit("/", 1)[-1]
+        if image_lower.startswith("/usr/lib/apt/methods/"):
+            return True
+        if exe_name in {"dnf", "yum"} and any(
+            token in command_lower for token in ("makecache", "check-update", "update")
+        ):
+            return True
+        if exe_name == "service-healthcheck":
+            return True
+        return exe_name == "java" and "integration-worker" in command_lower
+
+    @staticmethod
+    def _linux_background_helper_username(process_name: str, command_line: str) -> str:
+        """Return the service principal for a Linux background helper process."""
+        exe_name = process_name.lower().rsplit("/", 1)[-1]
+        if exe_name == "java" and "integration-worker" in command_line.lower():
+            return "www-data"
+        return "root"
+
     def generate_process(
         self,
         user: User,
@@ -9881,6 +10868,23 @@ class ActivityGenerator:
             process_username = service_process_account
             process_logon_id = _SYSTEM_ACCOUNT_LOGON_IDS[service_process_account]
             _integrity = "System"
+        linux_session_end_time = (
+            self.state_manager.get_session_end_time(process_logon_id)
+            if _get_os_category(system.os) == "linux" and process_logon_id
+            else None
+        )
+        if (
+            linux_session_end_time is not None
+            and ensure_utc(time) >= ensure_utc(linux_session_end_time)
+            and self._linux_process_is_system_background_helper(process_name, command_line)
+        ):
+            process_username = self._linux_background_helper_username(
+                process_name,
+                command_line,
+            )
+            process_logon_id = "0x3e7"
+            _integrity = "System"
+            parent_pid = self._linux_system_parent_fallback(system, time)
         session_end_time = self.state_manager.get_session_end_time(process_logon_id)
         if (
             session_end_time is not None
@@ -9938,7 +10942,15 @@ class ActivityGenerator:
                 if spaced_time != time:
                     time = spaced_time
                     self.state_manager.set_current_time(time)
-        if process_username != user.username and process_username not in _SYSTEM_ACCOUNTS:
+        if (
+            process_username != user.username
+            and process_username not in _SYSTEM_ACCOUNTS
+            and not (
+                _get_os_category(system.os) == "linux"
+                and process_logon_id == "0x3e7"
+                and process_username in {"root", "www-data", "proxy", "postfix"}
+            )
+        ):
             _integrity = "Medium"
         if _get_os_category(system.os) == "windows" and process_logon_type == 5:
             _integrity = "High" if _integrity == "Medium" else _integrity
@@ -10520,9 +11532,14 @@ class ActivityGenerator:
             return
 
         process_start_time = proc.start_time or event.timestamp
+        session_ready_floor = self._process_session_source_ready_floor(host.hostname, proc)
 
         if host.os_category == "windows":
             sysmon_not_before = event.timestamp
+            ecar_not_before = process_start_time
+            if session_ready_floor is not None:
+                sysmon_not_before = max(sysmon_not_before, session_ready_floor)
+                ecar_not_before = max(ecar_not_before, session_ready_floor)
             if proc.parent_pid > 0:
                 parent_visible_time = self.process_source_create_time(
                     host.hostname, proc.parent_pid
@@ -10548,7 +11565,7 @@ class ActivityGenerator:
                 event,
                 "source.ecar_process_create",
                 seed_parts=(host.hostname, proc.pid, process_start_time),
-                not_before=process_start_time,
+                not_before=ecar_not_before,
             )
             return
         else:
@@ -10560,6 +11577,23 @@ class ActivityGenerator:
             seed_parts=(host.hostname, proc.pid, process_start_time),
             not_before=ecar_not_before,
         )
+
+    def _process_session_source_ready_floor(
+        self,
+        hostname: str,
+        proc: ProcessContext,
+    ) -> datetime | None:
+        """Return the session-visible floor for process-owned source evidence."""
+        logon_id = str(getattr(proc, "logon_id", "") or "")
+        if not logon_id or logon_id in {"0x3e7", "0x3e4", "0x3e5", "-"}:
+            return None
+        session = self.state_manager.get_session(logon_id)
+        if session is None or session.system != hostname:
+            return None
+        ready_time = _session_source_ready_time(session)
+        if ready_time is None:
+            return None
+        return ready_time + timedelta(milliseconds=1)
 
     def _record_process_source_terminate_time(
         self,
@@ -11056,6 +12090,12 @@ class ActivityGenerator:
             command_line=command_line,
             parent_pid=parent_pid,
             suppress_command_file_effect=True,
+            concurrency_group_id=self._bash_history_process_group_id(
+                user,
+                source_system,
+                process_time,
+                command_line,
+            ),
         )
         self._record_user_process(source_system, user, pid, image)
         self._emit_bash_command_event(user, source_system, process_time, command_line)
@@ -11265,6 +12305,11 @@ class ActivityGenerator:
                 latest_allowed = running_proc.start_time + timedelta(milliseconds=100)
             if latest_allowed < session_end_time:
                 time = min(time, latest_allowed)
+        time = self._held_process_termination_time(
+            system=system,
+            pid=pid,
+            requested_time=time,
+        )
         if not process_logon_id:
             if process_username in _SYSTEM_ACCOUNTS:
                 process_logon_id = "0x3e7"
@@ -12420,14 +13465,18 @@ class ActivityGenerator:
                 hop_index=index,
                 user_agent=user_agent,
             )
-            last_reply = self._smtp_last_reply(
+            delivery_reply = self._smtp_last_reply(
                 outcome=spec.outcome,
                 message_id=message_id,
                 hop_index=index,
                 src_system=src_system,
                 dst_system=dst_system,
                 submission=bool(hop["submission"]),
+                queue_id=self._postfix_queue_id(message_id, dst_system)
+                if self._is_linux_mail_server(dst_system)
+                else "",
             )
+            last_reply = delivery_reply
             if tls:
                 last_reply = self._smtp_starttls_reply(
                     message_id=message_id,
@@ -12555,6 +13604,7 @@ class ActivityGenerator:
                     sender=sender,
                     actor=request.actor,
                     smtp=smtp_ctx,
+                    delivery_reply=delivery_reply,
                     size=int(transfer_sizes[index]["message_size"]),
                     source_pid=source_pid,
                 )
@@ -12726,6 +13776,7 @@ class ActivityGenerator:
         src_system: Any,
         dst_system: Any,
         submission: bool,
+        queue_id: str = "",
     ) -> str:
         """Return a deterministic source-native SMTP DATA completion reply."""
         seed = _stable_seed(
@@ -12769,6 +13820,14 @@ class ActivityGenerator:
                 f"250 2.6.0 {message_id} [InternalId={internal_id}] Queued mail for delivery",
                 f"250 2.0.0 {queue_hex[:10]} Message accepted for delivery",
                 f"250 2.1.5 {queue_short} queued for delivery",
+            ]
+            return replies[rng.randrange(len(replies))]
+
+        if queue_id:
+            replies = [
+                f"250 2.0.0 Ok: queued as {queue_id}",
+                f"250 2.0.0 {queue_id} Message accepted for delivery",
+                f"250 2.0.0 queued as {queue_id} on {dst_hostname}",
             ]
             return replies[rng.randrange(len(replies))]
 
@@ -13472,6 +14531,7 @@ class ActivityGenerator:
         sender: str,
         actor: "User",
         smtp: SmtpContext,
+        delivery_reply: str,
         size: int,
         source_pid: int,
     ) -> None:
@@ -13517,6 +14577,7 @@ class ActivityGenerator:
                 duration=duration,
                 message_id=message_id,
                 smtp=smtp,
+                delivery_reply=delivery_reply,
                 port=25,
                 delivery_pid=source_pid if source_pid > 0 else None,
             )
@@ -13682,6 +14743,7 @@ class ActivityGenerator:
         duration: float,
         message_id: str,
         smtp: SmtpContext,
+        delivery_reply: str,
         port: int,
         delivery_pid: int | None = None,
     ) -> None:
@@ -13690,8 +14752,8 @@ class ActivityGenerator:
         smtp_pid = delivery_pid or self._postfix_component_pid(system, "smtp", time)
         qmgr_pid = self._postfix_component_pid(system, "qmgr", time)
         peer_name = self._email_server_fqdn(peer_system.hostname)
-        relay_queue = self._postfix_queue_id(f"{message_id}:{peer_system.hostname}", peer_system)
         recipients = self._postfix_recipient_list(smtp.rcptto)
+        remote_reply = delivery_reply or smtp.last_reply or "250 2.0.0 Ok: queued for delivery"
         queue_state = self._postfix_queue_state(system, queue_id)
         queue_state.setdefault("recipients", recipients)
         queue_state.setdefault("delivered_recipients", set())
@@ -13709,7 +14771,7 @@ class ActivityGenerator:
                 (
                     f"{queue_id}: to=<{recipient}>, relay={peer_name}[{peer_system.ip}]:{port}, "
                     f"delay={delay}, delays={self._postfix_delays(delay)}, dsn=2.0.0, "
-                    f"status=sent (250 2.0.0 Ok: queued as {relay_queue})"
+                    f"status=sent ({remote_reply})"
                 ),
                 pid=smtp_pid,
             )
@@ -14123,17 +15185,24 @@ class ActivityGenerator:
             )
             outbound_system = self._email_system_for_server_name(outbound_server_name)
             if outbound_system.ip != sender_server_system.ip:
-                route.append(
-                    self._email_hop(
-                        sender_server_system,
-                        outbound_system,
-                        submission=False,
-                        server_to_server=True,
-                        src_server_name=sender_server_name,
-                        dst_server_name=outbound_server_name,
-                        recipients=external_recipients,
-                    )
+                merged = self._merge_email_route_hop_recipients(
+                    route,
+                    src_system=sender_server_system,
+                    dst_system=outbound_system,
+                    recipients=external_recipients,
                 )
+                if not merged:
+                    route.append(
+                        self._email_hop(
+                            sender_server_system,
+                            outbound_system,
+                            submission=False,
+                            server_to_server=True,
+                            src_server_name=sender_server_name,
+                            dst_server_name=outbound_server_name,
+                            recipients=external_recipients,
+                        )
+                    )
             external_by_domain: dict[str, list[str]] = {}
             for recipient in external_recipients:
                 external_by_domain.setdefault(self._email_domain(recipient), []).append(recipient)
@@ -14164,6 +15233,37 @@ class ActivityGenerator:
                     )
                 )
         return route
+
+    @staticmethod
+    def _merge_email_route_hop_recipients(
+        route: list[dict[str, Any]],
+        *,
+        src_system: "System",
+        dst_system: "System",
+        recipients: list[str],
+    ) -> bool:
+        """Merge recipients into an existing same-hop SMTP transaction when possible."""
+        for hop in route:
+            if bool(hop.get("submission")):
+                continue
+            if not bool(hop.get("server_to_server")):
+                continue
+            hop_src = hop.get("src_system")
+            hop_dst = hop.get("dst_system")
+            if getattr(hop_src, "ip", None) != src_system.ip:
+                continue
+            if getattr(hop_dst, "ip", None) != dst_system.ip:
+                continue
+            hop["recipients"] = list(
+                dict.fromkeys(
+                    [
+                        *(str(recipient).lower() for recipient in hop.get("recipients", [])),
+                        *(str(recipient).lower() for recipient in recipients),
+                    ]
+                )
+            )
+            return True
+        return False
 
     def _email_hop(
         self,
@@ -14206,7 +15306,7 @@ class ActivityGenerator:
         servers = self._email_servers_by_name()
         src_cfg = servers.get(src_server_name)
         dst_hostname = public_safe_mail_hostname(dst_hostname)
-        dst_ip = generate_public_mail_ip(f"email_external_mx:{dst_hostname}")
+        dst_ip = generate_public_mail_ip(f"email_external_mx:{dst_hostname}", dst_hostname)
         dst_system = type(src_system)(
             hostname=dst_hostname,
             ip=dst_ip,
@@ -14258,7 +15358,7 @@ class ActivityGenerator:
         hostname = self._external_mx_for_domain(domain)
         return type(next(iter(self._scenario_environment.systems)))(
             hostname=hostname,
-            ip=generate_public_mail_ip(f"email_external_sender:{sender}"),
+            ip=generate_public_mail_ip(f"email_external_sender:{sender}", hostname),
             os="Internet SMTP Server",
             type="server",
             services=["smtp"],
@@ -14354,6 +15454,11 @@ class ActivityGenerator:
             dst_system = hop["dst_system"]
             by_host = self._email_server_fqdn(hop["dst_system"].hostname)
             from_host = self._email_server_fqdn(hop["src_system"].hostname)
+            from_ip = self._received_header_peer_ip(
+                hop,
+                src_system=src_system,
+                dst_system=dst_system,
+            )
             duration = (
                 float(transfer_sizes[index]["duration"]) if index < len(transfer_sizes) else 1.0
             )
@@ -14377,7 +15482,7 @@ class ActivityGenerator:
             headers.insert(
                 0,
                 (
-                    f"from {from_host} ({src_system.ip}) by {by_host} "
+                    f"from {from_host} ({from_ip}) by {by_host} "
                     f"{transport_clause}{recipient_clause}; "
                     f"{received_time.strftime('%a, %d %b %Y %H:%M:%S +0000')}"
                 ),
@@ -14391,6 +15496,98 @@ class ActivityGenerator:
             )
         )
         return headers
+
+    def _received_header_peer_ip(
+        self,
+        hop: dict[str, Any],
+        *,
+        src_system: "System",
+        dst_system: "System",
+    ) -> str:
+        """Return the source IP seen by the receiving MTA for a Received hop."""
+        src_ip = str(src_system.ip)
+        dst_roles = set(getattr(dst_system, "roles", ()) or ())
+        if not bool(hop.get("server_to_server")):
+            return src_ip
+        if "external_mail_server" not in dst_roles and not hop.get("external_hostname"):
+            return src_ip
+        if not _is_modeled_local_ip(self, src_ip):
+            return src_ip
+        mapped_ip = self._outbound_nat_mapped_source_ip(src_ip, str(dst_system.ip))
+        return mapped_ip or src_ip
+
+    def _outbound_nat_mapped_source_ip(self, src_ip: str, dst_ip: str) -> str:
+        """Return the first rule-selected outbound NAT source IP without consuming PAT state."""
+        src_segments = self._network_segments_for_ip(src_ip)
+        dst_segments = self._network_segments_for_ip(dst_ip)
+        if dst_segments:
+            return ""
+        network = getattr(getattr(self, "_scenario_environment", None), "network", None)
+        if network is None:
+            return ""
+        for sensor in getattr(network, "sensors", []) or []:
+            if getattr(sensor, "type", "") != "firewall" or not getattr(sensor, "nat_rules", []):
+                continue
+            sensor_segments = set(getattr(sensor, "monitoring_segments", []) or [])
+            if src_segments and not (sensor_segments & src_segments):
+                continue
+            for rule in sensor.nat_rules:
+                mapped_ip = str(getattr(rule, "mapped_ip", "") or "")
+                if not mapped_ip:
+                    continue
+                if getattr(rule, "type", "") == "dynamic_pat" and self._nat_rule_matches_source(
+                    src_ip,
+                    rule,
+                    src_segments,
+                ):
+                    return mapped_ip
+                if (
+                    getattr(rule, "type", "") == "static"
+                    and str(getattr(rule, "real_ip", "") or "") == src_ip
+                ):
+                    return mapped_ip
+        return ""
+
+    def _network_segments_for_ip(self, ip: str) -> set[str]:
+        """Return scenario segment names containing an IP address."""
+        visibility = getattr(getattr(self, "dispatcher", None), "visibility_engine", None)
+        resolve_segments = getattr(visibility, "_resolve_ip_segments", None)
+        if callable(resolve_segments):
+            return set(resolve_segments(ip))
+
+        network = getattr(getattr(self, "_scenario_environment", None), "network", None)
+        if network is None:
+            return set()
+        try:
+            address = ipaddress.ip_address(ip)
+        except ValueError:
+            return set()
+        segments: set[str] = set()
+        for segment in getattr(network, "segments", []) or []:
+            try:
+                if address in ipaddress.ip_network(segment.cidr, strict=False):
+                    segments.add(str(segment.name))
+            except ValueError:
+                continue
+        return segments
+
+    @staticmethod
+    def _nat_rule_matches_source(src_ip: str, rule: Any, src_segments: set[str]) -> bool:
+        """Return whether a NAT rule source selector matches an IP."""
+        try:
+            address = ipaddress.ip_address(src_ip)
+        except ValueError:
+            return False
+        for src_entry in getattr(rule, "src", []) or []:
+            entry = str(src_entry)
+            if entry in src_segments or entry == src_ip:
+                return True
+            try:
+                if address in ipaddress.ip_network(entry, strict=False):
+                    return True
+            except ValueError:
+                continue
+        return False
 
     @staticmethod
     def _received_header_protocol(hop: dict[str, Any], *, tls: bool) -> str:
@@ -14546,13 +15743,15 @@ class ActivityGenerator:
             {
                 "host": mta_host,
                 "ip": generate_public_mail_ip(
-                    f"email_external_received_mta:{sender_domain}:{message_id}"
+                    f"email_external_received_mta:{sender_domain}:{message_id}",
+                    mta_host,
                 ),
             },
             {
                 "host": app_host,
                 "ip": generate_public_mail_ip(
-                    f"email_external_received_app:{sender_domain}:{message_id}"
+                    f"email_external_received_app:{sender_domain}:{message_id}",
+                    app_host,
                 ),
             },
         ]
@@ -14569,7 +15768,8 @@ class ActivityGenerator:
                 {
                     "host": transit_host,
                     "ip": generate_public_mail_ip(
-                        f"email_external_received_transit:{sender_domain}:{message_id}"
+                        f"email_external_received_transit:{sender_domain}:{message_id}",
+                        transit_host,
                     ),
                 },
             )
@@ -16051,6 +17251,23 @@ class ActivityGenerator:
                 )
                 pid = -1
 
+        if pid <= 0 and resolved_source_system is not None and not suppress_source_pid_inference:
+            pid, process_image = self._ensure_high_confidence_connection_owner(
+                source_system=resolved_source_system,
+                time=time,
+                service=service,
+                dst_port=dst_port,
+                proto=proto,
+                hostname=hostname,
+                http=http,
+                ssh_attempted_username=ssh_attempted_username,
+            )
+            if pid > 0:
+                resolved_process = self.state_manager.get_process(
+                    resolved_source_system.hostname,
+                    pid,
+                )
+
         if (
             ssh_attempted_username is None
             and proto == "tcp"
@@ -16567,14 +17784,21 @@ class ActivityGenerator:
         )
 
         if pid > 0 and resolved_source_system:
-            activity_time = time
-            if duration is not None:
-                activity_time = time + timedelta(seconds=max(0.0, duration))
-            self.state_manager.update_process_activity_time(
-                resolved_source_system.hostname,
-                pid,
-                activity_time,
+            close_time = (
+                time + timedelta(seconds=max(0.0, duration)) if duration is not None else None
             )
+            if close_time is None:
+                self.state_manager.update_process_activity_time(
+                    resolved_source_system.hostname,
+                    pid,
+                    time,
+                )
+            else:
+                self._remember_process_connection_hold(
+                    system=resolved_source_system,
+                    pid=pid,
+                    close_time=close_time,
+                )
 
         # Port-based service correction (Zeek detects service from payload, not scenario labels)
         _PORT_SERVICE = {
@@ -17137,7 +18361,6 @@ class ActivityGenerator:
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0",
-                "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko",
             ]
             _USER_AGENTS_LINUX = [
                 "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -18039,6 +19262,9 @@ class ActivityGenerator:
                 continue
             if proc.logon_id:
                 session = self.state_manager.get_session(proc.logon_id)
+                session_end = self.state_manager.get_session_end_time(proc.logon_id)
+                if session_end is not None and activity_time >= ensure_utc(session_end):
+                    continue
                 if session is not None and not _session_active_for_activity(
                     session,
                     activity_time,
@@ -18316,6 +19542,20 @@ class ActivityGenerator:
             return _background_linux_shell_command_if_needed(command)
         return command
 
+    @staticmethod
+    def _bash_history_process_group_id(
+        user: User,
+        system: System,
+        time: datetime,
+        command: str,
+    ) -> str:
+        """Return the internal eCAR marker for bash-history-synchronized processes."""
+        seed = _stable_seed(
+            "bash_history_process_sync:"
+            f"{system.hostname}:{user.username}:{ensure_utc(time).isoformat()}:{command}"
+        )
+        return f"bash-history:{seed:016x}"
+
     def _emit_bash_command_event(
         self,
         user: User,
@@ -18380,14 +19620,12 @@ class ActivityGenerator:
 
         shell_release_times: list[tuple[int, datetime, str]] = []
         base_process_time: datetime | None = None
-        concurrency_group_id = ""
-        if len(processes) > 1 and _contains_unquoted_shell_pipe(command):
-            pipeline_seed = _stable_seed(
-                "linux_shell_pipeline:"
-                f"{system.hostname}:{user.username}:{session.logon_id}:"
-                f"{time.isoformat()}:{command}"
-            )
-            concurrency_group_id = f"linux-shell-pipeline-{pipeline_seed:016x}"
+        concurrency_group_id = self._bash_history_process_group_id(
+            user,
+            system,
+            time,
+            command,
+        )
         for index, (image, process_command_line) in enumerate(processes):
             parent_pid = self._resolve_parent(system, user, time, session.logon_id, image)
             if base_process_time is None:
@@ -18537,6 +19775,19 @@ class ActivityGenerator:
         )
         if scheduled_time is None:
             return None
+        scheduled_time = self._align_bash_history_with_foreground_process(
+            user,
+            system,
+            scheduled_time,
+            command,
+        )
+        scheduled_time = self._fit_bash_history_time_to_linux_session(
+            user,
+            system,
+            scheduled_time,
+        )
+        if scheduled_time is None:
+            return None
         dwell_seconds = _bash_command_dwell_seconds(command)
         jitter_rng = random.Random(
             _stable_seed(
@@ -18576,6 +19827,56 @@ class ActivityGenerator:
             completion_time,
         )
         return scheduled_time
+
+    def _align_bash_history_with_foreground_process(
+        self,
+        user: User,
+        system: System,
+        scheduled_time: datetime,
+        command: str,
+    ) -> datetime:
+        """Move bash history to the same foreground-shell slot as process telemetry."""
+        if _get_os_category(system.os) != "linux":
+            return scheduled_time
+        if not _linux_command_processes_from_shell(
+            command,
+            max_processes=_LINUX_SHELL_MAX_INFERRED_PROCESSES,
+            username=user.username,
+        ):
+            return scheduled_time
+
+        activity_time = ensure_utc(scheduled_time)
+        sessions = [
+            session
+            for session in self.state_manager.get_sessions_for_user(user.username)
+            if session.system == system.hostname
+            and session.session_kind not in {"network", "service"}
+            and session.logon_type not in {3, 5}
+            and _session_active_for_activity(session, activity_time, margin_seconds=1.5)
+        ]
+        if not sessions:
+            return scheduled_time
+        session = max(sessions, key=lambda candidate: ensure_utc(candidate.start_time))
+
+        parent_pid = session.session_shell_pid
+        if parent_pid is None or not self._is_pid_active_at(system, parent_pid, activity_time):
+            parent_pid = self._active_session_shell_pid(
+                system,
+                user,
+                activity_time,
+                session.logon_id,
+            )
+        if parent_pid is None:
+            return scheduled_time
+
+        return self._reserve_foreground_shell_time(
+            system=system,
+            username=user.username,
+            logon_id=session.logon_id,
+            parent_pid=parent_pid,
+            requested_time=activity_time,
+            seed_text=command,
+        )
 
     def _remember_linux_bash_session_activity(
         self,
@@ -18844,14 +20145,12 @@ class ActivityGenerator:
         if singleton_service_pid is not None:
             return singleton_service_pid
 
+        system_logon_ids = {"SYSTEM": "0x3e7", "LOCAL SERVICE": "0x3e5", "NETWORK SERVICE": "0x3e4"}
+        logon_id = system_logon_ids.get(username, "0x3e7")
         parent_pid = self._repair_process_parent_pid(
             system=system,
             time=time,
-            logon_id={
-                "SYSTEM": "0x3e7",
-                "LOCAL SERVICE": "0x3e5",
-                "NETWORK SERVICE": "0x3e4",
-            }.get(username, "0x3e7"),
+            logon_id=logon_id,
             process_name=process_name,
             command_line=command_line,
             parent_pid=parent_pid,
@@ -18869,12 +20168,11 @@ class ActivityGenerator:
             command_line=command_line,
             username=username,
             integrity_level="System",
+            logon_id=logon_id,
         )
 
         # Determine system-level SID and logon ID
         sid = self.sid_registry.get(username, "S-1-5-18") if self.sid_registry else "S-1-5-18"
-        system_logon_ids = {"SYSTEM": "0x3e7", "LOCAL SERVICE": "0x3e5", "NETWORK SERVICE": "0x3e4"}
-        logon_id = system_logon_ids.get(username, "0x3e7")
 
         proc_obj_id = self.state_manager.get_process_object_id(system.hostname, pid)
         parent_obj_id = self.state_manager.get_process_object_id(system.hostname, parent_pid)
@@ -20420,6 +21718,16 @@ class ActivityGenerator:
                         )
                         if not self._is_within_scenario_window(process_time):
                             return
+                    bash_history_group_id = (
+                        self._bash_history_process_group_id(
+                            user,
+                            system,
+                            process_time,
+                            shell_command_line,
+                        )
+                        if os_category == "linux"
+                        else ""
+                    )
                     pid = -1
                     created_processes: list[tuple[int, str, str, datetime]] = []
                     for process_index, (
@@ -20439,6 +21747,7 @@ class ActivityGenerator:
                             source_process_name,
                             source_command_line,
                             parent_pid=parent_pid,
+                            concurrency_group_id=bash_history_group_id,
                         )
                         if pid < 0:
                             pid = source_pid
@@ -20651,6 +21960,12 @@ class ActivityGenerator:
                         process_name,
                         command_line,
                         parent_pid=parent_pid,
+                        concurrency_group_id=self._bash_history_process_group_id(
+                            user,
+                            system,
+                            process_time,
+                            command_line,
+                        ),
                     )
                     self._record_user_process(system, user, pid, process_name)
                     if active_session:
@@ -21102,6 +22417,15 @@ class ActivityGenerator:
             time,
             source_port,
         )
+        if source_port > 0:
+            self._ensure_visible_created_account_kerberos_exchange(
+                username=username,
+                source_ip=source_ip,
+                dc_hostname=dc_hostname,
+                time=time,
+                source_port=source_port,
+                domain=domain,
+            )
         time = self._kerberos_source_time(
             time,
             event_type="kerberos_service",
@@ -21279,6 +22603,12 @@ class ActivityGenerator:
 
         explicit_source_ip = source_ip.strip()
         if explicit_source_ip in {"", "-"}:
+            target_system = self._explicit_credentials_target_system(target_server)
+            if target_system is not None and (
+                target_system.ip != system.ip
+                and target_system.hostname.lower() != system.hostname.lower()
+            ):
+                return target_system.ip
             return "-"
 
         normalized_source_ip = explicit_source_ip.removeprefix("::ffff:")
@@ -21294,6 +22624,24 @@ class ActivityGenerator:
         ):
             return "-"
         return normalized_source_ip
+
+    def _explicit_credentials_target_system(self, target_server: str) -> System | None:
+        """Resolve a 4648 target server to a known scenario system when possible."""
+        target = target_server.strip()
+        if not target or target in {"-", "localhost", "127.0.0.1", "::1"}:
+            return None
+        normalized_target = target.removeprefix("::ffff:")
+        systems_by_ip = getattr(self, "_ip_to_system", {})
+        target_system = systems_by_ip.get(normalized_target)
+        if target_system is not None:
+            return target_system
+        world_model = getattr(self, "_world_model", None)
+        if world_model is None:
+            return None
+        hostname_key = normalized_target.split(".", 1)[0]
+        return world_model.systems_by_hostname.get(normalized_target) or (
+            world_model.systems_by_hostname.get(hostname_key) if hostname_key else None
+        )
 
     def _ensure_explicit_credentials_subject_logon(
         self,
@@ -22653,6 +24001,7 @@ class ActivityGenerator:
                 user_account_control="\n\t\t\t%%2080\n\t\t\t%%2082\n\t\t\t%%2084",
             ),
         )
+        self._remember_visible_account_created(target_username, time)
         self.dispatcher.dispatch(event)
 
     def generate_account_deleted(
@@ -22812,6 +24161,16 @@ class ActivityGenerator:
         target_image: str,
     ) -> bool:
         """Generate Sysmon Event 8 (CreateRemoteThread) for process injection."""
+        self._expand_and_emit(
+            "create_remote_thread",
+            time,
+            actor=user,
+            target_system=system,
+            source_pid=source_pid,
+            source_image=source_image,
+            target_pid=target_pid,
+            target_image=target_image,
+        )
         request = CreateRemoteThreadRequest(
             user=user,
             system=system,
@@ -22852,7 +24211,7 @@ class ActivityGenerator:
 
         from evidenceforge.events.contexts import ProcessContext
 
-        time = self._clamp_time_after_process_start(system, source_pid, time)
+        time = self._clamp_time_after_process_start(system, source_pid, time, offset_ms=180)
         rng = random.Random(
             _stable_seed(
                 "remote_thread:"
@@ -23269,6 +24628,7 @@ class ActivityGenerator:
         uid: str = "",
         msg_types: list[str] | None = None,
         domain: str | None = None,
+        renewal_interval: float | None = None,
     ) -> None:
         """Generate a DHCP lease event via canonical SecurityEvent dispatch."""
         request = DhcpLeaseRequest(
@@ -23280,6 +24640,7 @@ class ActivityGenerator:
             uid=uid,
             msg_types=msg_types,
             domain=domain,
+            renewal_interval=renewal_interval,
         )
         DhcpLeaseActionBundle(executor=self, request=request).execute()
 
@@ -23293,6 +24654,7 @@ class ActivityGenerator:
         uid = request.uid
         msg_types = request.msg_types
         domain = request.domain
+        renewal_interval = request.renewal_interval
 
         from evidenceforge.events.contexts import DhcpContext
 
@@ -23363,7 +24725,13 @@ class ActivityGenerator:
         if "syslog" in dispatcher_emitters and _get_os_category(system.os) == "linux":
             dhclient_pid = 500 + (_stable_seed(f"dhclient:{system.hostname}") % 59000)
             interface = linux_primary_interface(system)
-            renewal = max(60, int(lease_time / 2))
+            bound_message_index = 4 if is_initial_acquisition else 2
+            bound_message_offset = bound_message_index * 1.5
+            if renewal_interval is None:
+                displayed_renewal_interval = lease_time / 2
+            else:
+                displayed_renewal_interval = renewal_interval - bound_message_offset
+            renewal = max(60, int(round(displayed_renewal_interval)))
             if is_initial_acquisition:
                 messages = [
                     f"DHCPDISCOVER on {interface} to 255.255.255.255 port 67 interval 3",
@@ -23433,6 +24801,15 @@ class ActivityGenerator:
                 conn_state="SF",
                 source_system=source_system,
             )
+        logon_id = self.state_manager.allocate_logon_id(system.hostname, time)
+        session_obj_id = stable_uuid(
+            "anonymous-network-session",
+            system.hostname,
+            logon_id,
+            source_ip,
+            source_port,
+            time.isoformat(),
+        )
         event = SecurityEvent(
             timestamp=time,
             event_type="logon",
@@ -23440,7 +24817,7 @@ class ActivityGenerator:
             auth=AuthContext(
                 username="ANONYMOUS LOGON",
                 user_sid="S-1-5-7",
-                logon_id=self.state_manager.allocate_logon_id(system.hostname, time),
+                logon_id=logon_id,
                 logon_type=3,
                 auth_package="NTLM",
                 logon_process="NtLmSsp",
@@ -23454,8 +24831,28 @@ class ActivityGenerator:
                 source_port=source_port,
                 workstation_name=workstation_name,
             ),
+            edr=EdrContext(object_id=session_obj_id),
         )
         self.dispatcher.dispatch(event)
+        logoff_delay = rng.uniform(1.0, 30.0)
+        self.dispatcher.dispatch(
+            SecurityEvent(
+                timestamp=time + timedelta(seconds=logoff_delay),
+                event_type="logoff",
+                dst_host=self._build_host_context(system),
+                auth=AuthContext(
+                    username="ANONYMOUS LOGON",
+                    user_sid="S-1-5-7",
+                    logon_id=event.auth.logon_id,
+                    logon_type=3,
+                    auth_package="NTLM",
+                    source_ip=source_ip,
+                    source_port=source_port,
+                    workstation_name=workstation_name,
+                ),
+                edr=EdrContext(object_id=session_obj_id),
+            )
+        )
 
     def generate_syslog_event(
         self,
@@ -23466,6 +24863,7 @@ class ActivityGenerator:
         pid: int | None = None,
         facility: int = 3,
         severity: int = 6,
+        auth: AuthContext | None = None,
     ) -> None:
         """Generate a standalone syslog event via canonical SecurityEvent dispatch.
 
@@ -23487,6 +24885,7 @@ class ActivityGenerator:
             timestamp=time,
             event_type="syslog",
             src_host=self._build_host_context(system),
+            auth=auth,
             syslog=SyslogContext(
                 app_name=app_name,
                 message=message,
@@ -24743,11 +26142,14 @@ class ActivityGenerator:
         owner_keys: tuple[str, ...]
 
         if exe == "schtasks.exe" or "schtasks" in command:
-            owner_keys = ("taskhostw", "svchost_local_system", "services")
+            if "/create" in command or " /create" in command:
+                owner_keys = ("wmiprvse", "svchost_dcom", "services")
+            else:
+                owner_keys = ("taskhostw", "svchost_local_system", "services")
         elif exe in {"wmic.exe", "wmic"} or "wmic " in command:
             owner_keys = ("wmiprvse", "svchost_dcom", "services")
         elif exe in {"sc.exe", "sc"} or "sc.exe create" in command or " sc create" in command:
-            owner_keys = ("services", "svchost_dcom", "wmiprvse")
+            owner_keys = ("wmiprvse", "svchost_dcom", "services")
         elif exe in {"wevtutil.exe", "wevtutil", "net.exe", "net1.exe", "net", "net1"}:
             owner_keys = ("wmiprvse", "taskhostw", "services")
         elif "powershell" in command or "winrm" in command or "invoke-command" in command:
@@ -24949,6 +26351,15 @@ class ActivityGenerator:
                 logon_id=logon_id,
                 os_category=os_category,
             )
+            and (
+                os_category != "linux"
+                or self._linux_parent_usable_for_child_at(
+                    system=system,
+                    parent_pid=pid,
+                    time=time,
+                    logon_id=logon_id,
+                )
+            )
         ]
         self._user_process_history[key] = pruned[-10:]
         return self._user_process_history[key]
@@ -24962,10 +26373,60 @@ class ActivityGenerator:
                 return pid
         return 4
 
+    def _linux_parent_usable_for_child_at(
+        self,
+        *,
+        system: System,
+        parent_pid: int,
+        time: datetime,
+        logon_id: str = "",
+    ) -> bool:
+        """Return whether a Linux parent process is usable at a child timestamp."""
+        parent_proc = self.state_manager.get_process(system.hostname, parent_pid)
+        if parent_proc is None:
+            return False
+        if not self._is_pid_active_at(system, parent_pid, time):
+            return False
+        if self._process_termination_recorded(
+            system.hostname,
+            parent_pid,
+            parent_proc.start_time,
+        ):
+            return False
+
+        parent_logon_id = parent_proc.logon_id or ""
+        if parent_logon_id:
+            parent_session_end = self.state_manager.get_session_end_time(parent_logon_id)
+            if parent_session_end is not None and ensure_utc(time) >= ensure_utc(
+                parent_session_end
+            ):
+                return False
+            if logon_id and parent_logon_id != logon_id:
+                parent_username = parent_proc.username or ""
+                parent_exe = parent_proc.image.rsplit("/", 1)[-1].lower()
+                is_linux_ssh_priv_parent = (
+                    parent_username == "root"
+                    and parent_exe == "sshd"
+                    and parent_proc.command_line.startswith("sshd: ")
+                    and parent_proc.command_line.endswith(" [priv]")
+                )
+                if (
+                    not is_linux_ssh_priv_parent
+                    and parent_username not in _SYSTEM_ACCOUNTS
+                    and not parent_username.endswith("$")
+                ):
+                    return False
+
+        if logon_id and logon_id != "0x3e7":
+            child_session_end = self.state_manager.get_session_end_time(logon_id)
+            if child_session_end is not None and ensure_utc(time) >= ensure_utc(child_session_end):
+                return False
+        return True
+
     def _linux_system_parent_fallback(self, system: System, time: datetime) -> int:
         """Return a live Linux service ancestry fallback for system processes."""
         sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
-        for role in ("systemd", "init", "sshd", "bash"):
+        for role in ("systemd", "init", "cron", "crond"):
             pid = sys_pids.get(role)
             if pid and self._is_pid_active_at(system, pid, time):
                 return pid
@@ -25066,7 +26527,12 @@ class ActivityGenerator:
             parent_proc = self.state_manager.get_process(system.hostname, parent_pid)
             if parent_proc is not None and ensure_utc(parent_proc.start_time) > ensure_utc(time):
                 return parent_pid
-            if self._is_valid_process_parent_at(system=system, parent_pid=parent_pid, time=time):
+            if self._linux_parent_usable_for_child_at(
+                system=system,
+                parent_pid=parent_pid,
+                time=time,
+                logon_id=logon_id,
+            ):
                 return parent_pid
             session_shell = self._active_session_shell_pid(system, repair_user, time, logon_id)
             if session_shell is not None:
@@ -25079,9 +26545,19 @@ class ActivityGenerator:
                 process_name,
                 command_line,
             )
-            if self._is_valid_process_parent_at(system=system, parent_pid=resolved, time=time):
+            if self._linux_parent_usable_for_child_at(
+                system=system,
+                parent_pid=resolved,
+                time=time,
+                logon_id=logon_id,
+            ):
                 return resolved
-        if self._is_valid_process_parent_at(system=system, parent_pid=parent_pid, time=time):
+        if self._linux_parent_usable_for_child_at(
+            system=system,
+            parent_pid=parent_pid,
+            time=time,
+            logon_id=logon_id,
+        ):
             return parent_pid
         return self._linux_system_parent_fallback(system, time)
 
@@ -25294,10 +26770,11 @@ class ActivityGenerator:
         rng = _get_rng()
         sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
         os_cat = _get_os_category(system.os)
+        effective_time = time or self.state_manager.state.current_time or datetime.now(UTC)
         history = self._prune_user_process_history(
             system=system,
             username=user.username,
-            time=time or self.state_manager.state.current_time or datetime.now(UTC),
+            time=effective_time,
             logon_id=logon_id,
         )
         # Filter history to only include still-running processes
@@ -25322,8 +26799,6 @@ class ActivityGenerator:
                 if "\\" in process_name
                 else process_name.lower()
             )
-            effective_time = time or self.state_manager.state.current_time
-
             # Check if the user's active session on this system is a network
             # logon (type 3). Network logons never spawn explorer.exe — processes
             # are parented by svchost.exe or services.exe instead.
@@ -25434,7 +26909,16 @@ class ActivityGenerator:
             shells = [(pid, name) for pid, name in alive_history if name in self._LINUX_SHELLS]
             if shells:
                 return shells[-1][0]
-            return sys_pids.get("bash", sys_pids.get("sshd", 1))
+            for role in ("bash", "sshd"):
+                candidate = sys_pids.get(role)
+                if candidate and self._linux_parent_usable_for_child_at(
+                    system=system,
+                    parent_pid=candidate,
+                    time=effective_time or datetime.now(UTC),
+                    logon_id=logon_id,
+                ):
+                    return candidate
+            return self._linux_system_parent_fallback(system, effective_time or datetime.now(UTC))
 
     def _resolve_parent(
         self,
@@ -25676,6 +27160,13 @@ class ActivityGenerator:
         for _role, pid in sys_pids.items():
             proc = self.state_manager.get_process(system.hostname, pid)
             if proc and proc.start_time <= time:
+                if os_cat == "linux" and not self._linux_parent_usable_for_child_at(
+                    system=system,
+                    parent_pid=pid,
+                    time=time,
+                    logon_id=logon_id,
+                ):
+                    continue
                 if not self._parent_process_matches_logon(
                     hostname=system.hostname,
                     parent_pid=pid,
@@ -25798,7 +27289,12 @@ class ActivityGenerator:
                 and not self._is_one_shot_shell_parent(system, parent_pid)
             ):
                 return parent_pid
-        elif parent_proc is not None and self._is_pid_active_at(system, parent_pid, time):
+        elif parent_proc is not None and self._linux_parent_usable_for_child_at(
+            system=system,
+            parent_pid=parent_pid,
+            time=time,
+            logon_id=logon_id,
+        ):
             parent_exe = parent_image.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
             if parent_exe in {"bash", "sh", "zsh"}:
                 session = self.state_manager.get_session(logon_id)
@@ -25833,16 +27329,26 @@ class ActivityGenerator:
                 and self._is_pid_active_at(system, resolved, time)
             ):
                 return resolved
-        elif resolved_proc is not None and self._is_pid_active_at(system, resolved, time):
+        elif resolved_proc is not None and self._linux_parent_usable_for_child_at(
+            system=system,
+            parent_pid=resolved,
+            time=time,
+            logon_id=logon_id,
+        ):
             return resolved
 
         sys_pids = getattr(self, "_system_pids", {}).get(system.hostname, {})
         if os_category == "linux":
             for role in ("bash", "sshd", "systemd"):
                 candidate = sys_pids.get(role)
-                if candidate and self._is_pid_active_at(system, candidate, time):
+                if candidate and self._linux_parent_usable_for_child_at(
+                    system=system,
+                    parent_pid=candidate,
+                    time=time,
+                    logon_id=logon_id,
+                ):
                     return candidate
-            return parent_pid
+            return self._linux_system_parent_fallback(system, time)
         for role in ("explorer", "winlogon", "services", "svchost_dcom"):
             candidate = sys_pids.get(role)
             candidate_proc = self.state_manager.get_process(system.hostname, candidate or -1)

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -6738,8 +6738,7 @@ class ActivityGenerator:
             proxy_content_type = "text/html"
 
         apply_domain_user_agent = http is None or (
-            proxy_ua_override is None
-            and not _is_tool_http_user_agent(http.user_agent)
+            not _is_tool_http_user_agent(http.user_agent)
             and not is_browser_like_proxy_domain(proxy_hostname, domain_tags=domain_tags)
         )
         user_agent = self._proxy_user_agent_for_context(
@@ -13030,6 +13029,41 @@ class ActivityGenerator:
             return pid, running.image
         return pid, image
 
+    def _ensure_email_submission_session(
+        self,
+        *,
+        actor: "User",
+        system: "System",
+        time: datetime,
+    ) -> None:
+        """Ensure a sender has an interactive session before SMTP client activity."""
+        planner = getattr(self, "_world_planner", None)
+        if planner is None:
+            return
+        rng = random.Random(
+            _stable_seed(
+                f"email_submission_session:{system.hostname}:{actor.username}:{time.isoformat()}"
+            )
+        )
+        try:
+            planner.ensure_user_session(
+                actor,
+                system,
+                time,
+                rng,
+                session_kind="interactive",
+                allow_existing=True,
+                storyline_protected=True,
+                required_until=time + timedelta(seconds=30),
+            )
+        except (KeyError, RuntimeError, ValueError) as exc:
+            logger.debug(
+                "Unable to bootstrap email submission session for %s@%s: %s",
+                actor.username,
+                system.hostname,
+                exc,
+            )
+
     def _email_source_process_attribution(
         self,
         *,
@@ -13043,6 +13077,7 @@ class ActivityGenerator:
         if "external_mail_server" in (src_system.roles or []):
             return -1, None
         if hop.get("submission"):
+            self._ensure_email_submission_session(actor=actor, system=src_system, time=time)
             image = self._email_access_process_image(src_system, "smtp", user_agent, _get_rng())
             command_line = self._email_access_process_command_line(
                 image,
@@ -16133,9 +16168,15 @@ class ActivityGenerator:
         if pid <= 0 or not email_ctx.attachments:
             return
         rng = random.Random(_stable_seed(f"email_sender_files:{email_ctx.message_id}"))
+        proc = self.state_manager.get_process(system.hostname, pid)
+        min_file_time = proc.start_time + timedelta(milliseconds=250) if proc else None
         for index, attachment in enumerate(email_ctx.attachments[:4]):
             filename = self._safe_email_attachment_filename(attachment)
             file_time = time - timedelta(seconds=rng.uniform(1.5, 18.0))
+            if min_file_time is not None and file_time < min_file_time:
+                file_time = min_file_time + timedelta(milliseconds=index * 120)
+            if file_time >= time:
+                file_time = time - timedelta(milliseconds=max(100, 300 - index * 50))
             self._emit_email_endpoint_file_event(
                 email_ctx=email_ctx,
                 user=user,
@@ -16739,6 +16780,7 @@ class ActivityGenerator:
         packet_overhead_bytes = request.packet_overhead_bytes
         responding_pid = request.responding_pid
         ssh_attempted_username = request.ssh_attempted_username
+        caller_supplied_pid = pid > 0
 
         from evidenceforge.events.contexts import NetworkContext
 
@@ -17190,6 +17232,7 @@ class ActivityGenerator:
 
         if pid > 0 and resolved_source_system:
             resolved_process = self.state_manager.get_process(resolved_source_system.hostname, pid)
+            drop_explicit_pid_without_inference = False
             if (
                 resolved_process
                 and resolved_process.start_time
@@ -17207,6 +17250,7 @@ class ActivityGenerator:
                 )
                 pid = -1
                 resolved_process = None
+                drop_explicit_pid_without_inference = caller_supplied_pid
             elif self._process_termination_recorded(
                 resolved_source_system.hostname,
                 pid,
@@ -17221,6 +17265,7 @@ class ActivityGenerator:
                 )
                 pid = -1
                 resolved_process = None
+                drop_explicit_pid_without_inference = caller_supplied_pid
             elif (
                 resolved_process
                 and resolved_process.start_time
@@ -17241,6 +17286,7 @@ class ActivityGenerator:
                 )
                 pid = -1
                 resolved_process = None
+                drop_explicit_pid_without_inference = caller_supplied_pid
             elif resolved_process is None and pid != 4:
                 logger.debug(
                     "Dropping stale connection PID attribution: host=%s pid=%s dst=%s:%s",
@@ -17250,6 +17296,9 @@ class ActivityGenerator:
                     dst_port,
                 )
                 pid = -1
+                drop_explicit_pid_without_inference = caller_supplied_pid
+            if drop_explicit_pid_without_inference:
+                suppress_source_pid_inference = True
 
         if pid <= 0 and resolved_source_system is not None and not suppress_source_pid_inference:
             pid, process_image = self._ensure_high_confidence_connection_owner(

--- a/src/evidenceforge/generation/activity/mail_public_identities.py
+++ b/src/evidenceforge/generation/activity/mail_public_identities.py
@@ -119,6 +119,32 @@ def _provider_for_key(key: str) -> dict[str, Any]:
     return rng.choices(weighted, weights=weights, k=1)[0]
 
 
+def _provider_matches_hostname(provider: dict[str, Any], hostname: str) -> bool:
+    """Return whether a provider owns the given public mail hostname."""
+    lowered = public_safe_mail_hostname(hostname).lower()
+    if not lowered:
+        return False
+    patterns = [
+        str(pattern).strip().lower().rstrip(".")
+        for pattern in provider.get("hostname_patterns", [])
+        if str(pattern).strip()
+    ]
+    provider_name = str(provider.get("name", "")).strip().lower().replace("_", "-")
+    if provider_name:
+        patterns.append(provider_name)
+    return any(lowered == pattern or lowered.endswith(f".{pattern}") for pattern in patterns)
+
+
+def _provider_for_hostname(hostname: str | None) -> dict[str, Any]:
+    """Return the configured provider family for a public mail hostname."""
+    if not hostname:
+        return {}
+    for provider in load_mail_public_identities().get("providers", []):
+        if _provider_matches_hostname(provider, hostname):
+            return provider
+    return {}
+
+
 def _provider_for_ip(ip: str) -> dict[str, Any]:
     try:
         octets = [int(part) for part in ip.split(".")]
@@ -140,14 +166,20 @@ def _provider_for_ip(ip: str) -> dict[str, Any]:
     return {}
 
 
-def generate_public_mail_ip(identity_key: str) -> str:
+def _provider_name(provider: dict[str, Any]) -> str:
+    """Return a stable provider display key for seed material."""
+    return str(provider.get("name", "") or "mail").strip().lower() or "mail"
+
+
+def generate_public_mail_ip(identity_key: str, forward_hostname: str | None = None) -> str:
     """Return a stable public IPv4 address from mail-specific provider pools."""
-    provider = _provider_for_key(identity_key)
+    provider = _provider_for_hostname(forward_hostname) or _provider_for_key(identity_key)
     prefixes = list(provider.get("prefixes", []))
     if not prefixes:
         seed = _stable_seed(f"mail_public_ip:fallback:{identity_key.lower()}")
         return f"64.56.{32 + seed % 96}.{1 + (seed >> 8) % 253}"
-    rng = random.Random(_stable_seed(f"mail_public_ip:{identity_key.lower()}"))
+    seed_key = f"{identity_key.lower()}:{forward_hostname or ''}:{_provider_name(provider)}"
+    rng = random.Random(_stable_seed(f"mail_public_ip:{seed_key}"))
     prefix = list(rng.choice(prefixes))
     third = rng.randint(int(prefix[2]), int(prefix[3]))
     fourth = rng.randint(8, 246)
@@ -178,3 +210,15 @@ def public_mail_ptr_name(ip: str, forward_hostname: str | None) -> str:
 def is_public_mail_ip(ip: str) -> bool:
     """Return whether an IP belongs to a configured mail public identity pool."""
     return bool(_provider_for_ip(ip))
+
+
+def public_mail_provider_name_for_ip(ip: str) -> str:
+    """Return the configured mail provider family for an IP, or an empty string."""
+    return _provider_name(_provider_for_ip(ip)) if _provider_for_ip(ip) else ""
+
+
+def public_mail_provider_name_for_hostname(hostname: str) -> str:
+    """Return the configured mail provider family for a hostname, or an empty string."""
+    return (
+        _provider_name(_provider_for_hostname(hostname)) if _provider_for_hostname(hostname) else ""
+    )

--- a/src/evidenceforge/generation/activity/proxy_user_agents.py
+++ b/src/evidenceforge/generation/activity/proxy_user_agents.py
@@ -261,6 +261,66 @@ def normalize_proxy_user_agent_for_os(
     return user_agent
 
 
+def _browser_family_for_process(process_image: str) -> str:
+    """Return the browser family implied by a process image, if any."""
+    exe = process_image.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
+    if exe in {"chrome.exe", "chrome", "google-chrome", "chromium", "chromium-browser"}:
+        return "chrome"
+    if exe in {"msedge.exe", "microsoft-edge", "edge"}:
+        return "edge"
+    if exe in {"firefox.exe", "firefox"}:
+        return "firefox"
+    if exe in {"opera.exe", "opera"}:
+        return "opera"
+    return ""
+
+
+def _user_agent_matches_browser_family(user_agent: str, family: str) -> bool:
+    """Return whether a User-Agent belongs to the requested browser family."""
+    ua = user_agent.lower()
+    if family == "chrome":
+        return "chrome/" in ua and "edg/" not in ua and "opr/" not in ua
+    if family == "edge":
+        return "edg/" in ua or "edge/" in ua
+    if family == "firefox":
+        return "firefox/" in ua
+    if family == "opera":
+        return "opr/" in ua or "opera/" in ua
+    return False
+
+
+def browser_user_agent_for_process(
+    rng: random.Random,
+    source_system: "System | None",
+    process_image: str,
+    *,
+    hostname: str | None = None,
+    domain_tags: list[str] | None = None,
+) -> str:
+    """Pick a User-Agent that agrees with a known browser process image."""
+    family = _browser_family_for_process(process_image)
+    if not family:
+        return ""
+
+    data = load_proxy_user_agents()
+    os_category = _get_os_category(source_system.os) if source_system is not None else "windows"
+    pool_key = "linux" if os_category == "linux" else "windows"
+    candidates = [
+        user_agent
+        for user_agent in _pool(data, "workstation", pool_key)
+        if _user_agent_matches_browser_family(user_agent, family)
+    ]
+    if not candidates:
+        return ""
+    return normalize_proxy_user_agent_for_os(
+        rng,
+        source_system,
+        rng.choice(candidates),
+        hostname=hostname,
+        domain_tags=domain_tags,
+    )
+
+
 def pick_proxy_domain_user_agent(
     rng: random.Random,
     source_system: "System | None",

--- a/src/evidenceforge/generation/activity/site_maps.py
+++ b/src/evidenceforge/generation/activity/site_maps.py
@@ -14,6 +14,7 @@ import hashlib
 import random
 import uuid
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from evidenceforge.config import get_activity_directory
@@ -166,6 +167,19 @@ def _replace_hex_tokens(
     return path
 
 
+def _request_month_start_iso(request_time: datetime | None) -> str:
+    """Return a UTC month-start timestamp for browser API path templates."""
+
+    if request_time is None:
+        request_time = datetime(2024, 1, 1, tzinfo=UTC)
+    elif request_time.tzinfo is None:
+        request_time = request_time.replace(tzinfo=UTC)
+    else:
+        request_time = request_time.astimezone(UTC)
+    month_start = request_time.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return month_start.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _substitute_vars(
     rng: random.Random,
     path: str,
@@ -173,6 +187,7 @@ def _substitute_vars(
     *,
     hostname: str = "",
     content_type: str | None = None,
+    request_time: datetime | None = None,
 ) -> str:
     """Replace template variables in a URI path."""
     stable_asset_tokens = _uses_stable_asset_tokens(path, content_type)
@@ -205,6 +220,8 @@ def _substitute_vars(
         path = path.replace("{slug}", rng.choice(slugs), 1)
     if "{n}" in path:
         path = path.replace("{n}", str(rng.randint(1, 20)), 1)
+    if "{calendar_time_min}" in path:
+        path = path.replace("{calendar_time_min}", _request_month_start_iso(request_time))
     return path
 
 
@@ -213,6 +230,7 @@ def _build_subresources(
     raw_list: list[dict[str, str]],
     data: dict[str, Any],
     hostname: str,
+    request_time: datetime | None = None,
 ) -> list[SubresourceDef]:
     """Convert raw YAML subresource dicts to SubresourceDef objects."""
     result = []
@@ -223,6 +241,7 @@ def _build_subresources(
             data,
             hostname=item.get("host") or hostname,
             content_type=item.get("type", "application/octet-stream"),
+            request_time=request_time,
         )
         result.append(
             SubresourceDef(
@@ -240,20 +259,25 @@ def _build_pages_from_curated(
     hostname: str,
     domain_entry: dict[str, Any],
     data: dict[str, Any],
+    request_time: datetime | None = None,
 ) -> list[PageDef]:
     """Build PageDef list from a curated domain entry."""
     pages = []
     for page_raw in domain_entry.get("pages", []):
-        nav_targets = [_substitute_vars(rng, t, data) for t in page_raw.get("nav_targets", [])]
+        nav_targets = [
+            _substitute_vars(rng, t, data, request_time=request_time)
+            for t in page_raw.get("nav_targets", [])
+        ]
         subresources = _build_subresources(
             rng,
             page_raw.get("subresources", []),
             data,
             hostname,
+            request_time,
         )
         pages.append(
             PageDef(
-                path=_substitute_vars(rng, page_raw["path"], data),
+                path=_substitute_vars(rng, page_raw["path"], data, request_time=request_time),
                 content_type=page_raw.get("content_type", "text/html"),
                 nav_targets=nav_targets,
                 subresources=subresources,
@@ -267,6 +291,7 @@ def _build_pages_from_tag(
     hostname: str,
     tag_entry: dict[str, Any],
     data: dict[str, Any],
+    request_time: datetime | None = None,
 ) -> list[PageDef]:
     """Build PageDef list from a tag-based synthesis template."""
     patterns = tag_entry.get("subresource_patterns", {})
@@ -274,11 +299,14 @@ def _build_pages_from_tag(
     for tmpl in tag_entry.get("page_templates", []):
         pattern_name = tmpl.get("subresource_pattern", "")
         raw_subs = patterns.get(pattern_name, [])
-        nav_targets = [_substitute_vars(rng, t, data) for t in tmpl.get("nav_targets", [])]
-        subresources = _build_subresources(rng, raw_subs, data, hostname)
+        nav_targets = [
+            _substitute_vars(rng, t, data, request_time=request_time)
+            for t in tmpl.get("nav_targets", [])
+        ]
+        subresources = _build_subresources(rng, raw_subs, data, hostname, request_time)
         pages.append(
             PageDef(
-                path=_substitute_vars(rng, tmpl["path"], data),
+                path=_substitute_vars(rng, tmpl["path"], data, request_time=request_time),
                 nav_targets=nav_targets,
                 subresources=subresources,
             )
@@ -290,6 +318,7 @@ def get_site_map(
     hostname: str,
     domain_tags: list[str],
     rng: random.Random | None = None,
+    request_time: datetime | None = None,
 ) -> SiteMap:
     """Look up or synthesize a site map for a hostname.
 
@@ -303,6 +332,8 @@ def get_site_map(
         domain_tags: Tags from dns_registry (e.g., ["saas", "email"])
         rng: Random instance for template variable substitution.
             If None, a default Random(0) is used.
+        request_time: Optional modeled request time for time-relative URI
+            template variables.
 
     Returns:
         SiteMap with pages, subresources, and CDN domains.
@@ -316,7 +347,7 @@ def get_site_map(
     domains = data.get("domains", {})
     if hostname in domains:
         entry = domains[hostname]
-        pages = _build_pages_from_curated(rng, hostname, entry, data)
+        pages = _build_pages_from_curated(rng, hostname, entry, data, request_time)
         cdn = entry.get("cdn_domains", [])
         return SiteMap(hostname=hostname, pages=pages, cdn_domains=cdn)
 
@@ -324,10 +355,10 @@ def get_site_map(
     tags = data.get("tags", {})
     for tag in domain_tags:
         if tag in tags:
-            pages = _build_pages_from_tag(rng, hostname, tags[tag], data)
+            pages = _build_pages_from_tag(rng, hostname, tags[tag], data, request_time)
             return SiteMap(hostname=hostname, pages=pages)
 
     # Tier 3: Generic fallback
     generic = data.get("generic", {})
-    pages = _build_pages_from_tag(rng, hostname, generic, data)
+    pages = _build_pages_from_tag(rng, hostname, generic, data, request_time)
     return SiteMap(hostname=hostname, pages=pages)

--- a/src/evidenceforge/generation/causal/rules.py
+++ b/src/evidenceforge/generation/causal/rules.py
@@ -176,28 +176,32 @@ class DnsBeforeConnection(ExpansionRule):
 
 @dataclass
 class ProcessAccessAfterRemoteThread(ExpansionRule):
-    """Emit Sysmon Event 10 (ProcessAccess) before CreateRemoteThread targeting lsass.
+    """Emit Sysmon Event 10 (ProcessAccess) before CreateRemoteThread.
 
-    When a process injects into lsass.exe via CreateRemoteThread (Sysmon Event 8),
-    it must first obtain a handle to the target process. Sysmon Event 10 is the
-    primary detection signal for that credential-dumping prerequisite. This rule
-    centralizes the lsass check that was previously inline in
-    StorylineMixin._execute_typed_event().
+    When a process creates a remote thread (Sysmon Event 8), it must first
+    obtain a handle to the target process. Sysmon Event 10 is the primary
+    source-native evidence for that prerequisite. LSASS targets keep the stronger
+    credential-dumping access mask; ordinary remote-thread activity gets a
+    lower-friction process-open companion.
     """
 
     name: str = field(default="process_access_after_remote_thread")
-    description: str = field(default="Emit ProcessAccess before CreateRemoteThread targeting lsass")
+    description: str = field(default="Emit ProcessAccess before CreateRemoteThread")
     priority: int = field(default=40)
 
     def matches(self, event_type: str, ctx: ExpansionContext) -> bool:
         if event_type != "create_remote_thread":
             return False
         target = ctx.target_image or ""
-        return "lsass" in target.lower()
+        source_pid = ctx.source_pid or -1
+        target_pid = ctx.target_pid or -1
+        return bool(target and source_pid > 0 and target_pid > 0)
 
     def expand(self, event_type: str, ctx: ExpansionContext) -> list[ExpandedEvent]:
         from evidenceforge.generation.causal.engine import ExpandedEvent
 
+        target = ctx.target_image or ""
+        is_lsass = "lsass" in target.lower()
         return [
             ExpandedEvent(
                 method="generate_process_access",
@@ -208,15 +212,17 @@ class ProcessAccessAfterRemoteThread(ExpansionRule):
                     "source_image": ctx.source_image,
                     "target_pid": ctx.target_pid,
                     "target_image": ctx.target_image,
-                    "granted_access": "0x1FFFFF",
+                    "granted_access": "0x1FFFFF" if is_lsass else "0x1010",
                 },
                 timing=_timing_spec(
-                    "process.remote_thread_lsass_access",
-                    default_min_ms=1,
-                    default_max_ms=75,
+                    "process.remote_thread_lsass_access"
+                    if is_lsass
+                    else "process.remote_thread_process_access",
+                    default_min_ms=1 if is_lsass else 8,
+                    default_max_ms=75 if is_lsass else 180,
                     default_position="before",
                 ),
-                description="ProcessAccess for lsass credential dumping detection",
+                description="ProcessAccess prerequisite for CreateRemoteThread",
             )
         ]
 

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -29,7 +29,7 @@ from typing import Any
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext, NetworkContext
 from evidenceforge.generation.activity.endpoint_noise import ecar_flow_identity_config
-from evidenceforge.generation.activity.timing_profiles import get_timing_window
+from evidenceforge.generation.activity.timing_profiles import get_timing_window, sample_timing_delta
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.utils.rng import _stable_seed, stable_uuid
@@ -44,8 +44,8 @@ _ECAR_SORT_PRIORITY = {
     ("FILE", "READ"): 5,
     ("FILE", "WRITE"): 6,
     ("FLOW", "CONNECT"): 7,
-    ("THREAD", "REMOTE_CREATE"): 8,
-    ("PROCESS", "OPEN"): 9,
+    ("PROCESS", "OPEN"): 8,
+    ("THREAD", "REMOTE_CREATE"): 9,
     ("PROCESS", "TERMINATE"): 10,
     ("USER_SESSION", "LOGOUT"): 11,
 }
@@ -317,15 +317,19 @@ class EcarEmitter(HostMultiplexEmitter):
 
     @staticmethod
     def _apply_session_properties(event_data: dict[str, Any], event: SecurityEvent) -> None:
-        """Copy durable source-native session identifiers onto USER_SESSION rows."""
+        """Copy durable source-native session identifiers onto session-owned rows."""
         auth = event.auth
-        if auth is None:
-            return
-        if auth.logon_id:
-            event_data["logon_id"] = auth.logon_id
-        if auth.session_id:
+        process = event.process
+        logon_id = ""
+        if auth is not None:
+            logon_id = auth.logon_id
+        if not logon_id and process is not None:
+            logon_id = getattr(process, "logon_id", "") or ""
+        if logon_id:
+            event_data["logon_id"] = logon_id
+        if auth is not None and auth.session_id:
             event_data["session_id"] = auth.session_id
-        if auth.logon_guid:
+        if auth is not None and auth.logon_guid:
             event_data["logon_guid"] = auth.logon_guid
 
     @staticmethod
@@ -352,13 +356,11 @@ class EcarEmitter(HostMultiplexEmitter):
         if pid <= 0:
             return -1
         if os_category == "linux":
-            if salt == "process_create":
+            if salt in {"process_create", "process_terminate"}:
                 return pid
             seed = _stable_seed(
                 f"ecar_linux_tid:{hostname}:{pid}:{salt}:{int(timestamp.timestamp()) // 30}"
             )
-            if salt == "process_terminate" and seed % 100 < 55:
-                return pid
             return pid + 1 + (seed % 997)
         bucket_ms = int(timestamp.timestamp() * 1000)
         tid = 1000 + (_stable_seed(f"ecar_tid:{hostname}:{pid}:{bucket_ms}:{salt}") % 60000)
@@ -469,9 +471,12 @@ class EcarEmitter(HostMultiplexEmitter):
             if event.source_timing is not None
             else event.timestamp
         )
+        source_key = (
+            "source.ecar_session_logout" if lifecycle == "logout" else "source.ecar_session"
+        )
         timestamp = _SOURCE_TIMING.source_time(
             event,
-            "source.ecar_session",
+            source_key,
             seed_parts=(
                 lifecycle,
                 self._host_name(host),
@@ -549,6 +554,7 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["parent_image_path"] = proc.parent_image
         if proc.concurrency_group_id:
             event_data["_concurrency_group_id"] = proc.concurrency_group_id
+        self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
         event_data.setdefault(
             "tid",
@@ -576,6 +582,7 @@ class EcarEmitter(HostMultiplexEmitter):
             "image_path": proc.image,
             "_host_fqdn": self._host_fqdn(host),
         }
+        self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
         event_data.setdefault(
             "tid",
@@ -610,6 +617,7 @@ class EcarEmitter(HostMultiplexEmitter):
             "_host_fqdn": self._host_fqdn(host),
         }
         self._apply_process_provenance(event_data, proc)
+        self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
         event_data.setdefault(
             "tid",
@@ -639,6 +647,7 @@ class EcarEmitter(HostMultiplexEmitter):
             "_host_fqdn": self._host_fqdn(host),
         }
         self._apply_process_provenance(event_data, proc)
+        self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
         event_data.setdefault(
             "tid",
@@ -673,6 +682,7 @@ class EcarEmitter(HostMultiplexEmitter):
         }
         if proc:
             event_data["image_path"] = proc.image
+        self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
         event_data.setdefault(
             "tid",
@@ -1286,6 +1296,7 @@ class EcarEmitter(HostMultiplexEmitter):
             "user_stack_limit": f"{remote_thread.user_stack_limit:016x}" if remote_thread else "",
             "_host_fqdn": self._host_fqdn(host),
         }
+        self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
         self.emit_event(event_data)
 
@@ -1342,6 +1353,7 @@ class EcarEmitter(HostMultiplexEmitter):
             "call_trace": access.call_trace if access else "",
             "_host_fqdn": self._host_fqdn(host),
         }
+        self._apply_session_properties(event_data, event)
         self.emit_event(event_data)
 
     def _process_create_timestamp(
@@ -1453,6 +1465,7 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["service_name"] = service.service_name
             event_data["image_path"] = service.service_file_name
             event_data["service_account"] = service.service_account
+        self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
         self.emit_event(event_data)
 
@@ -1783,6 +1796,32 @@ class EcarEmitter(HostMultiplexEmitter):
         except (TypeError, ValueError):
             return default
 
+    @staticmethod
+    def _process_create_repair_gap_ms(record: dict[str, Any], parent: dict[str, Any]) -> int:
+        """Return a small deterministic parent/child ordering repair gap."""
+        seed = _stable_seed(
+            "ecar-process-create-repair-gap:"
+            f"{record.get('hostname', '')}:"
+            f"{record.get('objectID', '')}:"
+            f"{record.get('pid', '')}:"
+            f"{record.get('ppid', '')}:"
+            f"{parent.get('objectID', '')}:"
+            f"{parent.get('pid', '')}"
+        )
+        return 18 + (seed % 133)
+
+    @staticmethod
+    def _canonical_process_create_repair_gap_ms(record: dict[str, Any]) -> int:
+        """Return a small deterministic gap for canonical create-order repairs."""
+        seed = _stable_seed(
+            "ecar-canonical-process-create-repair-gap:"
+            f"{record.get('hostname', '')}:"
+            f"{record.get('objectID', '')}:"
+            f"{record.get('pid', '')}:"
+            f"{record.get('_canonical_ms', '')}"
+        )
+        return 3 + (seed % 47)
+
     @classmethod
     def _normalize_process_create_canonical_order(cls, lines: list[str]) -> list[str]:
         """Keep PROCESS/CREATE rows ordered by canonical process start time."""
@@ -1818,7 +1857,9 @@ class EcarEmitter(HostMultiplexEmitter):
                 continue
             timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
             if latest_render_ms and timestamp_ms <= latest_render_ms:
-                timestamp_ms = latest_render_ms + 1
+                timestamp_ms = latest_render_ms + cls._canonical_process_create_repair_gap_ms(
+                    record
+                )
                 record["timestamp_ms"] = timestamp_ms
             latest_render_ms = timestamp_ms
 
@@ -1905,6 +1946,315 @@ class EcarEmitter(HostMultiplexEmitter):
                 normalized.append(json.dumps(record, separators=(",", ":")))
         return normalized
 
+    @classmethod
+    def _normalize_session_dependents_after_login(cls, lines: list[str]) -> list[str]:
+        """Keep same-logon endpoint activity after the visible USER_SESSION LOGIN row."""
+        records: list[dict[str, Any] | None] = []
+        login_ms_by_session: dict[tuple[str, str], int] = {}
+        for line in lines:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                records.append(None)
+                continue
+            records.append(record)
+            if record.get("object") != "USER_SESSION" or record.get("action") != "LOGIN":
+                continue
+            props = record.get("properties") or {}
+            if str(props.get("outcome") or "success") == "failure":
+                continue
+            logon_id = str(props.get("logon_id") or "")
+            if not logon_id:
+                continue
+            key = (str(record.get("hostname") or ""), logon_id)
+            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+            current = login_ms_by_session.get(key)
+            if current is None or timestamp_ms < current:
+                login_ms_by_session[key] = timestamp_ms
+
+        dependent_objects = {"PROCESS", "FILE", "MODULE", "REGISTRY", "SERVICE"}
+        normalized: list[str] = []
+        for line, record in zip(lines, records, strict=True):
+            if record is None:
+                normalized.append(line)
+                continue
+            if record.get("object") not in dependent_objects:
+                normalized.append(line)
+                continue
+            props = record.get("properties") or {}
+            logon_id = str(props.get("logon_id") or "")
+            if not logon_id or logon_id in {"0x3e7", "0x3e4", "0x3e5", "-"}:
+                normalized.append(line)
+                continue
+            key = (str(record.get("hostname") or ""), logon_id)
+            login_ms = login_ms_by_session.get(key)
+            if login_ms is None:
+                normalized.append(line)
+                continue
+            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+            if timestamp_ms <= login_ms:
+                seed = _stable_seed(
+                    "ecar-session-dependent-after-login:"
+                    f"{key[0]}:{logon_id}:{record.get('objectID', '')}:"
+                    f"{record.get('id', '')}:{timestamp_ms}:{login_ms}"
+                )
+                record["timestamp_ms"] = login_ms + 15 + (seed % 120)
+                line = json.dumps(record, separators=(",", ":"))
+            normalized.append(line)
+        return normalized
+
+    @classmethod
+    def _normalize_user_session_logout_after_dependents(cls, lines: list[str]) -> list[str]:
+        """Keep USER_SESSION LOGOUT rows after same-session endpoint activity."""
+        records: list[dict[str, Any] | None] = []
+        latest_dependent_ms_by_session: dict[tuple[str, str], int] = {}
+        logout_indexes_by_session: dict[tuple[str, str], list[int]] = {}
+        dependent_objects = {
+            "PROCESS",
+            "FILE",
+            "MODULE",
+            "REGISTRY",
+            "SERVICE",
+            "THREAD",
+            "FLOW",
+        }
+
+        for index, line in enumerate(lines):
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                records.append(None)
+                continue
+            records.append(record)
+            props = record.get("properties") or {}
+            if not isinstance(props, dict):
+                props = {}
+            hostname = str(record.get("hostname") or "")
+            logon_id = str(props.get("logon_id") or "")
+            if (
+                logon_id
+                and logon_id not in {"0x3e7", "0x3e4", "0x3e5", "-"}
+                and record.get("object") in dependent_objects
+            ):
+                key = (hostname, logon_id)
+                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+                if timestamp_ms > latest_dependent_ms_by_session.get(key, 0):
+                    latest_dependent_ms_by_session[key] = timestamp_ms
+                continue
+
+            if record.get("object") != "USER_SESSION" or record.get("action") != "LOGOUT":
+                continue
+            session_id = str(
+                props.get("logon_id") or props.get("session_id") or record.get("objectID") or ""
+            )
+            if not session_id:
+                continue
+            logout_indexes_by_session.setdefault((hostname, session_id), []).append(index)
+
+        for key, indexes in logout_indexes_by_session.items():
+            latest_dependent_ms = latest_dependent_ms_by_session.get(key)
+            if latest_dependent_ms is None:
+                continue
+            next_logout_ms = latest_dependent_ms + 1
+            for index in sorted(
+                indexes,
+                key=lambda idx: (
+                    cls._ecar_int(records[idx].get("timestamp_ms"), 0)
+                    if records[idx] is not None
+                    else 0
+                ),
+            ):
+                record = records[index]
+                if record is None:
+                    continue
+                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+                if timestamp_ms <= latest_dependent_ms:
+                    delay = sample_timing_delta(
+                        "source.ecar_session_logout_after_dependents",
+                        seed_parts=(
+                            key[0],
+                            key[1],
+                            record.get("objectID", ""),
+                            record.get("id", ""),
+                            timestamp_ms,
+                            latest_dependent_ms,
+                        ),
+                    )
+                    delay_ms = max(1, int(delay.total_seconds() * 1000))
+                    timestamp_ms = max(next_logout_ms, latest_dependent_ms + delay_ms)
+                    record["timestamp_ms"] = timestamp_ms
+                next_logout_ms = max(next_logout_ms, timestamp_ms + 1)
+
+        normalized: list[str] = []
+        for line, record in zip(lines, records, strict=True):
+            if record is None:
+                normalized.append(line)
+            else:
+                normalized.append(json.dumps(record, separators=(",", ":")))
+        return normalized
+
+    @classmethod
+    def _normalize_remote_session_transport_order(cls, lines: list[str]) -> list[str]:
+        """Keep remote USER_SESSION LOGIN rows after same-host inbound FLOW rows."""
+        records: list[dict[str, Any] | None] = []
+        inbound_flow_ms_by_tuple: dict[tuple[str, str, int, int], int] = {}
+        for line in lines:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                records.append(None)
+                continue
+            records.append(record)
+            if record.get("object") != "FLOW" or record.get("action") != "CONNECT":
+                continue
+            props = record.get("properties") or {}
+            if str(props.get("direction") or "").upper() != "INBOUND":
+                continue
+            src_ip = str(props.get("src_ip") or "")
+            src_port = cls._ecar_int(props.get("src_port"))
+            dst_port = cls._ecar_int(props.get("dst_port"))
+            if not src_ip or src_port <= 0 or dst_port <= 0:
+                continue
+            key = (str(record.get("hostname") or ""), src_ip, src_port, dst_port)
+            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+            current = inbound_flow_ms_by_tuple.get(key)
+            if current is None or timestamp_ms < current:
+                inbound_flow_ms_by_tuple[key] = timestamp_ms
+
+        for record in records:
+            if (
+                record is None
+                or record.get("object") != "USER_SESSION"
+                or record.get("action") != "LOGIN"
+            ):
+                continue
+            props = record.get("properties") or {}
+            if str(props.get("outcome") or "success") == "failure":
+                continue
+            src_ip = str(props.get("src_ip") or "")
+            src_port = cls._ecar_int(props.get("src_port"))
+            if not src_ip or src_ip == "-" or src_port <= 0:
+                continue
+            session_type = str(props.get("session_type") or "").lower()
+            logon_type = str(props.get("logon_type") or "")
+            candidate_ports: tuple[int, ...]
+            if session_type == "ssh":
+                candidate_ports = (22,)
+            elif logon_type == "10":
+                candidate_ports = (3389,)
+            elif logon_type == "3":
+                candidate_ports = (445,)
+            else:
+                continue
+            flow_ms = min(
+                (
+                    inbound_flow_ms_by_tuple[key]
+                    for key in (
+                        (str(record.get("hostname") or ""), src_ip, src_port, dst_port)
+                        for dst_port in candidate_ports
+                    )
+                    if key in inbound_flow_ms_by_tuple
+                ),
+                default=None,
+            )
+            if flow_ms is None:
+                continue
+            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+            if timestamp_ms > flow_ms:
+                continue
+            seed_text = ":".join(
+                [
+                    str(record.get("hostname") or ""),
+                    src_ip,
+                    str(src_port),
+                    str(record.get("objectID") or ""),
+                    str(record.get("id") or ""),
+                    str(timestamp_ms),
+                ]
+            )
+            record["timestamp_ms"] = flow_ms + 12 + (sum(ord(ch) for ch in seed_text) % 83)
+
+        normalized: list[str] = []
+        for line, record in zip(lines, records, strict=True):
+            if record is None:
+                normalized.append(line)
+            else:
+                normalized.append(json.dumps(record, separators=(",", ":")))
+        return normalized
+
+    @staticmethod
+    def _is_linux_login_shell_create(record: dict[str, Any]) -> bool:
+        """Return whether a PROCESS/CREATE row is an interactive Linux login shell."""
+        if record.get("object") != "PROCESS" or record.get("action") != "CREATE":
+            return False
+        props = record.get("properties") or {}
+        image = str(props.get("image_path") or "")
+        if image not in {"/bin/bash", "/usr/bin/bash"}:
+            return False
+        command_line = str(props.get("command_line") or "").strip()
+        return command_line in {"-bash", "bash", "/bin/bash", "/usr/bin/bash"}
+
+    @classmethod
+    def _normalize_linux_login_shell_session_order(cls, lines: list[str]) -> list[str]:
+        """Keep interactive Linux shell creates after same-user session LOGIN rows."""
+        records: list[dict[str, Any] | None] = []
+        logins_by_host_user: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for line in lines:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                records.append(None)
+                continue
+            records.append(record)
+            if (
+                record.get("object") != "USER_SESSION"
+                or record.get("action") != "LOGIN"
+                or not record.get("principal")
+            ):
+                continue
+            props = record.get("properties") or {}
+            if str(props.get("outcome") or "success") == "failure":
+                continue
+            key = (str(record.get("hostname") or ""), str(record.get("principal") or ""))
+            logins_by_host_user.setdefault(key, []).append(record)
+
+        for logins in logins_by_host_user.values():
+            logins.sort(key=lambda record: cls._ecar_int(record.get("timestamp_ms"), 0))
+
+        max_forward_gap_ms = 10_000
+        normalized: list[str] = []
+        for line, record in zip(lines, records, strict=True):
+            if record is None:
+                normalized.append(line)
+                continue
+            if cls._is_linux_login_shell_create(record):
+                shell_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+                key = (str(record.get("hostname") or ""), str(record.get("principal") or ""))
+                candidate_login = next(
+                    (
+                        login
+                        for login in logins_by_host_user.get(key, [])
+                        if 0
+                        <= cls._ecar_int(login.get("timestamp_ms"), 0) - shell_ms
+                        <= max_forward_gap_ms
+                    ),
+                    None,
+                )
+                if candidate_login is not None:
+                    login_ms = cls._ecar_int(candidate_login.get("timestamp_ms"), 0)
+                    seed = _stable_seed(
+                        "ecar-linux-login-shell-after-session:"
+                        f"{record.get('hostname', '')}:"
+                        f"{record.get('principal', '')}:"
+                        f"{record.get('objectID', '')}:"
+                        f"{candidate_login.get('objectID', '')}:"
+                        f"{shell_ms}:{login_ms}"
+                    )
+                    record["timestamp_ms"] = login_ms + 80 + (seed % 240)
+                    line = json.dumps(record, separators=(",", ":"))
+            normalized.append(line)
+        return normalized
+
     _LINUX_SHELL_FOREGROUND_EXES = {
         "cargo",
         "cat",
@@ -1969,6 +2319,9 @@ class EcarEmitter(HostMultiplexEmitter):
         image = str(props.get("image_path") or "")
         parent_image = str(props.get("parent_image_path") or "")
         command_line = str(props.get("command_line") or "")
+        concurrency_group_id = str(record.get("_concurrency_group_id") or "")
+        if concurrency_group_id.startswith("bash-history:"):
+            return False
         if "|" in command_line or cls._is_backgrounded_shell_command(command_line):
             return False
         exe = image.rsplit("/", 1)[-1].lower()
@@ -2231,7 +2584,9 @@ class EcarEmitter(HostMultiplexEmitter):
                 parent_ms = cls._ecar_int(parent.get("timestamp_ms"), 0)
                 timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
                 if timestamp_ms <= parent_ms:
-                    record["timestamp_ms"] = parent_ms + 1
+                    record["timestamp_ms"] = parent_ms + cls._process_create_repair_gap_ms(
+                        record, parent
+                    )
                     changed = True
             if not changed:
                 break
@@ -2342,6 +2697,119 @@ class EcarEmitter(HostMultiplexEmitter):
             normalized.append(line)
         return normalized
 
+    @classmethod
+    def _remote_thread_process_open_keys(
+        cls,
+        record: dict[str, Any],
+    ) -> set[tuple[str, str, str, str, str]]:
+        """Return same-source/same-target keys for remote-thread prerequisite matching."""
+        hostname = str(record.get("hostname") or "")
+        props = record.get("properties") or {}
+        if not isinstance(props, dict):
+            props = {}
+
+        source_keys: list[tuple[str, str]] = []
+        actor_id = str(record.get("actorID") or "")
+        if actor_id:
+            source_keys.append(("actor", actor_id))
+        source_pid = cls._ecar_int(record.get("pid"))
+        if source_pid > 0:
+            source_keys.append(("pid", str(source_pid)))
+        source_pid_prop = cls._ecar_int(props.get("src_pid"))
+        if source_pid_prop > 0:
+            source_keys.append(("pid", str(source_pid_prop)))
+
+        target_keys: list[tuple[str, str]] = []
+        if record.get("object") == "PROCESS" and record.get("action") == "OPEN":
+            object_id = str(record.get("objectID") or "")
+            if object_id:
+                target_keys.append(("uuid", object_id))
+        target_uuid = str(props.get("target_process_uuid") or "")
+        if target_uuid:
+            target_keys.append(("uuid", target_uuid))
+        target_object_id = str(props.get("target_process_object_id") or "")
+        if target_object_id:
+            target_keys.append(("uuid", target_object_id))
+        target_pid = cls._ecar_int(props.get("target_pid"))
+        if target_pid > 0:
+            target_keys.append(("pid", str(target_pid)))
+
+        return {
+            (hostname, source_type, source_value, target_type, target_value)
+            for source_type, source_value in source_keys
+            for target_type, target_value in target_keys
+            if hostname and source_value and target_value
+        }
+
+    @classmethod
+    def _normalize_remote_thread_after_process_open(cls, lines: list[str]) -> list[str]:
+        """Keep eCAR remote-thread creation after the matching process-open row."""
+        records: list[dict[str, Any] | None] = []
+        open_ms_by_key: dict[tuple[str, str, str, str, str], list[int]] = {}
+
+        for line in lines:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                records.append(None)
+                continue
+            records.append(record)
+            if record.get("object") != "PROCESS" or record.get("action") != "OPEN":
+                continue
+            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+            if timestamp_ms <= 0:
+                continue
+            for key in cls._remote_thread_process_open_keys(record):
+                open_ms_by_key.setdefault(key, []).append(timestamp_ms)
+
+        for timestamps in open_ms_by_key.values():
+            timestamps.sort()
+
+        max_repair_gap_ms = 30_000
+        for record in records:
+            if (
+                record is None
+                or record.get("object") != "THREAD"
+                or record.get("action") != "REMOTE_CREATE"
+            ):
+                continue
+            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
+            if timestamp_ms <= 0:
+                continue
+            candidate_open_ms: list[int] = []
+            has_prior_open = False
+            for key in cls._remote_thread_process_open_keys(record):
+                for open_ms in open_ms_by_key.get(key, []):
+                    if open_ms < timestamp_ms:
+                        has_prior_open = True
+                        continue
+                    if open_ms - timestamp_ms <= max_repair_gap_ms:
+                        candidate_open_ms.append(open_ms)
+            if has_prior_open or not candidate_open_ms:
+                continue
+            prerequisite_ms = min(candidate_open_ms)
+            delay = sample_timing_delta(
+                "source.ecar_remote_thread_after_process_open",
+                seed_parts=(
+                    record.get("hostname", ""),
+                    record.get("objectID", ""),
+                    record.get("actorID", ""),
+                    record.get("pid", ""),
+                    timestamp_ms,
+                    prerequisite_ms,
+                ),
+            )
+            delay_ms = max(1, int(delay.total_seconds() * 1000))
+            record["timestamp_ms"] = prerequisite_ms + delay_ms
+
+        normalized: list[str] = []
+        for line, record in zip(lines, records, strict=True):
+            if record is None:
+                normalized.append(line)
+            else:
+                normalized.append(json.dumps(record, separators=(",", ":")))
+        return normalized
+
     @staticmethod
     def _drop_flow_process_identity(record: dict[str, Any]) -> None:
         """Remove process attribution from a FLOW that cannot safely claim it."""
@@ -2416,15 +2884,23 @@ class EcarEmitter(HostMultiplexEmitter):
                     writer.buffer = self._normalize_process_parent_order(writer.buffer)
                     writer.buffer = self._normalize_process_create_canonical_order(writer.buffer)
                     writer.buffer = self._normalize_linux_pid_morphology(writer.buffer)
+                    writer.buffer = self._normalize_remote_session_transport_order(writer.buffer)
                     writer.buffer = self._normalize_user_session_lifecycle_order(writer.buffer)
+                    writer.buffer = self._normalize_session_dependents_after_login(writer.buffer)
+                    writer.buffer = self._normalize_linux_login_shell_session_order(writer.buffer)
+                    writer.buffer = self._normalize_process_parent_order(writer.buffer)
                     writer.buffer = self._normalize_linux_shell_foreground_order(writer.buffer)
                     writer.buffer = self._normalize_linux_pid_morphology(writer.buffer)
                     writer.buffer = self._normalize_process_reference_order(writer.buffer)
+                    writer.buffer = self._normalize_remote_thread_after_process_open(writer.buffer)
                     writer.buffer = self._filter_stale_process_references_after_termination(
                         writer.buffer
                     )
                     writer.buffer = self._normalize_process_termination_order(writer.buffer)
                     writer.buffer = self._normalize_parent_termination_after_children(writer.buffer)
+                    writer.buffer = self._normalize_user_session_logout_after_dependents(
+                        writer.buffer
+                    )
                     writer.buffer = self._deduplicate_semantic_events(writer.buffer)
                     writer.buffer = self._filter_after_output_window(
                         writer.buffer,

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -29,7 +29,7 @@ from typing import Any
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext, NetworkContext
 from evidenceforge.generation.activity.endpoint_noise import ecar_flow_identity_config
-from evidenceforge.generation.activity.timing_profiles import get_timing_window, sample_timing_delta
+from evidenceforge.generation.activity.timing_profiles import get_timing_window
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.utils.rng import _stable_seed, stable_uuid
@@ -2069,18 +2069,12 @@ class EcarEmitter(HostMultiplexEmitter):
                     continue
                 timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
                 if timestamp_ms <= latest_dependent_ms:
-                    delay = sample_timing_delta(
-                        "source.ecar_session_logout_after_dependents",
-                        seed_parts=(
-                            key[0],
-                            key[1],
-                            record.get("objectID", ""),
-                            record.get("id", ""),
-                            timestamp_ms,
-                            latest_dependent_ms,
-                        ),
+                    seed = _stable_seed(
+                        "source.ecar_session_logout_after_dependents:"
+                        f"{key[0]}:{key[1]}:{record.get('objectID', '')}:"
+                        f"{record.get('id', '')}:{timestamp_ms}:{latest_dependent_ms}"
                     )
-                    delay_ms = max(1, int(delay.total_seconds() * 1000))
+                    delay_ms = 15 + (seed % 120)
                     timestamp_ms = max(next_logout_ms, latest_dependent_ms + delay_ms)
                     record["timestamp_ms"] = timestamp_ms
                 next_logout_ms = max(next_logout_ms, timestamp_ms + 1)
@@ -2788,18 +2782,13 @@ class EcarEmitter(HostMultiplexEmitter):
             if has_prior_open or not candidate_open_ms:
                 continue
             prerequisite_ms = min(candidate_open_ms)
-            delay = sample_timing_delta(
-                "source.ecar_remote_thread_after_process_open",
-                seed_parts=(
-                    record.get("hostname", ""),
-                    record.get("objectID", ""),
-                    record.get("actorID", ""),
-                    record.get("pid", ""),
-                    timestamp_ms,
-                    prerequisite_ms,
-                ),
+            seed = _stable_seed(
+                "source.ecar_remote_thread_after_process_open:"
+                f"{record.get('hostname', '')}:{record.get('objectID', '')}:"
+                f"{record.get('actorID', '')}:{record.get('pid', '')}:"
+                f"{timestamp_ms}:{prerequisite_ms}"
             )
-            delay_ms = max(1, int(delay.total_seconds() * 1000))
+            delay_ms = 15 + (seed % 120)
             record["timestamp_ms"] = prerequisite_ms + delay_ms
 
         normalized: list[str] = []

--- a/src/evidenceforge/generation/emitters/proxy.py
+++ b/src/evidenceforge/generation/emitters/proxy.py
@@ -216,6 +216,12 @@ def _ssl_bump_action(event_data: dict[str, Any]) -> str:
 def _proxy_metadata(event_data: dict[str, Any]) -> str:
     """Return optional key-value metadata for extended proxy combined logs."""
     parts: list[str] = []
+    cs_bytes = event_data.get("cs_bytes")
+    if cs_bytes not in {None, ""}:
+        parts.append(f"cs_bytes={_int_value(cs_bytes, 0)}")
+    sc_bytes = event_data.get("sc_bytes")
+    if sc_bytes not in {None, ""}:
+        parts.append(f"sc_bytes={_int_value(sc_bytes, 0)}")
     proxy_action = str(event_data.get("proxy_action") or "")
     if proxy_action:
         parts.append(f"proxy_action={proxy_action}")

--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -37,7 +37,7 @@ from typing import Any
 
 from evidenceforge.config.sysmon_filters import load_sysmon_filters
 from evidenceforge.events.base import SecurityEvent
-from evidenceforge.events.contexts import ProcessContext
+from evidenceforge.events.contexts import HostContext, ProcessContext
 from evidenceforge.formats.format_def import FormatDefinition
 from evidenceforge.generation.emitters.base import LogEmitter
 from evidenceforge.generation.emitters.host_base import _SingleHostWriter
@@ -975,6 +975,7 @@ class SysmonEventEmitter(LogEmitter):
         else:
             user = "NT AUTHORITY\\SYSTEM"
             logon_id = "0x3e7"
+        parent_user = self._sysmon_parent_user(host, parent_proc, proc, user)
 
         integrity = proc.integrity_level if proc.integrity_level else "Medium"
 
@@ -1003,6 +1004,7 @@ class SysmonEventEmitter(LogEmitter):
             "ParentCommandLine": proc.parent_command_line
             if hasattr(proc, "parent_command_line") and proc.parent_command_line
             else "-",
+            "ParentUser": parent_user,
             "CurrentDirectory": proc.current_directory or self._default_current_directory(proc),
         }
         # Populate PE metadata from known binary lookup
@@ -1013,6 +1015,26 @@ class SysmonEventEmitter(LogEmitter):
         event_data["Company"] = company
         event_data["OriginalFileName"] = orig
         self.emit_event(event_data)
+
+    def _sysmon_parent_user(
+        self,
+        host: HostContext,
+        parent_proc: Any | None,
+        proc: ProcessContext,
+        child_user: str,
+    ) -> str:
+        """Return Sysmon Event 1 ParentUser for the modeled parent process."""
+        parent_username = str(getattr(parent_proc, "username", "") or "")
+        if parent_username:
+            return self._format_user(parent_username, host.netbios_domain)
+        if proc.parent_pid in {0, 4}:
+            return "NT AUTHORITY\\SYSTEM"
+        parent_image = (proc.parent_image or "").lower()
+        if "\\windows\\system32\\services.exe" in parent_image or parent_image.endswith(
+            "\\services.exe"
+        ):
+            return "NT AUTHORITY\\SYSTEM"
+        return child_user or "-"
 
     @staticmethod
     def _default_current_directory(proc: ProcessContext) -> str:

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -2301,10 +2301,10 @@ class WindowsEventEmitter(LogEmitter):
         if self._spooled_count:
             self._spool_event_dicts_unlocked()
             self._shift_spooled_kerberos_tgts_before_service_tickets_unlocked()
+            self._shift_spooled_network_logons_after_transport_unlocked()
             self._shift_spooled_process_creates_after_logons_unlocked()
             self._shift_spooled_process_creates_after_visible_parent_unlocked()
             self._shift_spooled_process_dependents_after_create_unlocked()
-            self._shift_spooled_network_logons_after_transport_unlocked()
             self._shift_spooled_special_privileges_after_logons_unlocked()
             self._shift_spooled_process_terminations_after_dependents_unlocked()
             self._shift_spooled_logoffs_after_dependents_unlocked()
@@ -2312,10 +2312,10 @@ class WindowsEventEmitter(LogEmitter):
             events = self._iter_spooled_events_unlocked()
         else:
             self._shift_kerberos_tgts_before_service_tickets()
+            self._shift_network_logons_after_transport()
             self._shift_process_creates_after_logons()
             self._shift_process_creates_after_visible_parent()
             self._shift_process_dependents_after_create()
-            self._shift_network_logons_after_transport()
             self._shift_special_privileges_after_logons()
             self._shift_process_terminations_after_dependents()
             self._shift_logoffs_after_dependents()

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -55,6 +55,9 @@ from evidenceforge.utils.rng import _stable_seed
 
 logger = logging.getLogger(__name__)
 
+_BULK_TCP_FLOW_MIN_IP_BYTES = 10_000_000
+_BULK_TCP_FLOW_MISSED_CAP_BYTES = 65_536
+
 
 def zeek_format_observed(event: Any, format_name: str) -> bool:
     """Return whether a Zeek sibling format survived source observation.
@@ -343,6 +346,24 @@ def _locks_sensor_packet_accounting(render_data: dict[str, Any]) -> bool:
     return render_data.get("id.orig_p") == 53 or render_data.get("id.resp_p") == 53
 
 
+def _uses_bounded_bulk_tcp_accounting(render_data: dict[str, Any]) -> bool:
+    """Return whether TCP sensor texture should be capped to small packet deltas."""
+    if str(render_data.get("proto") or "").lower() != "tcp":
+        return False
+    missed = render_data.get("missed_bytes") or 0
+    if not isinstance(missed, int) or isinstance(missed, bool) or missed < 0:
+        return False
+    if missed > _BULK_TCP_FLOW_MISSED_CAP_BYTES:
+        return False
+
+    total = 0
+    for field in ("orig_ip_bytes", "resp_ip_bytes", "orig_bytes", "resp_bytes"):
+        value = render_data.get(field)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            total += value
+    return total >= _BULK_TCP_FLOW_MIN_IP_BYTES
+
+
 def _extend_locked_sensor_timing_field(
     render_data: dict[str, Any],
     field: str,
@@ -399,6 +420,25 @@ def _texture_locked_packet_accounting_observation(
     )
 
 
+def _texture_bounded_bulk_tcp_observation(
+    render_data: dict[str, Any],
+    hostname: str,
+    uid: Any,
+) -> None:
+    """Keep bulk TCP bytes coherent while adding source-native tap texture."""
+    if not render_data.get("_lock_duration"):
+        _jitter_duration_observation(
+            render_data,
+            hostname,
+            uid,
+            0.002,
+            max_delta_seconds=2.0,
+        )
+    _texture_lossless_tcp_packetization(render_data, hostname, uid)
+    _enforce_http_body_invariants(render_data)
+    _enforce_ip_byte_invariants(render_data)
+
+
 def _apply_sensor_observation_variance(
     render_data: dict[str, Any],
     hostname: str,
@@ -432,6 +472,9 @@ def _apply_sensor_observation_variance(
                 render_data["missed_bytes"] = missed + 16 + (seed % 496)
                 added_missed_bytes = True
                 lossy_observation = True
+    if lossy_observation and _uses_bounded_bulk_tcp_accounting(render_data):
+        _texture_bounded_bulk_tcp_observation(render_data, hostname, original_uid)
+        return
     if not lossy_observation:
         if not render_data.get("_lock_duration"):
             _extend_lossless_duration_observation(

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -48,6 +48,7 @@ from evidenceforge.generation.actions import (
     IdsAlertRequest,
     ScheduledScanOverlapActionBundle,
     ScheduledScanOverlapRequest,
+    dhcp_renewal_interval_seconds,
 )
 from evidenceforge.generation.activity.auth_noise import (
     scheduled_stale_credentials_config,
@@ -415,28 +416,51 @@ def _dhcp_renewal_epochs_for_hour(
     lease_time: float,
     current_hour: datetime,
     rng: random.Random,
-) -> tuple[list[float], float]:
-    """Return DHCP renewal epochs due in this hour and the updated schedule anchor."""
+    next_renewal: float | None = None,
+) -> tuple[list[tuple[float, float]], float, float | None]:
+    """Return DHCP renewal epochs and advertised next-renewal intervals due in this hour."""
     base_renewal = max(60.0, lease_time / 2)
     hour_start_epoch = current_hour.timestamp()
     hour_end_epoch = (current_hour + timedelta(hours=1)).timestamp()
-    due: list[float] = []
+    due: list[tuple[float, float]] = []
     schedule_anchor = last_renewal
+    previous_visible_index: int | None = None
+    pending_next_renewal: float | None = None
 
     max_iterations = max(
         8,
         int((hour_end_epoch - last_renewal) / max(60.0, base_renewal * 0.8)) + 4,
     )
     for _ in range(max_iterations):
-        jitter_factor = 1.0 + rng.uniform(-0.10, 0.10)
-        next_renewal = schedule_anchor + (base_renewal * jitter_factor)
-        if next_renewal >= hour_end_epoch:
-            break
-        schedule_anchor = next_renewal
-        if next_renewal >= hour_start_epoch:
-            due.append(next_renewal)
+        if next_renewal is None:
+            candidate_renewal = schedule_anchor + dhcp_renewal_interval_seconds(
+                lease_time,
+                rng,
+            )
+        else:
+            candidate_renewal = next_renewal
+            next_renewal = None
 
-    return due, schedule_anchor
+        if candidate_renewal >= hour_end_epoch and previous_visible_index is None:
+            pending_next_renewal = candidate_renewal
+            break
+        if candidate_renewal >= hour_start_epoch:
+            if previous_visible_index is not None:
+                previous_epoch = due[previous_visible_index][0]
+                due[previous_visible_index] = (
+                    previous_epoch,
+                    max(60.0, candidate_renewal - previous_epoch),
+                )
+            if candidate_renewal >= hour_end_epoch:
+                pending_next_renewal = candidate_renewal
+                break
+            due.append((candidate_renewal, base_renewal))
+            previous_visible_index = len(due) - 1
+        schedule_anchor = candidate_renewal
+        if candidate_renewal >= hour_end_epoch:
+            break
+
+    return due, schedule_anchor, pending_next_renewal
 
 
 def _linux_baseline_session_initiator(
@@ -531,6 +555,44 @@ def _linux_baseline_pam_open_lead(rng: random.Random) -> timedelta:
 def _linux_baseline_pam_close_lead(rng: random.Random) -> timedelta:
     """Return lead time for ambient PAM close rows before logind removal records."""
     return timedelta(milliseconds=rng.randint(1200, 4200))
+
+
+def _linux_sudo_command_runtime(command: str, rng: random.Random) -> timedelta:
+    """Return a source-native sudo session runtime for one COMMAND value."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    exe = tokens[0].rsplit("/", 1)[-1].lower() if tokens else ""
+
+    if exe in {"vmstat", "iostat"}:
+        numeric_args: list[float] = []
+        for token in tokens[1:]:
+            try:
+                numeric_args.append(float(token))
+            except ValueError:
+                continue
+        if len(numeric_args) >= 2:
+            delay = max(0.25, numeric_args[-2])
+            count = max(1.0, numeric_args[-1])
+            return timedelta(seconds=delay * count + rng.uniform(0.18, 0.95))
+        if len(numeric_args) == 1:
+            return timedelta(seconds=max(0.8, numeric_args[0]) + rng.uniform(0.2, 1.4))
+
+    normalized = " ".join(tokens).lower()
+    if any(marker in normalized for marker in ("apt-get", "apt list", "needrestart")):
+        return timedelta(seconds=rng.uniform(3.5, 18.0))
+    if any(marker in normalized for marker in ("systemctl restart", "service ") if marker):
+        return timedelta(seconds=rng.uniform(2.5, 15.0))
+    if "journalctl" in normalized or "find " in f" {normalized} ":
+        return timedelta(seconds=rng.uniform(1.2, 9.5))
+    if any(marker in normalized for marker in ("lsof", "iptables", "systemd-analyze")):
+        return timedelta(seconds=rng.uniform(1.0, 6.5))
+    if any(marker in normalized for marker in ("systemctl status", "systemctl list-")):
+        return timedelta(seconds=rng.uniform(0.9, 5.5))
+    if exe in {"df", "free", "ss", "lsblk", "tail", "grep", "du", "apt-cache"}:
+        return timedelta(seconds=rng.uniform(0.35, 3.2))
+    return timedelta(seconds=rng.uniform(0.25, 2.8))
 
 
 def _linux_transient_syslog_pid(
@@ -1546,6 +1608,11 @@ class BaselineMixin:
             return False
         return True
 
+    def _service_account_eligible_for_baseline_noise(self, username: str) -> bool:
+        """Return whether generic baseline noise may use a durable service account."""
+
+        return username.lower() not in self._storyline_account_lifecycle()
+
     def _pick_service_account_delegation_process(
         self,
         svc_name: str,
@@ -1991,6 +2058,25 @@ class BaselineMixin:
             )
         return process_path
 
+    @staticmethod
+    def _polkit_action_message_template(action_id: str, template: str) -> str:
+        """Return a source-native authorization template for a polkit action."""
+        if action_id != "org.freedesktop.login1.reboot":
+            return template
+        if template.startswith("Subject "):
+            return "Subject unix-process:{0}:{monotonic_start} is not authorized for action {action_id}"
+        return (
+            "Operator of unix-process:{0}:{monotonic_start} failed to authenticate as "
+            "unix-user:{auth_user} to gain TEMPORARY authorization for action {action_id} "
+            "for system-bus-name::1.{bus_id} [{process_path}] (owned by unix-user:{subject_user})"
+        )
+
+    @staticmethod
+    def _polkit_action_process_is_user_cli(process_path: str) -> bool:
+        """Return whether a polkit companion process is a foreground CLI client."""
+        executable = process_path.rsplit("/", 1)[-1]
+        return executable in {"loginctl", "nmcli", "pkcon", "systemctl", "timedatectl"}
+
     def _materialize_polkit_action_process(
         self,
         *,
@@ -2023,6 +2109,48 @@ class BaselineMixin:
             parent_pid = sys_pids.get("systemd", sys_pids.get("dbus", 1))
         command_line = self._polkit_action_command_line(action_id, process_path, rng)
         username = subject_user if subject_user else "root"
+        if _get_os_category(system.os) == "linux" and self._polkit_action_process_is_user_cli(
+            process_path
+        ):
+            user_resolver = getattr(activity_generator, "_user_model_for_username", None)
+            if callable(user_resolver):
+                user = user_resolver(username)
+            else:
+                user = User(username=username, full_name=username, email=f"{username}@example.com")
+            visible_parent = None
+            shell_parent = getattr(activity_generator, "ensure_linux_visible_shell_parent", None)
+            if callable(shell_parent):
+                visible_parent = shell_parent(
+                    user=user,
+                    target_system=system,
+                    activity_time=process_time,
+                )
+            if visible_parent is not None:
+                parent_pid = visible_parent
+            try:
+                pid = activity_generator.generate_process(
+                    user=user,
+                    system=system,
+                    time=process_time,
+                    logon_id="",
+                    process_name=process_path,
+                    command_line=command_line,
+                    parent_pid=parent_pid,
+                    suppress_command_file_effect=True,
+                )
+                self._schedule_foreground_process_termination(
+                    user=user,
+                    system=system,
+                    start_time=process_time,
+                    pid=pid,
+                    process_name=process_path,
+                    command_line=command_line,
+                    logon_id="",
+                    rng=rng,
+                )
+                return pid
+            except AttributeError:
+                return None
         try:
             return activity_generator.generate_system_process(
                 system=system,
@@ -2067,6 +2195,7 @@ class BaselineMixin:
         subject_user = rng.choice(
             (entry.get("params") or {}).get("subject_user") or ["root", "admin", "deploy"]
         )
+        template = self._polkit_action_message_template(action_id, template)
         process_id = None
         if "action {action_id}" in template:
             process_id = self._materialize_polkit_action_process(
@@ -5899,6 +6028,65 @@ class BaselineMixin:
         self._ssh_user_roster_cache[system.hostname] = roster
         return roster
 
+    def _get_baseline_ssh_users(self, system) -> list:
+        """Return scenario users eligible for ordinary baseline SSH sessions."""
+        if hasattr(self, "world_model") and hasattr(self.world_model, "get_ssh_admin_users"):
+            return self.world_model.get_ssh_admin_users(system)
+        return self._get_server_ssh_users(system)
+
+    def _baseline_ssh_source_system_for_user(
+        self,
+        user: User,
+        target_system: System,
+        rng: random.Random,
+    ) -> System | None:
+        """Pick the user's own plausible SSH source instead of a random host."""
+        if hasattr(self, "world_model"):
+            world_user = self.world_model.user_for(user.username)
+            if world_user is not None:
+                candidates = [
+                    system
+                    for system in world_user.remote_source_systems
+                    if system.hostname != target_system.hostname
+                    and (system.assigned_user in (None, user.username))
+                ]
+                if candidates:
+                    return rng.choice(candidates)
+
+        systems = list(self.scenario.environment.systems)
+        if user.primary_system:
+            primary = next((s for s in systems if s.hostname == user.primary_system), None)
+            if (
+                primary is not None
+                and primary.hostname != target_system.hostname
+                and primary.type == "workstation"
+                and primary.assigned_user in (None, user.username)
+            ):
+                return primary
+        assigned = [
+            system
+            for system in systems
+            if system.hostname != target_system.hostname
+            and system.type == "workstation"
+            and system.assigned_user == user.username
+        ]
+        return rng.choice(assigned) if assigned else None
+
+    def _pick_baseline_ssh_identity(
+        self,
+        target_system: System,
+        rng: random.Random,
+    ) -> tuple[User, System] | None:
+        """Pick a baseline SSH user and source host that agree with each other."""
+        roster = self._get_baseline_ssh_users(target_system)
+        if not roster:
+            return None
+        for user in rng.sample(roster, k=len(roster)):
+            source_system = self._baseline_ssh_source_system_for_user(user, target_system, rng)
+            if source_system is not None:
+                return user, source_system
+        return None
+
     def _linux_remote_admin_hour_probability(self, system: Any) -> float:
         """Return the hourly probability of an organic SSH admin session on a Linux server."""
         multiplier = self._activity_multiplier(system, "linux_remote_admin")
@@ -6145,6 +6333,13 @@ class BaselineMixin:
         if matcher is None:
             return None
         return matcher(src_ip=source_ip, dst_ip=dst_ip, dst_port=445, proto="tcp")
+
+    @staticmethod
+    def _smb_logon_transport_conn_state(service: Any, will_emit_logon: bool) -> str | None:
+        """Return the SMB transport state required by a successful companion logon."""
+        if will_emit_logon and str(service or "").lower() == "smb":
+            return "SF"
+        return None
 
     def _build_smb_targets(self, system: Any, dc_ips: list[str]) -> tuple[list[str], list[Any]]:
         """Build weighted SMB targets for Windows client browsing noise."""
@@ -6756,6 +6951,12 @@ class BaselineMixin:
                                 time=tgs_time,
                             )
 
+                        will_emit_smb_logon = bool(
+                            conn.get("service") == "smb"
+                            and is_internal_src
+                            and src_sys
+                            and "file_server" in roles
+                        )
                         self.activity_generator.generate_connection(
                             src_ip=src_ip,
                             dst_ip=effective_dst_ip,
@@ -6766,6 +6967,10 @@ class BaselineMixin:
                             duration=rng.uniform(0.05, 5.0),
                             orig_bytes=rng.randint(200, 5000),
                             resp_bytes=rng.randint(500, 50000),
+                            conn_state=self._smb_logon_transport_conn_state(
+                                conn.get("service"),
+                                will_emit_smb_logon,
+                            ),
                             source_system=src_sys,
                             emit_dns=is_internal_src,
                             hostname=dst_hostname,
@@ -7203,17 +7408,29 @@ class BaselineMixin:
             # DHCP lease renewal at T/2 with RFC 2131 jitter
             dhcp_state = getattr(self, "_dhcp_lease_state", {}).get(system.hostname)
             if dhcp_state and "zeek_dhcp" in self.emitters:
+                storyline_dhcp_time = self._storyline_dhcp_lease_time_in_hour(
+                    system.hostname,
+                    current_hour,
+                )
+                if storyline_dhcp_time is not None:
+                    dhcp_state["next_renewal"] = storyline_dhcp_time.timestamp()
+                    continue
                 lease_time = dhcp_state["lease_time"]
-                renewal_epochs, updated_last_renewal = _dhcp_renewal_epochs_for_hour(
+                (
+                    renewal_epochs,
+                    updated_last_renewal,
+                    pending_next_renewal,
+                ) = _dhcp_renewal_epochs_for_hour(
                     last_renewal=dhcp_state["last_renewal"],
                     lease_time=lease_time,
                     current_hour=current_hour,
                     rng=rng,
+                    next_renewal=dhcp_state.get("next_renewal"),
                 )
                 if renewal_epochs:
                     from evidenceforge.utils.ids import generate_zeek_uid
 
-                for next_renewal in renewal_epochs:
+                for next_renewal, renewal_interval in renewal_epochs:
                     renewal_ts = datetime.fromtimestamp(next_renewal, tz=current_hour.tzinfo)
                     # Randomize fractional seconds (OS timer imprecision)
                     renewal_ts = renewal_ts.replace(microsecond=rng.randint(0, 999999))
@@ -7226,6 +7443,7 @@ class BaselineMixin:
                         lease_time=lease_time,
                         uid=generate_zeek_uid("C"),
                         msg_types=["REQUEST", "ACK"],  # Renewal, not discovery
+                        renewal_interval=renewal_interval,
                     )
                     self._emit_dhcp_registry_side_effect(
                         system=dhcp_state["system"],
@@ -7235,6 +7453,10 @@ class BaselineMixin:
                         dhcp_state=dhcp_state,
                     )
                 dhcp_state["last_renewal"] = updated_last_renewal
+                if pending_next_renewal is None:
+                    dhcp_state.pop("next_renewal", None)
+                else:
+                    dhcp_state["next_renewal"] = pending_next_renewal
 
             # SMB browsing: Windows workstations to DCs (SYSVOL/GPO) and file servers
             dc_ips = self._infra_ips.get("dc", ["10.0.0.1"])
@@ -7295,6 +7517,7 @@ class BaselineMixin:
                             duration = rng.uniform(0.1, 2.0)
                             orig_bytes = rng.randint(200, 2_000)
                             resp_bytes = rng.randint(500, 5_000)
+                        will_emit_smb_logon = smb_dst_sys is not None
                         self.activity_generator.generate_connection(
                             src_ip=system.ip,
                             dst_ip=smb_dst_ip,
@@ -7305,6 +7528,10 @@ class BaselineMixin:
                             duration=duration,
                             orig_bytes=orig_bytes,
                             resp_bytes=resp_bytes,
+                            conn_state=self._smb_logon_transport_conn_state(
+                                "smb",
+                                will_emit_smb_logon,
+                            ),
                             emit_dns=rng.random() > 0.02,
                             source_system=system,
                             pid=4,  # SMB: kernel System process
@@ -7687,6 +7914,8 @@ class BaselineMixin:
                 all_systems = self.scenario.environment.systems
                 servers = [s for s in all_systems if s.type in ("server", "domain_controller")]
                 for svc_name in self.scenario.environment.service_accounts:
+                    if not self._service_account_eligible_for_baseline_noise(svc_name):
+                        continue
                     if rng.random() < delegation_probability:
                         target_sys = rng.choice(servers) if servers else None
                         if target_sys and target_sys.hostname != system.hostname:
@@ -7889,7 +8118,7 @@ class BaselineMixin:
             # SSH: connections to Linux servers
             sys_type = (system.type or "workstation").lower()
             if os_cat == "linux" and sys_type == "server":
-                roster = self._get_server_ssh_users(system)
+                roster = self._get_baseline_ssh_users(system)
                 if roster and rng.random() < self._linux_remote_admin_hour_probability(system):
                     from evidenceforge.generation.activity.bash_commands import (
                         pick_bash_session_commands,
@@ -7897,7 +8126,10 @@ class BaselineMixin:
 
                     num_ssh = self._linux_remote_admin_session_count(rng, system)
                     for _ in range(num_ssh):
-                        ssh_user = rng.choice(roster)
+                        ssh_identity = self._pick_baseline_ssh_identity(system, rng)
+                        if ssh_identity is None:
+                            continue
+                        ssh_user, source_system = ssh_identity
                         offset = rng.uniform(0, 3599)
                         ts = current_hour + timedelta(seconds=offset)
                         hour_end = current_hour + timedelta(hours=1)
@@ -7908,6 +8140,7 @@ class BaselineMixin:
                             time=ts,
                             rng=rng,
                             session_kind="ssh",
+                            source_system=source_system,
                             allow_existing=True,
                             required_until=hour_end,
                         )
@@ -8487,15 +8720,12 @@ class BaselineMixin:
                             facility=10,
                         )
                 elif source_roll < 0.32 + _LINUX_AMBIENT_SSH_NOISE_BAND and sys_type == "server":
-                    other_ips = [
-                        s.ip for s in self.scenario.environment.systems if s.ip != system.ip
-                    ]
-                    ip = rng.choice(other_ips) if other_ips else system.ip
+                    ssh_identity = self._pick_baseline_ssh_identity(system, rng)
+                    if ssh_identity is None:
+                        continue
+                    ssh_user_model, src_sys_obj = ssh_identity
+                    ip = src_sys_obj.ip
                     # Resolve source system for WFP 5156 emission and OS-aware port
-                    src_sys_obj = next(
-                        (s for s in self.scenario.environment.systems if s.ip == ip),
-                        None,
-                    )
                     from evidenceforge.generation.activity.generator import _ephemeral_port
 
                     _src_os = _get_os_category(src_sys_obj.os) if src_sys_obj else "linux"
@@ -8508,23 +8738,7 @@ class BaselineMixin:
                         time=ts,
                     )
                     ssh_duration = rng.uniform(30.0, 1800.0)
-                    ssh_roster = self._get_server_ssh_users(system)
-                    ssh_usernames = [user.username for user in ssh_roster]
-                    if ssh_usernames:
-                        fallback_users = ["admin", "root"]
-                        if not is_rhel_like:
-                            fallback_users.append("ubuntu")
-                        ssh_user = rng.choices(
-                            ssh_usernames + fallback_users,
-                            weights=([20] * len(ssh_usernames)) + [3, 1, 1][: len(fallback_users)],
-                            k=1,
-                        )[0]
-                    else:
-                        ssh_user = rng.choice(["admin", "root"] if is_rhel_like else ["admin"])
-                    ssh_user_model = next(
-                        (user for user in ssh_roster if user.username == ssh_user),
-                        self.activity_generator._user_model_for_username(ssh_user),
-                    )
+                    ssh_user = ssh_user_model.username
                     _key_rng = random.Random(
                         _stable_seed(f"ssh_client_key:{ip}:{system.hostname}:{ssh_user}")
                     )
@@ -8819,6 +9033,8 @@ class BaselineMixin:
                     if sudo_has_session:
                         sudo_user = (msg.split(" : ", 1)[0] or "admin").strip()
                         uid = _linux_uid_for_user(sudo_user)
+                        sudo_command = msg.split("COMMAND=", 1)[1].strip()
+                        sudo_runtime = _linux_sudo_command_runtime(sudo_command, rng)
                         self.activity_generator.generate_syslog_event(
                             system=system,
                             time=ts - timedelta(milliseconds=rng.randint(80, 420)),
@@ -8843,7 +9059,7 @@ class BaselineMixin:
                     if sudo_has_session:
                         self.activity_generator.generate_syslog_event(
                             system=system,
-                            time=ts + timedelta(milliseconds=rng.randint(90, 900)),
+                            time=ts + sudo_runtime + timedelta(milliseconds=rng.randint(120, 950)),
                             app_name="sudo",
                             message="pam_unix(sudo:session): session closed for user root",
                             pid=pid,

--- a/src/evidenceforge/generation/engine/core.py
+++ b/src/evidenceforge/generation/engine/core.py
@@ -461,6 +461,7 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
             state_manager=self.state_manager,
             activity_generator=self.activity_generator,
         )
+        self.activity_generator._world_planner = self.world_planner
 
         logger.info("Initialization complete")
 

--- a/src/evidenceforge/generation/engine/emitter_setup.py
+++ b/src/evidenceforge/generation/engine/emitter_setup.py
@@ -33,9 +33,10 @@ Contains the EmitterSetupMixin with methods for:
 
 import logging
 import random
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from evidenceforge.formats import load_format
+from evidenceforge.generation.actions import dhcp_renewal_interval_seconds
 from evidenceforge.generation.activity.edr_pools import normalize_defender_platform_path
 from evidenceforge.generation.activity.network_params import load_network_params, public_ntp_ips
 from evidenceforge.generation.emitters import (
@@ -93,6 +94,14 @@ def _system_uses_dhcp(system: System) -> bool:
         "server",
         "domain_controller",
     }
+
+
+def _has_dhcp_event(step: object) -> bool:
+    """Return whether a storyline step contains an explicit DHCP lease event."""
+
+    return any(
+        getattr(event, "type", None) == "dhcp_lease" for event in getattr(step, "events", [])
+    )
 
 
 def _build_emitter_classes() -> dict:
@@ -166,6 +175,38 @@ DB_SERVICE_MAP = {
 
 class EmitterSetupMixin:
     """Mixin providing emitter initialization and infrastructure setup methods."""
+
+    def _storyline_dhcp_lease_times_by_host(self) -> dict[str, list[datetime]]:
+        """Return explicit storyline DHCP lease times grouped by host."""
+
+        cached = getattr(self, "_storyline_dhcp_times_by_host", None)
+        if cached is not None:
+            return cached
+
+        times_by_host: dict[str, list[datetime]] = {}
+        for step in self.scenario.storyline or []:
+            hostname = getattr(step, "system", "")
+            if not hostname or not _has_dhcp_event(step):
+                continue
+            times_by_host.setdefault(hostname, []).append(self._parse_storyline_time(step.time))
+        for times in times_by_host.values():
+            times.sort()
+        self._storyline_dhcp_times_by_host = times_by_host
+        return times_by_host
+
+    def _storyline_dhcp_lease_time_in_hour(
+        self,
+        hostname: str,
+        current_hour: datetime,
+    ) -> datetime | None:
+        """Return the explicit DHCP storyline time for a host in the current hour."""
+
+        hour_start = current_hour.replace(minute=0, second=0, microsecond=0)
+        hour_end = hour_start + timedelta(hours=1)
+        for event_time in self._storyline_dhcp_lease_times_by_host().get(hostname, []):
+            if hour_start <= event_time < hour_end:
+                return event_time
+        return None
 
     def _init_emitters(self) -> None:
         """Initialize emitters for each requested format.
@@ -362,6 +403,7 @@ class EmitterSetupMixin:
             infra_ips = getattr(self, "_infra_ips", {})
             dhcp_servers = infra_ips.get("dc") or infra_ips.get("dns") or ["10.0.0.1"]
             dhcp_server = dhcp_servers[0] if isinstance(dhcp_servers, list) else dhcp_servers
+            renewal_interval = dhcp_renewal_interval_seconds(lease_time, rng)
             self.state_manager.set_current_time(ts)
             self.activity_generator.generate_dhcp_lease(
                 system=system,
@@ -370,12 +412,14 @@ class EmitterSetupMixin:
                 server_addr=dhcp_server,
                 lease_time=lease_time,
                 uid=uid,
+                renewal_interval=renewal_interval,
             )
             # Store state for renewals
             self._dhcp_lease_state[system.hostname] = {
                 "mac": mac,
                 "lease_time": lease_time,
                 "last_renewal": ts.timestamp(),
+                "next_renewal": ts.timestamp() + renewal_interval,
                 "server_addr": dhcp_server,
                 "system": system,
             }

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -56,6 +56,7 @@ from evidenceforge.generation.actions import (
     StagedArchiveSmbReadRequest,
     WebScanActionBundle,
     WebScanRequest,
+    dhcp_renewal_interval_seconds,
 )
 from evidenceforge.generation.activity.application_catalog import resolve_image_path
 from evidenceforge.generation.activity.dns_txt import choose_background_dns_txt_record
@@ -1926,6 +1927,98 @@ class StorylineMixin:
         normalized = normalized.lstrip("\\")
         return f"\\\\{system.hostname}\\{normalized}"
 
+    @staticmethod
+    def _local_staging_path_for_archive(
+        actor: User,
+        source_system: System,
+        archive_path: str,
+    ) -> str:
+        """Return the upload-host path that a browser reads after SMB staging."""
+
+        basename = re.split(r"[\\/]+", archive_path.rstrip("\\/"))[-1] or "staged_archive.zip"
+        if _get_os_category(source_system.os) == "windows":
+            return rf"C:\Users\{actor.username}\AppData\Local\Temp\{basename}"
+        home = "/root" if actor.username == "root" else f"/home/{actor.username}"
+        return f"{home}/.cache/{basename}"
+
+    def _storyline_logon_for_process_owner(
+        self,
+        actor: User,
+        system: System,
+        pid: int,
+        at_time: datetime,
+    ) -> str:
+        """Return a reasonable logon ID for a storyline process on a source host."""
+
+        running = self.state_manager.get_process(system.hostname, pid) if pid > 0 else None
+        running_logon_id = getattr(running, "logon_id", "") if running is not None else ""
+        if running_logon_id:
+            return running_logon_id
+        logon_id = self._last_storyline_logon_for_actor_system(actor, system, at_time=at_time)
+        if logon_id:
+            return logon_id
+        sessions = self.state_manager.get_sessions_for_user_at(actor.username, at_time)
+        for session in sessions:
+            if getattr(session, "system", "") == system.hostname:
+                return session.logon_id
+        return "0x3e7"
+
+    def _staged_archive_copy_process(
+        self,
+        *,
+        actor: User,
+        source_system: System | None,
+        source_pid: int,
+        archive_smb_path: str,
+        local_staging_path: str,
+        exfil_time: datetime,
+        rng: random.Random,
+    ) -> tuple[int, str, str, str, bool]:
+        """Create a short-lived copy process that stages the archive locally."""
+
+        if source_system is None or _get_os_category(source_system.os) != "windows":
+            return source_pid, "", "", "", False
+        logon_id = self._storyline_logon_for_process_owner(
+            actor,
+            source_system,
+            source_pid,
+            exfil_time,
+        )
+        process_name = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+        command_line = (
+            "powershell.exe -NoProfile -Command "
+            f"\"Copy-Item -LiteralPath '{archive_smb_path}' "
+            f"-Destination '{local_staging_path}' -Force\""
+        )
+        process_time = exfil_time - timedelta(
+            minutes=rng.randint(5, 8),
+            seconds=rng.randint(5, 55),
+        )
+        parent_resolver = getattr(self.activity_generator, "_resolve_parent", None)
+        parent_pid = 4
+        if callable(parent_resolver):
+            parent_pid = parent_resolver(
+                source_system,
+                actor,
+                process_time,
+                logon_id,
+                process_name,
+            )
+        pid = self.activity_generator.generate_process(
+            user=actor,
+            system=source_system,
+            time=process_time,
+            logon_id=logon_id,
+            process_name=process_name,
+            command_line=command_line,
+            parent_pid=parent_pid,
+            from_storyline=True,
+            suppress_command_file_effect=True,
+            allow_existing_browser_reuse=False,
+            allow_browser_launch_spacing=False,
+        )
+        return pid, process_name, command_line, logon_id, True
+
     def _record_storyline_staged_archive(
         self,
         *,
@@ -1974,6 +2067,53 @@ class StorylineMixin:
         exact_source = [archive for archive in candidates if archive.source_ip == source_ip]
         return max(exact_source or candidates, key=lambda archive: archive.staged_at)
 
+    @staticmethod
+    def _windows_browser_process_for_user_agent(user_agent: str) -> str:
+        """Return a Windows browser image that matches an authored browser User-Agent."""
+        ua = (user_agent or "").lower()
+        if "firefox/" in ua:
+            return r"C:\Program Files\Mozilla Firefox\firefox.exe"
+        if "edg/" in ua or "edge/" in ua:
+            return r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+        if "chrome/" in ua and "google update" not in ua:
+            return r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        return ""
+
+    @staticmethod
+    def _windows_browser_command_line(process_name: str, destination: str) -> str:
+        """Return a browser launch command line matching the selected image."""
+        exe = process_name.rsplit("\\", 1)[-1].lower()
+        if exe == "firefox.exe":
+            return f'"{process_name}" -osint -url "{destination}"'
+        if exe == "msedge.exe":
+            return f'"{process_name}" --single-argument "{destination}"'
+        return f'"{process_name}" --profile-directory=Default --new-window "{destination}"'
+
+    @staticmethod
+    def _storyline_http_user_agent_for_process(
+        *,
+        system: System | None,
+        process_image: str | None,
+        command_line: str,
+        rng: random.Random,
+    ) -> str:
+        """Return a source-native HTTP User-Agent for an upload owner process."""
+        image = process_image or ""
+        exe = image.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
+        command = command_line.lower()
+        if exe in {"curl", "curl.exe"} or command.startswith("curl "):
+            return "curl/7.88.1"
+        if exe in {"wget", "wget.exe"} or command.startswith("wget "):
+            return "Wget/1.21.3"
+        if "python" in exe and "requests" in command:
+            return "python-requests/2.31.0"
+
+        from evidenceforge.generation.activity.proxy_user_agents import (
+            browser_user_agent_for_process,
+        )
+
+        return browser_user_agent_for_process(rng, system, image)
+
     def _emit_storyline_archive_transfer_before_exfil(
         self,
         *,
@@ -1999,6 +2139,33 @@ class StorylineMixin:
         if target_system is None:
             return
         source_system = self._system_for_ip(source_ip)
+        source_file_read_path = archive.smb_filename
+        transfer_pid = source_pid
+        transfer_process = source_process
+        transfer_command = source_command
+        transfer_logon_id = ""
+        terminate_transfer_process = False
+        if source_system is not None:
+            source_file_read_path = self._local_staging_path_for_archive(
+                actor,
+                source_system,
+                archive.archive_path,
+            )
+            (
+                transfer_pid,
+                transfer_process,
+                transfer_command,
+                transfer_logon_id,
+                terminate_transfer_process,
+            ) = self._staged_archive_copy_process(
+                actor=actor,
+                source_system=source_system,
+                source_pid=source_pid,
+                archive_smb_path=archive.smb_filename,
+                local_staging_path=source_file_read_path,
+                exfil_time=exfil_time,
+                rng=rng,
+            )
         emitted = StagedArchiveSmbReadActionBundle(
             self,
             StagedArchiveSmbReadRequest(
@@ -2012,10 +2179,15 @@ class StorylineMixin:
                 upload_bytes=upload_bytes,
                 source_system=source_system,
                 target_system=target_system,
-                source_pid=source_pid,
-                source_process=source_process,
-                source_command=source_command,
-                source_file_read_path=archive.smb_filename,
+                source_pid=transfer_pid,
+                source_process=transfer_process,
+                source_command=transfer_command,
+                source_logon_id=transfer_logon_id,
+                terminate_source_process=terminate_transfer_process,
+                reader_pid=source_pid,
+                reader_process=source_process,
+                reader_command=source_command,
+                source_file_read_path=source_file_read_path,
             ),
             rng,
             emit_smb_logon_pair=getattr(self, "_emit_smb_logon_pair", None),
@@ -2046,7 +2218,15 @@ class StorylineMixin:
         )
         current_command = running.command_line if running is not None else current_image or ""
         image_name = (current_image or "").rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
-        if image_name in {"chrome.exe", "msedge.exe", "firefox.exe", "curl", "curl.exe"}:
+        expected_windows_browser = (
+            self._windows_browser_process_for_user_agent(spec.user_agent or "")
+            if _get_os_category(system.os) == "windows"
+            else ""
+        )
+        if image_name in {"chrome.exe", "msedge.exe", "firefox.exe", "curl", "curl.exe"} and (
+            not expected_windows_browser
+            or (current_image or "").lower() == expected_windows_browser.lower()
+        ):
             return current_pid, current_image, current_command
 
         os_category = _get_os_category(system.os)
@@ -2057,10 +2237,10 @@ class StorylineMixin:
             uri if re.match(r"^https?://", uri, re.IGNORECASE) else f"{scheme}://{host}{uri}"
         )
         if os_category == "windows":
-            process_name = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
-            command_line = (
-                f'"{process_name}" --profile-directory=Default --new-window "{destination}"'
+            process_name = (
+                expected_windows_browser or r"C:\Program Files\Google\Chrome\Application\chrome.exe"
             )
+            command_line = self._windows_browser_command_line(process_name, destination)
         else:
             process_name = "/usr/bin/curl"
             method = spec.method or "POST"
@@ -3439,6 +3619,18 @@ class StorylineMixin:
                         rng=rng,
                     )
                 )
+                if http_ctx is not None:
+                    upload_user_agent = self._storyline_http_user_agent_for_process(
+                        system=src_sys,
+                        process_image=story_image,
+                        command_line=story_command,
+                        rng=rng,
+                    )
+                    if upload_user_agent and (
+                        not (spec.user_agent or "").strip()
+                        or (http_ctx.user_agent or "").strip().lower() == "mozilla/5.0"
+                    ):
+                        http_ctx.user_agent = upload_user_agent
                 self._emit_storyline_archive_transfer_before_exfil(
                     actor=actor,
                     source_ip=source_ip,
@@ -3860,19 +4052,6 @@ class StorylineMixin:
                 malicious_event["target_process"] = target_image
                 if not evidence_emitted:
                     malicious_event["skipped_reason"] = "no_live_target_process"
-                # Emit ProcessAccess via causal expansion engine (or legacy fallback)
-                # when targeting lsass.exe — primary credential-dumping detection signal
-                elif "lsass" in target_name:
-                    self.activity_generator._expand_and_emit(
-                        "create_remote_thread",
-                        effect_time,
-                        actor=actor,
-                        target_system=system,
-                        source_pid=source_pid,
-                        source_image=source_image,
-                        target_pid=target_pid,
-                        target_image=target_image,
-                    )
 
         elif spec.type == "process_access":
             source_pid, source_image = self._last_storyline_process_for_system(system)
@@ -3936,6 +4115,7 @@ class StorylineMixin:
                 if existing_lease
                 else float(rng.choice([3600, 7200, 14400, 86400]))
             )
+            renewal_interval = dhcp_renewal_interval_seconds(lease_time, rng)
             msg_types = ["REQUEST", "ACK"] if existing_lease else None
             self.activity_generator.generate_dhcp_lease(
                 system=system,
@@ -3945,12 +4125,14 @@ class StorylineMixin:
                 lease_time=lease_time,
                 uid=generate_zeek_uid("C"),
                 msg_types=msg_types,
+                renewal_interval=renewal_interval,
             )
             if hasattr(self, "_dhcp_lease_state"):
                 self._dhcp_lease_state[system.hostname] = {
                     "mac": mac,
                     "lease_time": lease_time,
                     "last_renewal": time.timestamp(),
+                    "next_renewal": time.timestamp() + renewal_interval,
                     "server_addr": dhcp_server,
                     "system": system,
                 }

--- a/src/evidenceforge/generation/network_visibility.py
+++ b/src/evidenceforge/generation/network_visibility.py
@@ -466,6 +466,30 @@ class NetworkVisibilityEngine:
         src_segments = self._resolve_ip_segments(src_ip)
         dst_segments = self._resolve_ip_segments(dst_ip)
 
+        # Static VIPs inherit the real host's segment for visibility, but a
+        # connection aimed at the public VIP still needs DNAT context before
+        # endpoint sources render the host-local tuple.
+        for sensor in self._sensors:
+            if sensor.type != "firewall" or not sensor.nat_rules:
+                continue
+            sensor_segs = set(sensor.monitoring_segments)
+            if not (sensor_segs & src_segments or sensor_segs & dst_segments):
+                continue
+            for rule in sensor.nat_rules:
+                if (
+                    rule.type == "static"
+                    and rule.mapped_ip
+                    and rule.real_ip
+                    and dst_ip == rule.mapped_ip
+                ):
+                    return NatContext(
+                        nat_type="static",
+                        mapped_src_ip=src_ip,
+                        mapped_src_port=src_port,
+                        mapped_dst_ip=rule.real_ip,
+                        mapped_dst_port=dst_port,
+                    )
+
         # Same-segment traffic: no NAT
         if src_segments and dst_segments and src_segments & dst_segments:
             return None

--- a/src/evidenceforge/generation/world_model.py
+++ b/src/evidenceforge/generation/world_model.py
@@ -96,6 +96,22 @@ _DNS_SERVER_SERVICES = {
 }
 
 _ADMIN_PERSONAS = {"sysadmin", "help_desk"}
+_LINUX_SSH_ADMIN_PERSONAS = {"sysadmin"}
+_LINUX_SSH_ADMIN_GROUPS = {
+    "domain-admins",
+    "infrastructure",
+    "it-admins",
+    "linux-admins",
+    "server-admins",
+    "sysadmins",
+}
+_LINUX_SSH_ROLE_PERSONAS: dict[str, set[str]] = {
+    "app_server": {"developer"},
+    "database": {"developer"},
+    "forward_proxy": {"security_analyst"},
+    "log_server": {"security_analyst"},
+    "web_server": {"developer"},
+}
 
 _DB_PORTS = {
     "mssql": 1433,
@@ -528,6 +544,44 @@ class WorldModel:
                 if len(roster) >= 2:
                     break
 
+        return roster
+
+    def effective_user_groups(self, user: User) -> set[str]:
+        """Return direct and environment-group memberships for a user."""
+        groups = {group.lower() for group in user.groups}
+        for group in self.scenario.environment.groups or []:
+            if user.username in group.members:
+                groups.add(group.name.lower())
+        return groups
+
+    def can_user_ssh_admin(self, user: User, target_system: System) -> bool:
+        """Return whether a scenario user plausibly opens baseline SSH admin sessions."""
+        host = self.hosts[target_system.hostname]
+        if not host.supports_ssh or not host.is_server:
+            return False
+
+        persona = (user.persona or "").lower()
+        if persona in _LINUX_SSH_ADMIN_PERSONAS:
+            return True
+        if self.effective_user_groups(user) & _LINUX_SSH_ADMIN_GROUPS:
+            return True
+        for role in host.canonical_roles:
+            if persona in _LINUX_SSH_ROLE_PERSONAS.get(role, set()):
+                return True
+        return False
+
+    def get_ssh_admin_users(self, target_system: System) -> list[User]:
+        """Return scenario users eligible for ordinary baseline SSH to a Linux server."""
+        enabled = [user for user in self.scenario.environment.users if user.enabled]
+        roster: list[User] = []
+        seen: set[str] = set()
+        for user in enabled:
+            if user.username in seen:
+                continue
+            if not self.can_user_ssh_admin(user, target_system):
+                continue
+            seen.add(user.username)
+            roster.append(user)
         return roster
 
     def resolve_destination(

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -30,7 +30,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from evidenceforge.events.base import SecurityEvent
-from evidenceforge.events.contexts import FirewallContext, HttpContext, NetworkContext
+from evidenceforge.events.contexts import FirewallContext, HttpContext, NetworkContext, ProxyContext
 from evidenceforge.events.dispatcher import EventDispatcher
 from evidenceforge.generation.actions import (
     AccountChangedActionBundle,
@@ -1372,6 +1372,118 @@ class TestActivityGenerator:
         assert emitted_logons[0].auth.session_id == sessions[0].session_id
         assert sessions[0].session_id > 1
         assert any("New session" in msg and test_user.username in msg for msg in syslog_messages)
+        logind_events = [
+            call.args[0]
+            for call in syslog_emitter.emit.call_args_list
+            if call.args[0].syslog.message.startswith("New session")
+        ]
+        assert logind_events
+        assert logind_events[0].auth is not None
+        assert logind_events[0].auth.logon_id == logon_id
+        assert logind_events[0].auth.session_id == sessions[0].session_id
+
+    def test_linux_local_logon_with_stale_ssh_kind_gets_logind_companion(
+        self, state_manager, test_user
+    ):
+        """Local-looking Linux sessions should get logind evidence before eCAR rendering."""
+        syslog_emitter = Mock()
+        syslog_emitter.can_handle.side_effect = lambda event: event.syslog is not None
+        ecar_emitter = Mock()
+        ecar_emitter.can_handle.side_effect = lambda event: event.event_type == "logon"
+        emitters = {"syslog": syslog_emitter, "ecar": ecar_emitter}
+        dispatcher = EventDispatcher(state_manager=state_manager, emitters=emitters)
+        activity_gen = ActivityGenerator(state_manager, emitters, dispatcher=dispatcher)
+        linux_system = System(
+            hostname="DB-PROD-01",
+            ip="10.0.0.20",
+            os="Ubuntu 22.04",
+            type="server",
+        )
+        logon_time = datetime(2024, 1, 15, 12, 26, 0, tzinfo=UTC)
+        logon_id = state_manager.create_session(
+            username=test_user.username,
+            system=linux_system.hostname,
+            logon_type=2,
+            source_ip="-",
+            session_kind="ssh",
+            start_time=logon_time,
+        )
+
+        rendered_logon_id = activity_gen.generate_logon(
+            test_user,
+            linux_system,
+            logon_time,
+            logon_type=2,
+            source_ip="-",
+            logon_id=logon_id,
+        )
+
+        session = state_manager.get_session(logon_id)
+        emitted_logons = [
+            call.args[0]
+            for call in ecar_emitter.emit.call_args_list
+            if call.args[0].event_type == "logon"
+        ]
+        logind_events = [
+            call.args[0]
+            for call in syslog_emitter.emit.call_args_list
+            if call.args[0].syslog.message.startswith("New session")
+        ]
+        assert rendered_logon_id == logon_id
+        assert session is not None
+        assert session.session_id > 0
+        assert emitted_logons
+        assert emitted_logons[0].auth.session_id == session.session_id
+        assert logind_events
+        assert logind_events[0].auth.session_id == session.session_id
+
+    def test_linux_self_sourced_type3_logon_is_local_logind_session(self, state_manager, test_user):
+        """Linux self-sourced Type 3 compatibility calls should render as local logind sessions."""
+        syslog_emitter = Mock()
+        syslog_emitter.can_handle.side_effect = lambda event: event.syslog is not None
+        ecar_emitter = Mock()
+        ecar_emitter.can_handle.side_effect = lambda event: event.event_type == "logon"
+        emitters = {"syslog": syslog_emitter, "ecar": ecar_emitter}
+        dispatcher = EventDispatcher(state_manager=state_manager, emitters=emitters)
+        activity_gen = ActivityGenerator(state_manager, emitters, dispatcher=dispatcher)
+        linux_system = System(
+            hostname="DB-PROD-01",
+            ip="10.0.0.20",
+            os="CentOS 8",
+            type="server",
+        )
+        logon_time = datetime(2024, 1, 15, 14, 30, 0, tzinfo=UTC)
+
+        logon_id = activity_gen.generate_logon(
+            test_user,
+            linux_system,
+            logon_time,
+            logon_type=3,
+            source_ip=linux_system.ip,
+        )
+
+        session = state_manager.get_session(logon_id)
+        emitted_logons = [
+            call.args[0]
+            for call in ecar_emitter.emit.call_args_list
+            if call.args[0].event_type == "logon"
+        ]
+        logind_events = [
+            call.args[0]
+            for call in syslog_emitter.emit.call_args_list
+            if call.args[0].syslog.message.startswith("New session")
+        ]
+        assert session is not None
+        assert session.logon_type == 2
+        assert session.source_ip == "-"
+        assert session.session_id > 0
+        assert emitted_logons
+        assert emitted_logons[0].auth.logon_type == 2
+        assert emitted_logons[0].auth.source_ip == "-"
+        assert emitted_logons[0].auth.session_id == session.session_id
+        assert logind_events
+        assert logind_events[0].auth.logon_id == logon_id
+        assert logind_events[0].auth.session_id == session.session_id
 
     def test_overlapping_linux_local_sessions_keep_distinct_ecar_session_ids(
         self, state_manager, test_user
@@ -4371,6 +4483,448 @@ class TestActivityGenerator:
         )
         assert not any("unknown" in message for message in messages)
 
+    def test_web_to_database_connection_materializes_service_owner(
+        self, activity_gen, state_manager, mock_emitters
+    ):
+        """Known web-to-DB service flows should not render as actorless endpoint telemetry."""
+        timestamp = datetime(2024, 3, 18, 14, 20, tzinfo=UTC)
+        web_server = System(
+            hostname="WEB-EXT-01",
+            ip="10.10.3.10",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["web_server"],
+        )
+        db_server = System(
+            hostname="DB-PROD-01",
+            ip="10.10.4.10",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["database"],
+        )
+        activity_gen._ip_to_system = {web_server.ip: web_server, db_server.ip: db_server}
+        activity_gen._all_system_ips = [web_server.ip, db_server.ip]
+        activity_gen._scenario_start_time = timestamp - timedelta(hours=1)
+        state_manager.set_current_time(timestamp)
+
+        activity_gen.generate_connection(
+            src_ip=web_server.ip,
+            dst_ip=db_server.ip,
+            time=timestamp,
+            dst_port=3306,
+            proto="tcp",
+            service="mysql",
+            duration=0.45,
+            orig_bytes=420,
+            resp_bytes=3600,
+            conn_state="SF",
+            source_system=web_server,
+            hostname=db_server.hostname,
+        )
+
+        connection_event = next(
+            call.args[0]
+            for call in mock_emitters["zeek_conn"].emit.call_args_list
+            if call.args[0].event_type == "connection" and call.args[0].network.dst_port == 3306
+        )
+        assert connection_event.network.initiating_pid > 0
+        assert connection_event.process is not None
+        assert connection_event.process.image == "/usr/sbin/apache2"
+        assert connection_event.process.username == "www-data"
+
+    def test_proxy_service_owner_is_not_reused_across_targets(self, activity_gen, state_manager):
+        """Target-bearing service-health owners should match the current proxy host."""
+        timestamp = datetime(2024, 3, 18, 14, 20, tzinfo=UTC)
+        dc_system = System(
+            hostname="DC-01",
+            ip="10.10.2.10",
+            os="Windows Server 2022",
+            type="domain_controller",
+            roles=["domain_controller"],
+        )
+        activity_gen._ip_to_system = {dc_system.ip: dc_system}
+        state_manager.set_current_time(timestamp)
+        first_http = HttpContext(
+            method="CONNECT",
+            host="config.zscaler.net",
+            uri="config.zscaler.net:443",
+            user_agent="Go-http-client/1.1",
+        )
+        second_http = HttpContext(
+            method="CONNECT",
+            host="secure-client-updates.cisco.com",
+            uri="secure-client-updates.cisco.com:443",
+            user_agent="Go-http-client/1.1",
+        )
+
+        first_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=dc_system,
+            time=timestamp,
+            service="http",
+            dst_port=8080,
+            proto="tcp",
+            hostname=first_http.host,
+            http=first_http,
+        )
+        second_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=dc_system,
+            time=timestamp + timedelta(seconds=3),
+            service="http",
+            dst_port=8080,
+            proto="tcp",
+            hostname=second_http.host,
+            http=second_http,
+        )
+
+        first_proc = state_manager.get_process(dc_system.hostname, first_pid)
+        second_proc = state_manager.get_process(dc_system.hostname, second_pid)
+        assert first_proc is not None
+        assert second_proc is not None
+        assert first_pid != second_pid
+        assert "config.zscaler.net" in first_proc.command_line
+        assert "secure-client-updates.cisco.com" in second_proc.command_line
+
+    def test_service_connection_owner_command_lines_do_not_leak_planning_notes(self, activity_gen):
+        """Rendered endpoint command lines should not contain hidden generation labels."""
+        timestamp = datetime(2024, 3, 18, 14, 20, tzinfo=UTC)
+        mail_server = System(
+            hostname="MAIL-CLIN-01",
+            ip="10.10.2.25",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["mail_server"],
+        )
+        db_server = System(
+            hostname="DB-PROD-01",
+            ip="10.10.4.10",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["database"],
+        )
+
+        mail_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=mail_server,
+            time=timestamp,
+            service="http",
+            dst_port=8080,
+            proto="tcp",
+            hostname="api.github.com",
+            http=HttpContext(
+                method="CONNECT",
+                host="api.github.com",
+                uri="api.github.com:443",
+                user_agent="python-requests/2.31.0",
+            ),
+        )
+        smb_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=db_server,
+            time=timestamp,
+            service="smb",
+            dst_port=445,
+            proto="tcp",
+            hostname="FILE-SRV-01.meridianhcs.local",
+            http=None,
+        )
+
+        for system, pid in ((mail_server, mail_pid), (db_server, smb_pid)):
+            proc = activity_gen.state_manager.get_process(system.hostname, pid)
+            assert proc is not None
+            assert "#" not in proc.command_line
+
+    def test_workstation_ssh_connection_materializes_user_owner(
+        self, activity_gen, test_user, state_manager, mock_emitters
+    ):
+        """User-owned SSH flows should carry the interactive user's client process."""
+        timestamp = datetime(2024, 3, 18, 14, 20, tzinfo=UTC)
+        workstation = System(
+            hostname="WS-AJOHNSON-01",
+            ip="10.10.1.35",
+            os="Windows 11",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        app_server = System(
+            hostname="APP-INT-01",
+            ip="10.10.2.30",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["app_server"],
+            services=["ssh"],
+        )
+        activity_gen._ip_to_system = {workstation.ip: workstation, app_server.ip: app_server}
+        activity_gen._all_system_ips = [workstation.ip, app_server.ip]
+        activity_gen._users_by_username = {test_user.username: test_user}
+        state_manager.set_current_time(timestamp - timedelta(minutes=10))
+        state_manager.create_session(
+            username=test_user.username,
+            system=workstation.hostname,
+            logon_type=2,
+            source_ip="-",
+            session_kind="interactive",
+        )
+        state_manager.set_current_time(timestamp)
+
+        activity_gen.generate_connection(
+            src_ip=workstation.ip,
+            dst_ip=app_server.ip,
+            time=timestamp,
+            dst_port=22,
+            proto="tcp",
+            service="ssh",
+            duration=8.0,
+            orig_bytes=1500,
+            resp_bytes=3000,
+            conn_state="SF",
+            source_system=workstation,
+            hostname=app_server.hostname,
+        )
+
+        connection_event = next(
+            call.args[0]
+            for call in mock_emitters["zeek_conn"].emit.call_args_list
+            if call.args[0].event_type == "connection" and call.args[0].network.dst_port == 22
+        )
+        assert connection_event.network.initiating_pid > 0
+        assert connection_event.process is not None
+        assert connection_event.process.image == r"C:\Windows\System32\OpenSSH\ssh.exe"
+        assert connection_event.process.username == test_user.username
+
+    def test_workstation_ssh_owner_is_scoped_to_command_target(
+        self, activity_gen, test_user, state_manager
+    ):
+        """Target-bearing SSH client processes should not be reused across hosts."""
+        timestamp = datetime(2024, 3, 18, 14, 20, tzinfo=UTC)
+        workstation = System(
+            hostname="WS-AJOHNSON-01",
+            ip="10.10.1.35",
+            os="Windows 11",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        app_server = System(
+            hostname="APP-INT-01",
+            ip="10.10.2.30",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["app_server"],
+            services=["ssh"],
+        )
+        proxy_server = System(
+            hostname="PROXY-01",
+            ip="10.10.3.20",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["forward_proxy"],
+            services=["ssh"],
+        )
+        activity_gen._ip_to_system = {
+            workstation.ip: workstation,
+            app_server.ip: app_server,
+            proxy_server.ip: proxy_server,
+        }
+        activity_gen._users_by_username = {test_user.username: test_user}
+        state_manager.set_current_time(timestamp - timedelta(minutes=10))
+        state_manager.create_session(
+            username=test_user.username,
+            system=workstation.hostname,
+            logon_type=2,
+            source_ip="-",
+            session_kind="interactive",
+        )
+        state_manager.set_current_time(timestamp)
+
+        app_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=workstation,
+            time=timestamp,
+            service="ssh",
+            dst_port=22,
+            proto="tcp",
+            hostname=app_server.hostname,
+            http=None,
+        )
+        proxy_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=workstation,
+            time=timestamp + timedelta(seconds=3),
+            service="ssh",
+            dst_port=22,
+            proto="tcp",
+            hostname=proxy_server.hostname,
+            http=None,
+        )
+        app_reuse_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=workstation,
+            time=timestamp + timedelta(seconds=6),
+            service="ssh",
+            dst_port=22,
+            proto="tcp",
+            hostname=app_server.hostname,
+            http=None,
+        )
+
+        app_proc = state_manager.get_process(workstation.hostname, app_pid)
+        proxy_proc = state_manager.get_process(workstation.hostname, proxy_pid)
+        assert app_proc is not None
+        assert proxy_proc is not None
+        assert app_pid != proxy_pid
+        assert app_reuse_pid == app_pid
+        assert app_proc.command_line == "ssh.exe APP-INT-01"
+        assert proxy_proc.command_line == "ssh.exe PROXY-01"
+
+    def test_ssh_session_windows_client_command_names_remote_user(
+        self, activity_gen, state_manager, mock_emitters
+    ):
+        """Successful SSH sessions should expose alternate remote users in client commands."""
+        timestamp = datetime(2024, 3, 18, 14, 20, tzinfo=UTC)
+        source_user = User(
+            username="priya.patel",
+            full_name="Priya Patel",
+            email="priya.patel@example.local",
+        )
+        remote_user = User(
+            username="aisha.johnson",
+            full_name="Aisha Johnson",
+            email="aisha.johnson@example.local",
+        )
+        workstation = System(
+            hostname="WS-PPATEL-01",
+            ip="10.10.1.32",
+            os="Windows 11",
+            type="workstation",
+            assigned_user=source_user.username,
+        )
+        web_server = System(
+            hostname="WEB-EXT-01",
+            ip="10.10.3.10",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["web_server"],
+            services=["ssh"],
+        )
+        activity_gen._ip_to_system = {workstation.ip: workstation, web_server.ip: web_server}
+        activity_gen._all_system_ips = [workstation.ip, web_server.ip]
+        activity_gen._users_by_username = {
+            source_user.username: source_user,
+            remote_user.username: remote_user,
+        }
+        state_manager.set_current_time(timestamp - timedelta(minutes=10))
+        state_manager.create_session(
+            username=source_user.username,
+            system=workstation.hostname,
+            logon_type=2,
+            source_ip="-",
+            session_kind="interactive",
+        )
+        state_manager.set_current_time(timestamp)
+
+        activity_gen.generate_ssh_session(
+            user=remote_user,
+            target_system=web_server,
+            time=timestamp,
+            source_ip=workstation.ip,
+            source_system=workstation,
+            duration=30.0,
+        )
+
+        ssh_processes = [
+            proc
+            for proc in state_manager.get_processes_on_system(workstation.hostname)
+            if proc.image == r"C:\Windows\System32\OpenSSH\ssh.exe"
+        ]
+        assert ssh_processes
+        ssh_proc = ssh_processes[-1]
+        assert ssh_proc.username == source_user.username
+        assert ssh_proc.command_line == "ssh.exe aisha.johnson@WEB-EXT-01"
+
+        connection_event = next(
+            call.args[0]
+            for call in mock_emitters["zeek_conn"].emit.call_args_list
+            if call.args[0].event_type == "connection" and call.args[0].network.dst_port == 22
+        )
+        assert connection_event.process is not None
+        assert connection_event.process.username == source_user.username
+        assert connection_event.process.command_line == ssh_proc.command_line
+
+    def test_linux_smb_browse_owner_is_scoped_to_command_target(
+        self, activity_gen, test_user, state_manager
+    ):
+        """Target-bearing Linux SMB browse clients should not be reused across hosts."""
+        timestamp = datetime(2024, 3, 18, 14, 20, tzinfo=UTC)
+        workstation = System(
+            hostname="LT-MRIVERA-02",
+            ip="10.10.1.50",
+            os="Ubuntu 22.04",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        file_server = System(
+            hostname="FILE-SRV-01",
+            ip="10.10.2.20",
+            os="Windows Server 2022",
+            type="server",
+            roles=["file_server"],
+            services=["smb"],
+        )
+        dc_server = System(
+            hostname="DC-01",
+            ip="10.10.2.10",
+            os="Windows Server 2022",
+            type="domain_controller",
+            roles=["domain_controller"],
+            services=["smb"],
+        )
+        activity_gen._ip_to_system = {
+            workstation.ip: workstation,
+            file_server.ip: file_server,
+            dc_server.ip: dc_server,
+        }
+        activity_gen._users_by_username = {test_user.username: test_user}
+        state_manager.set_current_time(timestamp - timedelta(minutes=10))
+        state_manager.create_session(
+            username=test_user.username,
+            system=workstation.hostname,
+            logon_type=2,
+            source_ip="-",
+            session_kind="interactive",
+        )
+        state_manager.set_current_time(timestamp)
+
+        file_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=workstation,
+            time=timestamp,
+            service="smb",
+            dst_port=445,
+            proto="tcp",
+            hostname=file_server.hostname,
+            http=None,
+        )
+        dc_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=workstation,
+            time=timestamp + timedelta(seconds=3),
+            service="smb",
+            dst_port=445,
+            proto="tcp",
+            hostname=dc_server.hostname,
+            http=None,
+        )
+        file_reuse_pid, _ = activity_gen._ensure_high_confidence_connection_owner(
+            source_system=workstation,
+            time=timestamp + timedelta(seconds=6),
+            service="smb",
+            dst_port=445,
+            proto="tcp",
+            hostname=file_server.hostname,
+            http=None,
+        )
+
+        file_proc = state_manager.get_process(workstation.hostname, file_pid)
+        dc_proc = state_manager.get_process(workstation.hostname, dc_pid)
+        assert file_proc is not None
+        assert dc_proc is not None
+        assert file_pid != dc_pid
+        assert file_reuse_pid == file_pid
+        assert file_proc.command_line == "gvfsd-smb-browse smb://FILE-SRV-01/shared"
+        assert dc_proc.command_line == "gvfsd-smb-browse smb://DC-01/shared"
+
     def test_sqlcmd_unresolved_host_emits_failed_network_attempt(
         self, activity_gen, test_system, state_manager, mock_emitters
     ):
@@ -5642,11 +6196,22 @@ class TestActivityGenerator:
         )
 
         assert emitted is True
-        event = [
-            call[0][0]
-            for call in mock_emitters["windows_event_security"].emit.call_args_list
-            if call[0][0].event_type == "create_remote_thread"
+        emitted_events = [
+            call[0][0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+        ]
+        process_access = [
+            event for event in emitted_events if event.event_type == "process_access"
         ][-1]
+        event = [
+            emitted_event
+            for emitted_event in emitted_events
+            if emitted_event.event_type == "create_remote_thread"
+        ][-1]
+        assert process_access.timestamp < event.timestamp
+        assert process_access.process_access is not None
+        assert process_access.process_access.target_pid == target_pid
+        assert process_access.process_access.target_process_object_id == target_obj_id
+        assert process_access.edr.actor_id == source_obj_id
         assert event.remote_thread is not None
         assert event.remote_thread.target_pid == target_pid
         assert event.remote_thread.target_process_object_id == target_obj_id
@@ -6878,6 +7443,43 @@ class TestActivityGenerator:
         assert explicit.auth.source_ip == "-"
         assert explicit.auth.source_port == 0
 
+    def test_generate_explicit_credentials_resolves_known_remote_target_endpoint(
+        self, activity_gen, test_user, test_system, state_manager, mock_emitters
+    ):
+        """Known remote 4648 targets should render joinable destination endpoint metadata."""
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        state_manager.set_current_time(timestamp)
+        target_system = System(
+            hostname="FILE-SRV-01",
+            ip="10.0.0.50",
+            os="Windows Server 2022",
+            type="server",
+        )
+        activity_gen._ip_to_system = {
+            test_system.ip: test_system,
+            target_system.ip: target_system,
+        }
+        activity_gen._world_model = SimpleNamespace(
+            systems_by_hostname={target_system.hostname: target_system}
+        )
+
+        activity_gen.generate_explicit_credentials(
+            user=test_user,
+            system=test_system,
+            time=timestamp,
+            target_username="admin01",
+            target_server=target_system.hostname,
+            process_name=r"C:\Windows\System32\mmc.exe",
+            process_pid=4242,
+        )
+
+        emitted = [
+            call[0][0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+        ]
+        explicit = next(event for event in emitted if event.event_type == "explicit_credentials")
+        assert explicit.auth.source_ip == target_system.ip
+        assert 49152 <= explicit.auth.source_port <= 65535
+
     def test_generate_explicit_credentials_ignores_unrelated_source_ip_override(
         self, activity_gen, test_user, test_system, state_manager, mock_emitters
     ):
@@ -7685,6 +8287,86 @@ class TestActivityGenerator:
         assert service.timestamp < connection.timestamp
         assert service.kerberos.target_username == "WEB-EXT-01$@CORP.LOCAL"
         assert service.kerberos.source_port == connection.network.src_port
+
+    def test_newly_created_account_service_ticket_emits_visible_tgt_and_kdc_flow(
+        self, activity_gen, state_manager, mock_emitters
+    ):
+        """First visible TGS for a visible-created account should not use pre-window cache."""
+        created_at = datetime(2024, 3, 18, 16, 15, 24, tzinfo=UTC)
+        service_time = datetime(2024, 3, 18, 17, 1, 29, 335000, tzinfo=UTC)
+        state_manager.set_current_time(created_at)
+        actor = User(
+            username="aisha.johnson",
+            full_name="Aisha Johnson",
+            email="aisha.johnson@example.com",
+        )
+        source = System(
+            hostname="WS-AJOHNSON",
+            ip="10.10.1.35",
+            os="Windows 11",
+            type="workstation",
+        )
+        dc = System(
+            hostname="DC-01",
+            ip="10.10.1.10",
+            os="Windows Server 2022",
+            type="domain_controller",
+            services=["ad-ds", "kerberos"],
+            roles=["domain_controller"],
+        )
+        activity_gen._ip_to_system = {source.ip: source, dc.ip: dc}
+
+        activity_gen.generate_account_created(
+            actor=actor,
+            system=dc,
+            time=created_at,
+            target_username="svc_mhsync",
+            target_sid="S-1-5-21-1000-1000-1000-1901",
+        )
+        mock_emitters["windows_event_security"].emit.reset_mock()
+        mock_emitters["zeek_conn"].emit.reset_mock()
+
+        activity_gen.generate_kerberos_service_ticket(
+            username="svc_mhsync",
+            service_name="cifs/FILE-SRV-01",
+            source_ip=source.ip,
+            dc_hostname=dc.hostname,
+            time=service_time,
+            source_port=55466,
+        )
+
+        win_events = [
+            call.args[0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+        ]
+        kerberos_events = [
+            event
+            for event in win_events
+            if event.event_type in {"kerberos_tgt", "kerberos_service"}
+        ]
+        assert [event.event_type for event in kerberos_events] == [
+            "kerberos_tgt",
+            "kerberos_service",
+        ]
+        tgt, service = kerberos_events
+        assert tgt.timestamp < service.timestamp
+        assert tgt.kerberos.target_username == "svc_mhsync"
+        assert service.kerberos.target_username == "svc_mhsync"
+        assert tgt.kerberos.source_port == 55466
+        assert service.kerberos.source_port == 55466
+
+        conn_events = [
+            call.args[0]
+            for call in mock_emitters["zeek_conn"].emit.call_args_list
+            if call.args[0].event_type == "connection"
+        ]
+        assert len(conn_events) == 1
+        connection = conn_events[0]
+        assert connection.timestamp < service.timestamp
+        assert connection.network.src_ip == source.ip
+        assert connection.network.dst_ip == dc.ip
+        assert connection.network.src_port == 55466
+        assert connection.network.dst_port == 88
+        assert connection.network.service == "kerberos"
 
     def test_generate_connection_reuses_recent_kdc_audit_for_kerberos_flows(
         self, activity_gen, state_manager, mock_emitters
@@ -9155,6 +9837,273 @@ class TestActivityGenerator:
 
         assert npm_create.process.parent_pid == bash_pid
         assert npm_create.timestamp > blocked_until
+
+    def test_generate_bash_command_moves_history_with_busy_foreground_shell(
+        self, activity_gen, test_user, state_manager, mock_emitters
+    ):
+        """Bash history and process telemetry should share the foreground-shell slot."""
+        command_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        linux = System(
+            hostname="WS-LNGUYEN-01",
+            ip="10.0.2.60",
+            os="Ubuntu 22.04",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        logon_id = "0xabc458"
+        state_manager.set_current_time(command_time - timedelta(seconds=60))
+        systemd_pid = state_manager.create_process(
+            linux.hostname,
+            0,
+            "/usr/lib/systemd/systemd",
+            "/usr/lib/systemd/systemd --system",
+            "root",
+            "System",
+        )
+        sshd_pid = state_manager.create_process(
+            linux.hostname,
+            systemd_pid,
+            "/usr/sbin/sshd",
+            "/usr/sbin/sshd -D",
+            "root",
+            "System",
+        )
+        session = state_manager.register_session(
+            logon_id=logon_id,
+            username=test_user.username,
+            system=linux.hostname,
+            logon_type=10,
+            source_ip="10.0.0.50",
+            start_time=command_time - timedelta(seconds=30),
+        )
+        bash_pid = state_manager.create_process(
+            linux.hostname,
+            sshd_pid,
+            "/bin/bash",
+            "-bash",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        session.session_shell_pid = bash_pid
+        activity_gen._system_pids = {
+            linux.hostname: {"systemd": systemd_pid, "sshd": sshd_pid, "bash": bash_pid}
+        }
+        blocked_until = command_time + timedelta(minutes=30)
+        activity_gen._foreground_shell_next_time[
+            (linux.hostname, test_user.username, logon_id, bash_pid)
+        ] = blocked_until
+
+        scheduled = activity_gen.generate_bash_command(
+            test_user,
+            linux,
+            command_time,
+            "hostname -f",
+        )
+
+        events = [
+            call.args[0] for call in mock_emitters["windows_event_security"].emit.call_args_list
+        ]
+        bash_event = next(
+            event
+            for event in events
+            if event.event_type == "bash_command"
+            and event.shell is not None
+            and event.shell.command == "hostname -f"
+        )
+        hostname_create = next(
+            event
+            for event in events
+            if event.event_type == "process_create"
+            and event.process is not None
+            and event.process.image == "/usr/bin/hostname"
+        )
+
+        assert scheduled == bash_event.timestamp
+        assert bash_event.timestamp > blocked_until
+        assert hostname_create.process.parent_pid == bash_pid
+        assert hostname_create.process.concurrency_group_id.startswith("bash-history:")
+        assert (
+            timedelta(0) < hostname_create.timestamp - bash_event.timestamp < timedelta(seconds=1)
+        )
+
+    def test_foreground_termination_uses_source_visible_release_time(
+        self, activity_gen, test_user, state_manager, monkeypatch
+    ):
+        """Foreground shell availability should follow rendered endpoint completion."""
+        command_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        linux = System(
+            hostname="WS-LNGUYEN-01",
+            ip="10.0.2.60",
+            os="Ubuntu 22.04",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        logon_id = "0xabc459"
+        state_manager.set_current_time(command_time)
+        systemd_pid = state_manager.create_process(
+            linux.hostname,
+            0,
+            "/usr/lib/systemd/systemd",
+            "/usr/lib/systemd/systemd --system",
+            "root",
+            "System",
+        )
+        bash_pid = state_manager.create_process(
+            linux.hostname,
+            systemd_pid,
+            "/bin/bash",
+            "-bash",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        child_pid = state_manager.create_process(
+            linux.hostname,
+            bash_pid,
+            "/usr/bin/python3",
+            "python3 -m pytest",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        source_visible_done = command_time + timedelta(minutes=7)
+
+        def source_terminate_time(hostname: str, pid: int) -> datetime | None:
+            if hostname == linux.hostname and pid == child_pid:
+                return source_visible_done
+            return None
+
+        monkeypatch.setattr(
+            activity_gen,
+            "process_source_terminate_time",
+            source_terminate_time,
+        )
+
+        release_time = activity_gen._generate_bounded_foreground_process_termination(
+            user=test_user,
+            system=linux,
+            start_time=command_time,
+            pid=child_pid,
+            process_name="/usr/bin/python3",
+            logon_id=logon_id,
+            lifetime=(1.0, 1.0),
+            rng=random.Random(7),
+        )
+        activity_gen._remember_foreground_shell_available(
+            system=linux,
+            username=test_user.username,
+            logon_id=logon_id,
+            parent_pid=bash_pid,
+            termination_time=release_time,
+            seed_text="python3 -m pytest",
+        )
+        reserved = activity_gen.reserve_linux_foreground_process_start(
+            system=linux,
+            username=test_user.username,
+            logon_id=logon_id,
+            parent_pid=bash_pid,
+            requested_time=command_time + timedelta(seconds=2),
+            process_name="/usr/bin/hostname",
+            command_line="hostname -f",
+        )
+
+        assert release_time == source_visible_done
+        assert reserved > source_visible_done
+
+    def test_linux_proxy_client_process_uses_non_shell_session_parent(
+        self, activity_gen, test_user, state_manager
+    ):
+        """Synthetic Linux proxy socket owners should not occupy the foreground shell."""
+        request_time = datetime(2024, 1, 15, 10, 5, 0, tzinfo=UTC)
+        linux = System(
+            hostname="WS-LNGUYEN-01",
+            ip="10.0.2.60",
+            os="Ubuntu 22.04",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        proxy = System(
+            hostname="PROXY-01",
+            ip="10.0.3.20",
+            os="Ubuntu 22.04",
+            type="server",
+            roles=["forward_proxy"],
+        )
+        logon_id = "0xabc460"
+        state_manager.set_current_time(request_time - timedelta(minutes=10))
+        systemd_pid = state_manager.create_process(
+            linux.hostname,
+            0,
+            "/usr/lib/systemd/systemd",
+            "/usr/lib/systemd/systemd --system",
+            "root",
+            "System",
+        )
+        user_systemd_pid = state_manager.create_process(
+            linux.hostname,
+            systemd_pid,
+            "/usr/lib/systemd/systemd",
+            "/usr/lib/systemd/systemd --user",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        terminal_pid = state_manager.create_process(
+            linux.hostname,
+            user_systemd_pid,
+            "/usr/libexec/gnome-terminal-server",
+            "/usr/libexec/gnome-terminal-server",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        bash_pid = state_manager.create_process(
+            linux.hostname,
+            terminal_pid,
+            "/bin/bash",
+            "-bash",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        session = state_manager.register_session(
+            logon_id=logon_id,
+            username=test_user.username,
+            system=linux.hostname,
+            logon_type=2,
+            source_ip="-",
+            start_time=request_time - timedelta(minutes=9),
+            session_kind="interactive",
+        )
+        session.process_tree_root = terminal_pid
+        session.session_shell_pid = bash_pid
+        activity_gen._users_by_username = {test_user.username: test_user}
+        activity_gen._system_pids = {linux.hostname: {"systemd": systemd_pid, "bash": bash_pid}}
+        proxy_context = ProxyContext(
+            client_ip=linux.ip,
+            username=test_user.username,
+            method="GET",
+            url="https://api.gitlab.com/",
+            host="api.gitlab.com",
+            status_code=200,
+            user_agent="python-requests/2.31.0",
+            proxy_fqdn="PROXY-01.meridianhcs.local",
+        )
+
+        pid, image = activity_gen._ensure_explicit_proxy_client_process(
+            source_system=linux,
+            time=request_time,
+            proxy_context=proxy_context,
+            proxy_sys=proxy,
+            dst_port=443,
+        )
+
+        proc = state_manager.get_process(linux.hostname, pid)
+        assert image == "/usr/bin/python3"
+        assert proc is not None
+        assert proc.parent_pid == terminal_pid
+        assert proc.parent_pid != bash_pid
 
     def test_process_user_apps_bash_pool_respects_database_role(
         self, activity_gen, test_user, monkeypatch, mock_emitters

--- a/tests/unit/test_baseline_canonical.py
+++ b/tests/unit/test_baseline_canonical.py
@@ -1302,7 +1302,11 @@ class TestWebAccessCorrelation:
             hostname="WEB-EXT-01.meridianhcs.local",
         )
 
-        event = mock_emitters["zeek_http"].emit.call_args[0][0]
+        event = next(
+            call.args[0]
+            for call in mock_emitters["zeek_http"].emit.call_args_list
+            if call.args[0].event_type == "connection" and call.args[0].http is not None
+        )
         assert event.http is not None
         assert "Mozilla/" not in event.http.user_agent
         if event.process is not None:
@@ -1463,7 +1467,10 @@ class TestSyslogContext:
         ecar_session_events = [
             call.args[0]
             for call in mock_emitters["ecar"].emit.call_args_list
-            if call.args[0].auth is not None and call.args[0].auth.username == "alice"
+            if call.args[0].auth is not None
+            and call.args[0].auth.username == "alice"
+            and call.args[0].auth.logon_id == logon_id
+            and call.args[0].event_type == "ssh_session"
         ]
         assert [event.event_type for event in ecar_session_events] == ["ssh_session"]
         assert ecar_session_events[0].auth.logon_id == logon_id

--- a/tests/unit/test_baseline_canonical.py
+++ b/tests/unit/test_baseline_canonical.py
@@ -56,6 +56,7 @@ from evidenceforge.generation.engine.baseline import (
     _linux_baseline_pam_close_lead,
     _linux_baseline_pam_open_lead,
     _linux_baseline_session_initiator,
+    _linux_sudo_command_runtime,
     _linux_transient_syslog_pid,
     _materialize_registry_value_for_time,
     _module_matches_process,
@@ -410,6 +411,79 @@ def test_server_pam_initiator_favors_sudo_over_local_login():
     assert services.count("login") <= 12
 
 
+def test_baseline_ssh_identity_uses_role_scoped_user_and_owned_source():
+    """Ambient baseline SSH should not pair admin users with unrelated workstations."""
+    from evidenceforge.generation.world_model import WorldModel
+    from evidenceforge.models.scenario import (
+        BaselineActivity,
+        Environment,
+        OutputSpec,
+        Scenario,
+        TimeWindow,
+    )
+
+    marcus = User(
+        username="marcus.chen",
+        full_name="Marcus Chen",
+        email="marcus@example.com",
+        persona="sysadmin",
+        primary_system="WS-MCHEN-01",
+    )
+    diego = User(
+        username="diego.ramirez",
+        full_name="Diego Ramirez",
+        email="diego@example.com",
+        persona="accountant",
+        primary_system="WS-DRAMIREZ-01",
+    )
+    db_server = System(
+        hostname="DB-PROD-01",
+        ip="10.10.4.10",
+        os="CentOS 8",
+        type="server",
+        services=["mysql", "ssh"],
+        roles=["database"],
+    )
+    scenario = Scenario(
+        name="baseline-ssh-source-test",
+        description="SSH source-role regression",
+        environment=Environment(
+            description="SSH source-role regression",
+            users=[marcus, diego],
+            systems=[
+                System(
+                    hostname="WS-MCHEN-01",
+                    ip="10.10.1.31",
+                    os="Windows 11",
+                    type="workstation",
+                    assigned_user="marcus.chen",
+                ),
+                System(
+                    hostname="WS-DRAMIREZ-01",
+                    ip="10.10.1.34",
+                    os="Windows 11",
+                    type="workstation",
+                    assigned_user="diego.ramirez",
+                ),
+                db_server,
+            ],
+        ),
+        time_window=TimeWindow(start=datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC), duration="1h"),
+        baseline_activity=BaselineActivity(description="Normal", intensity="low", variation="low"),
+        output=OutputSpec(logs=[{"format": "zeek"}], destination="./out"),
+    )
+    engine = object.__new__(BaselineMixin)
+    engine.scenario = scenario
+    engine.world_model = WorldModel(scenario, "example.com")
+
+    identity = engine._pick_baseline_ssh_identity(db_server, random.Random(7))
+
+    assert identity is not None
+    ssh_user, source_system = identity
+    assert ssh_user.username == "marcus.chen"
+    assert source_system.hostname == "WS-MCHEN-01"
+
+
 def test_extra_sudo_command_template_uses_host_services():
     """Extra sudo COMMAND text should vary through host-aware service placeholders."""
     command = _render_extra_sudo_command_template(
@@ -450,6 +524,31 @@ def test_linux_baseline_pam_leads_leave_visible_ordering_margin():
     assert max(open_leads) <= timedelta(seconds=8)
     assert min(close_leads) >= timedelta(milliseconds=1200)
     assert max(close_leads) <= timedelta(milliseconds=4200)
+
+
+def test_linux_sudo_command_runtime_respects_interval_arguments():
+    """Interval sudo commands should keep the PAM session open for their runtime."""
+    rng = random.Random(17)
+
+    vmstat = _linux_sudo_command_runtime("/usr/bin/vmstat 1 5", rng)
+    iostat = _linux_sudo_command_runtime("/usr/bin/iostat -xz 1 3", rng)
+
+    assert vmstat >= timedelta(seconds=5)
+    assert iostat >= timedelta(seconds=3)
+
+
+def test_linux_sudo_command_runtime_varies_by_command_family():
+    """Ordinary sudo command families should not share one sub-second envelope."""
+    package_runtime = _linux_sudo_command_runtime("/usr/bin/apt-get -s upgrade", random.Random(3))
+    quick_runtime = _linux_sudo_command_runtime("/usr/bin/df -h /srv", random.Random(3))
+    journal_runtime = _linux_sudo_command_runtime(
+        "/usr/bin/journalctl -u sshd -n 80",
+        random.Random(3),
+    )
+
+    assert package_runtime > quick_runtime
+    assert journal_runtime > timedelta(seconds=1)
+    assert quick_runtime > timedelta(milliseconds=300)
 
 
 def test_linux_transient_syslog_pid_uses_host_pid_allocator():
@@ -1613,7 +1712,7 @@ class TestDhcpLease:
         current_hour = datetime(2024, 3, 15, 13, 0, 0, tzinfo=UTC)
         warmup_lease_epoch = datetime(2024, 3, 15, 11, 3, 0, tzinfo=UTC).timestamp()
 
-        due, updated_last = _dhcp_renewal_epochs_for_hour(
+        due, updated_last, pending_next = _dhcp_renewal_epochs_for_hour(
             last_renewal=warmup_lease_epoch,
             lease_time=3600.0,
             current_hour=current_hour,
@@ -1623,15 +1722,16 @@ class TestDhcpLease:
         hour_start = current_hour.timestamp()
         hour_end = (current_hour + timedelta(hours=1)).timestamp()
         assert len(due) >= 2
-        assert all(hour_start <= epoch < hour_end for epoch in due)
-        assert updated_last == due[-1]
+        assert all(hour_start <= epoch < hour_end for epoch, _interval in due)
+        assert updated_last >= due[-1][0]
+        assert pending_next is not None
 
     def test_dhcp_renewal_schedule_emits_multiple_due_renewals(self):
         """One-hour leases can have more than one visible renewal inside one hour."""
         current_hour = datetime(2024, 3, 15, 13, 0, 0, tzinfo=UTC)
         recent_renewal_epoch = datetime(2024, 3, 15, 12, 45, 0, tzinfo=UTC).timestamp()
 
-        due, updated_last = _dhcp_renewal_epochs_for_hour(
+        due, updated_last, pending_next = _dhcp_renewal_epochs_for_hour(
             last_renewal=recent_renewal_epoch,
             lease_time=3600.0,
             current_hour=current_hour,
@@ -1639,9 +1739,43 @@ class TestDhcpLease:
         )
 
         assert len(due) == 2
-        assert due == sorted(due)
-        assert updated_last == due[-1]
-        assert min(b - a for a, b in zip(due[:-1], due[1:], strict=True)) > 20 * 60
+        epochs = [epoch for epoch, _interval in due]
+        assert epochs == sorted(epochs)
+        assert updated_last >= epochs[-1]
+        assert pending_next is not None
+        assert min(b - a for a, b in zip(epochs[:-1], epochs[1:], strict=True)) > 20 * 60
+        assert due[0][1] == pytest.approx(epochs[1] - epochs[0])
+
+    def test_dhcp_renewal_schedule_advertises_next_cross_hour_interval(self):
+        """The final visible renewal should advertise the next scheduled renewal."""
+        current_hour = datetime(2024, 3, 15, 13, 0, 0, tzinfo=UTC)
+        recent_renewal_epoch = datetime(2024, 3, 15, 12, 45, 0, tzinfo=UTC).timestamp()
+
+        due, updated_last, pending_next = _dhcp_renewal_epochs_for_hour(
+            last_renewal=recent_renewal_epoch,
+            lease_time=3600.0,
+            current_hour=current_hour,
+            rng=random.Random(11),
+        )
+
+        assert due
+        last_epoch, advertised_interval = due[-1]
+        assert pending_next is not None
+        assert pending_next >= (current_hour + timedelta(hours=1)).timestamp()
+        assert updated_last == last_epoch
+        assert advertised_interval == pytest.approx(pending_next - last_epoch)
+
+        next_due, next_updated, next_pending = _dhcp_renewal_epochs_for_hour(
+            last_renewal=updated_last,
+            lease_time=3600.0,
+            current_hour=current_hour + timedelta(hours=1),
+            rng=random.Random(12),
+            next_renewal=pending_next,
+        )
+
+        assert next_due[0][0] == pending_next
+        assert next_updated >= next_due[-1][0]
+        assert next_pending is not None
 
     def test_dhcp_lease_bundle_anchor_is_stable(self, timestamp):
         """DHCP lease requests should expose durable deterministic anchors."""
@@ -1785,6 +1919,7 @@ class TestDhcpLease:
             server_addr="10.0.0.1",
             lease_time=7200.0,
             msg_types=["REQUEST", "ACK"],
+            renewal_interval=3425.0,
         )
 
         syslog_events = [
@@ -1799,7 +1934,7 @@ class TestDhcpLease:
         assert syslog_messages == [
             f"DHCPREQUEST for 10.0.10.2 on {interface} to 10.0.0.1 port 67",
             "DHCPACK of 10.0.10.2 from 10.0.0.1",
-            "bound to 10.0.10.2 -- renewal in 3600 seconds.",
+            "bound to 10.0.10.2 -- renewal in 3422 seconds.",
         ]
         gaps = [
             syslog_events[idx].timestamp - syslog_events[idx - 1].timestamp
@@ -1886,6 +2021,45 @@ class TestAnonymousLogon:
         sessions_after = len(state_manager.state.active_sessions)
         assert sessions_after == sessions_before
 
+    def test_anonymous_logon_emits_short_lived_logoff(
+        self, activity_gen, state_manager, mock_emitters, timestamp
+    ):
+        """Anonymous Type 3 logons should have paired 4634-style lifecycle evidence."""
+        dc = System(
+            hostname="DC-01",
+            ip="10.0.10.100",
+            os="Windows Server 2019",
+            type="domain_controller",
+        )
+        state_manager.set_current_time(timestamp)
+        sessions_before = len(state_manager.state.active_sessions)
+
+        activity_gen.generate_anonymous_logon(system=dc, time=timestamp)
+
+        win_events = [
+            call.args[0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call.args[0].event_type in {"logon", "logoff"}
+        ]
+        ecar_events = [
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type in {"logon", "logoff"}
+        ]
+        assert [event.event_type for event in win_events] == ["logon", "logoff"]
+        assert [event.event_type for event in ecar_events] == ["logon", "logoff"]
+        assert win_events[0].auth.username == "ANONYMOUS LOGON"
+        assert win_events[1].auth.username == "ANONYMOUS LOGON"
+        assert win_events[1].auth.logon_id == win_events[0].auth.logon_id
+        assert win_events[1].auth.logon_type == 3
+        assert ecar_events[0].edr is not None
+        assert ecar_events[1].edr is not None
+        assert ecar_events[0].edr.object_id
+        assert ecar_events[1].edr.object_id == ecar_events[0].edr.object_id
+        assert ecar_events[1].auth.logon_id == ecar_events[0].auth.logon_id
+        assert timestamp < win_events[1].timestamp <= timestamp + timedelta(seconds=30)
+        assert len(state_manager.state.active_sessions) == sessions_before
+
 
 class TestNoInternalGenerateRaw:
     """Verify no internal engine code calls generate_raw()."""
@@ -1941,8 +2115,9 @@ class TestBaselineSshTiming:
         assert 'source_roll < 0.32 + _LINUX_AMBIENT_SSH_NOISE_BAND and sys_type == "server"' in (
             source
         )
-        assert "ssh_roster = self._get_server_ssh_users(system)" in source
-        assert "ssh_usernames = [user.username for user in ssh_roster]" in source
+        assert "ssh_identity = self._pick_baseline_ssh_identity(system, rng)" in source
+        assert "ssh_user_model, src_sys_obj = ssh_identity" in source
+        assert "ssh_user = ssh_user_model.username" in source
 
 
 class TestBaselineRegistryRealism:
@@ -3109,6 +3284,10 @@ class TestWebAccessExternalVisitors:
                     "kind": "requests",
                     "request_count": [1, 1],
                     "user_agent_pool": "health_check",
+                    "user_agent_pool_by_os": {
+                        "windows": "health_check_windows",
+                        "linux": "health_check_linux",
+                    },
                     "source_type_any": ["server", "domain_controller"],
                     "source_role_any": ["monitoring", "load_balancer", "forward_proxy"],
                     "referrer_mode": "none",
@@ -3145,6 +3324,7 @@ class TestWebAccessExternalVisitors:
 
         collected = []
         activity_gen = MagicMock()
+        activity_gen._proxy_user_agent_for_context = None
         activity_gen._ip_to_system = {workstation.ip: workstation, monitor.ip: monitor}
         activity_gen.generate_connection.side_effect = lambda **kw: collected.append(kw)
         engine = MagicMock()
@@ -3169,4 +3349,11 @@ class TestWebAccessExternalVisitors:
         assert {kw["src_ip"] for kw in collected} == {monitor.ip}
         assert all(kw["source_system"] is monitor for kw in collected)
         assert all(kw["http"].uri == "/api/v1/health" for kw in collected)
+        linux_health_check_uas = set(
+            web_session_profiles.load_web_session_profiles()["user_agent_pools"][
+                "health_check_linux"
+            ]
+        )
+        assert all(kw["http"].user_agent in linux_health_check_uas for kw in collected)
+        assert all("kube-probe" not in kw["http"].user_agent for kw in collected)
         assert all(42 <= kw["http"].response_body_len <= 720 for kw in collected)

--- a/tests/unit/test_browsing_session.py
+++ b/tests/unit/test_browsing_session.py
@@ -73,6 +73,22 @@ class TestBrowsingSessionBasics:
             )
             assert not any(req.referrer.startswith("https://") for req in requests)
 
+    def test_calendar_api_time_min_tracks_session_month(self):
+        """Calendar API subresources should not carry fixed future dates."""
+        requests = generate_browsing_session(
+            random.Random(0),
+            "calendar.google.com",
+            ["saas"],
+            browsing_intensity="heavy",
+            request_time=datetime(2024, 3, 18, 9, 30, tzinfo=UTC),
+        )
+
+        calendar_paths = [request.path for request in requests if "timeMin=" in request.path]
+
+        assert calendar_paths
+        assert all("timeMin=2024-03-01T00:00:00Z" in path for path in calendar_paths)
+        assert all("2026-01-01" not in path for path in calendar_paths)
+
 
 class TestBrowserSessionActionBundle:
     """Action-bundle expansion behavior."""

--- a/tests/unit/test_causal_engine.py
+++ b/tests/unit/test_causal_engine.py
@@ -391,27 +391,48 @@ class TestKerberosBeforeLogon:
 class TestProcessAccessAfterRemoteThread:
     def test_matches_crt_targeting_lsass(self):
         rule = ProcessAccessAfterRemoteThread()
-        ctx = _make_ctx(target_image=r"C:\Windows\System32\lsass.exe")
+        ctx = _make_ctx(
+            source_pid=1234,
+            target_pid=636,
+            target_image=r"C:\Windows\System32\lsass.exe",
+        )
         assert rule.matches("create_remote_thread", ctx) is True
 
     def test_matches_lsass_case_insensitive(self):
         rule = ProcessAccessAfterRemoteThread()
-        ctx = _make_ctx(target_image=r"C:\Windows\System32\LSASS.EXE")
+        ctx = _make_ctx(
+            source_pid=1234,
+            target_pid=636,
+            target_image=r"C:\Windows\System32\LSASS.EXE",
+        )
         assert rule.matches("create_remote_thread", ctx) is True
 
-    def test_skips_non_lsass_target(self):
+    def test_matches_non_lsass_target(self):
         rule = ProcessAccessAfterRemoteThread()
-        ctx = _make_ctx(target_image=r"C:\Windows\System32\svchost.exe")
-        assert rule.matches("create_remote_thread", ctx) is False
+        ctx = _make_ctx(
+            source_pid=4600,
+            target_pid=4796,
+            target_image=r"C:\Windows\System32\svchost.exe",
+        )
+        assert rule.matches("create_remote_thread", ctx) is True
 
     def test_skips_non_crt_event(self):
         rule = ProcessAccessAfterRemoteThread()
-        ctx = _make_ctx(target_image=r"C:\Windows\System32\lsass.exe")
+        ctx = _make_ctx(
+            source_pid=1234,
+            target_pid=636,
+            target_image=r"C:\Windows\System32\lsass.exe",
+        )
         assert rule.matches("process_create", ctx) is False
 
     def test_skips_no_target_image(self):
         rule = ProcessAccessAfterRemoteThread()
-        ctx = _make_ctx(target_image=None)
+        ctx = _make_ctx(source_pid=1234, target_pid=636, target_image=None)
+        assert rule.matches("create_remote_thread", ctx) is False
+
+    def test_skips_missing_pid_context(self):
+        rule = ProcessAccessAfterRemoteThread()
+        ctx = _make_ctx(target_image=r"C:\Windows\System32\lsass.exe")
         assert rule.matches("create_remote_thread", ctx) is False
 
     def test_expand_returns_process_access(self):
@@ -434,6 +455,32 @@ class TestProcessAccessAfterRemoteThread:
         assert ev.timing.position == "before"
         assert ev.timing.min_ms == 1
         assert ev.timing.max_ms == 75
+
+    def test_expand_non_lsass_returns_lower_friction_process_access(self):
+        rule = ProcessAccessAfterRemoteThread()
+        ctx = _make_ctx(
+            actor="SYSTEM",
+            target_system="WS-01",
+            source_pid=4600,
+            source_image=(
+                r"C:\ProgramData\Microsoft\Windows Defender\Platform"
+                r"\4.18.2301.6-0\MsMpEng.exe"
+            ),
+            target_pid=4796,
+            target_image=r"C:\Windows\System32\RuntimeBroker.exe",
+        )
+
+        result = rule.expand("create_remote_thread", ctx)
+
+        assert len(result) == 1
+        ev = result[0]
+        assert ev.method == "generate_process_access"
+        assert ev.kwargs["granted_access"] == "0x1010"
+        assert ev.kwargs["source_pid"] == 4600
+        assert ev.kwargs["target_pid"] == 4796
+        assert ev.timing.position == "before"
+        assert ev.timing.min_ms == 8
+        assert ev.timing.max_ms == 180
 
 
 # --- SupplementaryAuditEvents rule ---

--- a/tests/unit/test_dhcp_setup.py
+++ b/tests/unit/test_dhcp_setup.py
@@ -103,7 +103,12 @@ def test_emit_dhcp_leases_keeps_storyline_hosts_in_warmup_state(tmp_path):
     assert kwargs["time"] < engine.start_time
     assert kwargs["time"] < engine.end_time
     assert "msg_types" not in kwargs
+    assert kwargs["renewal_interval"] > 0
     assert engine._dhcp_lease_state["TEST-01"]["last_renewal"] == kwargs["time"].timestamp()
+    assert (
+        engine._dhcp_lease_state["TEST-01"]["next_renewal"]
+        == kwargs["time"].timestamp() + kwargs["renewal_interval"]
+    )
 
 
 def test_emit_dhcp_leases_uses_storyline_mac_as_host_identity(tmp_path):
@@ -121,7 +126,12 @@ def test_emit_dhcp_leases_uses_storyline_mac_as_host_identity(tmp_path):
 
     kwargs = engine.activity_generator.generate_dhcp_lease.call_args.kwargs
     assert kwargs["mac"] == "dc:a6:32:44:91:7b"
+    assert kwargs["renewal_interval"] > 0
     assert engine._dhcp_lease_state["TEST-01"]["mac"] == "dc:a6:32:44:91:7b"
+    assert (
+        engine._dhcp_lease_state["TEST-01"]["next_renewal"]
+        == kwargs["time"].timestamp() + kwargs["renewal_interval"]
+    )
 
 
 def test_emit_dhcp_leases_handles_null_storyline(tmp_path):
@@ -141,7 +151,30 @@ def test_emit_dhcp_leases_handles_null_storyline(tmp_path):
     engine.activity_generator.generate_dhcp_lease.assert_called_once()
     kwargs = engine.activity_generator.generate_dhcp_lease.call_args.kwargs
     assert kwargs["system"].hostname == "TEST-01"
+    assert kwargs["renewal_interval"] > 0
     assert engine._dhcp_lease_state["TEST-01"]["mac"] == kwargs["mac"]
+    assert (
+        engine._dhcp_lease_state["TEST-01"]["next_renewal"]
+        == kwargs["time"].timestamp() + kwargs["renewal_interval"]
+    )
+
+
+def test_storyline_dhcp_lease_time_in_hour_finds_authored_event(tmp_path):
+    """Baseline DHCP scheduling should be able to defer to an authored DHCP event."""
+    scenario = _scenario_with_storyline_dhcp()
+    engine = GenerationEngine(scenario, tmp_path)
+    engine.start_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+    event_time = engine._storyline_dhcp_lease_time_in_hour("TEST-01", engine.start_time)
+
+    assert event_time == datetime(2024, 1, 15, 10, 0, 30, tzinfo=UTC)
+    assert (
+        engine._storyline_dhcp_lease_time_in_hour(
+            "OTHER-01",
+            engine.start_time,
+        )
+        is None
+    )
 
 
 def test_emit_dhcp_leases_skips_static_infrastructure_servers(tmp_path):

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -224,6 +224,128 @@ class TestObservationProfiles:
         assert event.timestamp == _make_ts()
         assert dispatcher.source_evidence_status["story-001"]["sysmon"] == {"delayed": 1}
 
+    def test_ssh_success_syslog_lifecycle_rows_share_observation_delay(self, monkeypatch):
+        """Successful SSH syslog lifecycle rows should not be reordered by delay."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "syslog": {
+                        "missingness": 0.0,
+                        "delay_ms": {"min_ms": 0, "max_ms": 1000},
+                    }
+                },
+            },
+        )
+        policy = ObservationPolicy("delay_test")
+        host = HostContext(
+            hostname="PROXY-01",
+            ip="10.10.3.20",
+            os="Ubuntu 22.04",
+            os_category="linux",
+            system_type="server",
+        )
+        auth = AuthContext(
+            username="marcus.chen",
+            logon_id="0x1079caef",
+            session_id=266599,
+            logon_type=10,
+            source_ip="10.10.1.31",
+            source_port=52267,
+        )
+        events = [
+            SecurityEvent(
+                timestamp=_make_ts(),
+                event_type="syslog",
+                src_host=host,
+                auth=auth,
+                syslog=SyslogContext(
+                    app_name="sshd",
+                    pid=658147,
+                    facility=10,
+                    severity=6,
+                    message="Connection from 10.10.1.31 port 52267 on 10.10.3.20 port 22",
+                ),
+            ),
+            SecurityEvent(
+                timestamp=_make_ts() + timedelta(milliseconds=100),
+                event_type="syslog",
+                src_host=host,
+                auth=auth,
+                syslog=SyslogContext(
+                    app_name="sshd",
+                    pid=658147,
+                    facility=10,
+                    severity=6,
+                    message="Accepted password for marcus.chen from 10.10.1.31 port 52267 ssh2",
+                ),
+            ),
+            SecurityEvent(
+                timestamp=_make_ts() + timedelta(milliseconds=180),
+                event_type="syslog",
+                src_host=host,
+                auth=auth,
+                syslog=SyslogContext(
+                    app_name="sshd",
+                    pid=658147,
+                    facility=10,
+                    severity=6,
+                    message=(
+                        "pam_unix(sshd:session): session opened for user "
+                        "marcus.chen(uid=4119) by (uid=0)"
+                    ),
+                ),
+            ),
+            SecurityEvent(
+                timestamp=_make_ts() + timedelta(milliseconds=240),
+                event_type="syslog",
+                src_host=host,
+                auth=auth,
+                syslog=SyslogContext(
+                    app_name="systemd-logind",
+                    pid=18702,
+                    facility=10,
+                    severity=6,
+                    message="New session 266599 of user marcus.chen.",
+                ),
+            ),
+            SecurityEvent(
+                timestamp=_make_ts() + timedelta(seconds=60),
+                event_type="logoff",
+                dst_host=host,
+                auth=auth,
+                syslog=SyslogContext(
+                    app_name="sshd",
+                    pid=658147,
+                    facility=10,
+                    severity=6,
+                    message="pam_unix(sshd:session): session closed for user marcus.chen",
+                ),
+            ),
+            SecurityEvent(
+                timestamp=_make_ts() + timedelta(seconds=60, milliseconds=120),
+                event_type="syslog",
+                src_host=host,
+                auth=auth,
+                syslog=SyslogContext(
+                    app_name="systemd-logind",
+                    pid=18702,
+                    facility=10,
+                    severity=6,
+                    message="Removed session 266599.",
+                ),
+            ),
+        ]
+
+        delays = {policy.decide("syslog", event).delay for event in events}
+
+        assert len(delays) == 1
+
     def test_delayed_process_source_observation_extends_process_activity(
         self,
         monkeypatch,
@@ -946,6 +1068,224 @@ class TestObservationProfiles:
             policy.decide("snort_alert", first).delay == policy.decide("snort_alert", second).delay
         )
 
+    def test_ecar_ssh_transport_and_session_observation_are_tuple_coherent(self, monkeypatch):
+        """Target eCAR SSH FLOW and USER_SESSION rows should share observation fate."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "ecar": {
+                        "missingness": 0.0,
+                        "delay_ms": {"min_ms": 5, "max_ms": 1000},
+                    }
+                },
+            },
+        )
+        policy = ObservationPolicy("ecar_ssh_tuple_delay_test")
+        target = HostContext(
+            hostname="WEB-01",
+            ip="10.0.3.10",
+            os="Ubuntu 22.04",
+            os_category="linux",
+            system_type="server",
+        )
+        transport = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="connection",
+            dst_host=target,
+            network=NetworkContext(
+                src_ip="10.0.1.25",
+                src_port=55122,
+                dst_ip="10.0.3.10",
+                dst_port=22,
+                protocol="tcp",
+                zeek_uid="CsshTransport123",
+            ),
+        )
+        login = SecurityEvent(
+            timestamp=_make_ts() + timedelta(seconds=2),
+            event_type="ssh_session",
+            dst_host=target,
+            auth=AuthContext(
+                username="alice",
+                source_ip="10.0.1.25",
+                source_port=55122,
+                logon_id="0x123",
+                logon_type=10,
+            ),
+        )
+
+        assert policy._coherent_group_key("ecar", transport) == policy._coherent_group_key(
+            "ecar", login
+        )
+        assert policy.decide("ecar", transport).delay == policy.decide("ecar", login).delay
+
+    def test_ecar_rdp_transport_and_session_observation_are_tuple_coherent(self, monkeypatch):
+        """Target eCAR RDP FLOW and Type 10 USER_SESSION rows should share observation fate."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "ecar": {
+                        "missingness": 0.0,
+                        "delay_ms": {"min_ms": 5, "max_ms": 1000},
+                    }
+                },
+            },
+        )
+        policy = ObservationPolicy("ecar_rdp_tuple_delay_test")
+        target = HostContext(
+            hostname="FILE-01",
+            ip="10.0.2.20",
+            os="Windows Server 2022",
+            os_category="windows",
+            system_type="server",
+        )
+        transport = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="connection",
+            dst_host=target,
+            network=NetworkContext(
+                src_ip="10.0.1.25",
+                src_port=55891,
+                dst_ip="10.0.2.20",
+                dst_port=3389,
+                protocol="tcp",
+                zeek_uid="CrdpTransport123",
+            ),
+        )
+        login = SecurityEvent(
+            timestamp=_make_ts() + timedelta(seconds=2),
+            event_type="logon",
+            dst_host=target,
+            auth=AuthContext(
+                username="alice",
+                source_ip="10.0.1.25",
+                source_port=55891,
+                logon_id="0x456",
+                logon_type=10,
+            ),
+        )
+
+        assert policy._coherent_group_key("ecar", transport) == policy._coherent_group_key(
+            "ecar", login
+        )
+        assert policy.decide("ecar", transport).delay == policy.decide("ecar", login).delay
+
+    def test_visible_ecar_rdp_transport_preserves_zeek_conn_parent(self, monkeypatch):
+        """A visible endpoint RDP FLOW should not orphan its successful Zeek transport."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "ecar": {
+                        "missingness": 0.0,
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    },
+                    "zeek": {
+                        "missingness": 0.0,
+                        "format_missingness": {"zeek_conn": 1.0},
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    },
+                },
+            },
+        )
+        sm = MagicMock(spec=StateManager)
+        ecar = _make_mock_emitter("ecar", handles=True)
+        conn = _make_mock_emitter("zeek_conn", handles=True)
+        dispatcher = EventDispatcher(
+            state_manager=sm,
+            emitters={"ecar": ecar, "zeek_conn": conn},
+            observation_policy=ObservationPolicy("rdp_transport_parent_test"),
+        )
+
+        event = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.1.25",
+                src_port=55891,
+                dst_ip="10.0.2.20",
+                dst_port=3389,
+                protocol="tcp",
+                service="rdp",
+                zeek_uid="CrdpTransport123",
+                conn_state="SF",
+            ),
+        )
+        dispatcher.dispatch(event)
+
+        ecar.emit.assert_called_once()
+        conn.emit.assert_called_once()
+        assert ecar.emit.call_args.args[0]._observed_formats == {"ecar", "zeek_conn"}
+        assert conn.emit.call_args.args[0]._observed_formats == {"ecar", "zeek_conn"}
+
+    def test_failed_rdp_transport_can_still_drop_zeek_conn(self, monkeypatch):
+        """RDP scanner/failure texture should still be eligible for Zeek missingness."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "ecar": {
+                        "missingness": 0.0,
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    },
+                    "zeek": {
+                        "missingness": 0.0,
+                        "format_missingness": {"zeek_conn": 1.0},
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    },
+                },
+            },
+        )
+        sm = MagicMock(spec=StateManager)
+        ecar = _make_mock_emitter("ecar", handles=True)
+        conn = _make_mock_emitter("zeek_conn", handles=True)
+        dispatcher = EventDispatcher(
+            state_manager=sm,
+            emitters={"ecar": ecar, "zeek_conn": conn},
+            observation_policy=ObservationPolicy("failed_rdp_transport_gap_test"),
+        )
+
+        event = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.1.25",
+                src_port=55891,
+                dst_ip="10.0.2.20",
+                dst_port=3389,
+                protocol="tcp",
+                service="rdp",
+                zeek_uid="CrdpFailure123",
+                conn_state="S0",
+            ),
+        )
+        dispatcher.dispatch(event)
+
+        ecar.emit.assert_called_once()
+        conn.emit.assert_not_called()
+
     def test_syslog_ssh_lifecycle_delay_preserves_session_order(self, monkeypatch):
         """SSH lifecycle syslog rows with one sshd PID should share collection delay."""
         monkeypatch.setattr(
@@ -1041,6 +1381,54 @@ class TestObservationProfiles:
             syslog=SyslogContext(
                 app_name="sshd",
                 pid=5158,
+                message=message,
+            ),
+        )
+
+        assert policy.decide("syslog", event).status == "visible"
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "New session 123 of user lina.nguyen.",
+            "Removed session 123.",
+        ],
+    )
+    def test_syslog_logind_lifecycle_rows_are_not_dropped(self, monkeypatch, message):
+        """Local logind rows should stay visible with correlated endpoint sessions."""
+        monkeypatch.setattr(
+            "evidenceforge.events.observation.get_observation_profile",
+            lambda _name: {
+                "default": {
+                    "missingness": 0.0,
+                    "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    "host_missingness_multiplier": {"min": 1.0, "max": 1.0},
+                },
+                "sources": {
+                    "syslog": {
+                        "missingness": 1.0,
+                        "delay_ms": {"min_ms": 0, "max_ms": 0},
+                    }
+                },
+            },
+        )
+        policy = ObservationPolicy("logind_drop_test")
+        host = HostContext(
+            hostname="DB-PROD-01",
+            ip="10.0.0.20",
+            os="Ubuntu 22.04",
+            os_category="linux",
+            system_type="server",
+        )
+        event = SecurityEvent(
+            timestamp=_make_ts(),
+            event_type="syslog",
+            src_host=host,
+            syslog=SyslogContext(
+                app_name="systemd-logind",
+                pid=701,
+                facility=10,
+                severity=6,
                 message=message,
             ),
         )

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -2308,6 +2308,7 @@ class TestChronologicalOutput:
         parent_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "parent-process")
         child_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "child-process")
         assert child_ms > parent_ms
+        assert 18 <= child_ms - parent_ms <= 150
 
     def test_close_moves_parent_termination_after_visible_child_termination(self, tmp_path, ts):
         """Visible eCAR parents should not terminate before foreground children."""
@@ -2558,6 +2559,7 @@ class TestChronologicalOutput:
         parent_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "parent-process")
         child_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "child-process")
         assert child_ms > parent_ms
+        assert 18 <= child_ms - parent_ms <= 150
 
     def test_parent_order_skips_self_parented_pid_without_hanging(self):
         """Raw eCAR self-parented PID records should not loop forever."""
@@ -2800,24 +2802,31 @@ class TestChronologicalOutput:
         assert process_open["pid"] == source_create["pid"]
         assert process_open["properties"]["target_pid"] == target_create["pid"]
 
-    def test_linux_stable_tid_is_not_universally_pid(self, ts):
-        """Linux eCAR TIDs should include source-native thread texture."""
+    def test_linux_process_lifecycle_tid_uses_main_thread(self, ts):
+        """Linux PROCESS/CREATE and PROCESS/TERMINATE rows should share main-thread TID."""
+        pid = 3200
+
+        create_tid = EcarEmitter._stable_tid("linux-01", pid, ts, "process_create", "linux")
+        terminate_tid = EcarEmitter._stable_tid(
+            "linux-01",
+            pid,
+            ts + timedelta(seconds=5),
+            "process_terminate",
+            "linux",
+        )
+
+        assert create_tid == pid
+        assert terminate_tid == pid
+
+    def test_linux_dependent_tids_keep_source_thread_texture(self, ts):
+        """Linux non-lifecycle eCAR rows may still carry source-native thread texture."""
         tids = {
             EcarEmitter._stable_tid("linux-01", 3200, ts + timedelta(seconds=i), salt, "linux")
-            for i, salt in enumerate(
-                [
-                    "process_create",
-                    "process_terminate",
-                    "flow_inbound",
-                    "flow_outbound",
-                    "file",
-                    "module",
-                ]
-            )
+            for i, salt in enumerate(["flow_inbound", "flow_outbound", "file", "module"])
         }
 
-        assert all(tid >= 3200 for tid in tids)
-        assert any(tid != 3200 for tid in tids)
+        assert all(tid > 3200 for tid in tids)
+        assert len(tids) > 1
 
     def test_flow_principal_visibility_is_stable_for_same_process_and_direction(self, ts):
         """FLOW principal attribution should be a process-level source decision."""
@@ -3012,6 +3021,357 @@ class TestChronologicalOutput:
         assert flow["timestamp_ms"] == 1710768760347
         assert login["timestamp_ms"] == 1710768760419
         assert logout["timestamp_ms"] > login["timestamp_ms"]
+
+    def test_user_session_logout_shifted_after_same_session_dependents(self):
+        """USER_SESSION LOGOUT must trail visible same-logon endpoint activity."""
+        lines = [
+            json.dumps(
+                {
+                    "timestamp_ms": 2000,
+                    "object": "USER_SESSION",
+                    "action": "LOGOUT",
+                    "objectID": "session-object",
+                    "hostname": "WS-01",
+                    "properties": {"logon_id": "0xabc", "session_id": "2"},
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 2600,
+                    "object": "PROCESS",
+                    "action": "TERMINATE",
+                    "objectID": "process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {"logon_id": "0xabc", "session_id": "2"},
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 2800,
+                    "object": "FILE",
+                    "action": "CREATE",
+                    "objectID": "file-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {"logon_id": "0xabc", "file_path": r"C:\Users\alice\a.txt"},
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 3200,
+                    "object": "FLOW",
+                    "action": "CONNECT",
+                    "objectID": "flow-object",
+                    "hostname": "WS-01",
+                    "properties": {
+                        "logon_id": "0xabc",
+                        "src_ip": "10.10.1.20",
+                        "dst_ip": "10.10.2.20",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 5000,
+                    "object": "PROCESS",
+                    "action": "TERMINATE",
+                    "objectID": "system-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4,
+                    "properties": {"logon_id": "0x3e7"},
+                },
+                separators=(",", ":"),
+            ),
+        ]
+
+        normalized = [
+            json.loads(line)
+            for line in EcarEmitter._normalize_user_session_logout_after_dependents(lines)
+        ]
+        logout = next(row for row in normalized if row["object"] == "USER_SESSION")
+        latest_dependent_ms = max(
+            row["timestamp_ms"]
+            for row in normalized
+            if row["object"] in {"PROCESS", "FILE", "FLOW"}
+            and row["properties"].get("logon_id") == "0xabc"
+        )
+
+        assert logout["timestamp_ms"] > latest_dependent_ms
+        assert logout["timestamp_ms"] < 5000
+
+    def test_remote_thread_shifted_after_matching_process_open(self):
+        """THREAD/REMOTE_CREATE must not precede its PROCESS/OPEN prerequisite."""
+        lines = [
+            json.dumps(
+                {
+                    "timestamp_ms": 2000,
+                    "object": "THREAD",
+                    "action": "REMOTE_CREATE",
+                    "objectID": "thread-object",
+                    "actorID": "source-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {
+                        "target_pid": "500",
+                        "target_process_uuid": "target-process-object",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 2600,
+                    "object": "PROCESS",
+                    "action": "OPEN",
+                    "objectID": "target-process-object",
+                    "actorID": "source-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {
+                        "target_pid": "500",
+                        "target_process_uuid": "target-process-object",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 1800,
+                    "object": "PROCESS",
+                    "action": "OPEN",
+                    "objectID": "other-target-process-object",
+                    "actorID": "source-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {
+                        "target_pid": "501",
+                        "target_process_uuid": "other-target-process-object",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ]
+
+        normalized = [
+            json.loads(line)
+            for line in EcarEmitter._normalize_remote_thread_after_process_open(lines)
+        ]
+        remote_thread = next(row for row in normalized if row["object"] == "THREAD")
+        matching_open = next(
+            row
+            for row in normalized
+            if row["object"] == "PROCESS" and row["objectID"] == "target-process-object"
+        )
+        other_open = next(
+            row
+            for row in normalized
+            if row["object"] == "PROCESS" and row["objectID"] == "other-target-process-object"
+        )
+
+        assert remote_thread["timestamp_ms"] > matching_open["timestamp_ms"]
+        assert other_open["timestamp_ms"] == 1800
+
+    def test_remote_thread_uses_pid_fallback_for_process_open_order(self):
+        """PID-only eCAR rows should still preserve access-before-thread ordering."""
+        lines = [
+            json.dumps(
+                {
+                    "timestamp_ms": 4000,
+                    "object": "THREAD",
+                    "action": "REMOTE_CREATE",
+                    "objectID": "thread-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {"target_pid": "500"},
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 4300,
+                    "object": "PROCESS",
+                    "action": "OPEN",
+                    "objectID": "target-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {"target_pid": "500"},
+                },
+                separators=(",", ":"),
+            ),
+        ]
+
+        normalized = [
+            json.loads(line)
+            for line in EcarEmitter._normalize_remote_thread_after_process_open(lines)
+        ]
+        remote_thread = next(row for row in normalized if row["object"] == "THREAD")
+        process_open = next(row for row in normalized if row["object"] == "PROCESS")
+
+        assert remote_thread["timestamp_ms"] > process_open["timestamp_ms"]
+
+    def test_remote_thread_preserves_existing_prior_process_open_order(self):
+        """A valid prior PROCESS/OPEN should not be shifted by a later matching row."""
+        lines = [
+            json.dumps(
+                {
+                    "timestamp_ms": 1900,
+                    "object": "PROCESS",
+                    "action": "OPEN",
+                    "objectID": "target-process-object",
+                    "actorID": "source-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {
+                        "target_pid": "500",
+                        "target_process_uuid": "target-process-object",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 2000,
+                    "object": "THREAD",
+                    "action": "REMOTE_CREATE",
+                    "objectID": "thread-object",
+                    "actorID": "source-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {
+                        "target_pid": "500",
+                        "target_process_uuid": "target-process-object",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 2600,
+                    "object": "PROCESS",
+                    "action": "OPEN",
+                    "objectID": "target-process-object",
+                    "actorID": "source-process-object",
+                    "hostname": "WS-01",
+                    "pid": 4300,
+                    "properties": {
+                        "target_pid": "500",
+                        "target_process_uuid": "target-process-object",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ]
+
+        normalized = [
+            json.loads(line)
+            for line in EcarEmitter._normalize_remote_thread_after_process_open(lines)
+        ]
+        remote_thread = next(row for row in normalized if row["object"] == "THREAD")
+
+        assert remote_thread["timestamp_ms"] == 2000
+
+    def test_remote_user_session_login_shifted_after_late_inbound_flow(self):
+        """Remote eCAR LOGIN rows should not precede same-tuple inbound FLOW rows."""
+        lines = [
+            json.dumps(
+                {
+                    "timestamp_ms": 1710764221308,
+                    "object": "USER_SESSION",
+                    "action": "LOGIN",
+                    "objectID": "session-object",
+                    "hostname": "MAIL-EDGE-01",
+                    "principal": "marcus.chen",
+                    "properties": {
+                        "outcome": "success",
+                        "session_type": "ssh",
+                        "src_ip": "10.10.1.34",
+                        "src_port": "61712",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 1710764222532,
+                    "object": "FLOW",
+                    "action": "CONNECT",
+                    "objectID": "flow-object",
+                    "hostname": "MAIL-EDGE-01",
+                    "properties": {
+                        "src_ip": "10.10.1.34",
+                        "src_port": "61712",
+                        "dst_ip": "10.10.2.25",
+                        "dst_port": "22",
+                        "protocol": "tcp",
+                        "direction": "INBOUND",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ]
+
+        normalized = [
+            json.loads(line)
+            for line in EcarEmitter._normalize_remote_session_transport_order(lines)
+        ]
+        login = next(row for row in normalized if row["object"] == "USER_SESSION")
+        flow = next(row for row in normalized if row["object"] == "FLOW")
+
+        assert login["timestamp_ms"] > flow["timestamp_ms"]
+
+    def test_linux_login_shell_create_shifted_after_session_login(self):
+        """Interactive Linux shell PROCESS/CREATE rows should not predate session LOGIN."""
+        lines = [
+            json.dumps(
+                {
+                    "timestamp_ms": 1710765140391,
+                    "object": "PROCESS",
+                    "action": "CREATE",
+                    "objectID": "shell-object",
+                    "hostname": "MAIL-EDGE-01",
+                    "principal": "aisha.johnson",
+                    "pid": 601049,
+                    "tid": 601049,
+                    "properties": {
+                        "command_line": "-bash",
+                        "image_path": "/bin/bash",
+                        "parent_image_path": "/usr/lib/systemd/systemd",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                {
+                    "timestamp_ms": 1710765142724,
+                    "object": "USER_SESSION",
+                    "action": "LOGIN",
+                    "objectID": "session-object",
+                    "hostname": "MAIL-EDGE-01",
+                    "principal": "aisha.johnson",
+                    "properties": {
+                        "outcome": "success",
+                        "session_type": "ssh",
+                        "src_ip": "10.10.2.20",
+                        "src_port": "64417",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ]
+
+        normalized = [
+            json.loads(line)
+            for line in EcarEmitter._normalize_linux_login_shell_session_order(lines)
+        ]
+        shell = next(row for row in normalized if row["object"] == "PROCESS")
+        login = next(row for row in normalized if row["object"] == "USER_SESSION")
+
+        assert shell["timestamp_ms"] > login["timestamp_ms"]
 
     def test_failed_user_session_login_does_not_anchor_logout_order(self):
         """Failed USER_SESSION LOGIN attempts should not become session start anchors."""

--- a/tests/unit/test_edr_object_graph.py
+++ b/tests/unit/test_edr_object_graph.py
@@ -187,6 +187,63 @@ class TestObjectIdLifecycle:
         assert terminate_event.event_type == "process_terminate"
         assert terminate_event.edr.object_id == create_obj_id
 
+    def test_linux_system_process_termination_preserves_original_logon(
+        self, activity_gen, timestamp, state_manager, mock_emitters
+    ):
+        """System-owned Linux process termination must not inherit a later root SSH session."""
+        system = System(
+            hostname="DB-PROD-01",
+            ip="10.10.4.10",
+            os="Ubuntu 22.04",
+            type="server",
+        )
+        root_user = User(
+            username="root",
+            full_name="root",
+            email="root@example.local",
+            enabled=True,
+        )
+        state_manager.set_current_time(timestamp)
+
+        pid = activity_gen.generate_system_process(
+            system=system,
+            time=timestamp,
+            process_name="/usr/bin/wget",
+            command_line="wget -q -e use_proxy=yes -O - https://internal-service/",
+            parent_pid=0,
+            username="root",
+            emit_linux_syslog=False,
+        )
+        create_event = mock_emitters["ecar"].emit.call_args_list[-1][0][0]
+        assert create_event.event_type == "system_process_create"
+        assert create_event.process.logon_id == "0x3e7"
+        assert state_manager.get_process(system.hostname, pid).logon_id == "0x3e7"
+
+        ssh_logon_id = state_manager.create_session(
+            "root",
+            system.hostname,
+            10,
+            "10.10.2.30",
+            source_port=55185,
+            session_kind="ssh",
+            start_time=timestamp + timedelta(minutes=20),
+            session_id=279177,
+        )
+        activity_gen.generate_process_termination(
+            user=root_user,
+            system=system,
+            time=timestamp + timedelta(minutes=21),
+            pid=pid,
+            process_name="/usr/bin/wget",
+            logon_id=ssh_logon_id,
+        )
+
+        terminate_event = mock_emitters["ecar"].emit.call_args_list[-1][0][0]
+        assert terminate_event.event_type == "process_terminate"
+        assert terminate_event.auth.logon_id == "0x3e7"
+        assert terminate_event.auth.session_id == 0
+        assert terminate_event.process.logon_id == "0x3e7"
+
     def test_late_termination_reuses_remembered_process_object_id(
         self, activity_gen, test_user, win_system, timestamp, state_manager, mock_emitters
     ):

--- a/tests/unit/test_edr_pools.py
+++ b/tests/unit/test_edr_pools.py
@@ -55,6 +55,11 @@ class TestLoadEdrPools:
         ]:
             assert len(pools[key]) > 0, f"{key} is empty"
 
+    def test_default_windows_file_paths_exclude_protected_event_logs(self):
+        paths = get_file_paths("windows")
+
+        assert not any(r"\winevt\Logs" in path for path in paths)
+
     def test_read_only_recon_tool_has_no_file_side_effect(self):
         import random
 
@@ -254,6 +259,20 @@ class TestFilePaths:
             rng=random.Random(3),
             user="SYSTEM",
             path_templates=[r"C:\Windows\Prefetch\SVCHOST.EXE-{hex}.pf"],
+            actions=["modify"],
+            weights=[1],
+        )
+
+        assert effect is None
+
+    def test_ambient_file_churn_filters_windows_protected_event_logs(self):
+        effect = select_ambient_file_churn_effect(
+            process_name=r"C:\Windows\System32\svchost.exe",
+            command_line="svchost.exe -k netsvcs",
+            os_category="windows",
+            rng=random.Random(3),
+            user="SYSTEM",
+            path_templates=[r"C:\Windows\System32\winevt\Logs\Security.evtx"],
             actions=["modify"],
             weights=[1],
         )

--- a/tests/unit/test_email_evidence.py
+++ b/tests/unit/test_email_evidence.py
@@ -25,7 +25,10 @@ from evidenceforge.events.dispatcher import FORMAT_GROUPS, expand_formats
 from evidenceforge.events.ground_truth import load_ground_truth_document
 from evidenceforge.generation.activity.generator import ActivityGenerator
 from evidenceforge.generation.activity.mail_public_identities import (
+    generate_public_mail_ip,
     is_public_mail_ip,
+    public_mail_provider_name_for_hostname,
+    public_mail_provider_name_for_ip,
     public_mail_ptr_name,
     public_safe_mail_hostname,
 )
@@ -609,6 +612,134 @@ def test_linux_mail_server_emits_postfix_syslog_lifecycle(tmp_path: Path) -> Non
     assert outbound_flow["properties"]["image_path"] == "/usr/lib/postfix/sbin/smtp"
 
 
+def test_plaintext_smtp_reply_uses_postfix_receive_queue_id(tmp_path: Path, monkeypatch) -> None:
+    scenario = _email_scenario()
+    systems = [
+        system.model_copy(update={"os": "Ubuntu 22.04"})
+        if system.hostname == "MAIL-ENG"
+        else system
+        for system in scenario.environment.systems
+    ]
+    scenario = scenario.model_copy(
+        update={
+            "environment": scenario.environment.model_copy(update={"systems": systems}),
+            "output": OutputSpec(
+                logs=[{"format": "zeek"}, {"format": "syslog"}],
+                destination="./data",
+            ),
+        }
+    )
+    monkeypatch.setattr(
+        ActivityGenerator,
+        "_smtp_hop_uses_starttls",
+        lambda self, **_kwargs: False,
+    )
+    engine = GenerationEngine(
+        scenario,
+        output_dir=tmp_path / "data",
+        ground_truth_dir=tmp_path,
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    engine.generate()
+
+    syslog_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in (tmp_path / "data").rglob("syslog.log")
+    )
+    client_match = re.search(
+        r"postfix/smtpd \d+ - - ([A-F0-9]{9,11}): "
+        r"client=WS-ALICE\.corp\.example\[10\.10\.1\.10\], "
+        r"sasl_method=LOGIN, sasl_username=alice",
+        syslog_text,
+    )
+    assert client_match is not None
+    queue_id = client_match.group(1)
+
+    smtp_records = _read_ndjson(tmp_path / "data" / "zeek-core" / "smtp.json")
+    submission_smtp = next(
+        row for row in smtp_records if row["id.resp_h"] == "10.10.2.25" and row["id.resp_p"] == 587
+    )
+    assert queue_id in submission_smtp["last_reply"]
+
+    manifest = _load_artifacts_manifest(tmp_path)
+    materialized = tmp_path / "artifacts" / "email" / manifest["email"]["messages"][0]["eml_path"]
+    received_lines = [
+        line
+        for line in materialized.read_text(encoding="utf-8").splitlines()
+        if line.startswith("Received:")
+    ]
+    assert any(f" id {queue_id}" in line for line in received_lines)
+
+
+def test_inbound_plaintext_smtp_reply_uses_postfix_receive_queue_id(
+    tmp_path: Path, monkeypatch
+) -> None:
+    scenario = _email_scenario()
+    systems = [
+        system.model_copy(update={"os": "Ubuntu 22.04"})
+        if system.hostname == "MAIL-ENG"
+        else system
+        for system in scenario.environment.systems
+    ]
+    scenario = scenario.model_copy(
+        update={
+            "environment": scenario.environment.model_copy(update={"systems": systems}),
+            "output": OutputSpec(
+                logs=[{"format": "zeek"}, {"format": "syslog"}],
+                destination="./data",
+            ),
+        }
+    )
+    scenario = _with_email_storyline(
+        scenario,
+        EmailMessageEventSpec(
+            sender="alerts@benefits.example",
+            to=["alice@corp.example"],
+            subject="Inbound queue check",
+            body="This inbound message should share one Postfix queue identity.\n",
+        ),
+    )
+    monkeypatch.setattr(
+        ActivityGenerator,
+        "_smtp_hop_uses_starttls",
+        lambda self, **_kwargs: False,
+    )
+    engine = GenerationEngine(
+        scenario,
+        output_dir=tmp_path / "data",
+        ground_truth_dir=tmp_path,
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    engine.generate()
+
+    syslog_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in (tmp_path / "data").rglob("syslog.log")
+    )
+    cleanup_match = re.search(
+        r"postfix/cleanup \d+ - - ([A-F0-9]{9,11}): message-id=<[^>]+>",
+        syslog_text,
+    )
+    assert cleanup_match is not None
+    queue_id = cleanup_match.group(1)
+
+    smtp_records = _read_ndjson(tmp_path / "data" / "zeek-core" / "smtp.json")
+    inbound_smtp = next(
+        row for row in smtp_records if row["id.resp_h"] == "10.10.2.25" and row["id.resp_p"] == 25
+    )
+    assert inbound_smtp["mailfrom"] == "alerts@benefits.example"
+    assert queue_id in inbound_smtp["last_reply"]
+
+    manifest = _load_artifacts_manifest(tmp_path)
+    materialized = tmp_path / "artifacts" / "email" / manifest["email"]["messages"][0]["eml_path"]
+    received_lines = [
+        line
+        for line in materialized.read_text(encoding="utf-8").splitlines()
+        if line.startswith("Received:")
+    ]
+    assert any(f" id {queue_id}" in line for line in received_lines)
+
+
 def test_outbound_route_group_override_and_global_isp_relay(tmp_path: Path, monkeypatch) -> None:
     def _tls12_starttls(self, *, dst_system, **_kwargs) -> SslContext:
         return SslContext(
@@ -719,13 +850,37 @@ def test_mixed_internal_external_outbound_hops_scope_recipients(tmp_path: Path) 
     )
     systems = [
         system.model_copy(update={"os": "Ubuntu 22.04"})
-        if system.hostname == "MAIL-ENG"
+        if system.hostname in {"MAIL-ENG", "MAIL-FIN"}
         else system
         for system in scenario.environment.systems
     ]
+    network = scenario.environment.network.model_copy(
+        update={
+            "sensors": [
+                *scenario.environment.network.sensors,
+                NetworkSensor(
+                    type="firewall",
+                    name="edge-fw",
+                    hostname="edge-fw",
+                    monitoring_segments=["corp"],
+                    log_formats=["cisco_asa"],
+                    default_action="permit",
+                    nat_rules=[
+                        {
+                            "type": "dynamic_pat",
+                            "src": ["corp"],
+                            "mapped_ip": "203.14.220.1",
+                        }
+                    ],
+                ),
+            ]
+        }
+    )
     scenario = scenario.model_copy(
         update={
-            "environment": scenario.environment.model_copy(update={"systems": systems}),
+            "environment": scenario.environment.model_copy(
+                update={"systems": systems, "network": network}
+            ),
             "output": OutputSpec(
                 logs=[{"format": "zeek"}, {"format": "syslog"}],
                 destination="./data",
@@ -746,8 +901,7 @@ def test_mixed_internal_external_outbound_hops_scope_recipients(tmp_path: Path) 
     assert [(row["id.orig_h"], row["id.resp_h"], row["id.resp_p"]) for row in smtp_records] == [
         ("10.10.1.10", "10.10.2.25", 587),
         ("10.10.2.25", "10.10.2.26", 25),
-        ("10.10.2.25", "10.10.2.26", 25),
-        ("10.10.2.26", smtp_records[3]["id.resp_h"], 25),
+        ("10.10.2.26", smtp_records[2]["id.resp_h"], 25),
     ]
     assert smtp_records[0]["tls"] is True
     assert smtp_records[0]["mailfrom"] == ""
@@ -755,9 +909,7 @@ def test_mixed_internal_external_outbound_hops_scope_recipients(tmp_path: Path) 
     assert smtp_records[0]["subject"] == ""
     assert smtp_records[1]["tls"] is True
     assert smtp_records[1]["rcptto"] == []
-    assert smtp_records[2]["tls"] is True
-    assert smtp_records[2]["rcptto"] == []
-    assert smtp_records[3]["rcptto"] == ["analyst@example.net"]
+    assert smtp_records[2]["rcptto"] == ["analyst@example.net"]
 
     syslog_records = _parse_syslog_records(tmp_path / "data")
     client_record = next(
@@ -793,6 +945,55 @@ def test_mixed_internal_external_outbound_hops_scope_recipients(tmp_path: Path) 
     assert all(
         record.timestamp is not None and record.timestamp <= removed_record.timestamp
         for record in delivery_records
+    )
+    relay_receive_records = [
+        record
+        for record in syslog_records
+        if record.fields.get("app_name") == "postfix/smtpd"
+        and "client=mail-eng.corp.example[10.10.2.25]" in record.fields.get("message", "").lower()
+    ]
+    assert len(relay_receive_records) == 1
+    relay_queue_match = re.search(
+        r"([A-F0-9]{9,11}): client=",
+        relay_receive_records[0].fields["message"],
+    )
+    assert relay_queue_match is not None
+    relay_queue_id = relay_queue_match.group(1)
+    assert any(f"queued as {relay_queue_id}" in message for message in delivery_messages)
+    assert (
+        sum(
+            1
+            for record in syslog_records
+            if record.fields.get("message", "").startswith(f"{relay_queue_id}: message-id=")
+        )
+        == 1
+    )
+    assert (
+        sum(
+            1
+            for record in syslog_records
+            if record.fields.get("message", "").startswith(f"{relay_queue_id}: from=")
+        )
+        == 1
+    )
+
+    manifest = _load_artifacts_manifest(tmp_path)
+    messages = manifest["email"]["messages"]
+    materialized = tmp_path / "artifacts" / "email" / messages[0]["eml_path"]
+    received_lines = [
+        line
+        for line in materialized.read_text(encoding="utf-8").splitlines()
+        if line.startswith("Received:")
+    ]
+    assert len(received_lines) == len(set(received_lines))
+    assert any(f" id {relay_queue_id}" in line for line in received_lines)
+    safe_isp_relay = public_safe_mail_hostname("smtp.isp.example")
+    external_received = next(line for line in received_lines if f" by {safe_isp_relay} " in line)
+    assert "from mail-fin.corp.example (203.14.220.1)" in external_received
+    assert "(10.10.2.26)" not in external_received
+    assert any(
+        "from mail-eng.corp.example (10.10.2.25) by mail-fin.corp.example" in line
+        for line in received_lines
     )
 
 
@@ -1009,6 +1210,83 @@ def test_external_inbound_sender_can_use_starttls(tmp_path: Path, monkeypatch) -
     assert inbound_smtp["fuids"] == []
 
 
+def test_plaintext_external_inbound_reply_uses_postfix_receive_queue_id(
+    tmp_path: Path, monkeypatch
+) -> None:
+    scenario = _email_scenario()
+    assert scenario.environment.email is not None
+    scenario.environment.email.inbound_route = ["fin"]
+    systems = [
+        system.model_copy(update={"os": "Ubuntu 22.04"})
+        if system.hostname == "MAIL-FIN"
+        else system
+        for system in scenario.environment.systems
+    ]
+    scenario = _with_email_storyline(
+        scenario.model_copy(
+            update={"environment": scenario.environment.model_copy(update={"systems": systems})}
+        ),
+        EmailMessageEventSpec(
+            sender="notices@example.net",
+            to=["alice@corp.example"],
+            subject="Plaintext inbound queue identity",
+            body="External sender should share the receive queue identity.\n",
+        ),
+    ).model_copy(
+        update={
+            "output": OutputSpec(
+                logs=[{"format": "zeek"}, {"format": "syslog"}],
+                destination="./data",
+            )
+        }
+    )
+    monkeypatch.setattr(
+        ActivityGenerator,
+        "_smtp_hop_uses_starttls",
+        lambda self, **_kwargs: False,
+    )
+    engine = GenerationEngine(
+        scenario,
+        output_dir=tmp_path / "data",
+        ground_truth_dir=tmp_path,
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    engine.generate()
+
+    smtp_records = _read_ndjson(tmp_path / "data" / "zeek-core" / "smtp.json")
+    inbound_smtp = next(
+        row for row in smtp_records if row["id.resp_h"] == "10.10.2.26" and row["id.resp_p"] == 25
+    )
+    assert inbound_smtp["tls"] is False
+    assert inbound_smtp["msg_id"].startswith("<notices-")
+
+    syslog_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in (tmp_path / "data").rglob("syslog.log")
+    )
+    cleanup_match = re.search(
+        rf"postfix/cleanup \d+ - - ([A-F0-9]{{9,11}}): "
+        rf"message-id={re.escape(inbound_smtp['msg_id'])}",
+        syslog_text,
+    )
+    assert cleanup_match is not None
+    queue_id = cleanup_match.group(1)
+
+    assert queue_id in inbound_smtp["last_reply"]
+
+    manifest = _load_artifacts_manifest(tmp_path)
+    materialized = tmp_path / "artifacts" / "email" / manifest["email"]["messages"][0]["eml_path"]
+    received_lines = [
+        line
+        for line in materialized.read_text(encoding="utf-8").splitlines()
+        if line.startswith("Received:")
+    ]
+    assert any(
+        " by mail-fin.corp.example " in line and f" id {queue_id}" in line
+        for line in received_lines
+    )
+
+
 def test_smtp_starttls_tls12_cipher_matches_certificate_key(tmp_path: Path) -> None:
     scenario = _email_scenario()
     engine = GenerationEngine(
@@ -1214,6 +1492,45 @@ def test_external_sender_received_headers_share_public_hop_model(tmp_path: Path)
     }
     assert sampled_lengths <= {2, 3}
     assert 3 in sampled_lengths
+
+
+def test_external_mail_ip_generation_follows_provider_hostname() -> None:
+    cases = {
+        "aspmx.l.google.com": "google_workspace",
+        "eu-smtp-inbound-1.mimecast.com": "mimecast",
+        "mx.zoho.com": "zoho",
+        "inbound-smtp.us-east-1.amazonaws.com": "amazon_ses",
+        "mxa.mailgun.org": "mailgun",
+    }
+
+    for hostname, provider in cases.items():
+        ip = generate_public_mail_ip(f"provider-probe:{hostname}", hostname)
+
+        assert public_mail_provider_name_for_hostname(hostname) == provider
+        assert public_mail_provider_name_for_ip(ip) == provider
+
+
+def test_external_source_mail_system_binds_mx_hostname_to_ip_provider(tmp_path: Path) -> None:
+    scenario = _email_scenario()
+    engine = GenerationEngine(
+        scenario,
+        output_dir=tmp_path / "data",
+        ground_truth_dir=tmp_path,
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    engine.generate()
+
+    generator = engine.activity_generator
+    assert generator is not None
+    source_system = generator._external_source_mail_system("alerts@gmail.com")
+
+    assert source_system.hostname == "aspmx.l.google.com"
+    assert (
+        public_mail_provider_name_for_ip(source_system.ip)
+        == public_mail_provider_name_for_hostname(source_system.hostname)
+        == "google_workspace"
+    )
 
 
 def test_inbound_email_does_not_emit_external_mx_endpoint_ecar(tmp_path: Path) -> None:

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -1146,6 +1146,69 @@ class TestWindowsEventEmitter:
         assert logon["TimeCreated"] == expected_logon_time
         assert privilege["TimeCreated"] == expected_logon_time + expected_privilege_delta
 
+    def test_flush_repairs_transport_shifted_logon_before_process_create(
+        self, format_def, temp_output, monkeypatch
+    ):
+        """Flush should move remote 4624 rows before repairing same-session 4688 rows."""
+        emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=10)
+        logon_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        process_time = logon_time + timedelta(milliseconds=250)
+        wfp_time = logon_time + timedelta(milliseconds=450)
+        emitter._event_dicts = [
+            {
+                "EventID": 4624,
+                "TimeCreated": logon_time,
+                "Computer": "FILE-SRV-01.corp.local",
+                "LogonType": 3,
+                "IpAddress": "10.10.1.35",
+                "IpPort": "59430",
+                "TargetLogonId": "0xf63a33e",
+            },
+            {
+                "EventID": 4688,
+                "TimeCreated": process_time,
+                "Computer": "FILE-SRV-01.corp.local",
+                "SubjectLogonId": "0xf63a33e",
+                "NewProcessId": "0x1084",
+            },
+            {
+                "EventID": 5156,
+                "TimeCreated": wfp_time,
+                "Computer": "FILE-SRV-01.corp.local",
+                "SourceAddress": "10.10.1.35",
+                "SourcePort": "59430",
+                "DestAddress": "10.10.2.20",
+                "DestPort": "445",
+                "Protocol": "6",
+                "Direction": "%%14592",
+            },
+        ]
+        calls: list[str] = []
+        rendered: list[dict] = []
+        shift_network = emitter._shift_network_logons_after_transport
+        shift_process = emitter._shift_process_creates_after_logons
+
+        def wrapped_network() -> None:
+            calls.append("network")
+            shift_network()
+
+        def wrapped_process() -> None:
+            calls.append("process")
+            shift_process()
+
+        monkeypatch.setattr(emitter, "_shift_network_logons_after_transport", wrapped_network)
+        monkeypatch.setattr(emitter, "_shift_process_creates_after_logons", wrapped_process)
+        monkeypatch.setattr(
+            emitter, "_render_event", lambda event: rendered.append(dict(event)) or ""
+        )
+
+        emitter._flush_unlocked()
+
+        assert calls.index("network") < calls.index("process")
+        logon = next(event for event in rendered if event["EventID"] == 4624)
+        process = next(event for event in rendered if event["EventID"] == 4688)
+        assert process["TimeCreated"] > logon["TimeCreated"]
+
     def test_reused_source_port_far_transport_does_not_shift_logon(self, format_def, temp_output):
         """Remote logon repair should not pair unrelated later source-port reuse."""
         emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=10)

--- a/tests/unit/test_explicit_proxy.py
+++ b/tests/unit/test_explicit_proxy.py
@@ -108,6 +108,33 @@ def test_activity_generator_uses_browser_agent_for_workstation_browser_domains()
     assert not any(token in user_agent for token in ("curl/", "Wget/", "python-requests/"))
 
 
+def test_generated_windows_browser_proxy_agents_exclude_legacy_ie():
+    from evidenceforge.generation.activity.proxy_user_agents import pick_proxy_user_agent
+
+    workstation = System(
+        hostname="ws01",
+        ip="10.0.1.20",
+        os="Windows 11",
+        type="workstation",
+        roles=["workstation"],
+    )
+
+    user_agents = {
+        pick_proxy_user_agent(
+            random.Random(seed),
+            workstation,
+            hostname="calendar.google.com",
+            domain_tags=["saas"],
+        )
+        for seed in range(200)
+    }
+
+    assert user_agents
+    assert all(
+        "Trident/" not in user_agent and "MSIE " not in user_agent for user_agent in user_agents
+    )
+
+
 def test_activity_generator_collapses_generated_browser_family_user_agents():
     generator = ActivityGenerator(StateManager(), {})
     workstation = System(
@@ -212,6 +239,132 @@ def test_activity_generator_preserves_override_browser_user_agent():
     )
 
     assert "Firefox/122.0" in user_agent
+
+
+def test_activity_generator_replaces_server_browser_user_agent_with_service_client():
+    generator = ActivityGenerator(StateManager(), {})
+    domain_controller = System(
+        hostname="DC-01",
+        ip="10.10.2.10",
+        os="Windows Server 2022",
+        type="domain_controller",
+        roles=["domain_controller"],
+    )
+
+    user_agent = generator._proxy_user_agent_for_context(
+        random.Random(23),
+        domain_controller,
+        hostname="api.westbridge-services.net",
+        domain_tags=[],
+        override_user_agent=(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "Chrome/121.0.0.0 Safari/537.36"
+        ),
+    )
+
+    assert user_agent == "Go-http-client/1.1"
+
+
+def test_build_proxy_context_preserves_caller_browser_user_agent_for_api_domain():
+    generator = ActivityGenerator(StateManager(), {})
+    workstation = System(
+        hostname="WS-AJOHNSON-01",
+        ip="10.10.1.35",
+        os="Windows 11",
+        type="workstation",
+    )
+    proxy = System(
+        hostname="PROXY-01",
+        ip="10.10.2.5",
+        os="Ubuntu 22.04",
+        type="server",
+        roles=["forward_proxy"],
+    )
+    chrome_user_agent = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "Chrome/121.0.0.0 Safari/537.36"
+    )
+
+    proxy_context = generator._build_proxy_context(
+        src_ip=workstation.ip,
+        dst_ip="45.33.32.30",
+        dst_port=443,
+        service="ssl",
+        duration=5.0,
+        orig_bytes=314_782_613,
+        resp_bytes=2048,
+        hostname="api.westbridge-services.net",
+        source_system=workstation,
+        proxy_sys=proxy,
+        http=HttpContext(
+            method="POST",
+            host="api.westbridge-services.net",
+            uri="/upload/telemetry/7f3a2b19",
+            user_agent=chrome_user_agent,
+            request_body_len=314_782_613,
+            response_body_len=2048,
+        ),
+        explicit_mode=True,
+        time=datetime(2026, 5, 18, 14, 25, tzinfo=UTC),
+    )
+
+    assert proxy_context.user_agent == chrome_user_agent
+
+
+def test_build_proxy_context_binds_server_proxy_user_agent_to_service_process():
+    generator = ActivityGenerator(StateManager(), {})
+    domain_controller = System(
+        hostname="DC-01",
+        ip="10.10.2.10",
+        os="Windows Server 2022",
+        type="domain_controller",
+        roles=["domain_controller"],
+    )
+    proxy = System(
+        hostname="PROXY-01",
+        ip="10.10.3.20",
+        os="Ubuntu 22.04",
+        type="server",
+        roles=["forward_proxy"],
+    )
+
+    proxy_context = generator._build_proxy_context(
+        src_ip=domain_controller.ip,
+        dst_ip="45.33.32.30",
+        dst_port=443,
+        service="ssl",
+        duration=2.5,
+        orig_bytes=600,
+        resp_bytes=4096,
+        hostname="api.westbridge-services.net",
+        source_system=domain_controller,
+        proxy_sys=proxy,
+        http=HttpContext(
+            method="GET",
+            host="api.westbridge-services.net",
+            uri="/api/v2/checkin",
+            user_agent=(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "Chrome/121.0.0.0 Safari/537.36"
+            ),
+            response_body_len=4096,
+        ),
+        explicit_mode=True,
+        time=datetime(2024, 3, 18, 16, 33, tzinfo=UTC),
+    )
+    hint = generator._explicit_proxy_client_process_hint(
+        user_agent=proxy_context.user_agent,
+        hostname=proxy_context.host,
+        dst_port=443,
+        proxy_sys=proxy,
+        source_system=domain_controller,
+    )
+
+    assert proxy_context.user_agent == "Go-http-client/1.1"
+    assert hint is not None
+    image, command_line = hint
+    assert image.endswith("service-healthcheck.exe")
+    assert "api.westbridge-services.net" in command_line
 
 
 def test_server_proxy_package_user_agents_are_destination_aware():
@@ -1607,8 +1760,99 @@ class TestExplicitProxyVisibility:
         assert client_event.process.pid != git_pid
         assert client_event.process.image == "/usr/lib/apt/methods/https"
         assert client_event.process.command_line == "/usr/lib/apt/methods/https"
+        assert client_event.process.username == "root"
+        assert client_event.process.logon_id != user_session.logon_id
 
-    def test_linux_proxy_scrubs_bad_caller_when_matching_process_cannot_be_owned(self):
+    def test_linux_package_proxy_client_uses_system_owner_after_session_logout(self):
+        generator, _emitters = _generator(
+            [
+                NetworkSensor(
+                    type="network",
+                    name="client-tap",
+                    monitoring_segments=["workstations"],
+                    direction="outbound",
+                    log_formats=["zeek"],
+                )
+            ]
+        )
+        _user, linux_system, shell_pid = _seed_linux_proxy_client_user_session(generator)
+        shell_proc = generator.state_manager.get_process(linux_system.hostname, shell_pid)
+        assert shell_proc is not None
+        logon_id = shell_proc.logon_id
+        request_time = datetime(2024, 1, 15, 10, 0, 1, tzinfo=UTC)
+        generator.state_manager.end_session(
+            logon_id,
+            request_time - timedelta(seconds=30),
+        )
+        proxy = generator._ip_to_system["10.0.3.10"]
+
+        pid, image = generator._ensure_explicit_proxy_client_process(
+            source_system=linux_system,
+            time=request_time,
+            proxy_context=ProxyContext(
+                client_ip=linux_system.ip,
+                method="CONNECT",
+                url="changelogs.ubuntu.com:443",
+                host="changelogs.ubuntu.com",
+                status_code=200,
+                user_agent="apt-http/2.4.11 (amd64)",
+                proxy_fqdn="PROXY-01.example.org",
+            ),
+            proxy_sys=proxy,
+            dst_port=443,
+        )
+
+        proc = generator.state_manager.get_process(linux_system.hostname, pid)
+        assert image == "/usr/lib/apt/methods/https"
+        assert proc is not None
+        assert proc.username == "root"
+        assert proc.logon_id != logon_id
+        assert proc.parent_pid != shell_pid
+        parent = generator.state_manager.get_process(linux_system.hostname, proc.parent_pid)
+        assert parent is not None
+        assert parent.image == "/usr/lib/systemd/systemd"
+
+    def test_linux_background_helper_process_drops_ended_user_session_parent(self):
+        generator, _emitters = _generator(
+            [
+                NetworkSensor(
+                    type="network",
+                    name="client-tap",
+                    monitoring_segments=["workstations"],
+                    direction="outbound",
+                    log_formats=["zeek"],
+                )
+            ]
+        )
+        user, linux_system, shell_pid = _seed_linux_proxy_client_user_session(generator)
+        shell_proc = generator.state_manager.get_process(linux_system.hostname, shell_pid)
+        assert shell_proc is not None
+        systemd_pid = shell_proc.parent_pid
+        logon_id = shell_proc.logon_id
+        request_time = datetime(2024, 1, 15, 10, 0, 1, tzinfo=UTC)
+        generator.state_manager.end_session(
+            logon_id,
+            request_time - timedelta(seconds=30),
+        )
+
+        pid = generator.generate_process(
+            user=user,
+            system=linux_system,
+            time=request_time,
+            logon_id=logon_id,
+            process_name="/usr/lib/apt/methods/https",
+            command_line="/usr/lib/apt/methods/https",
+            parent_pid=shell_pid,
+            suppress_command_file_effect=True,
+        )
+
+        proc = generator.state_manager.get_process(linux_system.hostname, pid)
+        assert proc is not None
+        assert proc.username == "root"
+        assert proc.logon_id == "0x3e7"
+        assert proc.parent_pid == systemd_pid
+
+    def test_linux_proxy_replaces_bad_caller_with_tool_owner(self):
         generator, emitters = _generator(
             [
                 NetworkSensor(
@@ -1688,10 +1932,12 @@ class TestExplicitProxyVisibility:
             and call.args[0].network.dst_port == 8080
         )
 
-        assert client_event.process is None
-        assert client_event.network.initiating_pid == -1
+        assert client_event.process is not None
+        assert client_event.process.image == "/usr/bin/curl"
+        assert client_event.process.username == "root"
+        assert client_event.network.initiating_pid != bash_pid
 
-    def test_linux_proxy_scrubs_service_daemon_for_tool_user_agent(self):
+    def test_linux_proxy_replaces_service_daemon_for_tool_user_agent(self):
         generator, emitters = _generator(
             [
                 NetworkSensor(
@@ -1763,8 +2009,10 @@ class TestExplicitProxyVisibility:
             and call.args[0].network.dst_port == 8080
         )
 
-        assert client_event.process is None
-        assert client_event.network.initiating_pid == -1
+        assert client_event.process is not None
+        assert client_event.process.image == "/usr/bin/python3"
+        assert client_event.process.username == "root"
+        assert client_event.network.initiating_pid != apache_pid
 
     def test_explicit_proxy_tunnel_reuse_is_user_agent_scoped(self):
         generator, emitters = _generator(
@@ -1847,7 +2095,7 @@ class TestExplicitProxyVisibility:
         assert len(client_events) == 2
         assert client_events[0].network.zeek_uid != client_events[1].network.zeek_uid
 
-    def test_direct_proxy_listener_flow_scrubs_linux_shell_owner(self):
+    def test_direct_proxy_listener_flow_replaces_linux_shell_with_service_owner(self):
         generator, emitters = _generator(
             [
                 NetworkSensor(
@@ -1921,8 +2169,10 @@ class TestExplicitProxyVisibility:
             and call.args[0].network.dst_port == 8080
         )
 
-        assert client_event.process is None
-        assert client_event.network.initiating_pid == -1
+        assert client_event.process is not None
+        assert client_event.process.image == "/usr/bin/wget"
+        assert client_event.process.username == "root"
+        assert client_event.network.initiating_pid != bash_pid
 
     def test_direct_proxy_listener_flow_replaces_mismatched_linux_browser(self):
         generator, emitters = _generator(

--- a/tests/unit/test_file_server_logon.py
+++ b/tests/unit/test_file_server_logon.py
@@ -12,6 +12,14 @@ from unittest.mock import MagicMock
 class TestEmitSmbLogonPair:
     """Test _emit_smb_logon_pair helper method."""
 
+    def test_successful_logon_requires_successful_smb_transport_state(self):
+        """SMB transports that anchor successful Type 3 logons must be successful."""
+        from evidenceforge.generation.engine.baseline import BaselineMixin
+
+        assert BaselineMixin._smb_logon_transport_conn_state("smb", True) == "SF"
+        assert BaselineMixin._smb_logon_transport_conn_state("ldap", True) is None
+        assert BaselineMixin._smb_logon_transport_conn_state("smb", False) is None
+
     def test_emits_logon_and_logoff(self):
         """Should call generate_logon(type=3) then generate_logoff(type=3)."""
         import random

--- a/tests/unit/test_logonid_scoping.py
+++ b/tests/unit/test_logonid_scoping.py
@@ -297,8 +297,7 @@ class TestLogonIdSystemScoping:
         kwargs = engine.activity_generator.generate_create_remote_thread.call_args.kwargs
         assert kwargs["target_pid"] == 620
         assert kwargs["target_image"] == r"C:\Windows\System32\lsass.exe"
-        expand_kwargs = engine.activity_generator._expand_and_emit.call_args.kwargs
-        assert expand_kwargs["target_image"] == r"C:\Windows\System32\lsass.exe"
+        engine.activity_generator._expand_and_emit.assert_not_called()
 
     def test_storyline_process_access_with_stale_source_is_marked_skipped(
         self, state_manager, mock_emitters, system_a, attacker

--- a/tests/unit/test_network_visibility.py
+++ b/tests/unit/test_network_visibility.py
@@ -27,6 +27,7 @@ Phase 2.5: Tests NetworkVisibilityEngine for sensor-based connection filtering.
 
 from evidenceforge.generation.network_visibility import NetworkVisibilityEngine
 from evidenceforge.models.scenario import (
+    NatRule,
     NetworkConfig,
     NetworkSegment,
     NetworkSensor,
@@ -90,6 +91,131 @@ class TestNoNetworkConfig:
         assert engine.is_connection_visible("10.10.10.1", "8.8.8.8") is False
         assert engine.get_observing_sensors("10.10.10.1", "8.8.8.8") == []
         assert engine.get_log_formats_for_connection("10.10.10.1", "8.8.8.8") == set()
+
+
+class TestNatComputation:
+    """Tests for firewall NAT context ownership."""
+
+    def test_static_vip_takes_precedence_for_internal_hairpin_flow(self):
+        """Internal traffic aimed at a known VIP should expose DNAT context."""
+        systems = [
+            System(
+                hostname="MAIL-EDGE-01",
+                ip="10.10.2.25",
+                os="Linux Ubuntu 22.04",
+                type="server",
+            ),
+            System(
+                hostname="MAIL-FIN-01",
+                ip="10.10.2.27",
+                os="Linux Ubuntu 22.04",
+                type="server",
+            ),
+        ]
+        config = NetworkConfig(
+            segments=[
+                NetworkSegment(
+                    name="server_vlan",
+                    cidr="10.10.2.0/24",
+                    systems=["MAIL-EDGE-01", "MAIL-FIN-01"],
+                    exposure="internal",
+                ),
+            ],
+            sensors=[
+                NetworkSensor(
+                    type="firewall",
+                    name="edge-fw",
+                    monitoring_segments=["server_vlan"],
+                    direction="bidirectional",
+                    log_formats=["asa"],
+                    nat_rules=[
+                        NatRule(
+                            type="dynamic_pat",
+                            src=["server_vlan"],
+                            mapped_ip="203.14.220.1",
+                        ),
+                        NatRule(
+                            type="static",
+                            src=["server_vlan"],
+                            mapped_ip="203.14.220.11",
+                            real_ip="10.10.2.25",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        engine = NetworkVisibilityEngine(config, systems)
+
+        nat = engine.compute_nat(
+            src_ip="10.10.2.27",
+            dst_ip="203.14.220.11",
+            src_port=60403,
+            dst_port=25,
+        )
+
+        assert nat is not None
+        assert nat.nat_type == "static"
+        assert nat.mapped_src_ip == "10.10.2.27"
+        assert nat.mapped_dst_ip == "10.10.2.25"
+
+    def test_same_segment_real_ip_flow_is_not_nat_translated(self):
+        """Ordinary server-to-server traffic should keep the no-NAT rule."""
+        systems = [
+            System(
+                hostname="MAIL-EDGE-01",
+                ip="10.10.2.25",
+                os="Linux Ubuntu 22.04",
+                type="server",
+            ),
+            System(
+                hostname="MAIL-FIN-01",
+                ip="10.10.2.27",
+                os="Linux Ubuntu 22.04",
+                type="server",
+            ),
+        ]
+        config = NetworkConfig(
+            segments=[
+                NetworkSegment(
+                    name="server_vlan",
+                    cidr="10.10.2.0/24",
+                    systems=["MAIL-EDGE-01", "MAIL-FIN-01"],
+                    exposure="internal",
+                ),
+            ],
+            sensors=[
+                NetworkSensor(
+                    type="firewall",
+                    name="edge-fw",
+                    monitoring_segments=["server_vlan"],
+                    direction="bidirectional",
+                    log_formats=["asa"],
+                    nat_rules=[
+                        NatRule(
+                            type="dynamic_pat",
+                            src=["server_vlan"],
+                            mapped_ip="203.14.220.1",
+                        ),
+                        NatRule(
+                            type="static",
+                            src=["server_vlan"],
+                            mapped_ip="203.14.220.11",
+                            real_ip="10.10.2.25",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        engine = NetworkVisibilityEngine(config, systems)
+
+        nat = engine.compute_nat(
+            src_ip="10.10.2.27",
+            dst_ip="10.10.2.25",
+            src_port=60403,
+            dst_port=25,
+        )
+
+        assert nat is None
 
 
 class TestBidirectionalSensor:

--- a/tests/unit/test_phase5_logoff.py
+++ b/tests/unit/test_phase5_logoff.py
@@ -23,6 +23,7 @@
 """Unit tests for Phase 5.1.2: Baseline logoff generation."""
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -73,6 +74,24 @@ def linux_system():
 @pytest.fixture
 def timestamp():
     return datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC)
+
+
+def _emitted_syslog_events(mock_emitters: dict[str, Any]) -> list[Any]:
+    """Return syslog-dispatched events from the mocked syslog emitter."""
+    return [
+        call.args[0]
+        for call in mock_emitters["syslog"].emit.call_args_list
+        if call.args[0].syslog is not None
+    ]
+
+
+def _emitted_pam_close_event(mock_emitters: dict[str, Any]) -> Any:
+    """Return the SSH PAM close event from mocked syslog calls."""
+    return next(
+        event
+        for event in _emitted_syslog_events(mock_emitters)
+        if event.syslog.message.startswith("pam_unix(sshd:session): session closed")
+    )
 
 
 class TestLogoffWindows:
@@ -227,7 +246,14 @@ class TestLogoffLinux:
             transport_pid=6505,
         )
         close_time = timestamp + timedelta(minutes=8)
-        state_manager.update_session_metadata(logon_id, network_close_time=close_time)
+        state_manager.update_session_metadata(
+            logon_id,
+            network_close_time=close_time,
+            session_id=12345,
+        )
+        session = state_manager.get_session(logon_id)
+        assert session is not None
+        expected_session_id = session.session_id
         session_obj_id = state_manager.get_session_object_id(logon_id)
         mock_emitters["syslog"].reset_mock()
         mock_emitters["ecar"].reset_mock()
@@ -240,8 +266,17 @@ class TestLogoffLinux:
             logon_type=10,
         )
 
-        event = mock_emitters["syslog"].emit.call_args[0][0]
-        ecar_event = mock_emitters["ecar"].emit.call_args[0][0]
+        event = _emitted_pam_close_event(mock_emitters)
+        removed_event = next(
+            event
+            for event in _emitted_syslog_events(mock_emitters)
+            if event.syslog.message == f"Removed session {expected_session_id}."
+        )
+        ecar_event = next(
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type == "logoff"
+        )
         expected_delta = sample_timing_delta(
             "windows.logoff_after_last_activity",
             seed_parts=(linux_system.hostname, logon_id, close_time),
@@ -253,6 +288,8 @@ class TestLogoffLinux:
         assert ecar_event.edr.object_id == session_obj_id
         assert ecar_event.auth.source_ip == "10.0.10.50"
         assert ecar_event.auth.source_port == 51111
+        assert removed_event.timestamp > event.timestamp
+        assert removed_event.timestamp <= event.timestamp + timedelta(seconds=1)
 
     def test_ssh_logoff_binds_late_cleanup_to_transport_close(
         self, activity_gen, test_user, linux_system, timestamp, state_manager, mock_emitters
@@ -284,7 +321,7 @@ class TestLogoffLinux:
             logon_type=10,
         )
 
-        event = mock_emitters["syslog"].emit.call_args[0][0]
+        event = _emitted_pam_close_event(mock_emitters)
         expected_delta = sample_timing_delta(
             "windows.logoff_after_last_activity",
             seed_parts=(linux_system.hostname, logon_id, close_time),
@@ -326,7 +363,7 @@ class TestLogoffLinux:
             "windows.logoff_after_last_activity",
             seed_parts=(linux_system.hostname, logon_id, close_time),
         )
-        syslog_event = mock_emitters["syslog"].emit.call_args[0][0]
+        syslog_event = _emitted_pam_close_event(mock_emitters)
         ecar_event = mock_emitters["ecar"].emit.call_args[0][0]
         assert syslog_event.timestamp == close_time + expected_delta
         assert ecar_event.timestamp == close_time + expected_delta
@@ -360,7 +397,7 @@ class TestLogoffLinux:
             from_storyline=True,
         )
 
-        syslog_event = mock_emitters["syslog"].emit.call_args[0][0]
+        syslog_event = _emitted_pam_close_event(mock_emitters)
         ecar_event = mock_emitters["ecar"].emit.call_args[0][0]
         assert syslog_event.timestamp == logoff_time
         assert ecar_event.timestamp == logoff_time
@@ -389,7 +426,7 @@ class TestLogoffLinux:
             logon_type=10,
         )
 
-        event = mock_emitters["syslog"].emit.call_args[0][0]
+        event = _emitted_pam_close_event(mock_emitters)
         assert event.syslog.message == (
             "pam_unix(sshd:session): session closed for user alice.smith"
         )

--- a/tests/unit/test_phase5_system_traffic.py
+++ b/tests/unit/test_phase5_system_traffic.py
@@ -330,6 +330,10 @@ def test_polkit_action_messages_materialize_companion_process(linux_system, stat
     engine.start_time = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
     engine.activity_generator = Mock()
     engine.activity_generator.generate_system_process.return_value = 4242
+    engine._polkit_action_profile = lambda _entry, _rng: (
+        "org.freedesktop.packagekit.system-update",
+        "/usr/lib/packagekit/packagekitd",
+    )
     entry = next(item for item in load_extra_syslog_messages() if item["app"] == "polkitd")
     template = next(message for message in entry["messages"] if "action {action_id}" in message)
     rng = random.Random(29)
@@ -349,6 +353,120 @@ def test_polkit_action_messages_materialize_companion_process(linux_system, stat
     assert call["process_name"] in message
     assert call["emit_linux_syslog"] is False
     assert call["time"] < timestamp
+
+
+def test_polkit_cli_companion_process_uses_visible_user_shell(
+    linux_system, state_manager, mock_emitters
+):
+    """Foreground polkit CLI tools should not appear as direct PID 1/systemd children."""
+    from evidenceforge.generation.engine import GenerationEngine
+
+    engine = object.__new__(GenerationEngine)
+    engine.state_manager = state_manager
+    engine.start_time = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+    engine._system_pids = {}
+
+    pids: dict[str, int] = {}
+    engine._seed_linux_process_tree(linux_system, pids)
+    engine._system_pids[linux_system.hostname] = pids
+
+    activity_generator = ActivityGenerator(state_manager, mock_emitters)
+    activity_generator._system_pids = engine._system_pids
+    engine.activity_generator = activity_generator
+
+    timestamp = datetime(2024, 3, 18, 12, 5, 0, tzinfo=UTC)
+    pid = engine._materialize_polkit_action_process(
+        system=linux_system,
+        timestamp=timestamp,
+        action_id="org.freedesktop.systemd1.manage-units",
+        process_path="/usr/bin/systemctl",
+        subject_user="deploy",
+        rng=random.Random(31),
+        sys_pids=pids,
+    )
+
+    emitted_events = [call.args[0] for call in mock_emitters["ecar"].emit.call_args_list]
+    create_event = next(
+        event
+        for event in emitted_events
+        if event.event_type == "process_create"
+        and event.process is not None
+        and event.process.image == "/usr/bin/systemctl"
+    )
+    terminate_event = next(
+        event
+        for event in emitted_events
+        if event.event_type == "process_terminate"
+        and event.process is not None
+        and event.process.pid == pid
+    )
+
+    assert pid is not None
+    assert create_event.auth.username == "deploy"
+    assert create_event.process.parent_image == "/bin/bash"
+    assert create_event.process.parent_pid != 1
+    assert terminate_event.timestamp > create_event.timestamp
+
+
+def test_polkit_reboot_action_is_explicitly_unsuccessful(
+    linux_system, state_manager, mock_emitters
+):
+    """Generic reboot attempts should not imply a successful host reboot lifecycle."""
+    from evidenceforge.generation.engine import GenerationEngine
+
+    engine = object.__new__(GenerationEngine)
+    engine.state_manager = state_manager
+    engine.start_time = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+    engine._system_pids = {}
+
+    pids: dict[str, int] = {}
+    engine._seed_linux_process_tree(linux_system, pids)
+    engine._system_pids[linux_system.hostname] = pids
+
+    activity_generator = ActivityGenerator(state_manager, mock_emitters)
+    activity_generator._system_pids = engine._system_pids
+    engine.activity_generator = activity_generator
+    engine._polkit_action_profile = lambda _entry, _rng: (
+        "org.freedesktop.login1.reboot",
+        "/usr/bin/loginctl",
+    )
+
+    entry = next(item for item in load_extra_syslog_messages() if item["app"] == "polkitd")
+    templates = [message for message in entry["messages"] if "action {action_id}" in message]
+    timestamp = datetime(2024, 3, 18, 12, 5, 0, tzinfo=UTC)
+
+    messages = [
+        engine._render_polkit_syslog_message(
+            {**entry, "messages": [template]},
+            random.Random(41 + index),
+            system=linux_system,
+            timestamp=timestamp + timedelta(seconds=index),
+            sys_pids=pids,
+        )
+        for index, template in enumerate(templates)
+    ]
+
+    emitted_events = [call.args[0] for call in mock_emitters["ecar"].emit.call_args_list]
+    reboot_commands = [
+        event
+        for event in emitted_events
+        if event.event_type == "process_create"
+        and event.process is not None
+        and event.process.image == "/usr/bin/loginctl"
+    ]
+
+    assert messages
+    assert all("org.freedesktop.login1.reboot" in message for message in messages)
+    assert all("successfully authenticated" not in message for message in messages)
+    assert all(" is authorized for action " not in message for message in messages)
+    assert all(
+        "failed to authenticate" in message or "is not authorized" in message
+        for message in messages
+    )
+    assert reboot_commands
+    assert all(
+        event.process.command_line == "/usr/bin/loginctl reboot" for event in reboot_commands
+    )
 
 
 def test_windows_scheduled_task_selector_honors_per_host_window_caps(win_system):

--- a/tests/unit/test_process_lifetimes.py
+++ b/tests/unit/test_process_lifetimes.py
@@ -235,6 +235,104 @@ def test_baseline_session_activity_stops_at_network_close() -> None:
     assert not _session_active_at(session, close + timedelta(seconds=1), start, None)
 
 
+def test_process_owned_ssh_transport_holds_client_process_until_close() -> None:
+    """A source SSH client should not terminate before its correlated transport closes."""
+    start = datetime(2024, 3, 18, 15, 59, 55, tzinfo=UTC)
+    state = StateManager()
+    state.set_current_time(start - timedelta(minutes=5))
+    events = []
+    dispatcher = EventDispatcher(state_manager=state, emitters={})
+    original_dispatch = dispatcher.dispatch
+
+    def capture(event):
+        events.append(event)
+        original_dispatch(event)
+
+    dispatcher.dispatch = capture
+    generator = ActivityGenerator(state, {}, dispatcher=dispatcher)
+    user = User(
+        username="aisha.johnson",
+        full_name="Aisha Johnson",
+        email="aisha.johnson@example.local",
+    )
+    source = System(
+        hostname="WS-AJOHNSON-01",
+        ip="10.10.1.35",
+        os="Windows 11",
+        type="workstation",
+        assigned_user=user.username,
+    )
+    target = System(
+        hostname="DB-PROD-01",
+        ip="10.10.4.10",
+        os="Ubuntu 22.04",
+        type="server",
+        roles=["database"],
+        services=["ssh"],
+    )
+    generator._ip_to_system = {source.ip: source, target.ip: target}
+    logon_id = state.create_session(
+        username=user.username,
+        system=source.hostname,
+        logon_type=2,
+        source_ip="-",
+        session_kind="interactive",
+        start_time=start - timedelta(minutes=5),
+    )
+    state.set_current_time(start - timedelta(seconds=5))
+    pid = state.create_process(
+        source.hostname,
+        0,
+        r"C:\Windows\System32\OpenSSH\ssh.exe",
+        "ssh.exe aisha.johnson@DB-PROD-01.meridianhcs.local",
+        user.username,
+        "Medium",
+        logon_id=logon_id,
+    )
+    state.set_current_time(start)
+
+    generator.generate_connection(
+        src_ip=source.ip,
+        dst_ip=target.ip,
+        time=start,
+        dst_port=22,
+        proto="tcp",
+        service="ssh",
+        duration=1800.0,
+        orig_bytes=38_000,
+        resp_bytes=58_000,
+        src_port=60175,
+        pid=pid,
+        source_system=source,
+        conn_state="SF",
+        process_image=r"C:\Windows\System32\OpenSSH\ssh.exe",
+        suppress_application_side_effects=True,
+        suppress_prereq_dns=True,
+    )
+    connection_event = next(
+        event
+        for event in events
+        if event.event_type == "connection"
+        and event.network is not None
+        and event.network.dst_port == 22
+    )
+    close_time = connection_event.timestamp + timedelta(seconds=connection_event.network.duration)
+
+    state.end_session(logon_id, start + timedelta(seconds=30))
+    generator.generate_process_termination(
+        user=user,
+        system=source,
+        time=start + timedelta(seconds=45),
+        pid=pid,
+        process_name=r"C:\Windows\System32\OpenSSH\ssh.exe",
+        logon_id=logon_id,
+    )
+
+    terminate_event = next(event for event in events if event.event_type == "process_terminate")
+    assert terminate_event.timestamp > close_time
+    assert state.get_process(source.hostname, pid) is None
+
+
 def test_finalize_foreground_process_lifetimes_closes_tracked_one_shot() -> None:
     start = datetime(2024, 3, 18, 17, 56, 39, tzinfo=UTC)
     state = StateManager()

--- a/tests/unit/test_proxy_referrer.py
+++ b/tests/unit/test_proxy_referrer.py
@@ -637,6 +637,8 @@ class TestProxyActionSemantics:
         assert connect_fields["method"] == "CONNECT"
         assert inspected_fields["method"] == "GET"
         assert connect_fields["status_code"] == 200
+        assert inspected_fields["cs_bytes"] == 700
+        assert inspected_fields["sc_bytes"] == 4096
         assert connect_fields["sc_bytes"] < inspected_fields["sc_bytes"]
         assert connect_fields["proxy_action"] == "tunnel-setup"
         assert connect_fields["ssl_bump_action"] == "peek"

--- a/tests/unit/test_remaining_expert_review.py
+++ b/tests/unit/test_remaining_expert_review.py
@@ -219,6 +219,31 @@ class TestStorylineAccountLifecycle:
             datetime(2024, 3, 18, 17, 1, tzinfo=UTC),
         )
 
+    def test_storyline_created_service_account_is_not_baseline_noise_eligible(self):
+        class Engine(BaselineMixin):
+            start_time = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+
+            def _parse_storyline_time(self, time_str):
+                hours = int(time_str.removeprefix("+").removesuffix("h"))
+                return self.start_time + timedelta(hours=hours)
+
+        engine = Engine()
+        engine.scenario = SimpleNamespace(
+            storyline=[
+                SimpleNamespace(
+                    time="+4h",
+                    events=[AccountCreatedEventSpec(target_username="svc_mhsync")],
+                )
+            ]
+        )
+
+        assert engine._service_account_available_at(
+            "svc_mhsync",
+            datetime(2024, 3, 18, 17, 0, tzinfo=UTC),
+        )
+        assert not engine._service_account_eligible_for_baseline_noise("svc_mhsync")
+        assert engine._service_account_eligible_for_baseline_noise("svc_backup")
+
     def test_service_account_delegation_uses_role_specific_caller_process(self):
         engine = object.__new__(BaselineMixin)
         config = {

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -379,6 +379,58 @@ def test_ecar_dependent_timestamp_follows_process_create(tmp_path: Path) -> None
     assert dependent_time > process_time
 
 
+def test_ecar_session_dependents_shift_after_visible_login() -> None:
+    """eCAR PROCESS/FILE/MODULE rows should not precede their same LogonID login."""
+    login_ms = 1_710_781_261_000
+    rows = [
+        {
+            "timestamp_ms": login_ms - 200,
+            "id": "process-event",
+            "hostname": "FILE-SRV-01",
+            "object": "PROCESS",
+            "action": "CREATE",
+            "objectID": "process-object",
+            "pid": 4242,
+            "principal": "MERIDIANHCS\\svc_mhsync",
+            "properties": {"logon_id": "0xf88578c", "image_path": "powershell.exe"},
+        },
+        {
+            "timestamp_ms": login_ms,
+            "id": "session-event",
+            "hostname": "FILE-SRV-01",
+            "object": "USER_SESSION",
+            "action": "LOGIN",
+            "objectID": "session-object",
+            "principal": "MERIDIANHCS\\svc_mhsync",
+            "properties": {
+                "logon_id": "0xf88578c",
+                "outcome": "success",
+                "logon_type": "3",
+            },
+        },
+        {
+            "timestamp_ms": login_ms + 50,
+            "id": "other-process",
+            "hostname": "FILE-SRV-01",
+            "object": "PROCESS",
+            "action": "CREATE",
+            "objectID": "other-object",
+            "pid": 5000,
+            "principal": "NT AUTHORITY\\SYSTEM",
+            "properties": {"logon_id": "0x3e7", "image_path": "svchost.exe"},
+        },
+    ]
+    normalized = EcarEmitter._normalize_session_dependents_after_login(
+        [json.dumps(row, separators=(",", ":")) for row in rows]
+    )
+    process = json.loads(normalized[0])
+    system_process = json.loads(normalized[2])
+
+    assert process["timestamp_ms"] > login_ms
+    assert process["properties"]["logon_id"] == "0xf88578c"
+    assert system_process["timestamp_ms"] == login_ms + 50
+
+
 def test_ecar_type3_login_timestamp_follows_matching_inbound_flow(tmp_path: Path) -> None:
     """eCAR type-3 USER_SESSION rows should not visibly precede same-tuple FLOW rows."""
     emitter = EcarEmitter(load_format("ecar"), tmp_path, threaded=False)
@@ -490,6 +542,7 @@ def test_ecar_process_create_normalization_preserves_canonical_order() -> None:
     rows = [json.loads(line) for line in normalized]
 
     assert rows[1]["timestamp_ms"] > rows[0]["timestamp_ms"]
+    assert 3 <= rows[1]["timestamp_ms"] - rows[0]["timestamp_ms"] <= 49
     assert "_canonical_ms" not in rows[0]
     assert "_canonical_ms" not in rows[1]
 
@@ -897,6 +950,68 @@ def test_ecar_linux_shell_foreground_order_serializes_close_unrelated_commands()
     rows = [json.loads(line) for line in normalized]
 
     assert rows[1]["timestamp_ms"] > rows[2]["timestamp_ms"]
+
+
+def test_ecar_linux_shell_foreground_order_preserves_bash_history_sync() -> None:
+    """Bash-history-synchronized process rows should keep their sibling timestamp."""
+    npm_create = {
+        "timestamp_ms": 1_000_000,
+        "id": "npm-create",
+        "hostname": "WS-LNGUYEN-01",
+        "object": "PROCESS",
+        "action": "CREATE",
+        "objectID": "npm-process",
+        "actorID": "bash-process",
+        "pid": 781867,
+        "ppid": 780919,
+        "principal": "lina.nguyen",
+        "properties": {
+            "image_path": "/usr/bin/npm",
+            "command_line": "npm run ci",
+            "parent_image_path": "/bin/bash",
+        },
+    }
+    npm_terminate = {
+        "timestamp_ms": 1_060_000,
+        "id": "npm-terminate",
+        "hostname": "WS-LNGUYEN-01",
+        "object": "PROCESS",
+        "action": "TERMINATE",
+        "objectID": "npm-process",
+        "pid": 781867,
+        "principal": "lina.nguyen",
+        "properties": {"image_path": "/usr/bin/npm"},
+    }
+    emacs_create = {
+        "timestamp_ms": 1_020_000,
+        "id": "emacs-create",
+        "hostname": "WS-LNGUYEN-01",
+        "object": "PROCESS",
+        "action": "CREATE",
+        "objectID": "emacs-process",
+        "actorID": "bash-process",
+        "_concurrency_group_id": "bash-history:abc123",
+        "pid": 781901,
+        "ppid": 780919,
+        "principal": "lina.nguyen",
+        "properties": {
+            "image_path": "/usr/bin/emacs",
+            "command_line": "emacs -nw /home/lina.nguyen/repos/infra-config/requirements.txt",
+            "parent_image_path": "/bin/bash",
+        },
+    }
+
+    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
+        [
+            json.dumps(npm_create, separators=(",", ":")),
+            json.dumps(emacs_create, separators=(",", ":")),
+            json.dumps(npm_terminate, separators=(",", ":")),
+        ]
+    )
+    rows = [json.loads(line) for line in normalized]
+
+    assert rows[1]["timestamp_ms"] == emacs_create["timestamp_ms"]
+    assert "_concurrency_group_id" not in rows[1]
 
 
 def test_ecar_linux_shell_foreground_order_keeps_pipeline_children_concurrent() -> None:

--- a/tests/unit/test_spawn_rules.py
+++ b/tests/unit/test_spawn_rules.py
@@ -1131,12 +1131,12 @@ class TestDualSessionParentSelection:
             (
                 r"C:\Windows\System32\sc.exe",
                 "sc.exe create DeviceSyncSvc binPath= C:\\ProgramData\\sync.exe",
-                "services",
+                "wmiprvse",
             ),
             (
                 r"C:\Windows\System32\schtasks.exe",
                 r'schtasks.exe /Create /TN "\Ops\Sync" /TR "C:\ProgramData\sync.exe"',
-                "taskhostw",
+                "wmiprvse",
             ),
             (
                 r"C:\Windows\System32\wevtutil.exe",
@@ -1178,6 +1178,33 @@ class TestDualSessionParentSelection:
         assert parent_proc.command_line == rf"C:\Windows\System32\cmd.exe /c {command_line}"
         assert parent_proc.parent_pid == pids[expected_parent_key]
         assert parent_proc.parent_pid != pids["svchost_netsvcs"]
+
+    def test_scheduled_task_execution_can_still_use_taskhostw_owner(
+        self, state_manager, mock_emitters, win_system
+    ):
+        """Task actions can remain taskhostw-owned while task authoring avoids taskhostw."""
+        system_user = User(
+            username="SYSTEM",
+            full_name="SYSTEM",
+            email="system@example.com",
+            enabled=True,
+        )
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        command_line = r'schtasks.exe /Run /TN "\Ops\Sync"'
+
+        parent_pid = ag._resolve_parent(
+            win_system,
+            system_user,
+            datetime(2024, 3, 18, 12, 15, 0, tzinfo=UTC),
+            "0x3e7",
+            r"C:\Windows\System32\schtasks.exe",
+            command_line,
+        )
+        parent_proc = state_manager.get_process(win_system.hostname, parent_pid)
+
+        assert parent_proc is not None
+        assert parent_proc.image == r"C:\Windows\System32\cmd.exe"
+        assert parent_proc.parent_pid == pids["taskhostw"]
 
     def test_interactive_logon_still_gets_explorer_when_network_exists(
         self, state_manager, mock_emitters, win_system, user
@@ -1305,6 +1332,45 @@ class TestLinuxParentSelection:
         )
 
         assert parent_pid == bash_pid
+
+    def test_ssh_login_shell_keeps_privileged_sshd_parent(
+        self, state_manager, mock_emitters, linux_system, user
+    ):
+        """The root-owned sshd privilege process may parent the user login shell."""
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, linux_system)
+        event_time = datetime(2024, 3, 18, 12, 0, 5, tzinfo=UTC)
+        logon_id = state_manager.create_session(
+            username=user.username,
+            system=linux_system.hostname,
+            logon_type=10,
+            source_ip="10.0.10.50",
+            session_kind="ssh",
+        )
+        session_sshd = state_manager.create_process(
+            linux_system.hostname,
+            pids["sshd"],
+            "/usr/sbin/sshd",
+            f"sshd: {user.username} [priv]",
+            "root",
+            "System",
+            logon_id="0x3e7",
+        )
+
+        bash_pid = ag.generate_process(
+            user=user,
+            system=linux_system,
+            time=event_time,
+            logon_id=logon_id,
+            process_name="/bin/bash",
+            command_line="-bash",
+            parent_pid=session_sshd,
+            suppress_command_file_effect=True,
+        )
+
+        bash_proc = state_manager.get_process(linux_system.hostname, bash_pid)
+        assert bash_proc is not None
+        assert bash_proc.parent_pid == session_sshd
+        assert bash_proc.logon_id == logon_id
 
     def test_linux_generate_process_replaces_untracked_parent_pid(
         self, state_manager, mock_emitters, linux_system, user

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -743,6 +743,56 @@ class TestStorylineCommandNetworks:
             event.source_timing.source_times.values()
         )
 
+    def test_process_preplan_waits_for_session_source_ready_time(self):
+        captured: dict[str, Any] = {}
+
+        class _CapturingDispatcher:
+            @staticmethod
+            def dispatch(event: Any) -> None:
+                if event.event_type == "process_create":
+                    captured["event"] = event
+
+        state_manager = StateManager()
+        generator = ActivityGenerator(state_manager, {})
+        generator.dispatcher = _CapturingDispatcher()
+        actor = User(username="svc_mhsync", full_name="Sync Service", email="svc@example.com")
+        system = System(
+            hostname="FILE-SRV-01",
+            ip="10.10.0.20",
+            os="Windows Server 2019",
+            type="server",
+        )
+        event_time = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
+        ready_time = event_time + timedelta(seconds=1)
+        state_manager.set_current_time(event_time)
+        logon_id = state_manager.create_session(
+            username=actor.username,
+            system=system.hostname,
+            logon_type=3,
+            source_ip="10.10.0.10",
+            start_time=event_time,
+        )
+        state_manager.update_session_metadata(logon_id, source_ready_time=ready_time)
+
+        generator.generate_process(
+            actor,
+            system,
+            event_time,
+            logon_id,
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            "powershell.exe -NoProfile -EncodedCommand SQBFAFgA",
+            parent_pid=4,
+        )
+
+        event = captured["event"]
+        assert event.source_timing is not None
+        source_times = event.source_timing.source_times
+        floor = ready_time + timedelta(milliseconds=1)
+        assert all(timestamp >= floor for timestamp in source_times.values())
+        assert generator.process_source_create_time(system.hostname, event.process.pid) == max(
+            source_times.values()
+        )
+
     def test_process_owned_windows_connection_waits_for_visible_process_create(self):
         captured: list[Any] = []
 
@@ -1912,6 +1962,10 @@ class TestStorylineCommandSideEffects:
                 description="Exfiltrate staged archive",
                 orig_bytes=314_782_613,
                 resp_bytes=2048,
+                user_agent=(
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                    "Chrome/121.0.0.0 Safari/537.36"
+                ),
             ),
             actor=actor,
             system=source,
@@ -1927,7 +1981,22 @@ class TestStorylineCommandSideEffects:
         assert smb_transfer["src_ip"] == source.ip
         assert smb_transfer["dst_ip"] == file_server.ip
         assert smb_transfer["pid"] > 0
-        assert smb_transfer["process_image"].endswith("chrome.exe")
+        assert smb_transfer["pid"] != upload["pid"]
+        assert smb_transfer["process_image"].endswith("powershell.exe")
+        copy_process = next(
+            process
+            for process in engine.activity_generator.processes
+            if "Copy-Item" in process["command_line"]
+        )
+        assert copy_process["process_name"].endswith("powershell.exe")
+        assert "Copy-Item" in copy_process["command_line"]
+        assert (
+            r"\\FILE-SRV-01\C$\ProgramData\Microsoft\cache_7f3a.zip" in copy_process["command_line"]
+        )
+        assert (
+            r"C:\Users\aisha.johnson\AppData\Local\Temp\cache_7f3a.zip"
+            in copy_process["command_line"]
+        )
         assert archive_time < smb_transfer["time"] < upload_time
         assert smb_transfer["resp_bytes"] > 300_000_000
         source_file_read = next(event for event in dispatched if event.event_type == "file_read")
@@ -1935,11 +2004,22 @@ class TestStorylineCommandSideEffects:
         assert source_file_read.auth.username == actor.username
         assert source_file_read.process.image.endswith("chrome.exe")
         assert source_file_read.file.path == (
-            r"\\FILE-SRV-01\C$\ProgramData\Microsoft\cache_7f3a.zip"
+            r"C:\Users\aisha.johnson\AppData\Local\Temp\cache_7f3a.zip"
         )
+        source_file_create = next(
+            event for event in dispatched if event.event_type == "file_create"
+        )
+        assert source_file_create.file.path == source_file_read.file.path
+        assert source_file_create.process.image.endswith("powershell.exe")
+        assert source_file_create.process.pid == smb_transfer["pid"]
+        assert smb_transfer["time"] < source_file_create.timestamp < source_file_read.timestamp
         assert smb_transfer["time"] < source_file_read.timestamp < upload_time
         assert upload["dst_port"] == 443
-        assert upload["pid"] == smb_transfer["pid"]
+        assert upload["pid"] == source_file_read.process.pid
+        assert upload["http"].user_agent == (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "Chrome/121.0.0.0 Safari/537.36"
+        )
 
         file_transfer = smb_transfer["file_transfer"]
         assert isinstance(file_transfer, FileTransferContext)
@@ -1956,6 +2036,7 @@ class TestStorylineCommandSideEffects:
                 "src_ip": source.ip,
             }
         ]
+        assert engine.activity_generator.process_terminations[0]["pid"] == smb_transfer["pid"]
 
     def test_compress_archive_exfil_handoff_uses_upload_host_source_read(self):
         staging_source = System(
@@ -2089,14 +2170,24 @@ class TestStorylineCommandSideEffects:
         smb_transfer, upload = engine.activity_generator.connections
         assert smb_transfer["src_ip"] == upload_source.ip
         assert smb_transfer["dst_ip"] == file_server.ip
-        assert smb_transfer["pid"] == upload["pid"]
+        assert smb_transfer["pid"] != upload["pid"]
+        assert smb_transfer["process_image"].endswith("powershell.exe")
         source_file_read = next(event for event in dispatched if event.event_type == "file_read")
         assert source_file_read.src_host.hostname == upload_source.hostname
         assert source_file_read.auth.username == upload_actor.username
         assert source_file_read.process.pid == upload["pid"]
         assert source_file_read.file.path == (
-            r"\\FILE-SRV-01\C$\ProgramData\Microsoft\cache_7f3a.zip"
+            r"C:\Users\aisha.johnson\AppData\Local\Temp\cache_7f3a.zip"
         )
+        source_file_create = next(
+            event for event in dispatched if event.event_type == "file_create"
+        )
+        assert source_file_create.file.path == source_file_read.file.path
+        assert source_file_create.process.pid == smb_transfer["pid"]
+        assert source_file_create.process.image.endswith("powershell.exe")
+        assert source_file_create.timestamp < source_file_read.timestamp
+        assert "Chrome/" in upload["http"].user_agent
+        assert "Firefox/" not in upload["http"].user_agent
         assert smb_logons == [
             {
                 "actor": upload_actor.username,
@@ -2970,3 +3061,8 @@ class TestStorylineCommandSideEffects:
         assert lease["mac"] == "f0:1f:af:b7:35:b2"
         assert lease["lease_time"] == 7200.0
         assert lease["msg_types"] == ["REQUEST", "ACK"]
+        assert lease["renewal_interval"] > 0
+        assert (
+            engine._dhcp_lease_state["ROGUE-LAPTOP"]["next_renewal"]
+            == lease["time"].timestamp() + lease["renewal_interval"]
+        )

--- a/tests/unit/test_sysmon_new_events.py
+++ b/tests/unit/test_sysmon_new_events.py
@@ -1493,6 +1493,31 @@ class TestUserFieldFormatting:
         content = list(emitter._host_writers.values())[0].output_path.read_text()
         assert "CORP\\jsmith" in content
 
+    def test_event1_version5_includes_parent_user(self, emitter):
+        event = SecurityEvent(
+            timestamp=datetime(2024, 1, 15, 10, 0, tzinfo=UTC),
+            event_type="process_create",
+            src_host=_win_host(),
+            auth=AuthContext(username="admin", logon_id="0x46a3f"),
+            process=ProcessContext(
+                pid=4100,
+                parent_pid=4000,
+                image=r"C:\Windows\System32\cmd.exe",
+                command_line="cmd.exe /c whoami",
+                username="admin",
+                parent_image=r"C:\Windows\explorer.exe",
+                parent_command_line=r"C:\Windows\explorer.exe",
+            ),
+        )
+
+        emitter._render_sysmon_process_create(event)
+        emitter.flush()
+        content = list(emitter._host_writers.values())[0].output_path.read_text()
+
+        assert "<EventID>1</EventID>" in content
+        assert "<Version>5</Version>" in content
+        assert '<Data Name="ParentUser">CORP\\admin</Data>' in content
+
     def test_process_access_target_user_gets_domain(self, emitter):
         """Sysmon Event 10 target user should use source-native domain formatting."""
         event = SecurityEvent(

--- a/tests/unit/test_timing_profiles.py
+++ b/tests/unit/test_timing_profiles.py
@@ -100,6 +100,26 @@ def test_timing_profiles_load_default_relationship():
     assert ecar_process_window.max_ms >= 900
     assert 0 < ecar_after_sysmon_window.min_ms < ecar_after_sysmon_window.max_ms
     assert ecar_after_sysmon_window.max_ms >= 3000
+    remote_thread_after_open_window = get_timing_window(
+        "source.ecar_remote_thread_after_process_open",
+        default_min_ms=0,
+        default_max_ms=0,
+        default_position="after",
+    )
+    assert 0 < remote_thread_after_open_window.min_ms < remote_thread_after_open_window.max_ms
+    assert remote_thread_after_open_window.max_ms <= 300
+    remote_thread_process_access_window = get_timing_window(
+        "process.remote_thread_process_access",
+        default_min_ms=0,
+        default_max_ms=0,
+        default_position="before",
+    )
+    assert (
+        0
+        < remote_thread_process_access_window.min_ms
+        < remote_thread_process_access_window.max_ms
+        <= 200
+    )
     security_gap_window = get_timing_window(
         "source.windows_security_after_sysmon_process_create_gap",
         default_min_ms=0,
@@ -114,6 +134,13 @@ def test_timing_profiles_load_default_relationship():
         default_position="after",
     )
     assert audit_after_command_window.min_ms > 0
+    remote_logon_ready_window = get_timing_window(
+        "windows.remote_logon_source_ready",
+        default_min_ms=0,
+        default_max_ms=0,
+        default_position="after",
+    )
+    assert 0 < remote_logon_ready_window.min_ms < remote_logon_ready_window.max_ms
 
     tls_window = get_timing_window(
         "network.tls_completed_min_duration",

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -2713,3 +2713,30 @@ class TestValidateConfig:
             and "must be a non-empty single-line string" in issue.message
             for issue in result.issues
         )
+
+    def test_validate_config_rejects_generic_kube_probe_health_check_ua(self, monkeypatch):
+        from evidenceforge.generation.activity import web_session_profiles
+
+        real_loader = web_session_profiles.load_web_session_profiles
+
+        def load_invalid_web_session_profiles():
+            data = real_loader()
+            user_agent_pools = dict(data["user_agent_pools"])
+            user_agent_pools["health_check_windows"] = [
+                *user_agent_pools["health_check_windows"],
+                "kube-probe/1.28",
+            ]
+            return {**data, "user_agent_pools": user_agent_pools}
+
+        monkeypatch.setattr(
+            web_session_profiles, "load_web_session_profiles", load_invalid_web_session_profiles
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "web_session_profiles.yaml"
+            and "kube-probe only with a Kubernetes-scoped source_role_any" in issue.message
+            for issue in result.issues
+        )

--- a/tests/unit/test_web_session_profiles.py
+++ b/tests/unit/test_web_session_profiles.py
@@ -49,6 +49,32 @@ def test_health_check_profile_is_server_scoped():
     assert "monitoring" in profile["source_role_any"]
 
 
+def test_health_check_user_agent_is_os_scoped_and_not_kubernetes_generic():
+    data = load_web_session_profiles()
+    profile = data["visitor_classes"]["health_check"]
+    pools = data["user_agent_pools"]
+
+    assert profile["user_agent_pool_by_os"] == {
+        "windows": "health_check_windows",
+        "linux": "health_check_linux",
+    }
+    checked_pool_names = [
+        profile["user_agent_pool"],
+        *profile["user_agent_pool_by_os"].values(),
+    ]
+    checked_user_agents = [
+        user_agent for pool_name in checked_pool_names for user_agent in pools[pool_name]
+    ]
+    assert checked_user_agents
+    assert all("kube-probe" not in user_agent for user_agent in checked_user_agents)
+
+    windows_ua = pick_web_user_agent(random.Random(0), profile, source_os="windows")
+    linux_ua = pick_web_user_agent(random.Random(0), profile, source_os="linux")
+
+    assert windows_ua in pools["health_check_windows"]
+    assert linux_ua in pools["health_check_linux"]
+
+
 def test_internal_human_browser_profile_is_workstation_scoped():
     profile = load_web_session_profiles()["visitor_classes"]["human_browser"]
 

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -29,12 +29,15 @@ from unittest.mock import Mock
 import pytest
 
 from evidenceforge.events.dispatcher import EventDispatcher
+from evidenceforge.generation.actions.rdp_session import RdpSessionActionBundle, RdpSessionRequest
 from evidenceforge.generation.activity import ActivityGenerator
+from evidenceforge.generation.activity.timing_profiles import get_timing_window
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.world_model import WorldModel, WorldPlanner
 from evidenceforge.models.scenario import (
     BaselineActivity,
     Environment,
+    Group,
     OutputSpec,
     Scenario,
     System,
@@ -239,6 +242,77 @@ def test_world_model_plan_session_selects_interactive_ssh_and_rdp(
     assert rdp_plan.logon_type == 10
     assert rdp_plan.source_system is not None
     assert rdp_plan.source_system.hostname == "WKS-01"
+
+
+def test_world_model_ssh_admin_roster_is_role_and_group_scoped(scenario: Scenario) -> None:
+    """Baseline SSH admin users should be narrower than generic DB access personas."""
+    scenario.environment.users.extend(
+        [
+            User(
+                username="data.user",
+                full_name="Data User",
+                email="data@corp.local",
+                persona="data_analyst",
+                primary_system="WKS-03",
+            ),
+            User(
+                username="sales.user",
+                full_name="Sales User",
+                email="sales@corp.local",
+                persona="sales",
+                primary_system="WKS-04",
+            ),
+            User(
+                username="helpdesk.user",
+                full_name="Helpdesk User",
+                email="helpdesk@corp.local",
+                persona="help_desk",
+                primary_system="WKS-05",
+            ),
+        ]
+    )
+    scenario.environment.systems.extend(
+        [
+            System(
+                hostname="WKS-03",
+                ip="10.10.10.53",
+                os="Windows 11",
+                type="workstation",
+                assigned_user="data.user",
+            ),
+            System(
+                hostname="WKS-04",
+                ip="10.10.10.54",
+                os="Windows 11",
+                type="workstation",
+                assigned_user="sales.user",
+            ),
+            System(
+                hostname="WKS-05",
+                ip="10.10.10.55",
+                os="Windows 11",
+                type="workstation",
+                assigned_user="helpdesk.user",
+            ),
+        ]
+    )
+    scenario.environment.groups = [
+        Group(name="it-admins", members=["helpdesk.user"]),
+    ]
+    model = WorldModel(scenario, "corp.local")
+
+    db_roster = {
+        user.username for user in model.get_ssh_admin_users(model.systems_by_hostname["DB-01"])
+    }
+    web_roster = {
+        user.username for user in model.get_ssh_admin_users(model.systems_by_hostname["PROXY-01"])
+    }
+
+    assert {"alice.admin", "dev.user", "helpdesk.user"} <= db_roster
+    assert "data.user" not in db_roster
+    assert "sales.user" not in db_roster
+    assert "dev.user" not in web_roster
+    assert {"alice.admin", "helpdesk.user"} <= web_roster
 
 
 def test_world_planner_preallocates_sessions_before_logon_emission(
@@ -685,6 +759,39 @@ def test_world_planner_bootstraps_rdp_session_with_owned_state(
     assert rdp_connections[0].protocol == "tcp"
     assert rdp_connections[0].initiating_pid > 0
     assert rdp_connections[0].source_system == "WKS-01"
+
+
+def test_rdp_target_logon_waits_for_endpoint_flow_visibility() -> None:
+    """RDP target logon timing should not precede same-tuple eCAR FLOW visibility."""
+    scenario = _make_scenario()
+    target = next(system for system in scenario.environment.systems if system.hostname == "APP-01")
+    user = scenario.environment.users[0]
+    base_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    bundle = RdpSessionActionBundle(
+        executor=Mock(),
+        request=RdpSessionRequest(
+            user=user,
+            target_system=target,
+            time=base_time,
+            source_ip="10.10.10.50",
+        ),
+    )
+    flow_window = get_timing_window(
+        "source.ecar_flow",
+        default_min_ms=40,
+        default_max_ms=300,
+        default_position="after",
+        default_class="source_latency",
+    )
+
+    logon_time = bundle._target_logon_time(
+        rng=random.Random(7),
+        source_ip="10.10.10.50",
+        src_port=52875,
+        transport_start_time=base_time,
+    )
+
+    assert logon_time > base_time + timedelta(milliseconds=flow_window.max_ms)
 
 
 def test_world_planner_moves_rdp_source_after_future_workstation_session(

--- a/tests/unit/test_zeek_activity_contexts.py
+++ b/tests/unit/test_zeek_activity_contexts.py
@@ -53,6 +53,7 @@ from evidenceforge.generation.activity import ActivityGenerator
 from evidenceforge.generation.activity import generator as generator_module
 from evidenceforge.generation.activity.dns_registry import resolve_domain_ip
 from evidenceforge.generation.activity.timing_profiles import (
+    get_timing_window,
     sample_packet_timing_delta,
     sample_timing_delta,
 )
@@ -681,6 +682,46 @@ class TestSslContextPopulation:
 
         assert resolved["accepted"] > EcarEmitter._flow_identity_deadline(event)
 
+    def test_ssh_session_auth_waits_for_jittered_ecar_flow_deadline(self, activity_gen):
+        """SSH auth timing should account for connection-start jitter before eCAR FLOW."""
+        gen, events = activity_gen
+        user = User(username="admin", full_name="Admin User", email="admin@example.com")
+        target = System(
+            hostname="linux01",
+            ip="10.0.20.10",
+            os="Ubuntu 24.04",
+            type="server",
+            roles=["web_server"],
+            services=["ssh"],
+        )
+        base_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        gen.generate_ssh_session(
+            user=user,
+            target_system=target,
+            time=base_time,
+            source_ip="10.0.10.50",
+            source_port=51111,
+        )
+
+        transport_event = _ssh_transport_event(events)
+        accepted_event = next(
+            event
+            for event in events
+            if event.syslog is not None and event.syslog.message.startswith("Accepted password")
+        )
+        flow_window = get_timing_window(
+            "source.ecar_flow",
+            default_min_ms=40,
+            default_max_ms=300,
+            default_position="after",
+            default_class="source_latency",
+        )
+
+        assert accepted_event.timestamp > transport_event.timestamp + timedelta(
+            milliseconds=flow_window.max_ms
+        )
+
     def test_ssh_connection_syslog_precedes_responder_process_source_time(self, activity_gen):
         gen, events = activity_gen
 
@@ -795,6 +836,12 @@ class TestSslContextPopulation:
             if event.syslog is not None and event.syslog.message.startswith("New session ")
         )
         logind_session_id = int(logind_event.syslog.message.split()[2])
+        logind_removed_event = next(
+            event
+            for event in events
+            if event.syslog is not None
+            and event.syslog.message == f"Removed session {logind_session_id}."
+        )
         transport_close = transport_event.timestamp + timedelta(seconds=120)
         assert close_event.event_type == "logoff"
         assert close_event.auth is not None
@@ -811,6 +858,9 @@ class TestSslContextPopulation:
         assert close_event.edr is not None
         assert login_event.edr is not None
         assert close_event.edr.object_id == login_event.edr.object_id
+        assert logind_removed_event.syslog.app_name == "systemd-logind"
+        assert logind_removed_event.timestamp > close_event.timestamp
+        assert logind_removed_event.timestamp <= close_event.timestamp + timedelta(seconds=1)
 
         terminate_event = next(
             event

--- a/tests/unit/test_zeek_eval_parsers.py
+++ b/tests/unit/test_zeek_eval_parsers.py
@@ -155,12 +155,15 @@ class TestProxyParserRegistration:
         record = parser._parse_line(
             "10.0.0.1 - jsmith [15/Jul/2024:10:00:00 +0000] "
             '"GET https://example.com/download?q=1 HTTP/1.1" 200 1024 '
-            '"-" "Mozilla/5.0 (Windows NT 10.0)" "proxy_action=ssl-inspect ssl_bump=bump"',
+            '"-" "Mozilla/5.0 (Windows NT 10.0)" '
+            '"cs_bytes=2048 sc_bytes=1024 proxy_action=ssl-inspect ssl_bump=bump"',
             1,
         )
 
         assert record.parse_errors == []
         assert record.fields["host"] == "example.com"
+        assert record.fields["cs_bytes"] == 2048
+        assert record.fields["sc_bytes"] == 1024
         assert record.fields["proxy_action"] == "ssl-inspect"
         assert record.fields["ssl_bump_action"] == "bump"
 

--- a/tests/unit/test_zeek_multiplex.py
+++ b/tests/unit/test_zeek_multiplex.py
@@ -788,6 +788,53 @@ class TestPerSensorDirectoryRouting:
                 assert row["orig_ip_bytes"] >= row["orig_bytes"] + (20 * row["orig_pkts"])
                 assert row["resp_ip_bytes"] >= row["resp_bytes"] + (20 * row["resp_pkts"])
 
+    def test_bulk_proxy_flow_sensor_accounting_stays_near_canonical_bytes(self):
+        """Bulk client-to-proxy rows should not drift by megabytes across sensors."""
+        fmt = load_format("zeek_conn")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            emitter = ZeekEmitter(fmt, base, sensor_hostnames=["core", "dmz"])
+
+            emitter.emit_event(
+                {
+                    "ts": datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+                    "uid": "CTestBulkProxy12",
+                    "id.orig_h": "10.10.1.35",
+                    "id.orig_p": 50872,
+                    "id.resp_h": "10.10.3.20",
+                    "id.resp_p": 8080,
+                    "proto": "tcp",
+                    "duration": 925.5,
+                    "orig_bytes": 2_200_000,
+                    "resp_bytes": 326_500_000,
+                    "orig_pkts": 1800,
+                    "resp_pkts": 223_700,
+                    "orig_ip_bytes": 2_272_000,
+                    "resp_ip_bytes": 335_448_000,
+                    "conn_state": "SF",
+                    "history": "ShADadfF",
+                    "missed_bytes": 308,
+                    "_allow_sensor_observation_variance": True,
+                    "_sensor_hostnames": ["core", "dmz"],
+                }
+            )
+            emitter.close()
+
+            core = json.loads((base / "core" / "conn.json").read_text().splitlines()[0])
+            dmz = json.loads((base / "dmz" / "conn.json").read_text().splitlines()[0])
+            core_total = core["orig_ip_bytes"] + core["resp_ip_bytes"]
+            dmz_total = dmz["orig_ip_bytes"] + dmz["resp_ip_bytes"]
+            allowed_delta = max(65_536, core["missed_bytes"] + dmz["missed_bytes"] + 8192)
+
+            assert dmz["orig_bytes"] == core["orig_bytes"]
+            assert dmz["resp_bytes"] == core["resp_bytes"]
+            assert abs(dmz_total - core_total) <= allowed_delta
+            assert abs(dmz_total - core_total) < 1_000_000
+            assert dmz["duration"] != core["duration"]
+            for row in (core, dmz):
+                assert row["orig_ip_bytes"] >= row["orig_bytes"] + (20 * row["orig_pkts"])
+                assert row["resp_ip_bytes"] >= row["resp_bytes"] + (20 * row["resp_pkts"])
+
     def test_single_sensor_single_subdir(self):
         """Single sensor creates a single subdirectory."""
         fmt = load_format("zeek_conn")


### PR DESCRIPTION
## Summary

- Improves iteration-test-expanded realism across endpoint, network, proxy, DHCP, SSH/RDP, browser/file-transfer, Sysmon, eCAR, and Zeek generation paths.
- Adds data/config updates and regression coverage for the repeated blind-review findings addressed during the assessment loop series.
- Adds the iteration-test-expanded assessment worklog with loop-by-loop handoff context through loop 49.

## Why

The blind assessment loops surfaced source-native realism gaps around lifecycle ownership, SSH/session ordering, proxy and protocol fan-out, endpoint object identity, and collection texture. This branch folds the accumulated fixes into the repo and records the latest loop findings so future loops can continue from the current state.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- Pre-commit hook ruff checks passed during commit.
- Loop 49 automated eval: `95.17991535282289` PASS over `94,702` records.
- Loop 49 hard probe: process termination ownership passed with `0` mismatches across `1,324` checked terminations.
- Loop 49 blind eval: initial mean synthetic-confidence `43.5`; deliberated mean `49.5` (`Mixed/Inconclusive`).
