### PR TITLE
Release v1.12.0: update agent skill installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Detailed development history for the EvidenceForge project. Transferred from TOD
 
 ## Unreleased
 
+## v1.12.0 (2026-07-10)
+
+This minor release aligns EvidenceForge skill installation with current Claude
+Code and ChatGPT project-local and user-wide discovery paths.
+
+**Agent skill installation**
+
+- Changed `eforge install-skills` to install both Claude Code and ChatGPT skills
+  by default, with explicit `all`, `claude`, and `chatgpt` agent selections and
+  `codex` retained as a compatibility alias (`1c585619`).
+- Added project-local and user-wide ChatGPT destinations under `.agents/skills`,
+  best-effort multi-agent installation, and warnings for preserved legacy
+  `.codex/skills` installations (`1c585619`).
+- Updated installer documentation and regression coverage for agent selection,
+  scope handling, compatibility, partial failures, and legacy detection
+  (`1c585619`).
+
 ## v1.11.1 (2026-07-08)
 
 This patch release preserves the expanded blind-review experiment results and

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ git clone https://github.com/Cisco-Talos/EvidenceForge.git
 cd EvidenceForge
 uv sync
 
-# Install agent skills (Claude Code by default)
+# Install project-local skills for all supported agents
 uv run eforge install-skills
 
-# Or install Codex skills
-uv run eforge install-skills --agent codex
+# Or select one agent or install user-wide
+uv run eforge install-skills --agent chatgpt
+uv run eforge install-skills --global
 
 # Create a scenario interactively
 # /eforge scenario
@@ -66,7 +67,12 @@ EvidenceForge includes agent skills for interactive, guided workflows. These are
 | `/eforge evaluate` | Runs the data quality evaluation, interprets scores, reviews records for realism, and suggests improvements. |
 | `/eforge config` | Add, modify, or remove personas, domains, applications, and other configuration data. Handles cross-file dependencies automatically. See [Customizing Configuration](docs/reference/CUSTOMIZING_CONFIG.md). |
 
-Install Claude Code skills with `uv run eforge install-skills` (project scope) or `uv run eforge install-skills --global`. Install Codex skills with `uv run eforge install-skills --agent codex`.
+`uv run eforge install-skills` installs project-local skills for both Claude Code
+and ChatGPT. Claude commands go under `.claude/commands/`; ChatGPT skills go
+under `.agents/skills/`. Add `--global` to install both user-wide under
+`~/.claude/commands/` and `~/.agents/skills/`, or select one with `--agent
+claude` or `--agent chatgpt`. The legacy name `--agent codex` remains an alias
+for `--agent chatgpt` and uses the same destinations.
 
 ## CLI Reference
 
@@ -79,7 +85,7 @@ For scripted or non-interactive use:
 | `eforge eval <output_dir> -s <scenario.yaml>` | Evaluate data quality (4 pillars, 20 sub-scores) |
 | `eforge info [field]` | Show installation info, config paths, and data inventories. Pass a dot-path field for a specific value (e.g., `eforge info personas`). Use `--fields` to list available fields, `--json` for machine output. |
 | `eforge validate-config` | Validate config files for cross-reference integrity. Use `--json` for machine output. |
-| `eforge install-skills [--agent claude\|codex] [--global]` | Install agent skills (`--global` is Claude-only) |
+| `eforge install-skills [--agent all\|claude\|chatgpt\|codex] [--global]` | Install project-local or user-wide agent skills; defaults to all agents (`codex` aliases `chatgpt`) |
 | `eforge version` | Show version |
 
 Useful command flags: `generate` accepts `--verbose` / `--debug` for logging,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "evidence-forge"
-version = "1.11.1"
+version = "1.12.0"
 description = "Generate realistic synthetic security logs for cybersecurity threat hunting training and research"
 readme = "README.md"
 license = "MIT"

--- a/src/evidenceforge/__init__.py
+++ b/src/evidenceforge/__init__.py
@@ -27,5 +27,5 @@ for cybersecurity threat hunting training and research. It uses a two-phase
 architecture combining LLM-driven scenario creation with deterministic log generation.
 """
 
-__version__ = "1.11.1"
+__version__ = "1.12.0"
 __all__ = []  # Will be expanded as modules are implemented

--- a/src/evidenceforge/cli/commands.py
+++ b/src/evidenceforge/cli/commands.py
@@ -1013,96 +1013,136 @@ def eval_cmd(
 @app.command("install-skills")
 def install_skills_cmd(
     agent: str = typer.Option(
-        "claude",
+        "all",
         "--agent",
-        help="Agent to install skills for: claude or codex",
+        help="Agent to install skills for: all, claude, chatgpt, or codex (alias)",
     ),
     global_install: bool = typer.Option(
-        False, "--global", help="Install to ~/.claude/commands/ (global)"
+        False,
+        "--global",
+        help="Install to each selected agent user directory",
     ),
 ) -> None:
     """Install EvidenceForge skills for supported agent workflows.
 
-    By default, installs Claude Code slash commands to .claude/commands/ in the
-    current directory. Use --global with Claude installs to install to
-    ~/.claude/commands/. Use --agent codex to install Codex skills to
-    ~/.codex/skills/.
+    By default, installs skills for Claude Code and ChatGPT in the current
+    project. Use --global to install to each selected agent user directory.
+    The codex agent name remains available as an alias for chatgpt.
 
     Existing installations are updated: new files are copied, changed files
     are overwritten, and stale files from previous versions are removed.
     """
-    from evidenceforge.cli.install_skills import install_codex_skills, install_skills
-
-    normalized_agent = agent.lower()
-    if normalized_agent not in {"claude", "codex"}:
-        console.print(
-            f"[bold red]Error:[/bold red] Unknown agent '{agent}'. Use 'claude' or 'codex'.",
-            style="red",
-        )
-        raise typer.Exit(EXIT_INPUT_ERROR)
-
-    if normalized_agent == "codex" and global_install:
-        console.print(
-            "[bold red]Error:[/bold red] --global is only valid for Claude installs. "
-            "Codex skills install to ~/.codex/skills/.",
-            style="red",
-        )
-        raise typer.Exit(EXIT_INPUT_ERROR)
-
-    if normalized_agent == "codex":
-        target_dir = Path.home() / ".codex" / "skills"
-        scope = "user"
-        install_func = install_codex_skills
-    elif global_install:
-        target_dir = Path.home() / ".claude" / "commands"
-        scope = "global"
-        install_func = install_skills
-    else:
-        target_dir = Path.cwd() / ".claude" / "commands"
-        scope = "project"
-        install_func = install_skills
-
-    console.print(
-        f"[bold blue]Installing EvidenceForge skills for {normalized_agent} ({scope})[/bold blue]"
+    from evidenceforge.cli.install_skills import (
+        find_evidenceforge_chatgpt_skills,
+        install_chatgpt_skills,
+        install_skills,
     )
-    console.print(f"Target: {target_dir}\n")
 
-    try:
-        installed, removed = install_func(target_dir)
-    except FileNotFoundError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}", style="red")
-        raise typer.Exit(EXIT_INPUT_ERROR)
-    except PermissionError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}", style="red")
-        raise typer.Exit(EXIT_INPUT_ERROR)
-
-    if installed:
-        console.print(f"[green]✓[/green] Installed {len(installed)} files:")
-        for f in installed:
-            if normalized_agent == "claude":
-                console.print(f"  eforge/{f}")
-            else:
-                console.print(f"  {f}")
-
-    if removed:
-        console.print(f"\n[yellow]Removed {len(removed)} stale files:[/yellow]")
-        for f in removed:
-            if normalized_agent == "claude":
-                console.print(f"  eforge/{f}", style="dim")
-            else:
-                console.print(f"  {f}", style="dim")
-
-    if normalized_agent == "claude":
-        console.print(f"\n[bold green]✓ Skills installed to {target_dir / 'eforge'}[/bold green]")
+    requested_agent = agent.lower()
+    valid_agents = {"all", "claude", "chatgpt", "codex"}
+    if requested_agent not in valid_agents:
         console.print(
-            "Use /eforge scenario, /eforge generate, /eforge validate, /eforge evaluate, or /eforge config."
+            f"[bold red]Error:[/bold red] Unknown agent {agent!r}. "
+            "Use all, claude, chatgpt, or codex.",
+            style="red",
         )
+        raise typer.Exit(EXIT_INPUT_ERROR)
+
+    if requested_agent == "all":
+        selected_agents = ("claude", "chatgpt")
+    elif requested_agent == "codex":
+        selected_agents = ("chatgpt",)
     else:
-        console.print(f"\n[bold green]✓ Skills installed to {target_dir}[/bold green]")
+        selected_agents = (requested_agent,)
+
+    scope = "global" if global_install else "project"
+    failures: list[tuple[str, str]] = []
+    successful_agents: set[str] = set()
+
+    for index, normalized_agent in enumerate(selected_agents):
+        if index:
+            console.print()
+
+        if normalized_agent == "claude":
+            target_dir = (
+                Path.home() / ".claude" / "commands"
+                if global_install
+                else Path.cwd() / ".claude" / "commands"
+            )
+        else:
+            target_dir = (
+                Path.home() / ".agents" / "skills"
+                if global_install
+                else Path.cwd() / ".agents" / "skills"
+            )
+
         console.print(
-            "Use the eforge-scenario, eforge-generate, eforge-validate, "
-            "eforge-evaluate, or eforge-config skills."
+            f"[bold blue]Installing EvidenceForge skills for "
+            f"{normalized_agent} ({scope})[/bold blue]"
         )
+        console.print(f"Target: {target_dir}\n")
+
+        try:
+            if normalized_agent == "claude":
+                installed, removed = install_skills(target_dir)
+            else:
+                installed, removed = install_chatgpt_skills(target_dir)
+        except (FileNotFoundError, PermissionError) as error:
+            console.print(f"[bold red]Error:[/bold red] {error}", style="red")
+            failures.append((normalized_agent, str(error)))
+            continue
+
+        successful_agents.add(normalized_agent)
+        if installed:
+            console.print(f"[green]✓[/green] Installed {len(installed)} files:")
+            for installed_file in installed:
+                if normalized_agent == "claude":
+                    console.print(f"  eforge/{installed_file}")
+                else:
+                    console.print(f"  {installed_file}")
+
+        if removed:
+            console.print(f"\n[yellow]Removed {len(removed)} stale files:[/yellow]")
+            for removed_file in removed:
+                if normalized_agent == "claude":
+                    console.print(f"  eforge/{removed_file}", style="dim")
+                else:
+                    console.print(f"  {removed_file}", style="dim")
+
+        if normalized_agent == "claude":
+            installed_dir = target_dir / "eforge"
+            console.print(f"\n[bold green]✓ Skills installed to {installed_dir}[/bold green]")
+            console.print(
+                "Use /eforge scenario, /eforge generate, /eforge validate, "
+                "/eforge evaluate, or /eforge config."
+            )
+        else:
+            console.print(f"\n[bold green]✓ Skills installed to {target_dir}[/bold green]")
+            console.print(
+                "Use the eforge-scenario, eforge-generate, eforge-validate, "
+                "eforge-evaluate, or eforge-config skills."
+            )
+
+    if global_install and "chatgpt" in successful_agents:
+        legacy_dir = Path.home() / ".codex" / "skills"
+        legacy_skills = find_evidenceforge_chatgpt_skills(legacy_dir)
+        if legacy_skills:
+            console.print(
+                "\n[bold yellow]Warning:[/bold yellow] Legacy EvidenceForge skills "
+                f"also exist under {legacy_dir} and may appear as duplicates:"
+            )
+            for legacy_skill in legacy_skills:
+                console.print(f"  {legacy_skill}", style="dim")
+            console.print(
+                "These legacy files were not modified. Remove them manually after "
+                "confirming the new installation works."
+            )
+
+    if failures:
+        console.print("\n[bold red]Skill installation completed with errors:[/bold red]")
+        for failed_agent, message in failures:
+            console.print(f"  {failed_agent}: {message}", style="red")
+        raise typer.Exit(EXIT_INPUT_ERROR)
 
 
 @app.command()

--- a/src/evidenceforge/cli/install_skills.py
+++ b/src/evidenceforge/cli/install_skills.py
@@ -29,9 +29,9 @@ from pathlib import Path
 
 from evidenceforge.utils.files import ensure_directory
 
-CODEX_SKILL_NAMES = ("scenario", "generate", "validate", "evaluate", "config")
+CHATGPT_SKILL_NAMES = ("scenario", "generate", "validate", "evaluate", "config")
 
-_CODEX_REFERENCES_BY_SKILL = {
+_CHATGPT_REFERENCES_BY_SKILL = {
     "config": (
         "references/config-apps-processes.md",
         "references/config-dependency-graph.md",
@@ -57,12 +57,12 @@ _CODEX_REFERENCES_BY_SKILL = {
     "validate": ("references/scenario-reference.md",),
 }
 
-_CODEX_REFERENCE_REWRITES = {
+_CHATGPT_REFERENCE_REWRITES = {
     "/eforge:references:scenario-reference": "`references/scenario-reference.md`",
     "/eforge:references:evidence-formats": "`references/evidence-formats.md`",
 }
 
-_CODEX_COMMAND_REWRITES = {
+_CHATGPT_COMMAND_REWRITES = {
     "/eforge scenario": "the `eforge-scenario` skill",
     "/eforge generate": "the `eforge-generate` skill",
     "/eforge validate": "the `eforge-validate` skill",
@@ -144,7 +144,7 @@ def _collect_source_files(data_root: Path) -> dict[str, Path]:
 def _collect_command_files(manifest: dict[str, Path]) -> dict[str, Path]:
     """Return top-level command skill files keyed by command name."""
     command_files: dict[str, Path] = {}
-    for name in CODEX_SKILL_NAMES:
+    for name in CHATGPT_SKILL_NAMES:
         rel_path = f"{name}.md"
         if rel_path not in manifest:
             raise FileNotFoundError(f"Required skill file not found: {rel_path}")
@@ -153,16 +153,16 @@ def _collect_command_files(manifest: dict[str, Path]) -> dict[str, Path]:
 
 
 def _collect_reference_files(manifest: dict[str, Path]) -> dict[str, Path]:
-    """Return reference files to bundle inside each Codex skill."""
+    """Return reference files to bundle inside each ChatGPT skill."""
     return {rel: source for rel, source in manifest.items() if rel.startswith("references/")}
 
 
-def _references_for_codex_skill(
+def _references_for_chatgpt_skill(
     skill_name: str, reference_files: dict[str, Path]
 ) -> dict[str, Path]:
-    """Return the reference files needed by a single Codex skill."""
+    """Return the reference files needed by a single ChatGPT skill."""
     refs: dict[str, Path] = {}
-    for rel_path in _CODEX_REFERENCES_BY_SKILL[skill_name]:
+    for rel_path in _CHATGPT_REFERENCES_BY_SKILL[skill_name]:
         if rel_path not in reference_files:
             raise FileNotFoundError(f"Required reference file not found: {rel_path}")
         refs[rel_path] = reference_files[rel_path]
@@ -267,8 +267,8 @@ def _remove_stale_files(eforge_dir: Path, manifest: dict[str, Path]) -> list[str
     return removed
 
 
-def _is_evidenceforge_codex_skill(path: Path) -> bool:
-    """Return True if path appears to be an EvidenceForge-owned Codex skill."""
+def _is_evidenceforge_chatgpt_skill(path: Path) -> bool:
+    """Return True if path appears to be an EvidenceForge-owned ChatGPT skill."""
     skill_file = path / "SKILL.md"
     if not skill_file.is_file():
         return False
@@ -333,8 +333,8 @@ def _extract_frontmatter_block(lines: list[str], key: str, source: Path) -> list
     raise ValueError(f"Skill file is missing required frontmatter field '{key}': {source}")
 
 
-def _codex_frontmatter_text(source: Path, frontmatter_lines: list[str]) -> str:
-    """Build Codex-compatible SKILL.md frontmatter from Claude command metadata."""
+def _chatgpt_frontmatter_text(source: Path, frontmatter_lines: list[str]) -> str:
+    """Build ChatGPT-compatible SKILL.md frontmatter from Claude command metadata."""
     name = _extract_frontmatter_value(frontmatter_lines, "name", source)
     description_lines = _extract_frontmatter_block(frontmatter_lines, "description", source)
 
@@ -351,12 +351,12 @@ def _codex_frontmatter_text(source: Path, frontmatter_lines: list[str]) -> str:
     )
 
 
-def _rewrite_codex_skill_body(body: str) -> str:
-    """Adapt Claude-specific references in a skill body for Codex."""
+def _rewrite_chatgpt_skill_body(body: str) -> str:
+    """Adapt Claude-specific references in a skill body for ChatGPT."""
     content = body
-    for old, new in _CODEX_REFERENCE_REWRITES.items():
+    for old, new in _CHATGPT_REFERENCE_REWRITES.items():
         content = content.replace(old, new)
-    for old, new in _CODEX_COMMAND_REWRITES.items():
+    for old, new in _CHATGPT_COMMAND_REWRITES.items():
         content = content.replace(old, new)
     return content
 
@@ -388,8 +388,8 @@ def _ensure_safe_eforge_directory(target_dir: Path) -> Path:
     return eforge_dir
 
 
-def _ensure_safe_codex_skill_directory(target_dir: Path, skill_name: str) -> Path:
-    """Create or validate a safe Codex skill directory."""
+def _ensure_safe_chatgpt_skill_directory(target_dir: Path, skill_name: str) -> Path:
+    """Create or validate a safe ChatGPT skill directory."""
     from evidenceforge.utils.paths import reject_symlink
 
     skill_dir = target_dir / skill_name
@@ -408,11 +408,11 @@ def _ensure_safe_codex_skill_directory(target_dir: Path, skill_name: str) -> Pat
     return skill_dir
 
 
-def _codex_skill_text(source: Path) -> str:
-    """Read a command file and convert it to a valid Codex SKILL.md file."""
+def _chatgpt_skill_text(source: Path) -> str:
+    """Read a command file and convert it to a valid ChatGPT SKILL.md file."""
     content = source.read_text(encoding="utf-8")
     frontmatter_lines, body = _split_frontmatter(content, source)
-    return _codex_frontmatter_text(source, frontmatter_lines) + _rewrite_codex_skill_body(body)
+    return _chatgpt_frontmatter_text(source, frontmatter_lines) + _rewrite_chatgpt_skill_body(body)
 
 
 def install_skills(target_dir: Path) -> tuple[list[str], list[str]]:
@@ -448,16 +448,16 @@ def install_skills(target_dir: Path) -> tuple[list[str], list[str]]:
     return installed, removed
 
 
-def install_codex_skills(target_dir: Path) -> tuple[list[str], list[str]]:
-    """Install EvidenceForge skills to a Codex skills directory.
+def install_chatgpt_skills(target_dir: Path) -> tuple[list[str], list[str]]:
+    """Install EvidenceForge skills to a ChatGPT skills directory.
 
-    Creates one Codex skill directory per EvidenceForge command, each with a
+    Creates one ChatGPT skill directory per EvidenceForge command, each with a
     SKILL.md file and bundled references. Existing EvidenceForge-owned skill
     directories are updated and stale EvidenceForge-owned skill directories are
     removed.
 
     Args:
-        target_dir: Codex skills directory, e.g. ~/.codex/skills/.
+        target_dir: ChatGPT skills directory, e.g. .agents/skills/.
 
     Returns:
         Tuple of (installed_files, removed_files) as relative path lists.
@@ -474,14 +474,14 @@ def install_codex_skills(target_dir: Path) -> tuple[list[str], list[str]]:
     removed: list[str] = []
     for name, source in sorted(command_files.items()):
         skill_name = f"eforge-{name}"
-        skill_dir = _ensure_safe_codex_skill_directory(target_dir, skill_name)
-        skill_reference_files = _references_for_codex_skill(name, reference_files)
+        skill_dir = _ensure_safe_chatgpt_skill_directory(target_dir, skill_name)
+        skill_reference_files = _references_for_chatgpt_skill(name, reference_files)
 
         skill_manifest: dict[str, Path] = {"SKILL.md": source}
         skill_manifest.update(skill_reference_files)
 
         skill_file = _safe_install_destination(skill_dir, "SKILL.md")
-        _write_text_no_follow(skill_file, _codex_skill_text(source))
+        _write_text_no_follow(skill_file, _chatgpt_skill_text(source))
         installed.append(f"{skill_name}/SKILL.md")
 
         for rel_path, ref_source in sorted(skill_reference_files.items()):
@@ -493,3 +493,34 @@ def install_codex_skills(target_dir: Path) -> tuple[list[str], list[str]]:
             removed.append(f"{skill_name}/{stale}")
 
     return installed, removed
+
+
+def install_codex_skills(target_dir: Path) -> tuple[list[str], list[str]]:
+    """Install ChatGPT-compatible skills using the legacy function name.
+
+    Args:
+        target_dir: ChatGPT skills directory.
+
+    Returns:
+        Tuple of (installed_files, removed_files) as relative path lists.
+    """
+    return install_chatgpt_skills(target_dir)
+
+
+def find_evidenceforge_chatgpt_skills(target_dir: Path) -> list[Path]:
+    """Find EvidenceForge-owned ChatGPT skill directories under a target.
+
+    Args:
+        target_dir: Directory containing ChatGPT skill directories.
+
+    Returns:
+        Sorted list of recognized EvidenceForge skill directories.
+    """
+    if not target_dir.is_dir():
+        return []
+
+    return sorted(
+        path
+        for path in target_dir.iterdir()
+        if path.is_dir() and _is_evidenceforge_chatgpt_skill(path)
+    )

--- a/tests/unit/test_install_skills.py
+++ b/tests/unit/test_install_skills.py
@@ -29,7 +29,12 @@ import yaml
 from typer.testing import CliRunner
 
 from evidenceforge.cli.commands import EXIT_SUCCESS, app
-from evidenceforge.cli.install_skills import install_codex_skills, install_skills
+from evidenceforge.cli.install_skills import (
+    find_evidenceforge_chatgpt_skills,
+    install_chatgpt_skills,
+    install_codex_skills,
+    install_skills,
+)
 
 runner = CliRunner()
 
@@ -170,20 +175,20 @@ class TestInstallSkills:
         assert isinstance(removed, list)
 
 
-class TestInstallCodexSkills:
-    """Tests for Codex skill installation."""
+class TestInstallChatGPTSkills:
+    """Tests for ChatGPT skill installation."""
 
-    def test_creates_codex_skill_directories(self, tmp_path):
-        """install_codex_skills creates one skill directory per command."""
-        install_codex_skills(tmp_path)
+    def test_creates_chatgpt_skill_directories(self, tmp_path):
+        """install_chatgpt_skills creates one skill directory per command."""
+        install_chatgpt_skills(tmp_path)
 
         for name in EXPECTED_SKILL_FILES:
             command_name = name.removesuffix(".md")
             assert (tmp_path / f"eforge-{command_name}" / "SKILL.md").is_file()
 
-    def test_codex_frontmatter_remains_valid(self, tmp_path):
-        """Installed Codex SKILL.md frontmatter is valid and Codex-only."""
-        install_codex_skills(tmp_path)
+    def test_chatgpt_frontmatter_remains_valid(self, tmp_path):
+        """Installed ChatGPT SKILL.md frontmatter is valid and minimal."""
+        install_chatgpt_skills(tmp_path)
 
         for skill_file in EXPECTED_SKILL_FILES:
             command_name = skill_file.removesuffix(".md")
@@ -195,9 +200,9 @@ class TestInstallCodexSkills:
             assert parsed["name"] == f"eforge-{command_name}"
             assert parsed["description"]
 
-    def test_codex_frontmatter_removes_claude_license(self, tmp_path):
-        """Codex SKILL.md files drop Claude-only license frontmatter fields."""
-        install_codex_skills(tmp_path)
+    def test_chatgpt_frontmatter_removes_claude_license(self, tmp_path):
+        """ChatGPT SKILL.md files drop Claude-only license frontmatter fields."""
+        install_chatgpt_skills(tmp_path)
 
         for skill_file in EXPECTED_SKILL_FILES:
             command_name = skill_file.removesuffix(".md")
@@ -205,18 +210,18 @@ class TestInstallCodexSkills:
             frontmatter = skill.split("---\n", 2)[1]
             assert "license:" not in frontmatter
 
-    def test_codex_references_are_bundled(self, tmp_path):
-        """Reference docs are copied beside each Codex skill."""
-        install_codex_skills(tmp_path)
+    def test_chatgpt_references_are_bundled(self, tmp_path):
+        """Reference docs are copied beside each ChatGPT skill."""
+        install_chatgpt_skills(tmp_path)
 
         for ref_path in EXPECTED_REFERENCES_MIN:
             ref = tmp_path / "eforge-scenario" / ref_path
             assert ref.is_file(), f"Missing reference: {ref_path}"
             assert len(ref.read_text()) > 100
 
-    def test_codex_config_skill_mentions_identity_pools(self, tmp_path):
-        """Installed Codex config skill includes identity-pool references."""
-        install_codex_skills(tmp_path)
+    def test_chatgpt_config_skill_mentions_identity_pools(self, tmp_path):
+        """Installed ChatGPT config skill includes identity-pool references."""
+        install_chatgpt_skills(tmp_path)
 
         config_skill = (tmp_path / "eforge-config" / "SKILL.md").read_text()
         config_ref = (
@@ -226,35 +231,35 @@ class TestInstallCodexSkills:
         assert "identity_pools" in config_skill
         assert "mail_public_identities.yaml" in config_ref
 
-    def test_codex_references_are_limited_per_skill(self, tmp_path):
-        """Codex skills only receive the references they need."""
-        install_codex_skills(tmp_path)
+    def test_chatgpt_references_are_limited_per_skill(self, tmp_path):
+        """ChatGPT skills only receive the references they need."""
+        install_chatgpt_skills(tmp_path)
 
         assert (tmp_path / "eforge-config" / "references" / "config-personas.md").is_file()
         assert not (tmp_path / "eforge-scenario" / "references" / "config-personas.md").exists()
         assert not (tmp_path / "eforge-validate" / "references" / "evidence-formats.md").exists()
 
-    def test_codex_install_prunes_no_longer_needed_references(self, tmp_path):
-        """Codex reinstall removes references left by older all-reference installs."""
+    def test_chatgpt_install_prunes_no_longer_needed_references(self, tmp_path):
+        """ChatGPT reinstall removes references left by older all-reference installs."""
         old_ref = tmp_path / "eforge-scenario" / "references" / "config-personas.md"
         old_ref.parent.mkdir(parents=True)
         old_ref.write_text("old duplicated reference")
 
-        _, removed = install_codex_skills(tmp_path)
+        _, removed = install_chatgpt_skills(tmp_path)
 
         assert "eforge-scenario/references/config-personas.md" in removed
         assert not old_ref.exists()
 
-    def test_codex_rewrites_claude_reference_invocations(self, tmp_path):
-        """Codex skills use local reference paths instead of Claude sub-skill syntax."""
-        install_codex_skills(tmp_path)
+    def test_chatgpt_rewrites_claude_reference_invocations(self, tmp_path):
+        """ChatGPT skills use local reference paths instead of Claude sub-skill syntax."""
+        install_chatgpt_skills(tmp_path)
 
         skill = (tmp_path / "eforge-scenario" / "SKILL.md").read_text()
         assert "/eforge:references:scenario-reference" not in skill
         assert "`references/scenario-reference.md`" in skill
 
-    def test_codex_preserves_user_managed_eforge_skills(self, tmp_path):
-        """Codex install does not remove sibling eforge-* skills it does not own."""
+    def test_chatgpt_preserves_user_managed_eforge_skills(self, tmp_path):
+        """ChatGPT install preserves sibling eforge-* skills it does not own."""
         assess_dir = tmp_path / "eforge-assess"
         assess_dir.mkdir()
         sentinel = assess_dir / "sentinel.txt"
@@ -263,23 +268,23 @@ class TestInstallCodexSkills:
             "---\nname: eforge-assess\ndescription: User managed skill\n---\n"
         )
 
-        _, removed = install_codex_skills(tmp_path)
+        _, removed = install_chatgpt_skills(tmp_path)
 
         assert "eforge-assess" not in removed
         assert sentinel.read_text() == "keep me"
         assert (assess_dir / "SKILL.md").is_file()
 
-    def test_codex_rejects_symlinked_skill_directory(self, tmp_path):
-        """install_codex_skills rejects a symlinked target skill directory."""
+    def test_chatgpt_rejects_symlinked_skill_directory(self, tmp_path):
+        """install_chatgpt_skills rejects a symlinked target skill directory."""
         victim_dir = tmp_path / "victim"
         victim_dir.mkdir()
         (tmp_path / "eforge-scenario").symlink_to(victim_dir, target_is_directory=True)
 
         with pytest.raises(PermissionError, match="symlinked path"):
-            install_codex_skills(tmp_path)
+            install_chatgpt_skills(tmp_path)
 
-    def test_codex_rejects_symlinked_skill_file(self, tmp_path):
-        """install_codex_skills rejects a symlinked SKILL.md destination file."""
+    def test_chatgpt_rejects_symlinked_skill_file(self, tmp_path):
+        """install_chatgpt_skills rejects a symlinked SKILL.md destination file."""
         victim_file = tmp_path / "victim.txt"
         victim_file.write_text("do not overwrite")
         skill_dir = tmp_path / "eforge-scenario"
@@ -287,12 +292,12 @@ class TestInstallCodexSkills:
         (skill_dir / "SKILL.md").symlink_to(victim_file)
 
         with pytest.raises(PermissionError, match="symlinked path"):
-            install_codex_skills(tmp_path)
+            install_chatgpt_skills(tmp_path)
 
         assert victim_file.read_text() == "do not overwrite"
 
-    def test_codex_rejects_symlinked_reference_directory(self, tmp_path):
-        """install_codex_skills rejects nested symlinked reference directories."""
+    def test_chatgpt_rejects_symlinked_reference_directory(self, tmp_path):
+        """install_chatgpt_skills rejects nested symlinked reference directories."""
         outside_refs = tmp_path / "outside_refs"
         outside_refs.mkdir()
         skill_dir = tmp_path / "eforge-scenario"
@@ -300,35 +305,74 @@ class TestInstallCodexSkills:
         (skill_dir / "references").symlink_to(outside_refs, target_is_directory=True)
 
         with pytest.raises(PermissionError, match="symlinked path"):
-            install_codex_skills(tmp_path)
+            install_chatgpt_skills(tmp_path)
 
         assert list(outside_refs.iterdir()) == []
+
+    def test_legacy_codex_function_is_compatibility_alias(self, tmp_path):
+        """The legacy installer function still creates ChatGPT-compatible skills."""
+        install_codex_skills(tmp_path)
+
+        assert (tmp_path / "eforge-scenario" / "SKILL.md").is_file()
+
+    def test_finds_only_installer_owned_chatgpt_skills(self, tmp_path):
+        """Legacy detection ignores unrelated and user-managed skill directories."""
+        install_chatgpt_skills(tmp_path)
+        unrelated_dir = tmp_path / "unrelated"
+        unrelated_dir.mkdir()
+        (unrelated_dir / "SKILL.md").write_text(
+            "---\nname: unrelated\ndescription: Another skill\n---\n"
+        )
+        assess_dir = tmp_path / "eforge-assess"
+        assess_dir.mkdir()
+        (assess_dir / "SKILL.md").write_text(
+            "---\nname: eforge-assess\ndescription: User managed skill\n---\n"
+        )
+
+        found = find_evidenceforge_chatgpt_skills(tmp_path)
+
+        assert {path.name for path in found} == {
+            "eforge-config",
+            "eforge-evaluate",
+            "eforge-generate",
+            "eforge-scenario",
+            "eforge-validate",
+        }
 
 
 class TestInstallSkillsCli:
     """Tests for the CLI command integration."""
 
     def test_install_skills_project_default(self, tmp_path, monkeypatch):
-        """eforge install-skills copies files to .claude/commands/ in cwd."""
+        """The default project install creates Claude and ChatGPT skill trees."""
         monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["install-skills"])
 
         assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
         assert (tmp_path / ".claude" / "commands" / "eforge" / "scenario.md").is_file()
-        assert (tmp_path / ".claude" / "commands" / "eforge" / "generate.md").is_file()
-        assert (tmp_path / ".claude" / "commands" / "eforge" / "validate.md").is_file()
-        assert (tmp_path / ".claude" / "commands" / "eforge" / "config.md").is_file()
+        assert (tmp_path / ".agents" / "skills" / "eforge-scenario" / "SKILL.md").is_file()
 
     def test_install_skills_global(self, tmp_path, monkeypatch):
-        """eforge install-skills --global copies files to ~/.claude/commands/."""
+        """The default global install creates both user-wide skill trees."""
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
         result = runner.invoke(app, ["install-skills", "--global"])
 
         assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
         assert (tmp_path / ".claude" / "commands" / "eforge" / "scenario.md").is_file()
-        assert (tmp_path / ".claude" / "commands" / "eforge" / "config.md").is_file()
+        assert (tmp_path / ".agents" / "skills" / "eforge-scenario" / "SKILL.md").is_file()
+
+    def test_install_skills_explicit_all(self, tmp_path, monkeypatch):
+        """--agent all installs each canonical agent exactly once."""
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["install-skills", "--agent", "all"])
+
+        assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
+        assert (tmp_path / ".claude" / "commands" / "eforge" / "scenario.md").is_file()
+        assert (tmp_path / ".agents" / "skills" / "eforge-scenario" / "SKILL.md").is_file()
+        assert result.stdout.count("Installing EvidenceForge skills for chatgpt") == 1
 
     def test_install_skills_claude_global_with_agent(self, tmp_path, monkeypatch):
         """eforge install-skills --agent claude --global keeps Claude global behavior."""
@@ -338,37 +382,51 @@ class TestInstallSkillsCli:
 
         assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
         assert (tmp_path / ".claude" / "commands" / "eforge" / "scenario.md").is_file()
+        assert not (tmp_path / ".agents").exists()
         assert "/eforge scenario" in result.stdout
 
-    def test_install_skills_codex(self, tmp_path, monkeypatch):
-        """eforge install-skills --agent codex copies files to ~/.codex/skills/."""
+    def test_install_skills_chatgpt_project(self, tmp_path, monkeypatch):
+        """--agent chatgpt installs project skills under .agents/skills."""
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["install-skills", "--agent", "chatgpt"])
+
+        assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
+        assert (tmp_path / ".agents" / "skills" / "eforge-scenario" / "SKILL.md").is_file()
+        assert not (tmp_path / ".claude").exists()
+        assert "eforge-scenario" in result.stdout
+
+    @pytest.mark.parametrize("agent", ["chatgpt", "codex"])
+    def test_install_skills_chatgpt_global(self, tmp_path, monkeypatch, agent):
+        """ChatGPT and its Codex alias install globally under .agents/skills."""
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        result = runner.invoke(app, ["install-skills", "--agent", agent, "--global"])
+
+        assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
+        assert (tmp_path / ".agents" / "skills" / "eforge-scenario" / "SKILL.md").is_file()
+        assert not (tmp_path / ".codex" / "skills").exists()
+
+    def test_install_skills_codex_project_alias(self, tmp_path, monkeypatch):
+        """The Codex alias uses the ChatGPT project destination."""
+        monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["install-skills", "--agent", "codex"])
 
         assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
-        assert (tmp_path / ".codex" / "skills" / "eforge-scenario" / "SKILL.md").is_file()
-        assert (tmp_path / ".codex" / "skills" / "eforge-config" / "SKILL.md").is_file()
-        assert "eforge-scenario" in result.stdout
-
-    def test_install_skills_codex_rejects_global(self, tmp_path, monkeypatch):
-        """--global is invalid for Codex installs."""
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
-
-        result = runner.invoke(app, ["install-skills", "--agent", "codex", "--global"])
-
-        assert result.exit_code == 1
-        assert "--global is only valid for Claude installs" in result.stdout
-        assert not (tmp_path / ".codex" / "skills").exists()
+        assert (tmp_path / ".agents" / "skills" / "eforge-config" / "SKILL.md").is_file()
+        assert "Installing EvidenceForge skills for chatgpt" in result.stdout
 
     def test_install_skills_rejects_unknown_agent(self, tmp_path, monkeypatch):
-        """Unknown agents return an input error."""
+        """Unknown agents fail before creating any skill destinations."""
         monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["install-skills", "--agent", "other"])
 
         assert result.exit_code == 1
         assert "Unknown agent" in result.stdout
+        assert not (tmp_path / ".claude").exists()
+        assert not (tmp_path / ".agents").exists()
 
     def test_install_skills_shows_file_list(self, tmp_path, monkeypatch):
         """Command output lists installed files."""
@@ -382,8 +440,8 @@ class TestInstallSkillsCli:
         assert "config.md" in result.stdout
         assert "installed" in result.stdout.lower() or "Installed" in result.stdout
 
-    def test_install_skills_rejects_symlink_target(self, tmp_path, monkeypatch):
-        """CLI returns input error when eforge target is a symlink."""
+    def test_install_skills_all_continues_after_one_failure(self, tmp_path, monkeypatch):
+        """A failed target does not prevent later selected agents from installing."""
         monkeypatch.chdir(tmp_path)
         commands_dir = tmp_path / ".claude" / "commands"
         commands_dir.mkdir(parents=True)
@@ -393,3 +451,21 @@ class TestInstallSkillsCli:
 
         assert result.exit_code == 1
         assert "symlinked path" in result.stdout
+        assert "Skill installation completed with errors" in result.stdout
+        assert (tmp_path / ".agents" / "skills" / "eforge-scenario" / "SKILL.md").is_file()
+
+    def test_global_chatgpt_warns_about_preserved_legacy_skills(self, tmp_path, monkeypatch):
+        """Global ChatGPT installs warn about legacy skills without changing them."""
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        legacy_dir = tmp_path / ".codex" / "skills"
+        install_chatgpt_skills(legacy_dir)
+        sentinel = legacy_dir / "eforge-scenario" / "legacy-sentinel.txt"
+        sentinel.write_text("preserve me")
+
+        result = runner.invoke(app, ["install-skills", "--agent", "chatgpt", "--global"])
+
+        assert result.exit_code == EXIT_SUCCESS, f"Output: {result.stdout}"
+        assert "Legacy EvidenceForge skills" in result.stdout
+        assert ".codex/skills" in result.stdout
+        assert "These legacy files were not modified" in result.stdout
+        assert sentinel.read_text() == "preserve me"

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "evidence-forge"
-version = "1.11.1"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- make `eforge install-skills` install Claude Code and ChatGPT skills by default
- add explicit `all`, `claude`, and `chatgpt` selections while retaining `codex` as a compatibility alias
- install ChatGPT skills under project-local or user-wide `.agents/skills`
- continue multi-agent installs after individual failures and warn about preserved legacy `.codex/skills` installations
- update documentation and regression coverage
- bump the release version to 1.12.0 and add the changelog entry

## Why

Current Codex/ChatGPT skill discovery uses `.agents/skills` for project-local and user-wide skills. The previous installer only supported a user-scoped `codex` target under the legacy `.codex/skills` path and installed Claude alone by default.

## User impact

Running `eforge install-skills` now configures both supported agent workflows locally. Users can select either agent explicitly or add `--global` for user-wide installation. Existing `--agent codex` commands remain compatible but use the current ChatGPT destination.

## Validation

- `uv run pytest --no-cov`: 4,886 passed, 19 skipped
- `uv run pytest --include-slow --no-cov`: 4,899 passed, 6 skipped
- post-version focused suite: 39 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
