### PR TITLE
feat: add explicit identity and lifecycle contract

### DIFF
--- a/docs/worklog/2026-07-15-explicit-identity-lifecycle-contract.md
+++ b/docs/worklog/2026-07-15-explicit-identity-lifecycle-contract.md
@@ -1,0 +1,78 @@
+# Explicit Identity and Lifecycle Contract
+
+## Scope
+
+This feature branch implements the identity/lifecycle realism family identified by the
+`iteration-test-expanded` assessments. The work owns canonical process, thread, and session
+identity; lifecycle groups and ordering; explicit eCAR source/target roles; and removal of
+renderer-side identity repair. Durable file/task/inventory and broader baseline-texture findings
+remain out of scope.
+
+## Branch and integration
+
+- Branch: `codex/explicit-identity-lifecycle-contract`
+- Target: `dev`
+- Shape: three milestone commits followed by one draft pull request
+- Version: unchanged on the feature branch
+- Dependency: PR #357 (`codex/network-transaction-observation-contract`)
+
+The branch was initially created from PR #357's exact tip, `d36e0d04`, while GitHub still reported
+the PR as open. After the merge completed, it was rebased before the first milestone commit onto
+`origin/dev` at merge commit `23feeadd`.
+
+## Family contract
+
+| Truth | Correct owner |
+|---|---|
+| Process/session/thread object identity and role semantics | Canonical identity plan |
+| Durable process, session, and thread existence | `StateManager` state |
+| Lifecycle group membership and parentage | Process/auth action bundles |
+| Lifecycle ordering and safe source attribution | Identity/lifecycle and source-timing planning |
+| Source-local missingness and delay | Observation planning |
+| eCAR field names and source-native serialization | eCAR schema/emitter |
+
+Canonical process identity is host- and start-scoped. Canonical thread identity is scoped by
+`(hostname, process_object_id, tid)`; PID and TID values themselves remain host-local and may
+legitimately repeat on different hosts or after a completed lifecycle.
+
+## Milestones
+
+### Milestone 1 — Canonical identity and thread state
+
+- Status: complete
+- Acceptance: deterministic immutable identity snapshots, primary-thread state, explicit remote
+  thread registration, cross-host collision resistance, and same-host PID-reuse isolation.
+
+Implemented immutable `ThreadIdentity`, `ProcessIdentity`, `SessionIdentity`, and
+`EventIdentityPlan` types. `StateManager` now allocates a durable primary thread with each process,
+indexes every live thread by `(hostname, process_object_id, tid)`, validates explicit worker/remote
+thread ownership, tears threads down with their owning process, and exposes immutable identity
+snapshots. Linux leaders use `tid == pid`; Windows TIDs use a deterministic host-native allocator.
+Process and session state now carry lifecycle group IDs, and `EdrContext` can validate its retained
+compatibility fields against a canonical plan.
+
+Focused acceptance:
+
+- `uv run pytest --no-cov tests/unit/test_identity_contract.py tests/unit/test_state_manager.py tests/unit/test_state_manager_threading.py tests/unit/test_process_lifetimes.py -q`
+  — 128 passed.
+- `uv run pytest --no-cov` — 4,961 passed, 19 skipped in 308.52 seconds.
+
+### Milestone 2 — Process and session lifecycle ownership
+
+- Status: pending
+- Acceptance: action-bundle ownership, durable lifecycle groups, upstream identity planning,
+  causally safe actor attribution, and lifecycle-compatible observation/timing/admission.
+
+### Milestone 3 — Explicit eCAR roles and renderer simplification
+
+- Status: pending
+- Acceptance: eCAR 1.1 optional source/target fields, unambiguous cross-process roles, canonical
+  TIDs only, and serialization-only flush behavior.
+
+## Final acceptance
+
+- Focused tests and the normal non-slow suite at each milestone.
+- Config validation, Ruff checks, and the complete default suite before final review.
+- Generate and evaluate `iteration-test-expanded`, run the identity family probes, then conduct
+  one independent four-reviewer blind panel.
+- Record commands, results, scorecard, residual findings, and PR handoff here.

--- a/docs/worklog/2026-07-15-explicit-identity-lifecycle-contract.md
+++ b/docs/worklog/2026-07-15-explicit-identity-lifecycle-contract.md
@@ -59,9 +59,38 @@ Focused acceptance:
 
 ### Milestone 2 — Process and session lifecycle ownership
 
-- Status: pending
+- Status: complete
 - Acceptance: action-bundle ownership, durable lifecycle groups, upstream identity planning,
   causally safe actor attribution, and lifecycle-compatible observation/timing/admission.
+
+Implemented `IdentityLifecyclePlanner` in the dispatcher before state application, observation,
+and source timing. It freezes process/session/thread subject, actor, and target roles while live
+state still exists; assigns process and session lifecycle groups; models Type 7 unlock as a child
+reauthentication; and omits unavailable attribution instead of inventing it. Process access no
+longer synthesizes a per-event source TID, and remote-thread creation now registers one durable
+target-owned thread.
+
+Process and logon action bundles pass their stable group IDs into state. SSH and RDP bundles now
+allocate their own session identities and return them to `WorldPlanner`; ordinary World planning
+also requests logon intent without pre-allocating state. Service logons use the same contract, and
+session bootstrap process teardown now routes through the process-termination bundle. Fixed
+kernel/bootstrap identities (Windows PID 4 and Linux PID 1) use a dedicated canonical
+`register_process()` boundary instead of direct dictionary insertion.
+
+Focused acceptance:
+
+- Identity/lifecycle, dispatcher, observation, source timing, eCAR, LogonID, proxy, and systemd
+  compatibility sets — 333 passed.
+- Activity, World planning, SSH/RDP, process access, and remote-thread sets — 445 passed.
+- Regression repairs (thread-local timing, engine mocks honoring bundle ownership, session-kind
+  reuse, Sysmon cross-process semantics) — 70 passed.
+- Representative deterministic/inbound integrations — 8 passed.
+- Adversarial generation integration family — 68 passed.
+- `uv run pytest --no-cov -q` — 4,968 passed, 19 skipped in 321.26 seconds.
+
+The first full-suite attempt exposed boot-seeded PID 4/System and PID 1/systemd bypassing the
+canonical registration boundary. The fix was made at `StateManager`/engine setup rather than in
+the identity planner or emitter; the complete suite passed after that owning-layer repair.
 
 ### Milestone 3 — Explicit eCAR roles and renderer simplification
 

--- a/docs/worklog/2026-07-15-explicit-identity-lifecycle-contract.md
+++ b/docs/worklog/2026-07-15-explicit-identity-lifecycle-contract.md
@@ -94,14 +94,104 @@ the identity planner or emitter; the complete suite passed after that owning-lay
 
 ### Milestone 3 — Explicit eCAR roles and renderer simplification
 
-- Status: pending
+- Status: complete
 - Acceptance: eCAR 1.1 optional source/target fields, unambiguous cross-process roles, canonical
   TIDs only, and serialization-only flush behavior.
 
+Extended the eCAR format compatibly to version 1.1 with optional source and target process UUID,
+PID, TID, image, and principal properties. `PROCESS/OPEN` now identifies the opened process as its
+object and the opener as its actor; `THREAD/REMOTE_CREATE` identifies the new target-owned thread
+as its object, the source process as its actor, and the owning target process explicitly. FLOW
+attribution consumes the same frozen identity plan and is omitted as a complete group when safe
+canonical ownership is unavailable.
+
+The emitter no longer performs process-state lookups, TID synthesis, service-PID inference, shared
+process identity invention, PID remapping, stale-reference filtering, lifecycle timestamp repair,
+identity scrubbing, or semantic deduplication. Its flush path now delegates directly to the base
+serializer/sorter/writer. Source-visible parent/create/dependent/terminate ordering moved to the
+dispatcher-owned `SourceTimingPlanner`, keyed by durable process object identity. Removing the old
+repair pipeline deleted roughly 1,400 lines of emitter normalization code and the legacy tests that
+invoked those private repairs; upstream planner and serialization-boundary tests replace them.
+
+The rendered acceptance run exposed one owning-layer classification gap: `system_process_create`
+events allocated canonical processes and primary threads but were not classified as process starts
+by `IdentityLifecyclePlanner`. Adding that event type to the canonical process-start contract made
+all 1,881 rendered process creates and all 1,420 terminations carry their canonical primary TID.
+The evaluation rule remains strict for CREATE and TERMINATE while dependent rows omit TID unless a
+thread is explicitly modeled.
+
+### Blind-gate owning-layer repairs
+
+The first data-only acceptance gate found three material defects that the earlier aggregate probes
+did not detect:
+
+- Sysmon cached an emitter-invented `TerminalSessionId` before the canonical RDP session ID became
+  available, causing five otherwise-identical eCAR/Sysmon process identities to disagree.
+- eCAR projected both canonical endpoint identities into each host-local FLOW observation, leaking
+  the remote host's process UUID, PID, image, and principal and exposing future SSH child identity.
+- Syslog finalization rewrote canonical SSH child PIDs to force monotonic presentation, creating
+  cross-source PID collisions with unrelated live Linux processes.
+
+The repairs stayed at the correct owners. Sysmon now trusts canonical session state and renders
+zero when it is unavailable; eCAR keeps both identities in the canonical plan but projects only the
+local actor into each source-native FLOW row; and syslog finalization preserves the PID allocated by
+the SSH/process bundle. Canonical event occurrence IDs also removed exact eCAR ID reuse, session
+closure now waits for all session-owned process evidence, canonical actor activity protects process
+lifetimes through dependent events and network close, and Sysmon ProcessAccess requires the
+modeled source primary thread.
+
+The material rework justified the plan's one permitted repeat panel. Findings about Windows record
+counter texture, DHCP/TLS/DNS timing texture, scan distribution, actor-coverage cliffs, privilege
+populations, and broader inventory remain outside this identity/lifecycle contract.
+
 ## Final acceptance
 
-- Focused tests and the normal non-slow suite at each milestone.
-- Config validation, Ruff checks, and the complete default suite before final review.
-- Generate and evaluate `iteration-test-expanded`, run the identity family probes, then conduct
-  one independent four-reviewer blind panel.
-- Record commands, results, scorecard, residual findings, and PR handoff here.
+`iteration-test-expanded` generated 86,294 records across 20 evaluated sources. Automated
+evaluation passed at 95.3421 overall: Parseability 100.00, Plausibility 97.27, Causality 88.02, and
+Timing 95.10. Contract gates passed at 86,294/86,294 spec and format checks, 26,618/26,618
+co-occurrence checks, 15,613/15,613 cross-source field pairs, 11,854/11,854 causal-order pairs, and
+12,833/12,833 rate-plausibility checks.
+
+Rendered identity/lifecycle probes on the corrected output found:
+
+- Zero duplicate eCAR IDs, TID-without-PID rows, missing or mismatched create/terminate primary
+  TIDs, post-termination actor references, or session-object mismatches.
+- Zero cross-host FLOW actors or remote process identity groups in host-local FLOW observations.
+- Zero syslog SSH PID collisions with non-SSH processes or one PID assigned to multiple tuples.
+- Zero eCAR/Sysmon terminal-session mismatches across 186 process pairs with canonical sessions.
+- Zero nonpositive source TIDs across all 658 Sysmon ProcessAccess records.
+- All three visible local Linux bootstrap chains included ordered login, PAM, logind, terminal, and
+  shell evidence.
+
+Final engineering gates:
+
+- Focused identity, eCAR, Sysmon, syslog, SSH/RDP, World, and source-timing set — 302 passed.
+- `uv run pytest --no-cov -q` — 4,948 passed, 19 skipped in 305.56 seconds.
+- `uv run eforge validate-config` — 87 configuration files valid with zero findings.
+- `uv run eforge validate scenarios/iteration-test-expanded/scenario.yaml` — valid with the
+  scenario's 26 pre-existing topology/storyline warnings.
+- Ruff checks, format checks, and `git diff --check` — clean.
+
+Acceptance artifacts are retained under
+`scenarios/iteration-test-expanded/blind-test/identity-lifecycle-contract/`.
+
+## Corrected blind panel
+
+The four reviewers inspected only a frozen copy of generated data. They received no scenario,
+ground truth, evaluation results, source, tests, repository history, prior panel findings, or other
+reviewer reports. The initial independent score spread exceeded 30 points, so the assessment
+protocol's single anonymized cross-review round was applied. After reconciliation, all four
+reviewers independently accepted the identity/lifecycle contract:
+
+| Reviewer role | Verdict | Verdict confidence | Synthetic confidence | Realism | Identity/lifecycle |
+|---|---|---:|---:|---:|---:|
+| Threat hunter | Inconclusive | 80 | 48 | 89 | 96 |
+| Detection engineer | Inconclusive | 86 | 47 | 88 | 95 |
+| Network forensics | Inconclusive | 86 | 47 | 88 | 95 |
+| Host/EDR forensics | Inconclusive | 84 | 47 | 89 | 95 |
+
+The panel found zero hard identity, lifecycle, actor/target-role, SSH PID, terminal-session, or
+network ownership contradictions. Residual synthetic signals were explicitly outside the phase's
+contract: narrow population timing, scan and service-coverage distributions, stable sensor-clock
+relationships without calibration data, curated collection-manifest language, and Windows record
+counter/export texture. Those findings remain inputs to the next baseline/source-texture effort.

--- a/src/evidenceforge/config/evaluation/co_occurrence.yaml
+++ b/src/evidenceforge/config/evaluation/co_occurrence.yaml
@@ -180,9 +180,18 @@ ecar:
       - field: pid
         present: true
 
-  - name: "PROCESS records have tid"
+  - name: "PROCESS/CREATE records have canonical primary tid"
     condition:
       object: "PROCESS"
+      action: "CREATE"
+    checks:
+      - field: tid
+        present: true
+
+  - name: "PROCESS/TERMINATE records have canonical primary tid"
+    condition:
+      object: "PROCESS"
+      action: "TERMINATE"
     checks:
       - field: tid
         present: true

--- a/src/evidenceforge/config/formats/ecar.yaml
+++ b/src/evidenceforge/config/formats/ecar.yaml
@@ -7,7 +7,7 @@
 # Full schema: see commands/eforge/references/config-formats.md
 
 name: ecar
-version: "1.0"
+version: "1.1"
 description: "eCAR (extended Cyber Analytics Repository) - EDR/XDR host telemetry"
 category: host
 
@@ -236,6 +236,41 @@ fields:
     type: string
     required: false
     description: "Target process objectID UUID for cross-reference"
+
+  - name: source_process_uuid
+    type: string
+    required: false
+    description: "Canonical UUID of the process performing a cross-process action"
+
+  - name: source_pid
+    type: string
+    required: false
+    description: "Canonical source process PID (string in properties)"
+
+  - name: source_tid
+    type: string
+    required: false
+    description: "Canonical source thread TID when an owning thread is explicitly modeled"
+
+  - name: source_image_path
+    type: string
+    required: false
+    description: "Canonical source process image for cross-process actions"
+
+  - name: source_principal
+    type: string
+    required: false
+    description: "Canonical source process principal for cross-process actions"
+
+  - name: target_tid
+    type: string
+    required: false
+    description: "Canonical target thread TID when an owning thread is explicitly modeled"
+
+  - name: target_principal
+    type: string
+    required: false
+    description: "Canonical target process principal for cross-process actions"
 
   - name: target_image_path
     type: string

--- a/src/evidenceforge/events/base.py
+++ b/src/evidenceforge/events/base.py
@@ -161,6 +161,8 @@ class SecurityEvent:
     source_timing: SourceTimingPlan | None = None
 
     # Correlated action lifecycle and frozen network-sensor projections.
+    # EventDispatcher allocates event_id before state application and observation.
+    event_id: str = ""
     lifecycle: ActionLifecycleContext | None = None
     identity_plan: EventIdentityPlan | None = None
     network_observations: tuple[NetworkSensorObservation, ...] = ()

--- a/src/evidenceforge/events/base.py
+++ b/src/evidenceforge/events/base.py
@@ -68,6 +68,7 @@ from evidenceforge.events.contexts import (
     WeirdContext,
     X509Context,
 )
+from evidenceforge.events.identity import EventIdentityPlan
 from evidenceforge.events.lifecycle import ActionLifecycleContext
 from evidenceforge.events.network import NetworkSensorObservation
 
@@ -161,6 +162,7 @@ class SecurityEvent:
 
     # Correlated action lifecycle and frozen network-sensor projections.
     lifecycle: ActionLifecycleContext | None = None
+    identity_plan: EventIdentityPlan | None = None
     network_observations: tuple[NetworkSensorObservation, ...] = ()
     network_observations_planned: bool = False
 

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from evidenceforge.events.identity import EventIdentityPlan
 from evidenceforge.events.network import (
     DirectionalTrafficLedger,
     NetworkTrafficLedger,
@@ -728,6 +729,16 @@ class EdrContext:
     object_id: str = ""
     actor_id: str = ""
     tid: int = -1
+
+    def validate_identity_plan(self, plan: EventIdentityPlan) -> None:
+        """Validate populated compatibility fields against canonical identity truth."""
+
+        if self.object_id and self.object_id != plan.object_id:
+            raise ValueError("EdrContext object_id contradicts the canonical identity subject")
+        if self.actor_id and self.actor_id != plan.actor_id:
+            raise ValueError("EdrContext actor_id contradicts the canonical identity actor")
+        if self.tid >= 0 and self.tid != plan.canonical_tid:
+            raise ValueError("EdrContext tid contradicts the canonical identity thread")
 
 
 @dataclass(slots=True)

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -733,11 +733,11 @@ class EdrContext:
     def validate_identity_plan(self, plan: EventIdentityPlan) -> None:
         """Validate populated compatibility fields against canonical identity truth."""
 
-        if self.object_id and self.object_id != plan.object_id:
+        if plan.object_id and self.object_id and self.object_id != plan.object_id:
             raise ValueError("EdrContext object_id contradicts the canonical identity subject")
-        if self.actor_id and self.actor_id != plan.actor_id:
+        if plan.actor_id and self.actor_id and self.actor_id != plan.actor_id:
             raise ValueError("EdrContext actor_id contradicts the canonical identity actor")
-        if self.tid >= 0 and self.tid != plan.canonical_tid:
+        if plan.canonical_tid >= 0 and self.tid >= 0 and self.tid != plan.canonical_tid:
             raise ValueError("EdrContext tid contradicts the canonical identity thread")
 
 

--- a/src/evidenceforge/events/dispatcher.py
+++ b/src/evidenceforge/events/dispatcher.py
@@ -43,6 +43,7 @@ from evidenceforge.events.observation import (
     ObservationSummary,
     source_family_for_format,
 )
+from evidenceforge.utils.rng import stable_uuid
 
 if TYPE_CHECKING:
     from evidenceforge.generation.emitters.base import LogEmitter
@@ -132,6 +133,7 @@ class EventDispatcher:
         self.observation_policy = observation_policy or ObservationPolicy("complete")
         self._source_evidence_status: dict[str, dict[str, ObservationSummary]] = {}
         self._network_identifiers_by_format: dict[tuple[str, str], str] = {}
+        self._event_sequence = 0
         self.storyline_cluster_id: str | None = None
         from evidenceforge.generation.source_timing import SourceTimingPlanner
 
@@ -201,6 +203,15 @@ class EventDispatcher:
         if event.network is not None:
             event.network.validate_finalized_transaction()
         self.identity_lifecycle_planner.plan(event)
+        if not event.event_id:
+            event.event_id = stable_uuid(
+                "security-event",
+                self._event_sequence,
+                event.event_type,
+                event.timestamp.isoformat(),
+                event.storyline_cluster_id or "",
+            )
+            self._event_sequence += 1
         self.state_manager.apply(event)
         if self._is_suppressed(event.timestamp):
             self._record_observation(event, "all", "out_of_window")
@@ -237,7 +248,10 @@ class EventDispatcher:
                 event_to_emit = replace(event, timestamp=event.timestamp + decision.delay)
                 status = "delayed"
             event_to_emit._observed_formats = observed_formats
-            event_to_emit = self.source_timing_planner.plan_event(event_to_emit)
+            event_to_emit = self.source_timing_planner.plan_event(
+                event_to_emit,
+                format_name=format_name,
+            )
             if not self._admit_source_event(event_to_emit, format_name):
                 self._record_observation(event, format_name, "out_of_window")
                 continue

--- a/src/evidenceforge/events/dispatcher.py
+++ b/src/evidenceforge/events/dispatcher.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from evidenceforge.events.base import RawLogEntry, SecurityEvent
@@ -141,6 +141,9 @@ class EventDispatcher:
         from evidenceforge.generation.network_observation import NetworkObservationPlanner
 
         self.network_observation_planner = NetworkObservationPlanner(visibility_engine)
+        from evidenceforge.generation.identity_lifecycle import IdentityLifecyclePlanner
+
+        self.identity_lifecycle_planner = IdentityLifecyclePlanner(state_manager)
 
     @property
     def source_evidence_status(self) -> dict[str, dict[str, dict[str, int]]]:
@@ -197,6 +200,7 @@ class EventDispatcher:
             event.storyline_cluster_id = self.storyline_cluster_id
         if event.network is not None:
             event.network.validate_finalized_transaction()
+        self.identity_lifecycle_planner.plan(event)
         self.state_manager.apply(event)
         if self._is_suppressed(event.timestamp):
             self._record_observation(event, "all", "out_of_window")
@@ -326,7 +330,10 @@ class EventDispatcher:
                 self.output_end_time,
             )
 
-        source_start = visible_time + (lifecycle.canonical_start - event.timestamp)
+        source_start = visible_time + self._timestamp_delta(
+            lifecycle.canonical_start,
+            event.timestamp,
+        )
         if self.output_end_time is not None and not self._is_before(
             source_start,
             self.output_end_time,
@@ -355,6 +362,18 @@ class EventDispatcher:
         elif ts.tzinfo is None and normalized_gate.tzinfo is not None:
             normalized_gate = normalized_gate.replace(tzinfo=None)
         return ts < normalized_gate
+
+    @staticmethod
+    def _timestamp_delta(later: datetime, earlier: datetime) -> timedelta:
+        """Return a delta after aligning naive/aware canonical timestamps."""
+
+        normalized_later = later
+        normalized_earlier = earlier
+        if normalized_later.tzinfo is not None and normalized_earlier.tzinfo is None:
+            normalized_earlier = normalized_earlier.replace(tzinfo=normalized_later.tzinfo)
+        elif normalized_later.tzinfo is None and normalized_earlier.tzinfo is not None:
+            normalized_later = normalized_later.replace(tzinfo=normalized_earlier.tzinfo)
+        return normalized_later - normalized_earlier
 
     def _enforce_source_observation_contracts(
         self,

--- a/src/evidenceforge/events/identity.py
+++ b/src/evidenceforge/events/identity.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Immutable canonical identity plans for evidence-producing occurrences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class ThreadIdentity:
+    """Immutable identity of one explicitly modeled host-native thread."""
+
+    hostname: str
+    process_object_id: str
+    pid: int
+    tid: int
+    object_id: str
+    started_at: datetime
+    kind: str = "worker"
+
+    def __post_init__(self) -> None:
+        """Reject incomplete or invalid canonical thread identities."""
+
+        if not self.hostname or not self.process_object_id or not self.object_id:
+            raise ValueError("Thread identity requires host, process object, and thread object")
+        if self.pid < 0 or self.tid < 0:
+            raise ValueError("Thread PID and TID must be non-negative host-local identifiers")
+
+    @property
+    def canonical_key(self) -> tuple[str, str, int]:
+        """Return the collision-safe durable thread key."""
+
+        return (self.hostname, self.process_object_id, self.tid)
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessIdentity:
+    """Immutable identity of one host- and process-start-scoped process object."""
+
+    hostname: str
+    object_id: str
+    pid: int
+    parent_pid: int
+    image: str
+    command_line: str
+    principal: str
+    logon_id: str
+    started_at: datetime
+    lifecycle_group_id: str
+    parent_lifecycle_group_id: str = ""
+    primary_thread: ThreadIdentity | None = None
+
+    def __post_init__(self) -> None:
+        """Reject incomplete process object identity."""
+
+        if not self.hostname or not self.object_id or not self.lifecycle_group_id:
+            raise ValueError("Process identity requires host, object, and lifecycle group")
+        if self.pid < 0 or self.parent_pid < 0:
+            raise ValueError("Process PIDs must be non-negative host-local identifiers")
+        if self.primary_thread is not None:
+            if self.primary_thread.hostname != self.hostname:
+                raise ValueError("Primary thread host must match its owning process")
+            if self.primary_thread.process_object_id != self.object_id:
+                raise ValueError("Primary thread must reference its owning process object")
+            if self.primary_thread.pid != self.pid:
+                raise ValueError("Primary thread PID must match its owning process")
+
+
+@dataclass(frozen=True, slots=True)
+class SessionIdentity:
+    """Immutable identity of one durable authentication/session object."""
+
+    hostname: str
+    object_id: str
+    logon_id: str
+    session_id: int
+    principal: str
+    session_kind: str
+    started_at: datetime
+    lifecycle_group_id: str
+    parent_lifecycle_group_id: str = ""
+
+    def __post_init__(self) -> None:
+        """Reject incomplete session identity."""
+
+        if not self.hostname or not self.object_id or not self.lifecycle_group_id:
+            raise ValueError("Session identity requires host, object, and lifecycle group")
+        if not self.logon_id:
+            raise ValueError("Session identity requires a canonical LogonID")
+        if self.session_id < 0:
+            raise ValueError("Session ID must be a non-negative host-local identifier")
+
+
+IdentityObject: TypeAlias = ProcessIdentity | ThreadIdentity | SessionIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class EventIdentityPlan:
+    """Frozen subject/actor/target roles for one canonical event.
+
+    ``subject`` is the object whose lifecycle or state the event describes,
+    ``actor`` is the identity that performed the action, and ``target`` is the
+    identity acted upon. A role is absent when that identity was not explicitly
+    modeled; planners and emitters must not synthesize it.
+    """
+
+    subject: IdentityObject | None = None
+    actor: IdentityObject | None = None
+    target: IdentityObject | None = None
+    session: SessionIdentity | None = None
+
+    @property
+    def object_id(self) -> str:
+        """Return the compatibility object identifier for the subject role."""
+
+        return self.subject.object_id if self.subject is not None else ""
+
+    @property
+    def actor_id(self) -> str:
+        """Return the compatibility actor identifier for the actor role."""
+
+        return self.actor.object_id if self.actor is not None else ""
+
+    @property
+    def canonical_tid(self) -> int:
+        """Return a TID only when the subject itself is an explicitly modeled thread."""
+
+        if isinstance(self.subject, ThreadIdentity):
+            return self.subject.tid
+        if isinstance(self.subject, ProcessIdentity) and self.subject.primary_thread is not None:
+            return self.subject.primary_thread.tid
+        return -1

--- a/src/evidenceforge/generation/actions/auth_session.py
+++ b/src/evidenceforge/generation/actions/auth_session.py
@@ -47,6 +47,7 @@ class LogonRequest:
     emit_transport_syslog: bool = True
     emit_network_evidence: bool = True
     logon_id: str | None = None
+    lifecycle_group_id: str = ""
     source: str = "activity_generator"
 
     @property
@@ -60,6 +61,7 @@ class LogonRequest:
             f"{self.logon_type}:{self.source_ip or ''}:{self.source_port or ''}:"
             f"{self.emit_transport_syslog}:{self.emit_network_evidence}:"
             f"{self.logon_id or ''}:{source_host}:{self.source}"
+            f":{self.lifecycle_group_id}"
         )
         return f"logon-{seed:016x}"
 

--- a/src/evidenceforge/generation/actions/process_execution.py
+++ b/src/evidenceforge/generation/actions/process_execution.py
@@ -50,6 +50,7 @@ class ProcessExecutionRequest:
     allow_existing_browser_reuse: bool = True
     allow_browser_launch_spacing: bool = True
     concurrency_group_id: str = ""
+    lifecycle_group_id: str = ""
     source: str = "activity_generator"
 
     @property
@@ -57,13 +58,15 @@ class ProcessExecutionRequest:
         """Return a deterministic intent identifier for durable references."""
 
         concurrency_suffix = f":{self.concurrency_group_id}" if self.concurrency_group_id else ""
+        lifecycle_suffix = f":{self.lifecycle_group_id}" if self.lifecycle_group_id else ""
         seed = _stable_seed(
             "action_bundle:process_execution:"
             f"{self.user.username}:{self.system.hostname}:{self.time.isoformat()}:"
             f"{self.logon_id}:{self.process_name}:{self.command_line}:"
             f"{self.parent_pid}:{self.ensure_file_event}:{self.from_storyline}:"
             f"{self.suppress_command_file_effect}:{self.allow_existing_browser_reuse}:"
-            f"{self.allow_browser_launch_spacing}{concurrency_suffix}:{self.source}"
+            f"{self.allow_browser_launch_spacing}{concurrency_suffix}{lifecycle_suffix}:"
+            f"{self.source}"
         )
         return f"process-execution-{seed:016x}"
 

--- a/src/evidenceforge/generation/actions/rdp_session.py
+++ b/src/evidenceforge/generation/actions/rdp_session.py
@@ -273,6 +273,7 @@ class RdpSessionActionBundle:
             source_port=src_port,
             emit_network_evidence=False,
             logon_id=logon_id or None,
+            lifecycle_group_id=self._request.stable_id,
         )
         self._rendered_logon_id = rendered_logon_id
         self._executor.state_manager.update_session_metadata(

--- a/src/evidenceforge/generation/actions/ssh_session.py
+++ b/src/evidenceforge/generation/actions/ssh_session.py
@@ -341,6 +341,12 @@ class SshSessionActionBundle:
     def execute(self) -> str:
         """Expand and dispatch SSH session evidence through the generator runtime."""
 
+        uid, _logon_id = self.execute_with_identity()
+        return uid
+
+    def execute_with_identity(self) -> tuple[str, str]:
+        """Expand the bundle and return its transport UID and owned session LogonID."""
+
         state = self._plan_transport()
         self._ensure_session_identity(state)
         auth_plan = self._prepare_linux_auth_plan(state)
@@ -366,7 +372,7 @@ class SshSessionActionBundle:
             self.request.target_system.hostname,
             state.uid,
         )
-        return state.uid if state.network_visible else ""
+        return (state.uid if state.network_visible else ""), state.logon_id
 
     def _source_os(self) -> str:
         """Return the source OS category used for source-port reservation."""
@@ -480,6 +486,11 @@ class SshSessionActionBundle:
                 source_port=state.source_port,
                 session_kind="ssh",
                 start_time=request.time,
+                lifecycle_group_id=(
+                    state.execution_anchor.stable_id
+                    if state.execution_anchor is not None
+                    else request.stable_id
+                ),
             )
         if not state.session_obj_id:
             state.session_obj_id = executor.state_manager.get_session_object_id(state.logon_id)

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -4216,6 +4216,7 @@ class ActivityGenerator:
         self._last_browser_launch_by_session: dict[tuple[str, str, str], datetime] = {}
         self._process_source_create_times: dict[tuple[str, int], datetime] = {}
         self._process_source_terminate_times: dict[tuple[str, int], datetime] = {}
+        self._session_process_source_terminate_times: dict[tuple[str, str], datetime] = {}
         self._process_connection_hold_until: dict[tuple[str, int], datetime] = {}
         self._source_timing_planner = SourceTimingPlanner(clock_profile_name=source_timing_profile)
 
@@ -10283,10 +10284,7 @@ class ActivityGenerator:
                 if is_ssh_session and session.network_close_time is not None
                 else None
             )
-            if (
-                ssh_transport_close_time is not None
-                and ensure_utc(time) >= ssh_transport_close_time
-            ):
+            if ssh_transport_close_time is not None:
                 transport_logoff_time = ssh_transport_close_time + sample_timing_delta(
                     "windows.logoff_after_last_activity",
                     seed_parts=(system.hostname, logon_id, ssh_transport_close_time),
@@ -10336,34 +10334,64 @@ class ActivityGenerator:
                 self._linux_shell_last_session_close[(system.hostname, user.username)] = ensure_utc(
                     time
                 )
-            bootstrap_pids = [
-                pid
-                for pid in (
-                    session.session_shell_pid,
-                    session.explorer_pid,
-                    session.session_winlogon_pid,
-                )
-                if pid is not None
+            session_processes = [
+                proc
+                for proc in self.state_manager.list_running_processes()
+                if proc.system == session.system and proc.logon_id == logon_id
             ]
-            for ordinal, bootstrap_pid in enumerate(dict.fromkeys(bootstrap_pids)):
-                bootstrap_process = self.state_manager.get_process(
-                    session.system,
-                    bootstrap_pid,
-                )
-                if bootstrap_process is None:
-                    continue
-                requested_termination_time = time - timedelta(
-                    milliseconds=450 - min(ordinal, 2) * 125
+            session_process_by_pid = {proc.pid: proc for proc in session_processes}
+
+            def _session_process_depth(pid: int) -> int:
+                depth = 0
+                seen: set[int] = set()
+                current = session_process_by_pid.get(pid)
+                while current is not None and current.parent_pid not in seen:
+                    seen.add(current.pid)
+                    parent = session_process_by_pid.get(current.parent_pid)
+                    if parent is None:
+                        break
+                    depth += 1
+                    current = parent
+                return depth
+
+            session_processes.sort(
+                key=lambda proc: (_session_process_depth(proc.pid), proc.start_time, proc.pid),
+                reverse=True,
+            )
+            termination_span = timedelta(milliseconds=max(500, 50 * (len(session_processes) + 1)))
+            termination_start = time - termination_span
+            prior_visible_termination = self._session_process_source_terminate_times.get(
+                (session.system, logon_id)
+            )
+            visible_termination_times = (
+                [prior_visible_termination] if prior_visible_termination is not None else []
+            )
+            for ordinal, session_process in enumerate(session_processes):
+                requested_termination_time = termination_start + timedelta(
+                    milliseconds=50 * ordinal
                 )
                 self.generate_process_termination(
                     user=user,
                     system=system,
                     time=requested_termination_time,
-                    pid=bootstrap_pid,
-                    process_name=bootstrap_process.image,
+                    pid=session_process.pid,
+                    process_name=session_process.image,
                     logon_id=logon_id,
                     from_storyline=from_storyline,
                 )
+                visible_termination_time = self.process_source_terminate_time(
+                    session.system,
+                    session_process.pid,
+                )
+                if visible_termination_time is not None:
+                    visible_termination_times.append(visible_termination_time)
+            if visible_termination_times:
+                latest_visible_termination = max(visible_termination_times)
+                minimum_logoff_time = latest_visible_termination + sample_timing_delta(
+                    "windows.logoff_after_rendered_dependents",
+                    seed_parts=(system.hostname, logon_id, latest_visible_termination),
+                )
+                time = max(time, minimum_logoff_time)
 
         # Build SecurityEvent (StateManager.apply() handles end_session)
         session_obj_id = self.state_manager.get_session_object_id(logon_id)
@@ -10865,6 +10893,7 @@ class ActivityGenerator:
         allow_existing_browser_reuse: bool = True,
         allow_browser_launch_spacing: bool = True,
         concurrency_group_id: str = "",
+        lifecycle_group_id: str = "",
     ) -> int:
         """Generate process creation event across all applicable log formats.
 
@@ -10892,6 +10921,7 @@ class ActivityGenerator:
                 launches. Causal connection-owner processes disable this so process
                 creation stays before the socket evidence they own.
             concurrency_group_id: Explicit same-shell concurrency group for true pipelines.
+            lifecycle_group_id: Optional owning lifecycle for session-bootstrap helpers.
 
         Returns:
             PID of the new process
@@ -10910,6 +10940,7 @@ class ActivityGenerator:
             allow_existing_browser_reuse=allow_existing_browser_reuse,
             allow_browser_launch_spacing=allow_browser_launch_spacing,
             concurrency_group_id=concurrency_group_id,
+            lifecycle_group_id=lifecycle_group_id,
         )
         return ProcessExecutionActionBundle(self, request).execute()
 
@@ -11232,7 +11263,7 @@ class ActivityGenerator:
             username=process_username,
             integrity_level=_integrity,
             logon_id=process_logon_id,
-            lifecycle_group_id=request.stable_id,
+            lifecycle_group_id=request.lifecycle_group_id or request.stable_id,
         )
 
         # Phase 2: Build SecurityEvent
@@ -11768,7 +11799,14 @@ class ActivityGenerator:
             if key.startswith("source.ecar_process_terminate|")
         ]
         if source_terminate_times:
-            self._process_source_terminate_times[(hostname, pid)] = max(source_terminate_times)
+            visible_terminate_time = max(source_terminate_times)
+            self._process_source_terminate_times[(hostname, pid)] = visible_terminate_time
+            logon_id = str(getattr(event.process, "logon_id", "") or "")
+            if logon_id:
+                key = (hostname, logon_id)
+                previous = self._session_process_source_terminate_times.get(key)
+                if previous is None or visible_terminate_time > previous:
+                    self._session_process_source_terminate_times[key] = visible_terminate_time
 
     def _plan_process_source_terminate_times(self, event: SecurityEvent) -> None:
         """Precompute eCAR terminate timestamps for source-visible shell ordering."""
@@ -17354,6 +17392,7 @@ class ActivityGenerator:
             user_systemd_time = logon_time + timedelta(milliseconds=90)
 
         session = self.state_manager.get_session(logon_id)
+        bootstrap_lifecycle_group_id = session.lifecycle_group_id if session is not None else ""
         user_systemd_pid = self._active_linux_session_user_manager_pid(
             user=user,
             target_system=target_system,
@@ -17370,6 +17409,7 @@ class ActivityGenerator:
                 command_line="/usr/lib/systemd/systemd --user",
                 parent_pid=root_parent_pid,
                 suppress_command_file_effect=True,
+                lifecycle_group_id=bootstrap_lifecycle_group_id,
             )
             if session is not None:
                 session.session_user_manager_pid = user_systemd_pid
@@ -17416,6 +17456,7 @@ class ActivityGenerator:
             command_line=parent_command,
             parent_pid=user_systemd_pid,
             suppress_command_file_effect=True,
+            lifecycle_group_id=bootstrap_lifecycle_group_id,
         )
         terminal_proc = self.state_manager.get_process(target_system.hostname, terminal_pid)
         if terminal_proc is not None:
@@ -17515,6 +17556,7 @@ class ActivityGenerator:
             command_line="-bash",
             parent_pid=parent_pid,
             suppress_command_file_effect=True,
+            lifecycle_group_id=session.lifecycle_group_id,
         )
         session.session_shell_pid = bash_pid
         session.process_tree_root = parent_pid
@@ -22679,6 +22721,14 @@ class ActivityGenerator:
         target_obj_id = self.state_manager.get_process_object_id(system.hostname, target_pid)
         if target_proc is None:
             return False
+        source_thread = self.state_manager.get_primary_thread(system.hostname, source_pid)
+        if source_thread is None:
+            logger.debug(
+                "Skipping remote thread without a canonical source thread: %s pid=%s",
+                system.hostname,
+                source_pid,
+            )
+            return False
         remote_thread_identity = self.state_manager.create_thread(
             system.hostname,
             target_proc.ecar_object_id,
@@ -22712,7 +22762,7 @@ class ActivityGenerator:
                 start_address=start_address,
                 start_module=start_module,
                 start_function=start_function,
-                source_thread_id=-1,
+                source_thread_id=source_thread.tid,
                 target_thread_id=remote_thread_identity.tid,
                 target_process_object_id=target_obj_id,
                 thread_object_id=remote_thread_identity.object_id,
@@ -22815,6 +22865,14 @@ class ActivityGenerator:
         self.state_manager.update_process_activity_time(system.hostname, source_pid, time)
         source_obj_id = self.state_manager.get_process_object_id(system.hostname, source_pid)
         target_obj_id = self.state_manager.get_process_object_id(system.hostname, target_pid)
+        source_thread = self.state_manager.get_primary_thread(system.hostname, source_pid)
+        if source_thread is None:
+            logger.debug(
+                "Skipping process access without a canonical source thread: %s pid=%s",
+                system.hostname,
+                source_pid,
+            )
+            return False
         from evidenceforge.generation.activity.calltrace_patterns import (
             render_call_trace_for_source,
         )
@@ -22843,7 +22901,7 @@ class ActivityGenerator:
             process_access=ProcessAccessContext(
                 source_pid=source_pid,
                 source_image=source_image,
-                source_thread_id=-1,
+                source_thread_id=source_thread.tid,
                 target_pid=target_pid,
                 target_image=target_image,
                 target_user=target_proc.username

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -209,7 +209,6 @@ from evidenceforge.models.state import ActiveSession, RunningProcess
 from evidenceforge.utils.ids import generate_stable_zeek_uid
 from evidenceforge.utils.rng import _stable_seed, stable_uuid
 from evidenceforge.utils.time import ensure_utc
-from evidenceforge.utils.windows_ids import windows_id_randint
 
 from .helpers import _get_os_category, _get_rng, _parameterize_command
 from .network import (
@@ -8957,6 +8956,7 @@ class ActivityGenerator:
         emit_transport_syslog: bool = True,
         emit_network_evidence: bool = True,
         logon_id: str | None = None,
+        lifecycle_group_id: str = "",
     ) -> str:
         """Generate logon event across all applicable log formats.
 
@@ -8987,6 +8987,7 @@ class ActivityGenerator:
             emit_transport_syslog=emit_transport_syslog,
             emit_network_evidence=emit_network_evidence,
             logon_id=logon_id,
+            lifecycle_group_id=lifecycle_group_id,
         )
         return LogonActionBundle(self, request).execute()
 
@@ -9002,6 +9003,7 @@ class ActivityGenerator:
         emit_transport_syslog = request.emit_transport_syslog
         emit_network_evidence = request.emit_network_evidence
         logon_id = request.logon_id
+        lifecycle_group_id = request.lifecycle_group_id or request.stable_id
 
         self.state_manager.set_current_time(time)
         os_cat = _get_os_category(system.os)
@@ -9119,6 +9121,7 @@ class ActivityGenerator:
                     source_ip=auth_source_ip,
                     source_port=source_port or 0,
                     session_kind="ssh",
+                    lifecycle_group_id=lifecycle_group_id,
                 )
             else:
                 existing_session = self.state_manager.get_session(logon_id)
@@ -9132,6 +9135,7 @@ class ActivityGenerator:
                         start_time=time,
                         source_port=source_port or 0,
                         session_kind="ssh",
+                        lifecycle_group_id=lifecycle_group_id,
                     )
                 else:
                     self.state_manager.update_session_metadata(
@@ -9179,6 +9183,7 @@ class ActivityGenerator:
                 source_ip=auth_source_ip,
                 source_port=source_port or 0,
                 session_kind=session_kind,
+                lifecycle_group_id=lifecycle_group_id,
             )
         else:
             existing_session = self.state_manager.get_session(logon_id)
@@ -9192,6 +9197,7 @@ class ActivityGenerator:
                     start_time=time,
                     source_port=source_port or 0,
                     session_kind=session_kind,
+                    lifecycle_group_id=lifecycle_group_id,
                 )
             else:
                 self.state_manager.update_session_metadata(
@@ -10330,14 +10336,34 @@ class ActivityGenerator:
                 self._linux_shell_last_session_close[(system.hostname, user.username)] = ensure_utc(
                     time
                 )
-            if session.explorer_pid is not None:
-                self.state_manager.end_process(session.system, session.explorer_pid)
-            # Clean up per-RDP-session winlogon chain
-            if session.session_winlogon_pid is not None:
-                self.state_manager.end_process(session.system, session.session_winlogon_pid)
-            # Clean up per-SSH-session bash
-            if session.session_shell_pid is not None:
-                self.state_manager.end_process(session.system, session.session_shell_pid)
+            bootstrap_pids = [
+                pid
+                for pid in (
+                    session.session_shell_pid,
+                    session.explorer_pid,
+                    session.session_winlogon_pid,
+                )
+                if pid is not None
+            ]
+            for ordinal, bootstrap_pid in enumerate(dict.fromkeys(bootstrap_pids)):
+                bootstrap_process = self.state_manager.get_process(
+                    session.system,
+                    bootstrap_pid,
+                )
+                if bootstrap_process is None:
+                    continue
+                requested_termination_time = time - timedelta(
+                    milliseconds=450 - min(ordinal, 2) * 125
+                )
+                self.generate_process_termination(
+                    user=user,
+                    system=system,
+                    time=requested_termination_time,
+                    pid=bootstrap_pid,
+                    process_name=bootstrap_process.image,
+                    logon_id=logon_id,
+                    from_storyline=from_storyline,
+                )
 
         # Build SecurityEvent (StateManager.apply() handles end_session)
         session_obj_id = self.state_manager.get_session_object_id(logon_id)
@@ -11206,6 +11232,7 @@ class ActivityGenerator:
             username=process_username,
             integrity_level=_integrity,
             logon_id=process_logon_id,
+            lifecycle_group_id=request.stable_id,
         )
 
         # Phase 2: Build SecurityEvent
@@ -16998,6 +17025,55 @@ class ActivityGenerator:
         )
         return SshSessionActionBundle(request=request, executor=self).execute()
 
+    def _execute_ssh_session_bundle(
+        self,
+        user: User,
+        target_system: System,
+        time: datetime,
+        source_ip: str,
+        source_system: Optional["System"] = None,
+        source_port: int | None = None,
+        source_pid: int = -1,
+        source_process_image: str = "",
+        sshd_pid: int | None = None,
+        logon_id: str = "",
+        session_obj_id: str = "",
+        min_duration: float | None = None,
+        duration: float | None = None,
+        orig_bytes: int | None = None,
+        resp_bytes: int | None = None,
+        auth_method: str = "password",
+        public_key_type: str = "",
+        public_key_hash: str = "",
+        emit_session_close: bool = False,
+        source: str = "activity_generator",
+    ) -> tuple[str, str]:
+        """Execute the canonical SSH bundle and return transport and session IDs."""
+
+        request = SshSessionRequest(
+            user=user,
+            target_system=target_system,
+            time=time,
+            source_ip=source_ip,
+            source_system=source_system,
+            source_port=source_port,
+            source_pid=source_pid,
+            source_process_image=source_process_image,
+            sshd_pid=sshd_pid,
+            logon_id=logon_id,
+            session_obj_id=session_obj_id,
+            min_duration=min_duration,
+            duration=duration,
+            orig_bytes=orig_bytes,
+            resp_bytes=resp_bytes,
+            auth_method=auth_method,
+            public_key_type=public_key_type,
+            public_key_hash=public_key_hash,
+            emit_session_close=emit_session_close,
+            source=source,
+        )
+        return SshSessionActionBundle(request=request, executor=self).execute_with_identity()
+
     @staticmethod
     def _ssh_tcp_success_history(rng: random.Random) -> str:
         """Choose a plausible Zeek TCP history string for SSH bundle expansion."""
@@ -21530,6 +21606,7 @@ class ActivityGenerator:
             source_ip="-",
             start_time=time,
             session_kind="service",
+            lifecycle_group_id=request.stable_id,
         )
         host = self._build_host_context(system)
         reporting_pid = self._get_system_pid(system.hostname, "lsass", 0x2E0)
@@ -22600,13 +22677,13 @@ class ActivityGenerator:
         self.state_manager.update_process_activity_time(system.hostname, source_pid, time)
         source_obj_id = self.state_manager.get_process_object_id(system.hostname, source_pid)
         target_obj_id = self.state_manager.get_process_object_id(system.hostname, target_pid)
-        thread_obj_id = stable_uuid(
-            "ecar-remote-thread",
+        if target_proc is None:
+            return False
+        remote_thread_identity = self.state_manager.create_thread(
             system.hostname,
-            source_pid,
-            target_pid,
-            time.isoformat(),
-            start_address,
+            target_proc.ecar_object_id,
+            kind="remote",
+            start_time=time,
         )
         stack_base = 0x000000C0000000 + (rng.randint(0, 0x7FFF) << 12)
         user_stack_base = stack_base
@@ -22631,20 +22708,24 @@ class ActivityGenerator:
             remote_thread=RemoteThreadContext(
                 target_pid=target_pid,
                 target_image=target_image,
-                new_thread_id=windows_id_randint(rng, 100, 9999),
+                new_thread_id=remote_thread_identity.tid,
                 start_address=start_address,
                 start_module=start_module,
                 start_function=start_function,
-                source_thread_id=windows_id_randint(rng, 1000, 9999),
-                target_thread_id=windows_id_randint(rng, 1000, 9999),
+                source_thread_id=-1,
+                target_thread_id=remote_thread_identity.tid,
                 target_process_object_id=target_obj_id,
-                thread_object_id=thread_obj_id,
+                thread_object_id=remote_thread_identity.object_id,
                 stack_base=stack_base,
                 stack_limit=stack_base - 0x6000,
                 user_stack_base=user_stack_base,
                 user_stack_limit=user_stack_base - 0x100000,
             ),
-            edr=EdrContext(object_id=thread_obj_id, actor_id=source_obj_id),
+            edr=EdrContext(
+                object_id=remote_thread_identity.object_id,
+                actor_id=source_obj_id,
+                tid=remote_thread_identity.tid,
+            ),
         )
         self.dispatcher.dispatch(event)
         return True
@@ -22734,12 +22815,6 @@ class ActivityGenerator:
         self.state_manager.update_process_activity_time(system.hostname, source_pid, time)
         source_obj_id = self.state_manager.get_process_object_id(system.hostname, source_pid)
         target_obj_id = self.state_manager.get_process_object_id(system.hostname, target_pid)
-        source_thread_id = -1
-        if source_proc is not None:
-            source_thread_rng = random.Random(
-                _stable_seed(f"process_access_thread:{system.hostname}:{source_pid}:{time}")
-            )
-            source_thread_id = windows_id_randint(source_thread_rng, 1000, 9999)
         from evidenceforge.generation.activity.calltrace_patterns import (
             render_call_trace_for_source,
         )
@@ -22768,7 +22843,7 @@ class ActivityGenerator:
             process_access=ProcessAccessContext(
                 source_pid=source_pid,
                 source_image=source_image,
-                source_thread_id=source_thread_id,
+                source_thread_id=-1,
                 target_pid=target_pid,
                 target_image=target_image,
                 target_user=target_proc.username

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -28,12 +28,11 @@ from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext, NetworkContext
-from evidenceforge.generation.activity.endpoint_noise import ecar_flow_identity_config
+from evidenceforge.events.identity import ProcessIdentity, ThreadIdentity
 from evidenceforge.generation.activity.timing_profiles import get_timing_window
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.utils.rng import _stable_seed, stable_uuid
-from evidenceforge.utils.windows_ids import align_windows_id
 
 _ECAR_SORT_PRIORITY = {
     ("USER_SESSION", "LOGIN"): 0,
@@ -48,22 +47,6 @@ _ECAR_SORT_PRIORITY = {
     ("THREAD", "REMOTE_CREATE"): 9,
     ("PROCESS", "TERMINATE"): 10,
     ("USER_SESSION", "LOGOUT"): 11,
-}
-
-_INBOUND_SERVICE_PID_CANDIDATES: dict[int, tuple[str, ...]] = {
-    53: ("dns", "svchost_netsvcs", "svchost_net_svc"),
-    88: ("lsass",),
-    123: ("timesyncd", "chronyd", "svchost_netsvcs"),
-    389: ("lsass",),
-    22: ("sshd",),
-    80: ("nginx", "apache2", "httpd"),
-    443: ("nginx", "apache2", "httpd"),
-    445: ("system", "smbd", "lanmanserver"),
-    1433: ("sqlservr",),
-    3306: ("mysqld",),
-    3389: ("svchost_termservice", "svchost_netsvcs"),
-    5432: ("postgres",),
-    8080: ("squid", "nginx", "apache2", "httpd"),
 }
 
 _ECAR_FAILURE_REASON_BY_SUBSTATUS = {
@@ -81,23 +64,6 @@ _ECAR_FAILURE_REASON_BY_WINDOWS_CODE = {
 
 _SOURCE_TIMING = SourceTimingPlanner()
 
-_SERVICE_PRINCIPAL_NAMES = {
-    "system",
-    "local service",
-    "network service",
-    "nt authority\\system",
-    "nt authority\\local service",
-    "nt authority\\network service",
-    "apache",
-    "mysql",
-    "nginx",
-    "postgres",
-    "postfix",
-    "proxy",
-    "squid",
-    "sshd",
-    "www-data",
-}
 _PORT_BEARING_PROTOCOLS = {"tcp", "udp", "sctp"}
 
 
@@ -179,31 +145,6 @@ def _ecar_session_source_ip(event: SecurityEvent) -> str:
     return source_ip
 
 
-def _ecar_probability_enabled(key: str, probability: float) -> bool:
-    """Return whether a stable per-record probability gate is enabled."""
-    clamped = max(0.0, min(1.0, float(probability)))
-    if clamped <= 0.0:
-        return False
-    if clamped >= 1.0:
-        return True
-    return (_stable_seed(key) % 10_000) / 10_000.0 < clamped
-
-
-def _flow_principal_probability(username: str, direction: str) -> float:
-    """Return the configured probability for FLOW principal attribution."""
-    cfg = ecar_flow_identity_config()
-    normalized = username.strip().lower()
-    if normalized == "root":
-        probability = float(cfg.get("root_process_probability", 0.42))
-    elif normalized in _SERVICE_PRINCIPAL_NAMES:
-        probability = float(cfg.get("service_process_probability", 0.48))
-    else:
-        probability = float(cfg.get("user_process_probability", 0.88))
-    if direction == "INBOUND":
-        probability = max(probability, float(cfg.get("inbound_listener_probability", 0.36)))
-    return probability
-
-
 class EcarEmitter(HostMultiplexEmitter):
     """Emitter for eCAR (extended Cyber Analytics Repository) format.
 
@@ -219,14 +160,6 @@ class EcarEmitter(HostMultiplexEmitter):
     _sort_flat_file = True
     _sort_key = staticmethod(_ecar_sort_key)
     _defer_sorted_flush_until_close = True
-    _stale_process_reference_grace_ms = 5 * 60 * 1000
-    _post_termination_dependent_grace_ms = 30 * 1000
-    _pre_process_flow_identity_repair_grace_ms = 30 * 1000
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize per-source ordering memory for cross-event eCAR contracts."""
-        super().__init__(*args, **kwargs)
-        self._remote_inbound_flow_times: dict[tuple[str, str, int, str, int], datetime] = {}
 
     _supported_types: set[str] = {
         "logon",
@@ -307,14 +240,90 @@ class EcarEmitter(HostMultiplexEmitter):
 
     @staticmethod
     def _apply_edr_context(event_data: dict[str, Any], event: SecurityEvent) -> None:
-        """Copy objectID, actorID, and tid from EdrContext into event_data."""
-        if event.edr:
+        """Project canonical identity roles into eCAR and retained compatibility fields."""
+        plan = event.identity_plan
+        if plan is not None:
+            if plan.object_id:
+                event_data["objectID"] = plan.object_id
+            if plan.actor_id:
+                event_data["actorID"] = plan.actor_id
+            if (
+                isinstance(plan.subject, ThreadIdentity)
+                and event.event_type != "create_remote_thread"
+            ):
+                event_data["tid"] = plan.subject.tid
+            elif (
+                isinstance(plan.subject, ProcessIdentity)
+                and event.event_type
+                in {"process_create", "system_process_create", "process_terminate"}
+                and plan.subject.primary_thread is not None
+            ):
+                event_data["tid"] = plan.subject.primary_thread.tid
+            EcarEmitter._apply_explicit_identity_roles(event_data, event)
+            return
+        if event.edr is not None:
             if event.edr.object_id:
                 event_data["objectID"] = event.edr.object_id
             if event.edr.actor_id:
                 event_data["actorID"] = event.edr.actor_id
-            if event.edr.tid != -1:
+            if event.edr.tid >= 0:
                 event_data["tid"] = event.edr.tid
+
+    @staticmethod
+    def _apply_explicit_identity_roles(
+        event_data: dict[str, Any],
+        event: SecurityEvent,
+    ) -> None:
+        """Render optional symmetric source/target process identity fields."""
+
+        plan = event.identity_plan
+        if plan is None:
+            return
+        source = plan.actor if isinstance(plan.actor, ProcessIdentity) else None
+        target = plan.target if isinstance(plan.target, ProcessIdentity) else None
+        if source is not None:
+            event_data.update(
+                {
+                    "source_process_uuid": source.object_id,
+                    "source_pid": str(source.pid),
+                    "source_image_path": source.image,
+                    "source_principal": source.principal,
+                    "src_pid": str(source.pid),
+                }
+            )
+            source_tid = -1
+            if event.process_access is not None:
+                source_tid = event.process_access.source_thread_id
+            elif event.remote_thread is not None:
+                source_tid = event.remote_thread.source_thread_id
+            if source_tid >= 0:
+                event_data["source_tid"] = str(source_tid)
+                event_data["src_tid"] = str(source_tid)
+        if target is not None:
+            event_data.update(
+                {
+                    "target_process_uuid": target.object_id,
+                    "target_pid": str(target.pid),
+                    "target_image_path": target.image,
+                    "target_principal": target.principal,
+                }
+            )
+        if isinstance(plan.subject, ThreadIdentity):
+            if source is not None and plan.subject.process_object_id == source.object_id:
+                event_data["source_tid"] = str(plan.subject.tid)
+                event_data["src_tid"] = str(plan.subject.tid)
+            if target is not None and plan.subject.process_object_id == target.object_id:
+                event_data["target_tid"] = str(plan.subject.tid)
+                event_data["tgt_tid"] = str(plan.subject.tid)
+
+    @staticmethod
+    def _apply_flow_actor(
+        event_data: dict[str, Any],
+        process: ProcessIdentity,
+    ) -> None:
+        """Project only the host-local actor onto a source-native FLOW row."""
+
+        event_data["actorID"] = process.object_id
 
     @staticmethod
     def _apply_session_properties(event_data: dict[str, Any], event: SecurityEvent) -> None:
@@ -346,28 +355,6 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["command_line"] = command_line
 
     @staticmethod
-    def _stable_tid(
-        hostname: str,
-        pid: int,
-        timestamp: datetime,
-        salt: str,
-        os_category: str = "",
-    ) -> int:
-        """Return a plausible source thread ID for process-owned eCAR events."""
-        if pid <= 0:
-            return -1
-        if os_category == "linux":
-            # A Linux process ID is also the thread-group leader's TID. Without
-            # an explicit modeled thread context, that leader is the only safe
-            # source-native identity to infer for process-owned evidence.
-            return pid
-        bucket_ms = int(timestamp.timestamp() * 1000)
-        tid = 1000 + (_stable_seed(f"ecar_tid:{hostname}:{pid}:{bucket_ms}:{salt}") % 60000)
-        if os_category == "windows":
-            return align_windows_id(tid)
-        return tid
-
-    @staticmethod
     def _stable_record_uuid(
         kind: str,
         event_data: dict[str, Any],
@@ -383,6 +370,17 @@ class EcarEmitter(HostMultiplexEmitter):
         comparable["timestamp_ms"] = timestamp_ms
         payload = json.dumps(comparable, sort_keys=True, default=str, separators=(",", ":"))
         return stable_uuid(f"ecar-{kind}", payload, *extra)
+
+    def _emit_canonical_event(
+        self,
+        event_data: dict[str, Any],
+        event: SecurityEvent,
+    ) -> None:
+        """Render one eCAR observation from its canonical occurrence identity."""
+
+        if event.event_id:
+            event_data["_event_id"] = event.event_id
+        self.emit_event(event_data)
 
     def _render_logon(self, event: SecurityEvent) -> None:
         """Render eCAR USER_SESSION/LOGIN event (logged on dst_host)."""
@@ -405,7 +403,7 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["session_type"] = _ecar_non_windows_session_type(event)
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_logoff(self, event: SecurityEvent) -> None:
         """Render eCAR USER_SESSION/LOGOUT event (logged on dst_host)."""
@@ -429,7 +427,7 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["session_type"] = _ecar_non_windows_session_type(event)
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_failed_logon(self, event: SecurityEvent) -> None:
         """Render eCAR failed USER_SESSION/LOGIN attempt on dst_host."""
@@ -454,7 +452,7 @@ class EcarEmitter(HostMultiplexEmitter):
         else:
             event_data["session_type"] = _ecar_non_windows_session_type(event)
         self._apply_edr_context(event_data, event)
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _session_timestamp(
         self,
@@ -488,57 +486,19 @@ class EcarEmitter(HostMultiplexEmitter):
                 canonical_timestamp,
             ),
         )
-        if event.event_type == "ssh_session" and lifecycle == "login":
-            return self._remote_session_timestamp_after_flow(event, host, timestamp, dst_port=22)
-        if (
-            event.event_type == "logon"
-            and lifecycle == "login"
-            and getattr(auth, "logon_type", None) in {3, 10}
-        ):
-            dst_port = 3389 if getattr(auth, "logon_type", None) == 10 else 445
-            return self._remote_session_timestamp_after_flow(
-                event, host, timestamp, dst_port=dst_port
-            )
         return timestamp
-
-    def _remote_session_timestamp_after_flow(
-        self,
-        event: SecurityEvent,
-        host: HostContext | None,
-        timestamp: datetime,
-        *,
-        dst_port: int,
-    ) -> datetime:
-        """Keep eCAR remote session login after the matching inbound FLOW row."""
-        auth = event.auth
-        if auth is None or host is None or not auth.source_ip or not auth.source_port:
-            return timestamp
-        flow_time = getattr(self, "_remote_inbound_flow_times", {}).get(
-            (
-                host.hostname,
-                auth.source_ip,
-                int(auth.source_port),
-                host.ip,
-                dst_port,
-            )
-        )
-        if flow_time is None or timestamp > flow_time:
-            return timestamp
-        seed = _stable_seed(
-            "ecar_remote_login_after_flow:"
-            f"{host.hostname}:{auth.source_ip}:{auth.source_port}:"
-            f"{dst_port}:{getattr(auth, 'logon_id', '')}:{timestamp.isoformat()}"
-        )
-        return flow_time + timedelta(milliseconds=12 + (seed % 83))
 
     def _render_process_create(self, event: SecurityEvent) -> None:
         """Render eCAR PROCESS/CREATE event (logged on src_host)."""
         host = event.src_host
         proc = event.process
-        event_ts = self._process_create_timestamp(event, proc)
+        plan = event.identity_plan
+        process_identity = (
+            plan.subject if plan is not None and isinstance(plan.subject, ProcessIdentity) else proc
+        )
+        event_ts = self._process_create_timestamp(event, process_identity)
         event_data = {
             "timestamp": event_ts,
-            "_canonical_ms": int((proc.start_time or event.timestamp).timestamp() * 1000),
             "hostname": self._host_name(host),
             "object": "PROCESS",
             "action": "CREATE",
@@ -551,28 +511,20 @@ class EcarEmitter(HostMultiplexEmitter):
         }
         if proc.parent_image:
             event_data["parent_image_path"] = proc.parent_image
-        if proc.concurrency_group_id:
-            event_data["_concurrency_group_id"] = proc.concurrency_group_id
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        event_data.setdefault(
-            "tid",
-            self._stable_tid(
-                self._host_name(host),
-                proc.pid,
-                event_ts,
-                "process_create",
-                getattr(host, "os_category", ""),
-            ),
-        )
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_process_terminate(self, event: SecurityEvent) -> None:
         """Render eCAR PROCESS/TERMINATE event (logged on src_host)."""
         host = event.src_host
         proc = event.process
+        plan = event.identity_plan
+        process_identity = (
+            plan.subject if plan is not None and isinstance(plan.subject, ProcessIdentity) else proc
+        )
         event_data = {
-            "timestamp": self._process_terminate_timestamp(event, proc),
+            "timestamp": self._process_terminate_timestamp(event, process_identity),
             "hostname": self._host_name(host),
             "object": "PROCESS",
             "action": "TERMINATE",
@@ -583,22 +535,16 @@ class EcarEmitter(HostMultiplexEmitter):
         }
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        event_data.setdefault(
-            "tid",
-            self._stable_tid(
-                self._host_name(host),
-                proc.pid,
-                event.timestamp,
-                "process_terminate",
-                getattr(host, "os_category", ""),
-            ),
-        )
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_file_event(self, event: SecurityEvent) -> None:
         """Render eCAR FILE event from canonical FileContext (logged on src_host)."""
         host = event.src_host
         proc = event.process
+        plan = event.identity_plan
+        process_identity = (
+            plan.actor if plan is not None and isinstance(plan.actor, ProcessIdentity) else proc
+        )
         action_map = {
             "file_read": "READ",
             "file_create": "CREATE",
@@ -606,7 +552,7 @@ class EcarEmitter(HostMultiplexEmitter):
             "file_delete": "DELETE",
         }
         event_data = {
-            "timestamp": self._after_process_create_timestamp(event, proc),
+            "timestamp": self._after_process_create_timestamp(event, process_identity),
             "hostname": self._host_name(host),
             "object": "FILE",
             "action": action_map.get(event.event_type, "CREATE"),
@@ -618,24 +564,18 @@ class EcarEmitter(HostMultiplexEmitter):
         self._apply_process_provenance(event_data, proc)
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        event_data.setdefault(
-            "tid",
-            self._stable_tid(
-                self._host_name(host),
-                event_data["pid"],
-                event.timestamp,
-                "file",
-                getattr(host, "os_category", ""),
-            ),
-        )
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_registry_event(self, event: SecurityEvent) -> None:
         """Render eCAR REGISTRY event from canonical RegistryContext (logged on src_host)."""
         host = event.src_host
         proc = event.process
+        plan = event.identity_plan
+        process_identity = (
+            plan.actor if plan is not None and isinstance(plan.actor, ProcessIdentity) else proc
+        )
         event_data = {
-            "timestamp": self._after_process_create_timestamp(event, proc),
+            "timestamp": self._after_process_create_timestamp(event, process_identity),
             "hostname": self._host_name(host),
             "object": "REGISTRY",
             "action": "MODIFY",
@@ -648,29 +588,23 @@ class EcarEmitter(HostMultiplexEmitter):
         self._apply_process_provenance(event_data, proc)
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        event_data.setdefault(
-            "tid",
-            self._stable_tid(
-                self._host_name(host),
-                event_data["pid"],
-                event.timestamp,
-                "registry",
-                getattr(host, "os_category", ""),
-            ),
-        )
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_module_event(self, event: SecurityEvent) -> None:
         """Render eCAR MODULE/LOAD event from canonical ImageLoadContext."""
         host = event.src_host
         proc = event.process
+        plan = event.identity_plan
+        process_identity = (
+            plan.actor if plan is not None and isinstance(plan.actor, ProcessIdentity) else proc
+        )
         module_path = ""
         if event.image_load is not None:
             module_path = event.image_load.image_loaded
         elif event.file is not None:
             module_path = event.file.path
         event_data = {
-            "timestamp": self._after_process_create_timestamp(event, proc),
+            "timestamp": self._after_process_create_timestamp(event, process_identity),
             "hostname": self._host_name(host),
             "object": "MODULE",
             "action": "LOAD",
@@ -683,17 +617,7 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["image_path"] = proc.image
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        event_data.setdefault(
-            "tid",
-            self._stable_tid(
-                self._host_name(host),
-                event_data["pid"],
-                event.timestamp,
-                "module",
-                getattr(host, "os_category", ""),
-            ),
-        )
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_connection(self, event: SecurityEvent) -> None:
         """Render eCAR FLOW/CONNECT events -- OUTBOUND on src_host, INBOUND on dst_host.
@@ -703,13 +627,14 @@ class EcarEmitter(HostMultiplexEmitter):
         For internal-to-external, emits only the OUTBOUND on src_host.
         """
         net = event.network
-        source_proc = event.process
-        if (
-            (source_proc is None or source_proc.start_time is None)
-            and event.src_host is not None
-            and net.initiating_pid > 0
-        ):
-            source_proc = self._lookup_running_process(event.src_host, net.initiating_pid)
+        plan = event.identity_plan
+        source_identity = (
+            plan.actor if plan is not None and isinstance(plan.actor, ProcessIdentity) else None
+        )
+        target_identity = (
+            plan.target if plan is not None and isinstance(plan.target, ProcessIdentity) else None
+        )
+        source_proc = source_identity
 
         # OUTBOUND FLOW on source host (if source is internal/known)
         if event.src_host:
@@ -736,7 +661,11 @@ class EcarEmitter(HostMultiplexEmitter):
                 paired_endpoint=event.dst_host is not None,
             )
             rendered_source_proc = source_proc if process_identity_safe else None
-            rendered_pid = net.initiating_pid if process_identity_safe else -1
+            rendered_pid = (
+                int(getattr(rendered_source_proc, "pid", -1))
+                if rendered_source_proc is not None
+                else -1
+            )
             event_data = {
                 "timestamp": event_ts,
                 "hostname": event.src_host.hostname,
@@ -749,41 +678,23 @@ class EcarEmitter(HostMultiplexEmitter):
             if self._flow_connection_failed(net):
                 event_data["outcome"] = "failure"
                 event_data["connection_state"] = net.conn_state
-            principal = self._flow_principal_for_process(
-                event,
-                event.src_host,
-                rendered_source_proc,
-                "OUTBOUND",
+            principal = str(
+                getattr(rendered_source_proc, "principal", "")
+                or getattr(rendered_source_proc, "username", "")
             )
             if principal:
                 event_data["principal"] = principal
-            if process_identity_safe:
+            if process_identity_safe and rendered_source_proc is not None:
                 self._apply_process_provenance(event_data, rendered_source_proc)
-            self._apply_flow_edr_context(
-                event_data,
-                event,
-                include_actor=process_identity_safe and bool(principal),
-            )
-            if process_identity_safe and principal and "actorID" not in event_data:
-                actor_id = self._process_actor_id(event.src_host, rendered_source_proc)
-                if actor_id:
-                    event_data["actorID"] = actor_id
-            event_data.setdefault(
-                "tid",
-                self._stable_tid(
-                    event.src_host.hostname,
-                    rendered_pid,
-                    event_ts,
-                    "flow_outbound",
-                    getattr(event.src_host, "os_category", ""),
-                ),
-            )
-            self.emit_event(event_data)
+            if process_identity_safe and rendered_source_proc is not None:
+                self._apply_flow_actor(event_data, rendered_source_proc)
+            self._emit_canonical_event(event_data, event)
 
         # INBOUND FLOW on destination host (if destination is internal/known)
         if event.dst_host:
             listener_observed = self._inbound_listener_observed(event)
-            inbound_pid = self._resolve_inbound_service_pid(event) if listener_observed else -1
+            inbound_proc = target_identity if listener_observed else None
+            inbound_pid = target_identity.pid if inbound_proc is not None else -1
             inbound_seed = (
                 "inbound",
                 event.dst_host.hostname,
@@ -815,62 +726,34 @@ class EcarEmitter(HostMultiplexEmitter):
             if self._flow_connection_failed(net):
                 event_data["outcome"] = "failure"
                 event_data["connection_state"] = net.conn_state
-            if listener_observed:
-                inbound_proc = self._lookup_running_process(event.dst_host, inbound_pid)
-                if inbound_proc is not None:
-                    event_ts, process_identity_safe = self._flow_source_time(
-                        event,
-                        seed_parts=inbound_seed,
-                        not_before=self._process_identity_not_before_timestamp(
-                            event,
-                            inbound_proc,
-                        ),
-                        drop_late_process_identity=(
-                            net.protocol == "tcp" and net.dst_port in {22, 3389}
-                        ),
-                        paired_endpoint=event.src_host is not None,
-                    )
-                    if not process_identity_safe:
-                        inbound_proc = None
-                        inbound_pid = -1
-                        event_data["pid"] = inbound_pid
-                    event_data["timestamp"] = event_ts
-                principal = self._flow_principal_for_process(
+            if listener_observed and inbound_proc is not None:
+                event_ts, process_identity_safe = self._flow_source_time(
                     event,
-                    event.dst_host,
-                    inbound_proc,
-                    "INBOUND",
+                    seed_parts=inbound_seed,
+                    not_before=self._process_identity_not_before_timestamp(
+                        event,
+                        inbound_proc,
+                    ),
+                    drop_late_process_identity=(
+                        net.protocol == "tcp" and net.dst_port in {22, 3389}
+                    ),
+                    paired_endpoint=event.src_host is not None,
+                )
+                if not process_identity_safe:
+                    inbound_proc = None
+                    inbound_pid = -1
+                    event_data["pid"] = inbound_pid
+                event_data["timestamp"] = event_ts
+            if inbound_proc is not None:
+                principal = str(
+                    getattr(inbound_proc, "principal", "") or getattr(inbound_proc, "username", "")
                 )
                 if principal:
                     event_data["principal"] = principal
-                if listener_observed and inbound_proc is not None:
-                    self._apply_process_provenance(event_data, inbound_proc)
-                    if principal:
-                        actor_id = self._process_actor_id(event.dst_host, inbound_proc)
-                        if actor_id:
-                            event_data["actorID"] = actor_id
-                event_data.setdefault(
-                    "tid",
-                    self._stable_tid(
-                        event.dst_host.hostname,
-                        inbound_pid,
-                        event_ts,
-                        "flow_inbound",
-                        getattr(event.dst_host, "os_category", ""),
-                    ),
-                )
-                if net.protocol == "tcp":
-                    self._remote_inbound_flow_times[
-                        (
-                            event.dst_host.hostname,
-                            net.src_ip,
-                            int(net.src_port or 0),
-                            event.dst_host.ip,
-                            int(net.dst_port or 0),
-                        )
-                    ] = event_ts
+                self._apply_process_provenance(event_data, inbound_proc)
+                self._apply_flow_actor(event_data, inbound_proc)
             # INBOUND flow gets its own objectID (separate telemetry observation)
-            self.emit_event(event_data)
+            self._emit_canonical_event(event_data, event)
 
     def _flow_source_time(
         self,
@@ -1152,70 +1035,6 @@ class EcarEmitter(HostMultiplexEmitter):
         return net.conn_state in {"S0", "REJ", "RSTO", "RSTR", "SH", "SHR", "OTH"}
 
     @staticmethod
-    def _apply_flow_edr_context(
-        event_data: dict[str, Any],
-        event: SecurityEvent,
-        *,
-        include_actor: bool,
-    ) -> None:
-        """Copy eCAR FLOW identity fields, omitting actors when process timing conflicts."""
-
-        if event.edr is None:
-            return
-        if event.edr.object_id:
-            event_data["objectID"] = event.edr.object_id
-        if include_actor and event.edr.actor_id:
-            event_data["actorID"] = event.edr.actor_id
-        if event.edr.tid != -1:
-            event_data["tid"] = event.edr.tid
-
-    def _flow_principal_for_process(
-        self,
-        event: SecurityEvent,
-        host: HostContext | None,
-        process: Any | None,
-        direction: str,
-    ) -> str:
-        """Return a source-native mixed FLOW principal attribution value."""
-        if host is None or process is None:
-            return ""
-        username = str(getattr(process, "username", "") or "").strip()
-        if not username or username == "-":
-            return ""
-        if (
-            direction == "OUTBOUND"
-            and event.edr is not None
-            and event.edr.actor_id
-            and username.strip().lower() not in _SERVICE_PRINCIPAL_NAMES
-        ):
-            return username
-        pid = int(getattr(process, "pid", -1) or -1)
-        probability = _flow_principal_probability(username, direction)
-        key = (
-            f"ecar_flow_principal:{host.hostname}:{pid}:{username}:{getattr(process, 'image', '')}"
-        )
-        return username if _ecar_probability_enabled(key, probability) else ""
-
-    def _process_actor_id(self, host: HostContext | None, process: Any | None) -> str:
-        """Return the eCAR object ID for a known local process."""
-        if host is None or process is None:
-            return ""
-        pid = int(getattr(process, "pid", -1) or -1)
-        if pid <= 0:
-            return ""
-        state_manager = getattr(self, "_state_manager", None)
-        if state_manager is None:
-            return ""
-        return str(state_manager.get_process_object_id(host.hostname, pid) or "")
-
-    def _lookup_running_process(self, host: HostContext, pid: int) -> Any | None:
-        """Read a process from attached state when a connection only carries a PID."""
-        state_manager = getattr(self, "_state_manager", None)
-        if state_manager is None:
-            return None
-        return state_manager.get_process(host.hostname, pid)
-
-    @staticmethod
     def _inbound_listener_observed(event: SecurityEvent) -> bool:
         """Return whether destination EDR should attribute the flow to a listener process."""
         net = event.network
@@ -1232,31 +1051,6 @@ class EcarEmitter(HostMultiplexEmitter):
         # progressed far enough for an application listener to own it.
         return any(marker in history for marker in ("h", "a", "d", "r", "f"))
 
-    def _resolve_inbound_service_pid(self, event: SecurityEvent) -> int:
-        """Resolve destination-local listener PID for host-observed inbound flows."""
-        net = event.network
-        host = event.dst_host
-        if net is None or host is None:
-            return -1
-        if net.dst_port in {22, 3389}:
-            return self._resolve_system_listener_pid(host, net.dst_port)
-        if net.responding_pid > 0:
-            return net.responding_pid
-
-        listener_pid = self._resolve_system_listener_pid(host, net.dst_port)
-        if listener_pid > 0:
-            return listener_pid
-        return -1
-
-    def _resolve_system_listener_pid(self, host: HostContext, dst_port: int) -> int:
-        """Resolve a stable service listener PID for endpoint transport ownership."""
-        system_pids = getattr(self, "_system_pids", {}).get(host.hostname, {})
-        for candidate in _INBOUND_SERVICE_PID_CANDIDATES.get(dst_port, ()):
-            pid = system_pids.get(candidate)
-            if pid and pid > 0:
-                return pid
-        return -1
-
     def _render_create_remote_thread(self, event: SecurityEvent) -> None:
         """Render eCAR THREAD/REMOTE_CREATE event (logged on src_host).
 
@@ -1270,6 +1064,16 @@ class EcarEmitter(HostMultiplexEmitter):
         proc = event.process
         auth = event.auth
         remote_thread = event.remote_thread
+        plan = event.identity_plan
+        source_identity = (
+            plan.actor if plan is not None and isinstance(plan.actor, ProcessIdentity) else None
+        )
+        target_identity = (
+            plan.target if plan is not None and isinstance(plan.target, ProcessIdentity) else None
+        )
+        created_thread = (
+            plan.subject if plan is not None and isinstance(plan.subject, ThreadIdentity) else None
+        )
         target_pid = (
             remote_thread.target_pid
             if remote_thread is not None
@@ -1287,31 +1091,28 @@ class EcarEmitter(HostMultiplexEmitter):
                 remote_thread.new_thread_id if remote_thread else 0,
                 event.timestamp,
             ),
-            not_before=self._after_process_create_timestamp(event, proc),
+            not_before=self._after_process_create_timestamp(
+                event,
+                source_identity if source_identity is not None else proc,
+            ),
         )
         event_data = {
             "timestamp": event_ts,
             "hostname": self._host_name(host),
             "object": "THREAD",
             "action": "REMOTE_CREATE",
-            "pid": proc.pid,
-            "ppid": proc.parent_pid,
-            "tid": remote_thread.source_thread_id if remote_thread else 0,
-            "principal": proc.username if proc.username else "NT AUTHORITY\\SYSTEM",
-            "image_path": proc.image,
-            "src_pid": str(proc.pid),
-            "src_tid": str(remote_thread.source_thread_id if remote_thread else 0),
-            "target_pid": str(target_pid),
-            "target_process_uuid": remote_thread.target_process_object_id
+            "pid": source_identity.pid if source_identity is not None else proc.pid,
+            "ppid": source_identity.parent_pid if source_identity is not None else proc.parent_pid,
+            "principal": source_identity.principal
+            if source_identity is not None
+            else proc.username or "NT AUTHORITY\\SYSTEM",
+            "image_path": source_identity.image if source_identity is not None else proc.image,
+            "target_pid": str(target_identity.pid if target_identity is not None else target_pid),
+            "target_process_uuid": target_identity.object_id
+            if target_identity is not None
+            else remote_thread.target_process_object_id
             if remote_thread
-            else stable_uuid(
-                "ecar-remote-thread-target",
-                self._host_name(host),
-                proc.pid if proc is not None else -1,
-                target_pid,
-                event_ts.isoformat(),
-            ),
-            "tgt_tid": str(remote_thread.new_thread_id if remote_thread else 0),
+            else "",
             "start_address": f"{remote_thread.start_address:016x}" if remote_thread else "",
             "stack_base": f"{remote_thread.stack_base:016x}" if remote_thread else "",
             "stack_limit": f"{remote_thread.stack_limit:016x}" if remote_thread else "",
@@ -1319,9 +1120,15 @@ class EcarEmitter(HostMultiplexEmitter):
             "user_stack_limit": f"{remote_thread.user_stack_limit:016x}" if remote_thread else "",
             "_host_fqdn": self._host_fqdn(host),
         }
+        if created_thread is not None:
+            event_data["target_tid"] = str(created_thread.tid)
+            event_data["tgt_tid"] = str(created_thread.tid)
+        elif remote_thread is not None:
+            event_data["target_tid"] = str(remote_thread.target_thread_id)
+            event_data["tgt_tid"] = str(remote_thread.target_thread_id)
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _render_process_access(self, event: SecurityEvent) -> None:
         """Render eCAR PROCESS/OPEN event (logged on src_host).
@@ -1339,45 +1146,47 @@ class EcarEmitter(HostMultiplexEmitter):
         target_image = access.target_image if access else ""
         target_pid = access.target_pid if access else -1
         granted_access = access.granted_access if access else "0x0"
+        plan = event.identity_plan
+        source_identity = (
+            plan.actor if plan is not None and isinstance(plan.actor, ProcessIdentity) else None
+        )
+        target_identity = (
+            plan.target if plan is not None and isinstance(plan.target, ProcessIdentity) else None
+        )
         event_data = {
-            "timestamp": self._after_process_create_timestamp(event, proc),
+            "timestamp": self._after_process_create_timestamp(
+                event,
+                source_identity if source_identity is not None else proc,
+            ),
             "hostname": self._host_name(host),
             "object": "PROCESS",
             "action": "OPEN",
-            "objectID": event.edr.object_id
-            if event.edr
-            else stable_uuid(
-                "ecar-process-access-object",
-                self._host_name(host),
-                proc.pid,
-                target_pid,
-                event.timestamp.isoformat(),
-            ),
-            "actorID": event.edr.actor_id
-            if event.edr
-            else stable_uuid(
-                "ecar-process-access-actor",
-                self._host_name(host),
-                proc.pid,
-                target_pid,
-                event.timestamp.isoformat(),
-            ),
-            "pid": proc.pid,
-            "ppid": proc.parent_pid,
-            "tid": access.source_thread_id if access else -1,
-            "principal": proc.username if proc.username else "NT AUTHORITY\\SYSTEM",
-            "image_path": proc.image,
-            "command_line": proc.command_line,
+            "pid": source_identity.pid if source_identity is not None else proc.pid,
+            "ppid": source_identity.parent_pid if source_identity is not None else proc.parent_pid,
+            "principal": source_identity.principal
+            if source_identity is not None
+            else proc.username or "NT AUTHORITY\\SYSTEM",
+            "image_path": source_identity.image if source_identity is not None else proc.image,
+            "command_line": source_identity.command_line
+            if source_identity is not None
+            else proc.command_line,
             "parent_image_path": proc.parent_image or "",
-            "target_pid": target_pid,
-            "target_image_path": target_image,
-            "target_process_uuid": access.target_process_object_id if access else "",
+            "target_pid": str(target_identity.pid if target_identity is not None else target_pid),
+            "target_image_path": target_identity.image
+            if target_identity is not None
+            else target_image,
+            "target_process_uuid": target_identity.object_id
+            if target_identity is not None
+            else access.target_process_object_id
+            if access
+            else "",
             "granted_access": granted_access,
             "call_trace": access.call_trace if access else "",
             "_host_fqdn": self._host_fqdn(host),
         }
         self._apply_session_properties(event_data, event)
-        self.emit_event(event_data)
+        self._apply_edr_context(event_data, event)
+        self._emit_canonical_event(event_data, event)
 
     def _process_create_timestamp(
         self,
@@ -1389,12 +1198,18 @@ class EcarEmitter(HostMultiplexEmitter):
             return event.timestamp
         host = event.src_host
         hostname = host.hostname if host is not None else ""
-        start_time = proc.start_time or event.timestamp
+        start_time = (
+            getattr(proc, "started_at", None)
+            or getattr(proc, "start_time", None)
+            or event.timestamp
+        )
         not_before = start_time
+        identity_hostname = str(getattr(proc, "hostname", "") or "")
+        identity_pid = int(getattr(proc, "pid", -1))
         return _SOURCE_TIMING.source_time(
             event,
             "source.ecar_process_create",
-            seed_parts=(hostname, proc.pid, start_time),
+            seed_parts=(identity_hostname or hostname, identity_pid, start_time),
             not_before=not_before,
         )
 
@@ -1404,16 +1219,17 @@ class EcarEmitter(HostMultiplexEmitter):
         proc: Any,
     ) -> datetime:
         """Clamp dependent eCAR observations after their PROCESS/CREATE record."""
-        if proc is None or proc.start_time is None:
+        start_time = getattr(proc, "started_at", None) or getattr(proc, "start_time", None)
+        if proc is None or start_time is None:
             return event.timestamp
-        if event.timestamp - proc.start_time >= timedelta(seconds=5):
+        if event.timestamp - start_time >= timedelta(seconds=5):
             return _SOURCE_TIMING.source_time(
                 event,
                 "source.ecar_dependent_after_process_create",
                 seed_parts=(
                     event.event_type,
                     self._host_name(event.src_host),
-                    proc.pid,
+                    getattr(proc, "pid", -1),
                     event.timestamp,
                 ),
                 not_before=event.timestamp,
@@ -1425,7 +1241,7 @@ class EcarEmitter(HostMultiplexEmitter):
             seed_parts=(
                 event.event_type,
                 self._host_name(event.src_host),
-                proc.pid,
+                getattr(proc, "pid", -1),
                 event.timestamp,
             ),
             not_before=process_create_ts + timedelta(milliseconds=1),
@@ -1437,11 +1253,12 @@ class EcarEmitter(HostMultiplexEmitter):
         proc: Any,
     ) -> datetime:
         """Return the earliest eCAR time that can safely claim a process identity."""
-        if proc is None or proc.start_time is None:
+        start_time = getattr(proc, "started_at", None) or getattr(proc, "start_time", None)
+        if proc is None or start_time is None:
             return event.timestamp
-        if event.timestamp - proc.start_time >= timedelta(seconds=5):
-            return proc.start_time
-        return self._after_process_create_timestamp(event, proc)
+        if event.timestamp - start_time >= timedelta(seconds=5):
+            return start_time
+        return self._process_create_timestamp(event, proc) + timedelta(milliseconds=1)
 
     def _process_terminate_timestamp(
         self,
@@ -1449,23 +1266,22 @@ class EcarEmitter(HostMultiplexEmitter):
         proc: Any,
     ) -> datetime:
         """Return an eCAR terminate timestamp preserving rendered process lifetime."""
-        if proc is None or proc.start_time is None:
+        start_time = getattr(proc, "started_at", None) or getattr(proc, "start_time", None)
+        if proc is None or start_time is None:
             return event.timestamp
-        canonical_lifetime = max(timedelta(milliseconds=100), event.timestamp - proc.start_time)
-        create_anchor_event = SecurityEvent(
-            timestamp=proc.start_time,
-            event_type="process_create",
-            src_host=event.src_host,
-            process=proc,
+        canonical_lifetime = max(timedelta(milliseconds=100), event.timestamp - start_time)
+        process_create_ts = (
+            self._process_create_timestamp(event, proc)
+            if isinstance(proc, ProcessIdentity)
+            else start_time
         )
-        process_create_ts = self._process_create_timestamp(create_anchor_event, proc)
         return _SOURCE_TIMING.source_time(
             event,
             "source.ecar_process_terminate",
             seed_parts=(
                 self._host_name(event.src_host),
-                proc.pid,
-                proc.start_time,
+                getattr(proc, "pid", -1),
+                start_time,
                 event.timestamp,
             ),
             not_before=max(event.timestamp, process_create_ts + canonical_lifetime),
@@ -1490,7 +1306,7 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["service_account"] = service.service_account
         self._apply_session_properties(event_data, event)
         self._apply_edr_context(event_data, event)
-        self.emit_event(event_data)
+        self._emit_canonical_event(event_data, event)
 
     def _dispatch(self, event_data: dict[str, Any]) -> None:
         """Route event to per-host writer."""
@@ -1498,1440 +1314,9 @@ class EcarEmitter(HostMultiplexEmitter):
         host_fqdn = event_data.pop("_host_fqdn", "")
         self.emit_to_host(rendered, host_fqdn)
 
-    @staticmethod
-    def _referenced_process_ids(record: dict[str, Any]) -> set[str]:
-        """Return process object IDs referenced by an eCAR record."""
-        refs = set()
-        object_id = record.get("objectID")
-        if object_id and not (
-            record.get("object") == "PROCESS" and record.get("action") == "TERMINATE"
-        ):
-            refs.add(str(object_id))
-        actor_id = record.get("actorID")
-        if actor_id:
-            refs.add(str(actor_id))
-        props = record.get("properties") or {}
-        for key in (
-            "target_process_uuid",
-            "target_process_object_id",
-            "source_process_object_id",
-        ):
-            value = props.get(key)
-            if value:
-                refs.add(str(value))
-        return refs
-
-    @staticmethod
-    def _looks_like_linux_process(record: dict[str, Any]) -> bool:
-        """Return whether a PROCESS row is rendering a POSIX process image."""
-        props = record.get("properties") or {}
-        image_path = str(props.get("image_path") or "")
-        return image_path.startswith("/")
-
-    @staticmethod
-    def _preserves_canonical_linux_pid(record: dict[str, Any]) -> bool:
-        """Return whether the PID is shared with another source and must not be remapped."""
-        return str(record.get("_concurrency_group_id") or "").startswith("cron:")
-
-    @classmethod
-    def _normalize_linux_pid_morphology(cls, lines: list[str]) -> list[str]:
-        """Keep Linux eCAR process PIDs increasing in source timestamp order."""
-        records: list[dict[str, Any] | None] = []
-        for line in lines:
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                records.append(None)
-
-        create_indexes = [
-            index
-            for index, record in enumerate(records)
-            if record is not None
-            and record.get("object") == "PROCESS"
-            and record.get("action") == "CREATE"
-            and cls._looks_like_linux_process(record)
-            and not cls._preserves_canonical_linux_pid(record)
-            and cls._ecar_int(record.get("pid")) > 0
-        ]
-        create_indexes.sort(
-            key=lambda index: (
-                cls._ecar_int(records[index].get("timestamp_ms"), 0)
-                if records[index] is not None
-                else 0,
-                cls._ecar_int(records[index].get("pid")),
-            )
-        )
-
-        new_pid_by_object_id: dict[str, int] = {}
-        old_to_new_candidates: dict[int, set[int]] = {}
-        latest_pid = 0
-        for index in create_indexes:
-            record = records[index]
-            if record is None:
-                continue
-            old_pid = cls._ecar_int(record.get("pid"))
-            new_pid = old_pid
-            if latest_pid and new_pid <= latest_pid:
-                seed_text = ":".join(
-                    [
-                        str(record.get("objectID", "")),
-                        str(record.get("timestamp_ms", "")),
-                        str(old_pid),
-                    ]
-                )
-                new_pid = latest_pid + 1 + (sum(ord(ch) for ch in seed_text) % 17)
-            latest_pid = new_pid
-            object_id = str(record.get("objectID") or "")
-            if object_id:
-                new_pid_by_object_id[object_id] = new_pid
-            old_to_new_candidates.setdefault(old_pid, set()).add(new_pid)
-
-        old_pid_map = {
-            old_pid: next(iter(new_pids))
-            for old_pid, new_pids in old_to_new_candidates.items()
-            if len(new_pids) == 1
-        }
-
-        def rewrite_pid_field(record: dict[str, Any]) -> None:
-            object_id = str(record.get("objectID") or "")
-            actor_id = str(record.get("actorID") or "")
-            if record.get("object") == "PROCESS" and record.get("action") == "OPEN":
-                new_pid = new_pid_by_object_id.get(actor_id) or new_pid_by_object_id.get(object_id)
-            else:
-                new_pid = new_pid_by_object_id.get(object_id) or new_pid_by_object_id.get(actor_id)
-            if new_pid is None:
-                old_pid = cls._ecar_int(record.get("pid"))
-                new_pid = old_pid_map.get(old_pid)
-            if new_pid is None:
-                return
-            old_pid = cls._ecar_int(record.get("pid"))
-            old_tid = cls._ecar_int(record.get("tid"))
-            record["pid"] = new_pid
-            if record.get("object") == "PROCESS" and record.get("action") == "CREATE":
-                record["tid"] = new_pid
-            elif old_tid == old_pid:
-                record["tid"] = new_pid
-            elif old_tid > old_pid:
-                record["tid"] = new_pid + min(old_tid - old_pid, 5000)
-
-        def rewrite_parent_field(record: dict[str, Any]) -> None:
-            parent_id = str(record.get("actorID") or "")
-            parent_pid = cls._ecar_int(record.get("ppid"))
-            new_parent_pid = new_pid_by_object_id.get(parent_id) or old_pid_map.get(parent_pid)
-            if new_parent_pid is not None:
-                record["ppid"] = new_parent_pid
-
-        def rewrite_property_pid(record: dict[str, Any], pid_key: str, object_key: str) -> None:
-            props = record.get("properties")
-            if not isinstance(props, dict):
-                return
-            object_id = str(props.get(object_key) or "")
-            old_pid = cls._ecar_int(props.get(pid_key))
-            new_pid = new_pid_by_object_id.get(object_id) or old_pid_map.get(old_pid)
-            if new_pid is not None:
-                props[pid_key] = new_pid
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if not cls._preserves_canonical_linux_pid(record):
-                rewrite_pid_field(record)
-                if record.get("object") == "PROCESS":
-                    rewrite_parent_field(record)
-                rewrite_property_pid(record, "target_pid", "target_process_uuid")
-                rewrite_property_pid(record, "target_pid", "target_process_object_id")
-                rewrite_property_pid(record, "source_pid", "source_process_object_id")
-            normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @classmethod
-    def _normalize_process_termination_order(cls, lines: list[str]) -> list[str]:
-        """Move PROCESS/TERMINATE rows after later same-process references."""
-        records: list[dict[str, Any] | None] = []
-        latest_reference_ms: dict[str, int] = {}
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            timestamp_ms = int(record.get("timestamp_ms", 0))
-            for process_id in cls._referenced_process_ids(record):
-                latest_reference_ms[process_id] = max(
-                    latest_reference_ms.get(process_id, 0),
-                    timestamp_ms,
-                )
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if record.get("object") == "PROCESS" and record.get("action") == "TERMINATE":
-                process_id = str(record.get("objectID", ""))
-                latest_ms = latest_reference_ms.get(process_id)
-                timestamp_ms = int(record.get("timestamp_ms", 0))
-                if latest_ms is not None and latest_ms >= timestamp_ms:
-                    stable_delay_ms = 100 + (sum(ord(ch) for ch in process_id) % 1900)
-                    record["timestamp_ms"] = latest_ms + stable_delay_ms
-                    line = json.dumps(record, separators=(",", ":"))
-            normalized.append(line)
-        return normalized
-
-    @classmethod
-    def _filter_stale_process_references_after_termination(cls, lines: list[str]) -> list[str]:
-        """Drop or de-attrib stale process-owned rows after PROCESS/TERMINATE."""
-        records: list[dict[str, Any] | None] = []
-        terminate_ms_by_process_id: dict[str, int] = {}
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            if record.get("object") != "PROCESS" or record.get("action") != "TERMINATE":
-                continue
-            process_id = str(record.get("objectID") or "")
-            if not process_id:
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            current = terminate_ms_by_process_id.get(process_id)
-            if current is None or timestamp_ms < current:
-                terminate_ms_by_process_id[process_id] = timestamp_ms
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if record.get("object") == "PROCESS":
-                normalized.append(line)
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            stale_threshold_ms = (
-                cls._stale_process_reference_grace_ms
-                if record.get("object") == "FLOW"
-                else cls._post_termination_dependent_grace_ms
-            )
-            stale_refs = [
-                process_id
-                for process_id in cls._referenced_process_ids(record)
-                if (
-                    process_id in terminate_ms_by_process_id
-                    and timestamp_ms > terminate_ms_by_process_id[process_id] + stale_threshold_ms
-                )
-            ]
-            if not stale_refs:
-                normalized.append(line)
-                continue
-            if record.get("object") == "FLOW":
-                cls._drop_flow_process_identity(record)
-                normalized.append(json.dumps(record, separators=(",", ":")))
-                continue
-            continue
-        return normalized
-
-    @classmethod
-    def _normalize_parent_termination_after_children(cls, lines: list[str]) -> list[str]:
-        """Keep visible parents alive through visible child process lifecycles."""
-        records: list[dict[str, Any] | None] = []
-        object_by_pid: dict[int, str] = {}
-        child_parent: dict[str, tuple[str | None, int, int]] = {}
-        child_last_ms: dict[str, int] = {}
-
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            if record.get("object") != "PROCESS":
-                continue
-            action = record.get("action")
-            object_id = str(record.get("objectID", ""))
-            pid = cls._ecar_int(record.get("pid"))
-            if action == "CREATE":
-                if object_id and pid > 0:
-                    object_by_pid[pid] = object_id
-                parent_id = str(record.get("actorID") or "") or None
-                parent_pid = cls._ecar_int(record.get("ppid"))
-                child_parent[object_id] = (parent_id, parent_pid, timestamp_ms)
-                child_last_ms[object_id] = max(child_last_ms.get(object_id, 0), timestamp_ms)
-            elif action == "TERMINATE" and object_id:
-                child_last_ms[object_id] = max(child_last_ms.get(object_id, 0), timestamp_ms)
-
-        latest_child_ms_by_parent_id: dict[str, int] = {}
-        latest_child_ms_by_parent_pid: dict[int, int] = {}
-        for child_id, (parent_id, parent_pid, create_ms) in child_parent.items():
-            latest_child_ms = max(create_ms, child_last_ms.get(child_id, create_ms))
-            if parent_id:
-                latest_child_ms_by_parent_id[parent_id] = max(
-                    latest_child_ms_by_parent_id.get(parent_id, 0),
-                    latest_child_ms,
-                )
-            elif parent_pid > 0:
-                resolved_parent_id = object_by_pid.get(parent_pid)
-                if resolved_parent_id:
-                    latest_child_ms_by_parent_id[resolved_parent_id] = max(
-                        latest_child_ms_by_parent_id.get(resolved_parent_id, 0),
-                        latest_child_ms,
-                    )
-            if parent_pid > 0:
-                latest_child_ms_by_parent_pid[parent_pid] = max(
-                    latest_child_ms_by_parent_pid.get(parent_pid, 0),
-                    latest_child_ms,
-                )
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if record.get("object") == "PROCESS" and record.get("action") == "TERMINATE":
-                object_id = str(record.get("objectID", ""))
-                pid = cls._ecar_int(record.get("pid"))
-                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                latest_child_ms = max(
-                    latest_child_ms_by_parent_id.get(object_id, 0),
-                    latest_child_ms_by_parent_pid.get(pid, 0),
-                )
-                if (
-                    latest_child_ms >= timestamp_ms
-                    and latest_child_ms - timestamp_ms <= cls._stale_process_reference_grace_ms
-                ):
-                    stable_delay_ms = 20 + (sum(ord(ch) for ch in object_id) % 480)
-                    record["timestamp_ms"] = latest_child_ms + stable_delay_ms
-                    line = json.dumps(record, separators=(",", ":"))
-            normalized.append(line)
-        return normalized
-
-    @staticmethod
-    def _ecar_int(value: Any, default: int = -1) -> int:
-        """Return an integer eCAR field value or a deterministic fallback."""
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return default
-
-    @staticmethod
-    def _process_create_repair_gap_ms(record: dict[str, Any], parent: dict[str, Any]) -> int:
-        """Return a small deterministic parent/child ordering repair gap."""
-        seed = _stable_seed(
-            "ecar-process-create-repair-gap:"
-            f"{record.get('hostname', '')}:"
-            f"{record.get('objectID', '')}:"
-            f"{record.get('pid', '')}:"
-            f"{record.get('ppid', '')}:"
-            f"{parent.get('objectID', '')}:"
-            f"{parent.get('pid', '')}"
-        )
-        return 18 + (seed % 133)
-
-    @staticmethod
-    def _canonical_process_create_repair_gap_ms(record: dict[str, Any]) -> int:
-        """Return a small deterministic gap for canonical create-order repairs."""
-        seed = _stable_seed(
-            "ecar-canonical-process-create-repair-gap:"
-            f"{record.get('hostname', '')}:"
-            f"{record.get('objectID', '')}:"
-            f"{record.get('pid', '')}:"
-            f"{record.get('_canonical_ms', '')}"
-        )
-        return 3 + (seed % 47)
-
-    @classmethod
-    def _normalize_process_create_canonical_order(cls, lines: list[str]) -> list[str]:
-        """Keep PROCESS/CREATE rows ordered by canonical process start time."""
-        records: list[dict[str, Any] | None] = []
-        for line in lines:
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                records.append(None)
-
-        create_indexes = [
-            index
-            for index, record in enumerate(records)
-            if record is not None
-            and record.get("object") == "PROCESS"
-            and record.get("action") == "CREATE"
-            and "_canonical_ms" in record
-            and not cls._looks_like_linux_process(record)
-        ]
-        create_indexes.sort(
-            key=lambda index: (
-                cls._ecar_int(records[index].get("_canonical_ms"), 0)
-                if records[index] is not None
-                else 0,
-                cls._ecar_int(records[index].get("pid"), 0) if records[index] is not None else 0,
-            )
-        )
-
-        latest_render_ms = 0
-        for index in create_indexes:
-            record = records[index]
-            if record is None:
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            if latest_render_ms and timestamp_ms <= latest_render_ms:
-                timestamp_ms = latest_render_ms + cls._canonical_process_create_repair_gap_ms(
-                    record
-                )
-                record["timestamp_ms"] = timestamp_ms
-            latest_render_ms = timestamp_ms
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            record.pop("_canonical_ms", None)
-            normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @classmethod
-    def _normalize_user_session_lifecycle_order(cls, lines: list[str]) -> list[str]:
-        """Keep USER_SESSION LOGOUT rows after matching successful LOGIN rows."""
-        records: list[dict[str, Any] | None] = []
-        sessions: dict[tuple[str, str], dict[str, list[int]]] = {}
-        for index, line in enumerate(lines):
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            if record.get("object") != "USER_SESSION":
-                continue
-            action = str(record.get("action") or "")
-            if action not in {"LOGIN", "LOGOUT"}:
-                continue
-            props = record.get("properties") or {}
-            if action == "LOGIN" and str(props.get("outcome") or "success") == "failure":
-                continue
-            session_id = str(
-                props.get("logon_id") or props.get("session_id") or record.get("objectID") or ""
-            )
-            if not session_id:
-                continue
-            key = (str(record.get("hostname") or ""), session_id)
-            sessions.setdefault(key, {"LOGIN": [], "LOGOUT": []})[action].append(index)
-
-        for key, session_indexes in sessions.items():
-            login_indexes = session_indexes["LOGIN"]
-            logout_indexes = session_indexes["LOGOUT"]
-            if not login_indexes or not logout_indexes:
-                continue
-            latest_login_ms = max(
-                cls._ecar_int(records[index].get("timestamp_ms"), 0)
-                for index in login_indexes
-                if records[index] is not None
-            )
-            next_logout_ms = latest_login_ms + 1
-            for index in sorted(
-                logout_indexes,
-                key=lambda idx: (
-                    cls._ecar_int(records[idx].get("timestamp_ms"), 0)
-                    if records[idx] is not None
-                    else 0
-                ),
-            ):
-                record = records[index]
-                if record is None:
-                    continue
-                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                if timestamp_ms <= latest_login_ms:
-                    seed_text = ":".join(
-                        [
-                            key[0],
-                            key[1],
-                            str(record.get("id") or ""),
-                            str(record.get("objectID") or ""),
-                            str(timestamp_ms),
-                        ]
-                    )
-                    stable_delay_ms = 25 + (sum(ord(ch) for ch in seed_text) % 175)
-                    timestamp_ms = max(next_logout_ms, latest_login_ms + stable_delay_ms)
-                    record["timestamp_ms"] = timestamp_ms
-                next_logout_ms = max(next_logout_ms, timestamp_ms + 1)
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-            else:
-                normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @classmethod
-    def _normalize_session_dependents_after_login(cls, lines: list[str]) -> list[str]:
-        """Keep same-logon endpoint activity after the visible USER_SESSION LOGIN row."""
-        records: list[dict[str, Any] | None] = []
-        login_ms_by_session: dict[tuple[str, str], int] = {}
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            if record.get("object") != "USER_SESSION" or record.get("action") != "LOGIN":
-                continue
-            props = record.get("properties") or {}
-            if str(props.get("outcome") or "success") == "failure":
-                continue
-            if str(props.get("logon_type") or "") == "7":
-                continue
-            logon_id = str(props.get("logon_id") or "")
-            if not logon_id:
-                continue
-            key = (str(record.get("hostname") or ""), logon_id)
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            current = login_ms_by_session.get(key)
-            if current is None or timestamp_ms < current:
-                login_ms_by_session[key] = timestamp_ms
-
-        dependent_objects = {"PROCESS", "FILE", "MODULE", "REGISTRY", "SERVICE"}
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if record.get("object") not in dependent_objects:
-                normalized.append(line)
-                continue
-            props = record.get("properties") or {}
-            logon_id = str(props.get("logon_id") or "")
-            if not logon_id or logon_id in {"0x3e7", "0x3e4", "0x3e5", "-"}:
-                normalized.append(line)
-                continue
-            key = (str(record.get("hostname") or ""), logon_id)
-            login_ms = login_ms_by_session.get(key)
-            if login_ms is None:
-                normalized.append(line)
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            if timestamp_ms <= login_ms:
-                seed = _stable_seed(
-                    "ecar-session-dependent-after-login:"
-                    f"{key[0]}:{logon_id}:{record.get('objectID', '')}:"
-                    f"{record.get('id', '')}:{timestamp_ms}:{login_ms}"
-                )
-                record["timestamp_ms"] = login_ms + 15 + (seed % 120)
-                line = json.dumps(record, separators=(",", ":"))
-            normalized.append(line)
-        return normalized
-
-    @classmethod
-    def _normalize_user_session_logout_after_dependents(cls, lines: list[str]) -> list[str]:
-        """Keep USER_SESSION LOGOUT rows after same-session endpoint activity."""
-        records: list[dict[str, Any] | None] = []
-        latest_dependent_ms_by_session: dict[tuple[str, str], int] = {}
-        logout_indexes_by_session: dict[tuple[str, str], list[int]] = {}
-        dependent_objects = {
-            "PROCESS",
-            "FILE",
-            "MODULE",
-            "REGISTRY",
-            "SERVICE",
-            "THREAD",
-            "FLOW",
-        }
-
-        for index, line in enumerate(lines):
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            props = record.get("properties") or {}
-            if not isinstance(props, dict):
-                props = {}
-            hostname = str(record.get("hostname") or "")
-            logon_id = str(props.get("logon_id") or "")
-            if (
-                logon_id
-                and logon_id not in {"0x3e7", "0x3e4", "0x3e5", "-"}
-                and record.get("object") in dependent_objects
-            ):
-                key = (hostname, logon_id)
-                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                if timestamp_ms > latest_dependent_ms_by_session.get(key, 0):
-                    latest_dependent_ms_by_session[key] = timestamp_ms
-                continue
-
-            if record.get("object") != "USER_SESSION" or record.get("action") != "LOGOUT":
-                continue
-            session_id = str(
-                props.get("logon_id") or props.get("session_id") or record.get("objectID") or ""
-            )
-            if not session_id:
-                continue
-            logout_indexes_by_session.setdefault((hostname, session_id), []).append(index)
-
-        for key, indexes in logout_indexes_by_session.items():
-            latest_dependent_ms = latest_dependent_ms_by_session.get(key)
-            if latest_dependent_ms is None:
-                continue
-            next_logout_ms = latest_dependent_ms + 1
-            for index in sorted(
-                indexes,
-                key=lambda idx: (
-                    cls._ecar_int(records[idx].get("timestamp_ms"), 0)
-                    if records[idx] is not None
-                    else 0
-                ),
-            ):
-                record = records[index]
-                if record is None:
-                    continue
-                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                if timestamp_ms <= latest_dependent_ms:
-                    seed = _stable_seed(
-                        "source.ecar_session_logout_after_dependents:"
-                        f"{key[0]}:{key[1]}:{record.get('objectID', '')}:"
-                        f"{record.get('id', '')}:{timestamp_ms}:{latest_dependent_ms}"
-                    )
-                    delay_ms = 15 + (seed % 120)
-                    timestamp_ms = max(next_logout_ms, latest_dependent_ms + delay_ms)
-                    record["timestamp_ms"] = timestamp_ms
-                next_logout_ms = max(next_logout_ms, timestamp_ms + 1)
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-            else:
-                normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @classmethod
-    def _normalize_remote_session_transport_order(cls, lines: list[str]) -> list[str]:
-        """Keep remote USER_SESSION LOGIN rows after same-host inbound FLOW rows."""
-        records: list[dict[str, Any] | None] = []
-        inbound_flow_ms_by_tuple: dict[tuple[str, str, int, int], int] = {}
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            if record.get("object") != "FLOW" or record.get("action") != "CONNECT":
-                continue
-            props = record.get("properties") or {}
-            if str(props.get("direction") or "").upper() != "INBOUND":
-                continue
-            src_ip = str(props.get("src_ip") or "")
-            src_port = cls._ecar_int(props.get("src_port"))
-            dst_port = cls._ecar_int(props.get("dst_port"))
-            if not src_ip or src_port <= 0 or dst_port <= 0:
-                continue
-            key = (str(record.get("hostname") or ""), src_ip, src_port, dst_port)
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            current = inbound_flow_ms_by_tuple.get(key)
-            if current is None or timestamp_ms < current:
-                inbound_flow_ms_by_tuple[key] = timestamp_ms
-
-        for record in records:
-            if (
-                record is None
-                or record.get("object") != "USER_SESSION"
-                or record.get("action") != "LOGIN"
-            ):
-                continue
-            props = record.get("properties") or {}
-            if str(props.get("outcome") or "success") == "failure":
-                continue
-            src_ip = str(props.get("src_ip") or "")
-            src_port = cls._ecar_int(props.get("src_port"))
-            if not src_ip or src_ip == "-" or src_port <= 0:
-                continue
-            session_type = str(props.get("session_type") or "").lower()
-            logon_type = str(props.get("logon_type") or "")
-            candidate_ports: tuple[int, ...]
-            if session_type == "ssh":
-                candidate_ports = (22,)
-            elif logon_type == "10":
-                candidate_ports = (3389,)
-            elif logon_type == "3":
-                candidate_ports = (445,)
-            else:
-                continue
-            flow_ms = min(
-                (
-                    inbound_flow_ms_by_tuple[key]
-                    for key in (
-                        (str(record.get("hostname") or ""), src_ip, src_port, dst_port)
-                        for dst_port in candidate_ports
-                    )
-                    if key in inbound_flow_ms_by_tuple
-                ),
-                default=None,
-            )
-            if flow_ms is None:
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            if timestamp_ms > flow_ms:
-                continue
-            seed_text = ":".join(
-                [
-                    str(record.get("hostname") or ""),
-                    src_ip,
-                    str(src_port),
-                    str(record.get("objectID") or ""),
-                    str(record.get("id") or ""),
-                    str(timestamp_ms),
-                ]
-            )
-            record["timestamp_ms"] = flow_ms + 12 + (sum(ord(ch) for ch in seed_text) % 83)
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-            else:
-                normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @staticmethod
-    def _is_linux_login_shell_create(record: dict[str, Any]) -> bool:
-        """Return whether a PROCESS/CREATE row is an interactive Linux login shell."""
-        if record.get("object") != "PROCESS" or record.get("action") != "CREATE":
-            return False
-        props = record.get("properties") or {}
-        image = str(props.get("image_path") or "")
-        if image not in {"/bin/bash", "/usr/bin/bash"}:
-            return False
-        command_line = str(props.get("command_line") or "").strip()
-        return command_line in {"-bash", "bash", "/bin/bash", "/usr/bin/bash"}
-
-    @classmethod
-    def _normalize_linux_login_shell_session_order(cls, lines: list[str]) -> list[str]:
-        """Keep interactive Linux shell creates after same-user session LOGIN rows."""
-        records: list[dict[str, Any] | None] = []
-        logins_by_host_user: dict[tuple[str, str], list[dict[str, Any]]] = {}
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            if (
-                record.get("object") != "USER_SESSION"
-                or record.get("action") != "LOGIN"
-                or not record.get("principal")
-            ):
-                continue
-            props = record.get("properties") or {}
-            if str(props.get("outcome") or "success") == "failure":
-                continue
-            key = (str(record.get("hostname") or ""), str(record.get("principal") or ""))
-            logins_by_host_user.setdefault(key, []).append(record)
-
-        for logins in logins_by_host_user.values():
-            logins.sort(key=lambda record: cls._ecar_int(record.get("timestamp_ms"), 0))
-
-        max_forward_gap_ms = 10_000
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if cls._is_linux_login_shell_create(record):
-                shell_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                key = (str(record.get("hostname") or ""), str(record.get("principal") or ""))
-                candidate_login = next(
-                    (
-                        login
-                        for login in logins_by_host_user.get(key, [])
-                        if 0
-                        <= cls._ecar_int(login.get("timestamp_ms"), 0) - shell_ms
-                        <= max_forward_gap_ms
-                    ),
-                    None,
-                )
-                if candidate_login is not None:
-                    login_ms = cls._ecar_int(candidate_login.get("timestamp_ms"), 0)
-                    seed = _stable_seed(
-                        "ecar-linux-login-shell-after-session:"
-                        f"{record.get('hostname', '')}:"
-                        f"{record.get('principal', '')}:"
-                        f"{record.get('objectID', '')}:"
-                        f"{candidate_login.get('objectID', '')}:"
-                        f"{shell_ms}:{login_ms}"
-                    )
-                    record["timestamp_ms"] = login_ms + 80 + (seed % 240)
-                    line = json.dumps(record, separators=(",", ":"))
-            normalized.append(line)
-        return normalized
-
-    _LINUX_SHELL_FOREGROUND_EXES = {
-        "cargo",
-        "cat",
-        "curl",
-        "date",
-        "df",
-        "docker",
-        "du",
-        "emacs",
-        "env",
-        "find",
-        "free",
-        "gcc",
-        "grep",
-        "gzip",
-        "head",
-        "hostname",
-        "id",
-        "ip",
-        "journalctl",
-        "kubectl",
-        "ldapsearch",
-        "ls",
-        "make",
-        "mysql",
-        "mysqldump",
-        "nano",
-        "npm",
-        "pg_isready",
-        "printenv",
-        "ps",
-        "psql",
-        "pt-query-digest",
-        "pwd",
-        "python",
-        "python3",
-        "redis-cli",
-        "scp",
-        "sleep",
-        "ss",
-        "sqlite3",
-        "systemctl",
-        "tar",
-        "test",
-        "tail",
-        "true",
-        "uname",
-        "vi",
-        "vim",
-        "wc",
-        "wget",
-        "whoami",
-        "zip",
-    }
-
-    @classmethod
-    def _is_linux_shell_foreground_create(cls, record: dict[str, Any]) -> bool:
-        """Return whether an eCAR row is a foreground Linux child of a shell."""
-        if record.get("object") != "PROCESS" or record.get("action") != "CREATE":
-            return False
-        props = record.get("properties") or {}
-        image = str(props.get("image_path") or "")
-        parent_image = str(props.get("parent_image_path") or "")
-        command_line = str(props.get("command_line") or "")
-        concurrency_group_id = str(record.get("_concurrency_group_id") or "")
-        if concurrency_group_id.startswith("bash-history:"):
-            return False
-        if "|" in command_line or cls._is_backgrounded_shell_command(command_line):
-            return False
-        exe = image.rsplit("/", 1)[-1].lower()
-        parent_exe = parent_image.rsplit("/", 1)[-1].lower()
-        return exe in cls._LINUX_SHELL_FOREGROUND_EXES and parent_exe in {"bash", "sh", "zsh"}
-
-    @staticmethod
-    def _is_backgrounded_shell_command(command_line: str) -> bool:
-        """Return whether a shell command should not block later foreground children."""
-        normalized = command_line.strip().lower()
-        if not normalized:
-            return False
-        return (
-            normalized.endswith("&")
-            or " nohup " in f" {normalized} "
-            or "tail -f" in normalized
-            or "watch " in normalized
-            or "--follow" in normalized
-        )
-
-    @classmethod
-    def _normalize_linux_shell_foreground_order(cls, lines: list[str]) -> list[str]:
-        """Serialize foreground shell commands while preserving pipeline concurrency."""
-        records: list[dict[str, Any] | None] = []
-        for line in lines:
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                records.append(None)
-
-        terminate_ms_by_object_id: dict[str, int] = {}
-        for record in records:
-            if (
-                record is not None
-                and record.get("object") == "PROCESS"
-                and record.get("action") == "TERMINATE"
-            ):
-                object_id = str(record.get("objectID") or "")
-                if object_id:
-                    terminate_ms_by_object_id[object_id] = max(
-                        terminate_ms_by_object_id.get(object_id, 0),
-                        cls._ecar_int(record.get("timestamp_ms"), 0),
-                    )
-
-        create_indexes_by_shell: dict[tuple[str, str, int, str], list[int]] = {}
-        for index, record in enumerate(records):
-            if record is None or not cls._is_linux_shell_foreground_create(record):
-                continue
-            shell_key = (
-                str(record.get("hostname") or ""),
-                str(record.get("principal") or ""),
-                cls._ecar_int(record.get("ppid")),
-                str(record.get("actorID") or ""),
-            )
-            create_indexes_by_shell.setdefault(shell_key, []).append(index)
-
-        shift_by_object_id: dict[str, int] = {}
-        for indexes in create_indexes_by_shell.values():
-            original_indexes = list(indexes)
-            indexes.sort(
-                key=lambda index: (
-                    cls._ecar_int(records[index].get("timestamp_ms"), 0)
-                    if records[index] is not None
-                    else 0,
-                    cls._ecar_int(records[index].get("pid"), 0)
-                    if records[index] is not None
-                    else 0,
-                )
-            )
-            next_available_ms = 0
-            groups: list[list[int]] = []
-            original_group_by_concurrency_id: dict[str, list[int]] = {}
-            for index in original_indexes:
-                record = records[index]
-                if record is None:
-                    continue
-                concurrency_group_id = str(record.get("_concurrency_group_id") or "")
-                if concurrency_group_id:
-                    original_group_by_concurrency_id.setdefault(concurrency_group_id, []).append(
-                        index
-                    )
-            group_by_concurrency_id: dict[str, list[int]] = {}
-            for index in indexes:
-                record = records[index]
-                if record is None:
-                    continue
-                concurrency_group_id = str(record.get("_concurrency_group_id") or "")
-                if concurrency_group_id:
-                    group = group_by_concurrency_id.get(concurrency_group_id)
-                    if group is None:
-                        group = original_group_by_concurrency_id[concurrency_group_id]
-                        group_by_concurrency_id[concurrency_group_id] = group
-                        groups.append(group)
-                    continue
-                groups.append([index])
-
-            for group in groups:
-                group_records = [records[index] for index in group if records[index] is not None]
-                if not group_records:
-                    continue
-                group_start_ms = min(
-                    cls._ecar_int(record.get("timestamp_ms"), 0) for record in group_records
-                )
-                shift_ms = 0
-                if next_available_ms and group_start_ms <= next_available_ms:
-                    seed_text = ":".join(
-                        ":".join(
-                            [
-                                str(record.get("objectID") or ""),
-                                str(record.get("pid", "")),
-                                str(record.get("id", "")),
-                            ]
-                        )
-                        for record in group_records
-                    )
-                    shifted_ms = next_available_ms + 50 + (sum(ord(ch) for ch in seed_text) % 950)
-                    shift_ms = shifted_ms - group_start_ms
-
-                group_latest_ms = next_available_ms
-                next_stage_ms = 0
-                for index in sorted(group):
-                    record = records[index]
-                    if record is None:
-                        continue
-                    timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                    object_id = str(record.get("objectID") or "")
-                    total_shift_ms = shift_ms
-                    if shift_ms:
-                        timestamp_ms += shift_ms
-                        record["timestamp_ms"] = timestamp_ms
-                    if next_stage_ms and timestamp_ms < next_stage_ms:
-                        stage_shift_ms = next_stage_ms - timestamp_ms
-                        timestamp_ms = next_stage_ms
-                        total_shift_ms += stage_shift_ms
-                        record["timestamp_ms"] = timestamp_ms
-                    next_stage_ms = timestamp_ms + 15
-                    if object_id and total_shift_ms:
-                        shift_by_object_id[object_id] = total_shift_ms
-                    if object_id and object_id in terminate_ms_by_object_id:
-                        group_latest_ms = max(
-                            group_latest_ms,
-                            terminate_ms_by_object_id[object_id] + total_shift_ms,
-                        )
-                    else:
-                        group_latest_ms = max(group_latest_ms, timestamp_ms)
-                next_available_ms = max(next_available_ms, group_latest_ms)
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            object_id = str(record.get("objectID") or "")
-            shift_ms = shift_by_object_id.get(object_id, 0)
-            if (
-                shift_ms
-                and record.get("object") == "PROCESS"
-                and record.get("action") == "TERMINATE"
-            ):
-                record["timestamp_ms"] = cls._ecar_int(record.get("timestamp_ms"), 0) + shift_ms
-            normalized.append(json.dumps(record, separators=(",", ":")))
-        return cls._strip_internal_fields(normalized)
-
-    @classmethod
-    def _strip_internal_fields(cls, lines: list[str]) -> list[str]:
-        """Remove eCAR-only normalization helpers before final writer flush."""
-        normalized: list[str] = []
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                normalized.append(line)
-                continue
-            record.pop("_concurrency_group_id", None)
-            record.pop("_canonical_ms", None)
-            normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @classmethod
-    def _normalize_process_parent_order(cls, lines: list[str]) -> list[str]:
-        """Move PROCESS/CREATE rows after visible parent PROCESS/CREATE rows."""
-        records: list[dict[str, Any] | None] = []
-        for line in lines:
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                records.append(None)
-
-        create_indexes = [
-            index
-            for index, record in enumerate(records)
-            if record is not None
-            and record.get("object") == "PROCESS"
-            and record.get("action") == "CREATE"
-        ]
-        index_by_object_id: dict[str, int] = {}
-        index_by_pid: dict[int, int] = {}
-        for index in create_indexes:
-            record = records[index]
-            if record is None:
-                continue
-            object_id = record.get("objectID")
-            if object_id:
-                index_by_object_id[str(object_id)] = index
-            pid = cls._ecar_int(record.get("pid"))
-            if pid > 0:
-                current_index = index_by_pid.get(pid)
-                if current_index is None:
-                    index_by_pid[pid] = index
-                    continue
-                current_record = records[current_index]
-                current_ms = (
-                    cls._ecar_int(current_record.get("timestamp_ms"), 0)
-                    if current_record is not None
-                    else 0
-                )
-                if cls._ecar_int(record.get("timestamp_ms"), 0) >= current_ms:
-                    index_by_pid[pid] = index
-
-        parent_by_index: dict[int, int] = {}
-        for index in create_indexes:
-            record = records[index]
-            if record is None:
-                continue
-            parent_index: int | None = None
-            parent_id = record.get("actorID")
-            if parent_id:
-                parent_index = index_by_object_id.get(str(parent_id))
-            if parent_index is None:
-                pid = cls._ecar_int(record.get("pid"))
-                parent_pid = cls._ecar_int(record.get("ppid"))
-                if parent_pid > 0 and parent_pid != pid:
-                    parent_index = index_by_pid.get(parent_pid)
-            if parent_index is not None and parent_index != index:
-                parent_by_index[index] = parent_index
-
-        cyclic_indexes: set[int] = set()
-        for index in parent_by_index:
-            seen: set[int] = set()
-            current = index
-            while current in parent_by_index:
-                if current in seen:
-                    cyclic_indexes.update(seen)
-                    break
-                seen.add(current)
-                current = parent_by_index[current]
-        parent_by_index = {
-            index: parent_index
-            for index, parent_index in parent_by_index.items()
-            if index not in cyclic_indexes and parent_index not in cyclic_indexes
-        }
-
-        for _ in range(len(parent_by_index)):
-            changed = False
-            for index, parent_index in parent_by_index.items():
-                record = records[index]
-                parent = records[parent_index]
-                if record is None or parent is None:
-                    continue
-                parent_ms = cls._ecar_int(parent.get("timestamp_ms"), 0)
-                timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-                if timestamp_ms <= parent_ms:
-                    record["timestamp_ms"] = parent_ms + cls._process_create_repair_gap_ms(
-                        record, parent
-                    )
-                    changed = True
-            if not changed:
-                break
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-            else:
-                normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @classmethod
-    def _normalize_process_reference_order(cls, lines: list[str]) -> list[str]:
-        """Move process-owned telemetry after visible PROCESS/CREATE rows."""
-        records: list[dict[str, Any] | None] = []
-        for line in lines:
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                records.append(None)
-
-        create_ms_by_object_id: dict[str, int] = {}
-        create_ms_by_pid: dict[int, int] = {}
-        for record in records:
-            if (
-                record is None
-                or record.get("object") != "PROCESS"
-                or record.get("action") != "CREATE"
-            ):
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            object_id = record.get("objectID")
-            if object_id:
-                create_ms_by_object_id[str(object_id)] = max(
-                    create_ms_by_object_id.get(str(object_id), 0),
-                    timestamp_ms,
-                )
-            pid = cls._ecar_int(record.get("pid"))
-            if pid > 0:
-                create_ms_by_pid[pid] = max(create_ms_by_pid.get(pid, 0), timestamp_ms)
-
-        def referenced_process_ids(record: dict[str, Any]) -> set[str]:
-            refs: set[str] = set()
-            actor_id = record.get("actorID")
-            if actor_id:
-                refs.add(str(actor_id))
-            if record.get("object") == "PROCESS" and record.get("action") == "OPEN":
-                object_id = record.get("objectID")
-                if object_id:
-                    refs.add(str(object_id))
-            props = record.get("properties") or {}
-            for key in (
-                "target_process_uuid",
-                "target_process_object_id",
-                "source_process_object_id",
-            ):
-                value = props.get(key)
-                if value:
-                    refs.add(str(value))
-            return refs
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if record.get("object") == "PROCESS" and record.get("action") == "CREATE":
-                normalized.append(line)
-                continue
-
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            referenced_create_ms = [
-                create_ms_by_object_id[process_id]
-                for process_id in referenced_process_ids(record)
-                if process_id in create_ms_by_object_id
-            ]
-            pid = cls._ecar_int(record.get("pid"))
-            if pid > 0 and pid in create_ms_by_pid:
-                referenced_create_ms.append(create_ms_by_pid[pid])
-            if referenced_create_ms:
-                minimum_ms = max(referenced_create_ms)
-                if timestamp_ms <= minimum_ms:
-                    if record.get("object") == "FLOW":
-                        if record.get("action") == "CONNECT":
-                            cls._drop_flow_process_identity(record)
-                            normalized.append(json.dumps(record, separators=(",", ":")))
-                            continue
-                        if (
-                            minimum_ms - timestamp_ms
-                            > cls._pre_process_flow_identity_repair_grace_ms
-                        ):
-                            cls._drop_flow_process_identity(record)
-                            normalized.append(json.dumps(record, separators=(",", ":")))
-                            continue
-                    seed_text = ":".join(
-                        [
-                            str(record.get("id", "")),
-                            str(record.get("object", "")),
-                            str(record.get("action", "")),
-                            str(record.get("objectID", "")),
-                            str(record.get("actorID", "")),
-                        ]
-                    )
-                    stable_delay_ms = 1 + (sum(ord(ch) for ch in seed_text) % 37)
-                    record["timestamp_ms"] = minimum_ms + stable_delay_ms
-                    line = json.dumps(record, separators=(",", ":"))
-            normalized.append(line)
-        return normalized
-
-    @classmethod
-    def _remote_thread_process_open_keys(
-        cls,
-        record: dict[str, Any],
-    ) -> set[tuple[str, str, str, str, str]]:
-        """Return same-source/same-target keys for remote-thread prerequisite matching."""
-        hostname = str(record.get("hostname") or "")
-        props = record.get("properties") or {}
-        if not isinstance(props, dict):
-            props = {}
-
-        source_keys: list[tuple[str, str]] = []
-        actor_id = str(record.get("actorID") or "")
-        if actor_id:
-            source_keys.append(("actor", actor_id))
-        source_pid = cls._ecar_int(record.get("pid"))
-        if source_pid > 0:
-            source_keys.append(("pid", str(source_pid)))
-        source_pid_prop = cls._ecar_int(props.get("src_pid"))
-        if source_pid_prop > 0:
-            source_keys.append(("pid", str(source_pid_prop)))
-
-        target_keys: list[tuple[str, str]] = []
-        if record.get("object") == "PROCESS" and record.get("action") == "OPEN":
-            object_id = str(record.get("objectID") or "")
-            if object_id:
-                target_keys.append(("uuid", object_id))
-        target_uuid = str(props.get("target_process_uuid") or "")
-        if target_uuid:
-            target_keys.append(("uuid", target_uuid))
-        target_object_id = str(props.get("target_process_object_id") or "")
-        if target_object_id:
-            target_keys.append(("uuid", target_object_id))
-        target_pid = cls._ecar_int(props.get("target_pid"))
-        if target_pid > 0:
-            target_keys.append(("pid", str(target_pid)))
-
-        return {
-            (hostname, source_type, source_value, target_type, target_value)
-            for source_type, source_value in source_keys
-            for target_type, target_value in target_keys
-            if hostname and source_value and target_value
-        }
-
-    @classmethod
-    def _normalize_remote_thread_after_process_open(cls, lines: list[str]) -> list[str]:
-        """Keep eCAR remote-thread creation after the matching process-open row."""
-        records: list[dict[str, Any] | None] = []
-        open_ms_by_key: dict[tuple[str, str, str, str, str], list[int]] = {}
-
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            if record.get("object") != "PROCESS" or record.get("action") != "OPEN":
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            if timestamp_ms <= 0:
-                continue
-            for key in cls._remote_thread_process_open_keys(record):
-                open_ms_by_key.setdefault(key, []).append(timestamp_ms)
-
-        for timestamps in open_ms_by_key.values():
-            timestamps.sort()
-
-        max_repair_gap_ms = 30_000
-        for record in records:
-            if (
-                record is None
-                or record.get("object") != "THREAD"
-                or record.get("action") != "REMOTE_CREATE"
-            ):
-                continue
-            timestamp_ms = cls._ecar_int(record.get("timestamp_ms"), 0)
-            if timestamp_ms <= 0:
-                continue
-            candidate_open_ms: list[int] = []
-            has_prior_open = False
-            for key in cls._remote_thread_process_open_keys(record):
-                for open_ms in open_ms_by_key.get(key, []):
-                    if open_ms < timestamp_ms:
-                        has_prior_open = True
-                        continue
-                    if open_ms - timestamp_ms <= max_repair_gap_ms:
-                        candidate_open_ms.append(open_ms)
-            if has_prior_open or not candidate_open_ms:
-                continue
-            prerequisite_ms = min(candidate_open_ms)
-            seed = _stable_seed(
-                "source.ecar_remote_thread_after_process_open:"
-                f"{record.get('hostname', '')}:{record.get('objectID', '')}:"
-                f"{record.get('actorID', '')}:{record.get('pid', '')}:"
-                f"{timestamp_ms}:{prerequisite_ms}"
-            )
-            delay_ms = 15 + (seed % 120)
-            record["timestamp_ms"] = prerequisite_ms + delay_ms
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-            else:
-                normalized.append(json.dumps(record, separators=(",", ":")))
-        return normalized
-
-    @classmethod
-    def _normalize_flow_process_actor_visibility(cls, lines: list[str]) -> list[str]:
-        """Drop FLOW process actors that are not source-visible in the host stream."""
-        records: list[dict[str, Any] | None] = []
-        visible_process_ids: set[str] = set()
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                records.append(None)
-                continue
-            records.append(record)
-            if record.get("object") != "PROCESS" or record.get("action") != "CREATE":
-                continue
-            object_id = str(record.get("objectID") or "")
-            if object_id:
-                visible_process_ids.add(object_id)
-
-        normalized: list[str] = []
-        for line, record in zip(lines, records, strict=True):
-            if record is None:
-                normalized.append(line)
-                continue
-            if record.get("object") != "FLOW" or record.get("action") != "CONNECT":
-                normalized.append(line)
-                continue
-            actor_id = str(record.get("actorID") or "")
-            if actor_id and actor_id not in visible_process_ids:
-                cls._drop_flow_process_identity(record)
-                normalized.append(json.dumps(record, separators=(",", ":")))
-                continue
-            normalized.append(line)
-        return normalized
-
-    @staticmethod
-    def _drop_flow_process_identity(record: dict[str, Any]) -> None:
-        """Remove process attribution from a FLOW that cannot safely claim it."""
-        record.pop("actorID", None)
-        record.pop("pid", None)
-        record.pop("tid", None)
-        record.pop("principal", None)
-        props = record.get("properties")
-        if isinstance(props, dict):
-            for key in ("image_path", "command_line", "parent_image_path"):
-                props.pop(key, None)
-
-    @staticmethod
-    def _semantic_dedup_key(record: dict[str, Any]) -> str:
-        """Return an eCAR semantic identity that ignores generated UUID fields."""
-        comparable = {
-            key: value for key, value in record.items() if key not in {"id", "objectID", "actorID"}
-        }
-        props = comparable.get("properties")
-        if isinstance(props, dict):
-            comparable["properties"] = {key: props[key] for key in sorted(props)}
-        return json.dumps(comparable, sort_keys=True, separators=(",", ":"))
-
-    def _deduplicate_semantic_events(self, lines: list[str]) -> list[str]:
-        """Drop exact duplicate eCAR facts emitted with fresh UUID wrappers."""
-        seen: set[str] = set()
-        deduped: list[str] = []
-        for line in lines:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                deduped.append(line)
-                continue
-            key = self._semantic_dedup_key(record)
-            if key in seen:
-                continue
-            seen.add(key)
-            deduped.append(line)
-        return deduped
-
     def flush(self, force: bool = False) -> None:
-        """Flush per-host eCAR records after final lifecycle normalization."""
-        if force:
-            with self._writers_lock:
-                writers = list(self._writers.values())
-            for writer in writers:
-                with writer._lock:
-                    writer.buffer = self._normalize_process_parent_order(writer.buffer)
-                    writer.buffer = self._normalize_process_create_canonical_order(writer.buffer)
-                    writer.buffer = self._normalize_linux_pid_morphology(writer.buffer)
-                    writer.buffer = self._normalize_process_parent_order(writer.buffer)
-                    writer.buffer = self._normalize_process_create_canonical_order(writer.buffer)
-                    writer.buffer = self._normalize_linux_pid_morphology(writer.buffer)
-                    writer.buffer = self._normalize_remote_session_transport_order(writer.buffer)
-                    writer.buffer = self._normalize_user_session_lifecycle_order(writer.buffer)
-                    writer.buffer = self._normalize_session_dependents_after_login(writer.buffer)
-                    writer.buffer = self._normalize_linux_login_shell_session_order(writer.buffer)
-                    writer.buffer = self._normalize_process_parent_order(writer.buffer)
-                    writer.buffer = self._normalize_linux_shell_foreground_order(writer.buffer)
-                    writer.buffer = self._normalize_linux_pid_morphology(writer.buffer)
-                    writer.buffer = self._normalize_process_reference_order(writer.buffer)
-                    writer.buffer = self._normalize_remote_thread_after_process_open(writer.buffer)
-                    writer.buffer = self._filter_stale_process_references_after_termination(
-                        writer.buffer
-                    )
-                    writer.buffer = self._normalize_process_termination_order(writer.buffer)
-                    writer.buffer = self._normalize_parent_termination_after_children(writer.buffer)
-                    writer.buffer = self._normalize_user_session_logout_after_dependents(
-                        writer.buffer
-                    )
-                    writer.buffer = self._deduplicate_semantic_events(writer.buffer)
-                    writer.buffer = self._normalize_flow_process_actor_visibility(writer.buffer)
-                    writer.buffer = self._deduplicate_semantic_events(writer.buffer)
-                    writer.buffer = self._strip_internal_fields(writer.buffer)
+        """Serialize buffered records in source-timestamp order without semantic mutation."""
+
         super().flush(force=force)
 
     # Property keys that belong in the eCAR properties map.
@@ -2964,7 +1349,13 @@ class EcarEmitter(HostMultiplexEmitter):
         "sub_status",
         "src_pid",
         "src_tid",
+        "source_process_uuid",
+        "source_pid",
+        "source_tid",
+        "source_image_path",
+        "source_principal",
         "tgt_tid",
+        "target_tid",
         "start_address",
         "stack_base",
         "stack_limit",
@@ -2975,6 +1366,7 @@ class EcarEmitter(HostMultiplexEmitter):
         "target_pid",
         "target_image_path",
         "target_process_uuid",
+        "target_principal",
         "service_name",
         "service_account",
     )
@@ -3012,11 +1404,6 @@ class EcarEmitter(HostMultiplexEmitter):
             "action": event_data["action"],
             "objectID": object_id,
         }
-        if "_canonical_ms" in event_data:
-            record["_canonical_ms"] = event_data["_canonical_ms"]
-        if event_data.get("_concurrency_group_id"):
-            record["_concurrency_group_id"] = event_data["_concurrency_group_id"]
-
         if event_data.get("actorID"):
             record["actorID"] = event_data["actorID"]
 

--- a/src/evidenceforge/generation/emitters/syslog.py
+++ b/src/evidenceforge/generation/emitters/syslog.py
@@ -85,14 +85,7 @@ _KERNEL_UPTIME_RE = re.compile(
     r"(?P<uptime>\d+\.\d{6})"
     r"(?P<suffix>\])"
 )
-_SSHD_PID_RFC3164_RE = re.compile(r"(?P<prefix>\bsshd\[)(?P<pid>\d+)(?P<suffix>\]:)")
-_SSHD_PID_RFC5424_RE = re.compile(
-    r"(?P<prefix>^<\d{1,3}>1\s+\S+\s+\S+\s+sshd\s+)"
-    r"(?P<pid>\d+)"
-    r"(?P<suffix>\s+-\s+-\s+)"
-)
 _MAX_LOGIND_SESSION_ID_DIGITS = 18
-_MAX_SSHD_PID_DIGITS = 18
 _PAM_OPEN_VISIBLE_WINDOW = timedelta(seconds=20)
 
 
@@ -154,16 +147,6 @@ def _linux_uid_collision_repaired(lines: list[str], host_key: str) -> list[str]:
 def _parse_logind_session_id(value: str) -> int | None:
     """Parse bounded systemd-logind session IDs without triggering huge-int failures."""
     if len(value) > _MAX_LOGIND_SESSION_ID_DIGITS:
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
-
-
-def _parse_sshd_pid(value: str) -> int | None:
-    """Parse bounded sshd PID strings without triggering huge-int failures."""
-    if len(value) > _MAX_SSHD_PID_DIGITS:
         return None
     try:
         return int(value)
@@ -391,7 +374,6 @@ class SyslogEmitter(HostMultiplexEmitter):
         self._normalize_pam_uid_collisions()
         self._normalize_sudo_session_lifecycles()
         self._normalize_kernel_uptime_stamps()
-        self._normalize_sshd_child_pids()
         self.flush(force=True)
 
     def _normalize_sof_elk_buffers(self) -> None:
@@ -404,7 +386,6 @@ class SyslogEmitter(HostMultiplexEmitter):
                 normalized = self._normalize_logind_session_ids_for_lines(normalized, host_key)
                 normalized = self._normalize_sudo_session_lifecycles_for_lines(normalized)
                 normalized = self._normalize_kernel_uptime_stamps_for_lines(normalized)
-                normalized = self._normalize_sshd_child_pids_for_lines(normalized, host_key)
                 self._replace_buffers_by_sorted_rows(rows, normalized)
 
     def _sorted_lines_by_host(self) -> dict[str, list[tuple[int, tuple[Any, ...], str, str]]]:
@@ -530,66 +511,6 @@ class SyslogEmitter(HostMultiplexEmitter):
                     [line for _year, _sort_key, _route_key, line in rows]
                 )
                 self._replace_buffers_by_sorted_rows(rows, normalized)
-
-    def _normalize_sshd_child_pids(self) -> None:
-        """Keep visible sshd child PIDs monotonic in final syslog order."""
-        with self._writers_lock:
-            for host_key, rows in self._sorted_lines_by_host().items():
-                if not rows:
-                    continue
-                normalized = self._normalize_sshd_child_pids_for_lines(
-                    [line for _year, _sort_key, _route_key, line in rows],
-                    host_key,
-                )
-                self._replace_buffers_by_sorted_rows(rows, normalized)
-
-    @staticmethod
-    def _sshd_pid_match(line: str) -> re.Match[str] | None:
-        """Return the sshd PID match for RFC5424 or RFC3164 syslog."""
-        return _SSHD_PID_RFC5424_RE.search(line) or _SSHD_PID_RFC3164_RE.search(line)
-
-    @classmethod
-    def _normalize_sshd_child_pids_for_lines(cls, lines: list[str], host_key: str) -> list[str]:
-        """Return lines with per-session sshd child PIDs increasing by source time."""
-        pid_map: dict[str, int] = {}
-        latest_session_pid = 0
-        normalized: list[str] = []
-        for line in lines:
-            match = cls._sshd_pid_match(line)
-            if match is None:
-                normalized.append(line)
-                continue
-            old_pid = match.group("pid")
-            new_pid = pid_map.get(old_pid)
-            if new_pid is None:
-                parsed_old_pid = _parse_sshd_pid(old_pid)
-                if parsed_old_pid is None:
-                    normalized.append(line)
-                    continue
-                opens_visible_session = (
-                    "Connection from " in line
-                    or "Accepted " in line
-                    or "pam_unix(sshd:session): session opened" in line
-                )
-                if not opens_visible_session:
-                    new_pid = parsed_old_pid
-                    pid_map[old_pid] = new_pid
-                elif parsed_old_pid > latest_session_pid:
-                    new_pid = parsed_old_pid
-                    latest_session_pid = new_pid
-                    pid_map[old_pid] = new_pid
-                else:
-                    bump = 1 + (
-                        _stable_seed(f"syslog_sshd_pid:{host_key}:{old_pid}:{len(pid_map)}") % 17
-                    )
-                    new_pid = latest_session_pid + bump
-                    latest_session_pid = new_pid
-                    pid_map[old_pid] = new_pid
-            normalized.append(
-                f"{line[: match.start()]}{match.group('prefix')}{new_pid}{match.group('suffix')}"
-                f"{line[match.end() :]}"
-            )
-        return normalized
 
     @staticmethod
     def _normalize_logind_session_ids_for_lines(lines: list[str], host_key: str) -> list[str]:

--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -1123,26 +1123,17 @@ class SysmonEventEmitter(LogEmitter):
         return image
 
     def _terminal_session_id(self, hostname: str, auth, logon_id: str) -> int:
-        """Return a source-native TerminalSessionId for Sysmon process creates."""
+        """Return the canonical TerminalSessionId for Sysmon process creates."""
         if auth is None:
             return 0
         username = (auth.username or "").upper()
         if username in {"SYSTEM", "LOCAL SERVICE", "NETWORK SERVICE", "ANONYMOUS LOGON"}:
             return 0
         key = (hostname, logon_id or username)
-        cached_session_id = self._terminal_session_ids_by_logon.get(key)
-        if cached_session_id is not None:
-            return cached_session_id
         if auth.session_id > 0:
             self._terminal_session_ids_by_logon[key] = auth.session_id
             return auth.session_id
-        if auth.logon_type in {2, 7, 10, 11}:
-            session_id = 1 + (
-                _stable_seed(f"sysmon_terminal_session:{hostname}:{logon_id or username}") % 8
-            )
-            self._terminal_session_ids_by_logon[key] = session_id
-            return session_id
-        return 0
+        return self._terminal_session_ids_by_logon.get(key, 0)
 
     def _render_sysmon_create_remote_thread(self, event: SecurityEvent) -> None:
         """Render Sysmon Event 8 (CreateRemoteThread)."""
@@ -1237,6 +1228,8 @@ class SysmonEventEmitter(LogEmitter):
             if access and access.target_user
             else "NT AUTHORITY\\SYSTEM"
         )
+        if access is None or access.source_thread_id < 0:
+            raise ValueError("Sysmon ProcessAccess requires a canonical source thread ID")
 
         event_data = {
             "EventID": 10,
@@ -1250,7 +1243,7 @@ class SysmonEventEmitter(LogEmitter):
             "SourceProcessGUID": source_guid,
             "SourceProcessId": proc.pid,
             "SourceImage": proc.image,
-            "SourceThreadId": access.source_thread_id if access else -1,
+            "SourceThreadId": access.source_thread_id,
             "SourceUser": user,
             "TargetProcessGUID": target_guid,
             "TargetProcessId": target_pid,

--- a/src/evidenceforge/generation/engine/core.py
+++ b/src/evidenceforge/generation/engine/core.py
@@ -416,10 +416,6 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
         if "windows_event_security" in self.emitters:
             self.emitters["windows_event_security"]._state_manager = self.state_manager
             self.emitters["windows_event_security"]._system_pids = self._system_pids
-        if "ecar" in self.emitters:
-            self.emitters["ecar"]._state_manager = self.state_manager
-            self.emitters["ecar"]._system_pids = self._system_pids
-
         # Phase 6.3: Pre-parse storyline event times for interleaved generation
         self._storyline_by_hour: dict[int, list] = {}  # hour_epoch -> list of (time, event_idx)
         if self.scenario.storyline:

--- a/src/evidenceforge/generation/engine/emitter_setup.py
+++ b/src/evidenceforge/generation/engine/emitter_setup.py
@@ -67,7 +67,7 @@ from evidenceforge.generation.emitters import (
 from evidenceforge.generation.identity import IdentityDirectory
 from evidenceforge.generation.world_model import database_services_for_host
 from evidenceforge.models.scenario import System
-from evidenceforge.utils.rng import _stable_seed, stable_uuid
+from evidenceforge.utils.rng import _stable_seed
 
 logger = logging.getLogger(__name__)
 
@@ -652,20 +652,17 @@ class EmitterSetupMixin:
             image = normalize_defender_platform_path(image, hn)
             return sm.create_process(hn, parent, image, cmd, user, "System")
 
-        # PID 4 is always the Windows System process (parent of smss.exe).
-        # Register it directly — create_process() auto-allocates PIDs so we
-        # bypass it to hardcode PID 4 as Windows requires.
-        from evidenceforge.models.state import RunningProcess
-
-        sm.state.running_processes[(hn, 4)] = RunningProcess(
+        # PID 4 is always the Windows System process. Keep the fixed native PID
+        # while registering it through the same canonical identity boundary.
+        sm.register_process(
+            system=hn,
             pid=4,
             parent_pid=0,
             image="System",
             command_line="",
             username="SYSTEM",
-            system=hn,
-            start_time=sm.state.current_time,
             integrity_level="System",
+            os_category="windows",
         )
         pids["system"] = 4
         pids["smss"] = _c(4, r"C:\Windows\System32\smss.exe", "smss.exe", "SYSTEM")
@@ -806,21 +803,16 @@ class EmitterSetupMixin:
             _advance_boot_clock()
             return sm.create_process(hn, parent, image, cmd, user, "System")
 
-        from evidenceforge.models.state import RunningProcess
-
-        systemd_object_id = stable_uuid("linux-systemd", hn)
-        sm.state.running_processes[(hn, 1)] = RunningProcess(
+        sm.register_process(
+            system=hn,
             pid=1,
             parent_pid=0,
             image="/usr/lib/systemd/systemd",
             command_line="/usr/lib/systemd/systemd --system --deserialize 26",
             username="root",
-            system=hn,
-            start_time=sm.state.current_time,
             integrity_level="System",
-            ecar_object_id=systemd_object_id,
+            os_category="linux",
         )
-        sm._process_object_ids[(hn, 1)] = systemd_object_id
         pids["systemd"] = 1
 
         journal_path = "/usr/lib/systemd/systemd-journald"

--- a/src/evidenceforge/generation/identity_lifecycle.py
+++ b/src/evidenceforge/generation/identity_lifecycle.py
@@ -38,9 +38,9 @@ from evidenceforge.events.lifecycle import ActionLifecycleContext
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.utils.rng import stable_uuid
 
-_PROCESS_START_TYPES = {"process_create"}
+_PROCESS_START_TYPES = {"process_create", "system_process_create"}
 _PROCESS_CLOSURE_TYPES = {"process_terminate"}
-_SESSION_START_TYPES = {"logon"}
+_SESSION_START_TYPES = {"logon", "machine_logon", "ssh_session"}
 _SESSION_CLOSURE_TYPES = {"logoff"}
 
 
@@ -87,7 +87,7 @@ class IdentityLifecyclePlanner:
             )
             return EventIdentityPlan(
                 subject=process,
-                actor=actor if event.event_type == "process_create" else None,
+                actor=actor if event.event_type in _PROCESS_START_TYPES else None,
                 session=session,
             )
 
@@ -142,8 +142,9 @@ class IdentityLifecyclePlanner:
             return EventIdentityPlan(subject=session, session=session)
 
         actor = process or self._network_actor_identity(event)
-        if actor is not None or session is not None:
-            return EventIdentityPlan(actor=actor, session=session)
+        target = self._network_target_identity(event)
+        if actor is not None or target is not None or session is not None:
+            return EventIdentityPlan(actor=actor, target=target, session=session)
         return None
 
     def _plan_lifecycle(
@@ -153,8 +154,12 @@ class IdentityLifecyclePlanner:
         process: ProcessIdentity | None,
         session: SessionIdentity | None,
     ) -> ActionLifecycleContext | None:
-        if event.event_type == "logon" and session is not None:
-            if event.auth is not None and event.auth.logon_type == 7:
+        if event.event_type in _SESSION_START_TYPES and session is not None:
+            if (
+                event.event_type == "logon"
+                and event.auth is not None
+                and event.auth.logon_type == 7
+            ):
                 return ActionLifecycleContext(
                     group_id=stable_uuid(
                         "session-reauth-lifecycle",
@@ -223,6 +228,14 @@ class IdentityLifecyclePlanner:
         return self._state_manager.get_process_identity(
             event.src_host.hostname,
             event.network.initiating_pid,
+        )
+
+    def _network_target_identity(self, event: SecurityEvent) -> ProcessIdentity | None:
+        if event.network is None or event.dst_host is None or event.network.responding_pid < 0:
+            return None
+        return self._state_manager.get_process_identity(
+            event.dst_host.hostname,
+            event.network.responding_pid,
         )
 
     def _target_process_identity(self, event: SecurityEvent) -> ProcessIdentity | None:

--- a/src/evidenceforge/generation/identity_lifecycle.py
+++ b/src/evidenceforge/generation/identity_lifecycle.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Canonical identity-role and lifecycle planning before source observation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.contexts import EdrContext
+from evidenceforge.events.identity import (
+    EventIdentityPlan,
+    ProcessIdentity,
+    SessionIdentity,
+    ThreadIdentity,
+)
+from evidenceforge.events.lifecycle import ActionLifecycleContext
+from evidenceforge.generation.state_manager import StateManager
+from evidenceforge.utils.rng import stable_uuid
+
+_PROCESS_START_TYPES = {"process_create"}
+_PROCESS_CLOSURE_TYPES = {"process_terminate"}
+_SESSION_START_TYPES = {"logon"}
+_SESSION_CLOSURE_TYPES = {"logoff"}
+
+
+class IdentityLifecyclePlanner:
+    """Resolve canonical identity roles and lifecycle groups for one event."""
+
+    def __init__(self, state_manager: StateManager) -> None:
+        self._state_manager = state_manager
+
+    def plan(self, event: SecurityEvent) -> None:
+        """Attach a frozen identity plan and lifecycle metadata in place.
+
+        Planning runs before ``StateManager.apply`` so termination and logoff
+        events can still resolve their live durable identities. Missing process
+        or thread state remains missing; this layer never invents attribution.
+        """
+
+        session = self._session_identity(event)
+        process = self._process_identity(event)
+        plan = self._plan_roles(event, process=process, session=session)
+        if plan is not None:
+            event.identity_plan = plan
+            self._project_compatibility(event, plan)
+        if event.lifecycle is None:
+            event.lifecycle = self._plan_lifecycle(
+                event,
+                process=process,
+                session=session,
+            )
+
+    def _plan_roles(
+        self,
+        event: SecurityEvent,
+        *,
+        process: ProcessIdentity | None,
+        session: SessionIdentity | None,
+    ) -> EventIdentityPlan | None:
+        if event.event_type in _PROCESS_START_TYPES | _PROCESS_CLOSURE_TYPES:
+            if process is None:
+                return None
+            actor = self._state_manager.get_process_identity(
+                process.hostname,
+                process.parent_pid,
+            )
+            return EventIdentityPlan(
+                subject=process,
+                actor=actor if event.event_type == "process_create" else None,
+                session=session,
+            )
+
+        if event.event_type == "process_access":
+            target = self._target_process_identity(event)
+            if process is None and target is None:
+                return None
+            return EventIdentityPlan(
+                subject=target,
+                actor=process,
+                target=target,
+                session=session,
+            )
+
+        if event.event_type == "create_remote_thread":
+            target = self._target_process_identity(event)
+            thread = self._remote_thread_identity(event, target)
+            if process is None and target is None and thread is None:
+                return None
+            return EventIdentityPlan(
+                subject=thread,
+                actor=process,
+                target=target,
+                session=session,
+            )
+
+        if event.event_type in _SESSION_START_TYPES | _SESSION_CLOSURE_TYPES:
+            if session is None:
+                return None
+            if (
+                event.event_type == "logon"
+                and event.auth is not None
+                and event.auth.logon_type == 7
+            ):
+                child_group_id = stable_uuid(
+                    "session-reauth-lifecycle",
+                    session.object_id,
+                    event.timestamp.isoformat(),
+                )
+                reauth = replace(
+                    session,
+                    object_id=stable_uuid(
+                        "session-reauth",
+                        session.object_id,
+                        event.timestamp.isoformat(),
+                    ),
+                    started_at=event.timestamp,
+                    lifecycle_group_id=child_group_id,
+                    parent_lifecycle_group_id=session.lifecycle_group_id,
+                )
+                return EventIdentityPlan(subject=reauth, actor=session, session=session)
+            return EventIdentityPlan(subject=session, session=session)
+
+        actor = process or self._network_actor_identity(event)
+        if actor is not None or session is not None:
+            return EventIdentityPlan(actor=actor, session=session)
+        return None
+
+    def _plan_lifecycle(
+        self,
+        event: SecurityEvent,
+        *,
+        process: ProcessIdentity | None,
+        session: SessionIdentity | None,
+    ) -> ActionLifecycleContext | None:
+        if event.event_type == "logon" and session is not None:
+            if event.auth is not None and event.auth.logon_type == 7:
+                return ActionLifecycleContext(
+                    group_id=stable_uuid(
+                        "session-reauth-lifecycle",
+                        session.object_id,
+                        event.timestamp.isoformat(),
+                    ),
+                    canonical_start=event.timestamp,
+                    phase="start",
+                    parent_group_id=session.lifecycle_group_id,
+                )
+            return ActionLifecycleContext(
+                group_id=session.lifecycle_group_id,
+                canonical_start=session.started_at,
+                phase="start",
+                parent_group_id=session.parent_lifecycle_group_id or None,
+            )
+        if event.event_type == "logoff" and session is not None:
+            return ActionLifecycleContext(
+                group_id=session.lifecycle_group_id,
+                canonical_start=session.started_at,
+                phase="closure",
+                parent_group_id=session.parent_lifecycle_group_id or None,
+            )
+        if process is not None:
+            phase = "dependent"
+            if event.event_type in _PROCESS_START_TYPES:
+                phase = "start"
+            elif event.event_type in _PROCESS_CLOSURE_TYPES:
+                phase = "closure"
+            return ActionLifecycleContext(
+                group_id=process.lifecycle_group_id,
+                canonical_start=process.started_at,
+                phase=phase,
+                parent_group_id=process.parent_lifecycle_group_id or None,
+            )
+        if session is not None:
+            return ActionLifecycleContext(
+                group_id=session.lifecycle_group_id,
+                canonical_start=session.started_at,
+                phase="dependent",
+                parent_group_id=session.parent_lifecycle_group_id or None,
+            )
+        return None
+
+    def _session_identity(self, event: SecurityEvent) -> SessionIdentity | None:
+        if event.auth is None or not event.auth.logon_id:
+            return None
+        return self._state_manager.get_session_identity(event.auth.logon_id)
+
+    def _process_identity(self, event: SecurityEvent) -> ProcessIdentity | None:
+        host = event.src_host or event.dst_host
+        if host is None:
+            return None
+        if event.process is not None and event.process.pid >= 0:
+            return self._state_manager.get_process_identity(host.hostname, event.process.pid)
+        if event.network is not None and event.network.initiating_pid >= 0 and event.src_host:
+            return self._state_manager.get_process_identity(
+                event.src_host.hostname,
+                event.network.initiating_pid,
+            )
+        return None
+
+    def _network_actor_identity(self, event: SecurityEvent) -> ProcessIdentity | None:
+        if event.network is None or event.src_host is None or event.network.initiating_pid < 0:
+            return None
+        return self._state_manager.get_process_identity(
+            event.src_host.hostname,
+            event.network.initiating_pid,
+        )
+
+    def _target_process_identity(self, event: SecurityEvent) -> ProcessIdentity | None:
+        host = event.src_host or event.dst_host
+        if host is None:
+            return None
+        object_id = ""
+        target_pid = -1
+        if event.process_access is not None:
+            object_id = event.process_access.target_process_object_id
+            target_pid = event.process_access.target_pid
+        elif event.remote_thread is not None:
+            object_id = event.remote_thread.target_process_object_id
+            target_pid = event.remote_thread.target_pid
+        if object_id:
+            return self._state_manager.get_process_identity_by_object_id(object_id)
+        if target_pid >= 0:
+            return self._state_manager.get_process_identity(host.hostname, target_pid)
+        return None
+
+    def _remote_thread_identity(
+        self,
+        event: SecurityEvent,
+        target: ProcessIdentity | None,
+    ) -> ThreadIdentity | None:
+        remote = event.remote_thread
+        if remote is None or target is None or remote.new_thread_id < 0:
+            return None
+        return self._state_manager.get_thread(
+            target.hostname,
+            target.object_id,
+            remote.new_thread_id,
+        )
+
+    @staticmethod
+    def _project_compatibility(event: SecurityEvent, plan: EventIdentityPlan) -> None:
+        """Fill legacy eCAR fields from canonical truth and reject contradictions."""
+
+        if event.edr is None:
+            event.edr = EdrContext()
+        if plan.object_id:
+            event.edr.object_id = plan.object_id
+        if plan.actor_id:
+            event.edr.actor_id = plan.actor_id
+        if plan.canonical_tid >= 0 and (
+            event.event_type in _PROCESS_START_TYPES | _PROCESS_CLOSURE_TYPES
+            or isinstance(plan.subject, ThreadIdentity)
+        ):
+            event.edr.tid = plan.canonical_tid
+        event.edr.validate_identity_plan(plan)

--- a/src/evidenceforge/generation/source_timing.py
+++ b/src/evidenceforge/generation/source_timing.py
@@ -10,10 +10,11 @@ profiles and explicit constraints instead of independent emitter-local jitter.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from evidenceforge.events.identity import ProcessIdentity
 from evidenceforge.generation.activity.timing_profiles import (
     endpoint_clock_timing,
     get_timing_window,
@@ -33,6 +34,7 @@ _PROCESS_CREATE_SOURCE_KEYS = {
     "source.sysmon_process_create",
     "source.ecar_process_create",
 }
+_PROCESS_START_EVENT_TYPES = {"process_create", "system_process_create"}
 
 
 @dataclass(slots=True)
@@ -49,11 +51,116 @@ class SourceTimingPlanner:
 
     def __init__(self, clock_profile_name: str = "complete") -> None:
         self.clock_profile_name = clock_profile_name or "complete"
+        self._ecar_process_create_times: dict[str, datetime] = {}
 
-    def plan_event(self, event: SecurityEvent) -> SecurityEvent:
+    def plan_event(
+        self,
+        event: SecurityEvent,
+        format_name: str | None = None,
+    ) -> SecurityEvent:
         """Return ``event`` with an attached source timing plan."""
         self._ensure_plan(event)
+        if format_name in {None, "ecar"}:
+            self._plan_ecar_identity_times(event)
         return event
+
+    def _plan_ecar_identity_times(self, event: SecurityEvent) -> None:
+        """Prime stable process-create anchors for eCAR lifecycle consumers.
+
+        Process creation and dependent telemetry are separate canonical events.
+        Their independent source-latency samples must still share the exact
+        source-visible process-create anchor, including parent-before-child
+        ordering. The dispatcher-owned planner retains that cross-event state;
+        emitters only consume the timestamp recorded on each event plan.
+        """
+
+        identity_plan = event.identity_plan
+        if identity_plan is None:
+            return
+        identities: list[ProcessIdentity] = []
+        for identity in (
+            identity_plan.subject,
+            identity_plan.actor,
+            identity_plan.target,
+        ):
+            if isinstance(identity, ProcessIdentity) and identity not in identities:
+                identities.append(identity)
+        if not identities:
+            return
+
+        subject = (
+            identity_plan.subject if isinstance(identity_plan.subject, ProcessIdentity) else None
+        )
+        parent = (
+            identity_plan.actor
+            if event.event_type in _PROCESS_START_EVENT_TYPES
+            and isinstance(identity_plan.actor, ProcessIdentity)
+            else None
+        )
+        parent_time = self._ecar_process_create_times.get(parent.object_id) if parent else None
+        if parent is not None and parent_time is None:
+            parent_time = self._prime_ecar_process_create_time(event, parent)
+
+        for identity in identities:
+            anchor_timestamp = (
+                event.timestamp
+                if event.event_type in _PROCESS_START_EVENT_TYPES and identity is subject
+                else identity.started_at
+            )
+            not_before = None
+            if identity is subject and parent_time is not None:
+                not_before = parent_time + sample_timing_delta(
+                    "source.ecar_dependent_after_process_create",
+                    seed_parts=(
+                        "parent-before-child",
+                        parent.object_id,
+                        identity.object_id,
+                    ),
+                )
+            create_time = self._prime_ecar_process_create_time(
+                event,
+                identity,
+                anchor_timestamp=anchor_timestamp,
+                not_before=not_before,
+            )
+            self.record_source_time(
+                event,
+                "source.ecar_process_create",
+                create_time,
+                seed_parts=(identity.hostname, identity.pid, identity.started_at),
+            )
+
+    def _prime_ecar_process_create_time(
+        self,
+        event: SecurityEvent,
+        identity: ProcessIdentity,
+        *,
+        anchor_timestamp: datetime | None = None,
+        not_before: datetime | None = None,
+    ) -> datetime:
+        """Return and retain one source-visible eCAR create time per process object."""
+
+        cached = self._ecar_process_create_times.get(identity.object_id)
+        if cached is not None:
+            if not_before is not None and cached < not_before:
+                cached = not_before
+                self._ecar_process_create_times[identity.object_id] = cached
+            return cached
+        anchor = replace(
+            event,
+            timestamp=anchor_timestamp or identity.started_at,
+            source_timing=None,
+        )
+        create_time = self.source_time(
+            anchor,
+            "source.ecar_process_create",
+            seed_parts=(identity.hostname, identity.pid, identity.started_at),
+            not_before=max(identity.started_at, not_before)
+            if not_before is not None
+            else identity.started_at,
+        )
+        self._ecar_process_create_times[identity.object_id] = create_time
+        return create_time
 
     def admission_time(self, event: SecurityEvent, format_name: str) -> datetime:
         """Return the finalized source-visible timestamp used for window admission."""

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -33,6 +33,7 @@ from datetime import datetime, timedelta
 from threading import RLock
 
 from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.identity import ProcessIdentity, SessionIdentity, ThreadIdentity
 from evidenceforge.events.network import NetworkTransactionPlan
 from evidenceforge.models.exceptions import StateError
 from evidenceforge.models.state import (
@@ -40,6 +41,7 @@ from evidenceforge.models.state import (
     GeneratorState,
     OpenConnection,
     RunningProcess,
+    RunningThread,
 )
 from evidenceforge.utils.ids import generate_zeek_uid
 from evidenceforge.utils.rng import _stable_seed, stable_uuid
@@ -113,6 +115,8 @@ class StateManager:
         self._linux_pid_used_ids: dict[str, set[int]] = {}
         self._linux_pid_allocations: dict[str, list[tuple[datetime, int]]] = {}
         self._connection_id_counter = 0
+        self._thread_id_counters: dict[str, int] = {}
+        self._thread_id_rngs: dict[str, random.Random] = {}
         self._windows_session_id_counters: dict[str, int] = {}
         self._linux_logind_session_counters: dict[str, int] = {}
         self._linux_logind_session_initials: dict[str, int] = {}
@@ -127,6 +131,8 @@ class StateManager:
         self._system_boot_times: dict[str, datetime] = {}
         self._ended_sessions: dict[str, tuple[ActiveSession, datetime]] = {}
         self._process_object_ids: dict[tuple[str, int], str] = {}
+        self._processes_by_object_id: dict[str, RunningProcess] = {}
+        self._ended_threads: dict[tuple[str, str, int], RunningThread] = {}
 
     # ========================================
     # Session Management
@@ -303,6 +309,8 @@ class StateManager:
         start_time: datetime | None = None,
         logon_guid: str = "",
         session_id: int | None = None,
+        lifecycle_group_id: str = "",
+        parent_lifecycle_group_id: str = "",
     ) -> str:
         """Create a new active session.
 
@@ -341,6 +349,18 @@ class StateManager:
                     session_kind,
                 )
             )
+            session_object_id = stable_uuid(
+                "session",
+                system,
+                username,
+                logon_type,
+                session_kind,
+                source_ip,
+                source_port,
+                session_start_time.isoformat(),
+                logon_id,
+                windows_session_id,
+            )
             session = ActiveSession(
                 logon_id=logon_id,
                 username=username,
@@ -352,19 +372,11 @@ class StateManager:
                 source_port=source_port,
                 session_kind=session_kind,
                 transport_pid=transport_pid,
-                ecar_object_id=stable_uuid(
-                    "session",
-                    system,
-                    username,
-                    logon_type,
-                    session_kind,
-                    source_ip,
-                    source_port,
-                    session_start_time.isoformat(),
-                    logon_id,
-                    windows_session_id,
-                ),
+                ecar_object_id=session_object_id,
                 logon_guid=logon_guid,
+                lifecycle_group_id=lifecycle_group_id
+                or stable_uuid("session-lifecycle", session_object_id),
+                parent_lifecycle_group_id=parent_lifecycle_group_id,
             )
 
             self.state.active_sessions[logon_id] = session
@@ -447,6 +459,8 @@ class StateManager:
         transport_pid: int | None = None,
         logon_guid: str = "",
         session_id: int | None = None,
+        lifecycle_group_id: str = "",
+        parent_lifecycle_group_id: str = "",
     ) -> ActiveSession:
         """Register a pre-existing session in state.
 
@@ -470,6 +484,18 @@ class StateManager:
                     session_kind,
                 )
             )
+            session_object_id = stable_uuid(
+                "registered-session",
+                system,
+                username,
+                logon_type,
+                session_kind,
+                source_ip,
+                source_port,
+                ensure_utc(start_time).isoformat(),
+                logon_id,
+                windows_session_id,
+            )
             session = ActiveSession(
                 logon_id=logon_id,
                 username=username,
@@ -481,19 +507,11 @@ class StateManager:
                 source_port=source_port,
                 session_kind=session_kind,
                 transport_pid=transport_pid,
-                ecar_object_id=stable_uuid(
-                    "registered-session",
-                    system,
-                    username,
-                    logon_type,
-                    session_kind,
-                    source_ip,
-                    source_port,
-                    ensure_utc(start_time).isoformat(),
-                    logon_id,
-                    windows_session_id,
-                ),
+                ecar_object_id=session_object_id,
                 logon_guid=logon_guid,
+                lifecycle_group_id=lifecycle_group_id
+                or stable_uuid("session-lifecycle", session_object_id),
+                parent_lifecycle_group_id=parent_lifecycle_group_id,
             )
             self.state.active_sessions[logon_id] = session
             self._logon_id_aliases.pop(logon_id, None)
@@ -515,6 +533,8 @@ class StateManager:
         source_ready_time: datetime | None = None,
         logon_guid: str | None = None,
         session_id: int | None = None,
+        lifecycle_group_id: str | None = None,
+        parent_lifecycle_group_id: str | None = None,
     ) -> bool:
         """Update mutable metadata on an existing session."""
         with self._lock:
@@ -541,7 +561,36 @@ class StateManager:
                 session.logon_guid = logon_guid
             if session_id is not None:
                 session.session_id = session_id
+            if lifecycle_group_id is not None:
+                session.lifecycle_group_id = lifecycle_group_id
+            if parent_lifecycle_group_id is not None:
+                session.parent_lifecycle_group_id = parent_lifecycle_group_id
             return True
+
+    def get_session_identity(self, logon_id: str) -> SessionIdentity | None:
+        """Return an immutable snapshot of an active or ended session identity."""
+
+        with self._lock:
+            resolved_logon_id = self._resolve_logon_id(logon_id)
+            session = self.state.active_sessions.get(resolved_logon_id)
+            if session is None:
+                ended = self._ended_sessions.get(resolved_logon_id) or self._ended_sessions.get(
+                    logon_id
+                )
+                session = ended[0] if ended is not None else None
+            if session is None:
+                return None
+            return SessionIdentity(
+                hostname=session.system,
+                object_id=session.ecar_object_id,
+                logon_id=session.logon_id,
+                session_id=session.session_id,
+                principal=session.username,
+                session_kind=session.session_kind,
+                started_at=session.start_time,
+                lifecycle_group_id=session.lifecycle_group_id,
+                parent_lifecycle_group_id=session.parent_lifecycle_group_id,
+            )
 
     def get_session_id(self, logon_id: str) -> int:
         """Return the canonical rendered session ID for an active or ended logon."""
@@ -956,6 +1005,8 @@ class StateManager:
         username: str,
         integrity_level: str,
         logon_id: str = "",
+        lifecycle_group_id: str = "",
+        parent_lifecycle_group_id: str = "",
     ) -> int:
         """Create a new running process.
 
@@ -1042,6 +1093,13 @@ class StateManager:
                 self.state.current_time.isoformat(),
                 logon_id,
             )
+            owning_session = self.get_session(logon_id) if logon_id else None
+            process_lifecycle_group_id = lifecycle_group_id or stable_uuid(
+                "process-lifecycle", ecar_object_id
+            )
+            process_parent_group_id = parent_lifecycle_group_id or (
+                owning_session.lifecycle_group_id if owning_session is not None else ""
+            )
             process = RunningProcess(
                 pid=pid,
                 parent_pid=parent_pid,
@@ -1053,13 +1111,232 @@ class StateManager:
                 integrity_level=integrity_level,
                 logon_id=logon_id,
                 ecar_object_id=ecar_object_id,
+                lifecycle_group_id=process_lifecycle_group_id,
+                parent_lifecycle_group_id=process_parent_group_id,
             )
 
             key = (system, pid)
             self.state.running_processes[key] = process
             self._process_object_ids[key] = ecar_object_id
+            self._processes_by_object_id[ecar_object_id] = process
+            primary_tid = (
+                pid
+                if self._pid_os.get(system) == "linux"
+                else self._allocate_thread_id(
+                    system,
+                    ecar_object_id,
+                    pid,
+                )
+            )
+            primary_thread = self._register_thread(
+                process,
+                tid=primary_tid,
+                kind="primary",
+                start_time=self.state.current_time,
+            )
+            process.primary_tid = primary_thread.tid
             logger.debug(f"Created process {pid} on {system}: {image}")
             return pid
+
+    def _allocate_thread_id(self, system: str, process_object_id: str, pid: int) -> int:
+        """Allocate a deterministic host-native TID for an explicitly modeled thread."""
+
+        os_category = self._pid_os.get(system, "windows")
+        if os_category == "linux":
+            candidate = pid + 1 + (_stable_seed(f"linux_tid:{system}:{process_object_id}") % 1024)
+            used = {
+                thread.tid
+                for thread in self.state.running_threads.values()
+                if thread.hostname == system and thread.process_object_id == process_object_id
+            }
+            while candidate in used:
+                candidate += 1
+            return candidate
+
+        counter = self._thread_id_counters.get(
+            system,
+            2000 + (4 * (_stable_seed(f"windows_tid_initial:{system}") % 5000)),
+        )
+        rng = self._thread_id_rngs.setdefault(
+            system,
+            random.Random(_stable_seed(f"windows_tid_alloc:{system}")),
+        )
+        used = {
+            thread.tid
+            for thread in self.state.running_threads.values()
+            if thread.hostname == system
+        }
+        candidate = counter - (counter % 4)
+        while candidate in used or candidate <= 0:
+            candidate += 4
+        self._thread_id_counters[system] = candidate + (4 * rng.randint(1, 17))
+        return candidate
+
+    def _register_thread(
+        self,
+        process: RunningProcess,
+        *,
+        tid: int,
+        kind: str,
+        start_time: datetime,
+    ) -> RunningThread:
+        """Register a thread after its live owning process has been validated."""
+
+        key = (process.system, process.ecar_object_id, tid)
+        existing = self.state.running_threads.get(key)
+        if existing is not None:
+            return existing
+        thread = RunningThread(
+            hostname=process.system,
+            process_object_id=process.ecar_object_id,
+            pid=process.pid,
+            tid=tid,
+            object_id=stable_uuid(
+                "thread",
+                process.system,
+                process.ecar_object_id,
+                process.pid,
+                tid,
+                ensure_utc(start_time).isoformat(),
+                kind,
+            ),
+            start_time=ensure_utc(start_time),
+            kind=kind,
+        )
+        self.state.running_threads[key] = thread
+        self._ended_threads.pop(key, None)
+        return thread
+
+    def create_thread(
+        self,
+        system: str,
+        process_object_id: str,
+        *,
+        tid: int | None = None,
+        kind: str = "worker",
+        start_time: datetime | None = None,
+    ) -> ThreadIdentity:
+        """Create an explicit thread owned by a live canonical process."""
+
+        with self._lock:
+            process = self._processes_by_object_id.get(process_object_id)
+            if (
+                process is None
+                or process.system != system
+                or self.state.running_processes.get((system, process.pid)) is not process
+            ):
+                raise StateError(
+                    f"Cannot create thread: owning process object is not live on {system}"
+                )
+            thread_id = tid
+            if thread_id is None:
+                thread_id = self._allocate_thread_id(system, process_object_id, process.pid)
+            if thread_id < 0:
+                raise StateError("Cannot create thread: TID must be non-negative")
+            effective_start = start_time or self.state.current_time
+            if effective_start is None:
+                raise StateError("Cannot create thread: current_time not set")
+            thread = self._register_thread(
+                process,
+                tid=thread_id,
+                kind=kind,
+                start_time=effective_start,
+            )
+            return self._thread_identity(thread)
+
+    @staticmethod
+    def _thread_identity(thread: RunningThread) -> ThreadIdentity:
+        """Project mutable runtime thread state to an immutable identity snapshot."""
+
+        return ThreadIdentity(
+            hostname=thread.hostname,
+            process_object_id=thread.process_object_id,
+            pid=thread.pid,
+            tid=thread.tid,
+            object_id=thread.object_id,
+            started_at=thread.start_time,
+            kind=thread.kind,
+        )
+
+    def get_thread(
+        self,
+        system: str,
+        process_object_id: str,
+        tid: int,
+    ) -> ThreadIdentity | None:
+        """Resolve an active thread by its collision-safe canonical key."""
+
+        with self._lock:
+            thread = self.state.running_threads.get((system, process_object_id, tid))
+            return self._thread_identity(thread) if thread is not None else None
+
+    def get_primary_thread(self, system: str, pid: int) -> ThreadIdentity | None:
+        """Return the immutable primary-thread identity for a live process."""
+
+        with self._lock:
+            process = self.state.running_processes.get((system, pid))
+            if process is None or process.primary_tid < 0:
+                return None
+            return self.get_thread(system, process.ecar_object_id, process.primary_tid)
+
+    def end_thread(
+        self,
+        system: str,
+        process_object_id: str,
+        tid: int,
+        end_time: datetime | None = None,
+    ) -> bool:
+        """End one explicit thread without affecting identically numbered threads."""
+
+        with self._lock:
+            key = (system, process_object_id, tid)
+            thread = self.state.running_threads.pop(key, None)
+            if thread is None:
+                return False
+            effective_end = end_time or self.state.current_time
+            thread.end_time = ensure_utc(effective_end) if effective_end is not None else None
+            self._ended_threads[key] = thread
+            return True
+
+    def get_process_identity(self, system: str, pid: int) -> ProcessIdentity | None:
+        """Return an immutable snapshot for the currently live process at a host-local PID."""
+
+        with self._lock:
+            process = self.state.running_processes.get((system, pid))
+            if process is None:
+                return None
+            return self._process_identity(process)
+
+    def get_process_identity_by_object_id(self, object_id: str) -> ProcessIdentity | None:
+        """Resolve a live or ended process by its durable process object identity."""
+
+        with self._lock:
+            process = self._processes_by_object_id.get(object_id)
+            return self._process_identity(process) if process is not None else None
+
+    def _process_identity(self, process: RunningProcess) -> ProcessIdentity:
+        """Project mutable runtime process state to an immutable identity snapshot."""
+
+        primary_thread = None
+        if process.primary_tid >= 0:
+            key = (process.system, process.ecar_object_id, process.primary_tid)
+            thread = self.state.running_threads.get(key) or self._ended_threads.get(key)
+            if thread is not None:
+                primary_thread = self._thread_identity(thread)
+        return ProcessIdentity(
+            hostname=process.system,
+            object_id=process.ecar_object_id,
+            pid=process.pid,
+            parent_pid=process.parent_pid,
+            image=process.image,
+            command_line=process.command_line,
+            principal=process.username,
+            logon_id=process.logon_id,
+            started_at=process.start_time,
+            lifecycle_group_id=process.lifecycle_group_id,
+            parent_lifecycle_group_id=process.parent_lifecycle_group_id,
+            primary_thread=primary_thread,
+        )
 
     def get_process(self, system: str, pid: int) -> RunningProcess | None:
         """Get a running process.
@@ -1157,7 +1434,12 @@ class StateManager:
             if proc:
                 proc.story_created = True
 
-    def end_process(self, system: str, pid: int) -> bool:
+    def end_process(
+        self,
+        system: str,
+        pid: int,
+        end_time: datetime | None = None,
+    ) -> bool:
         """End a running process.
 
         Args:
@@ -1169,7 +1451,15 @@ class StateManager:
         """
         with self._lock:
             key = (system, pid)
-            if key in self.state.running_processes:
+            process = self.state.running_processes.get(key)
+            if process is not None:
+                thread_keys = [
+                    thread_key
+                    for thread_key in self.state.running_threads
+                    if thread_key[0] == system and thread_key[1] == process.ecar_object_id
+                ]
+                for thread_key in thread_keys:
+                    self.end_thread(*thread_key, end_time=end_time)
                 del self.state.running_processes[key]
                 self._clear_session_process_references(system, pid)
                 logger.debug(f"Ended process {pid} on {system}")
@@ -1603,7 +1893,7 @@ class StateManager:
             if event.event_type == "logoff" and event.auth:
                 self.end_session(event.auth.logon_id, event.timestamp)
             elif event.event_type == "process_terminate" and event.process and event.src_host:
-                self.end_process(event.src_host.hostname, event.process.pid)
+                self.end_process(event.src_host.hostname, event.process.pid, event.timestamp)
             elif event.event_type == "connection" and event.network:
                 event.network.validate_finalized_transaction()
                 if event.network.conn_id:

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -996,6 +996,98 @@ class StateManager:
             pid_rng = self._pid_rngs[system]
             return self._allocate_linux_pid(system, pid_rng, event_time)
 
+    def register_process(
+        self,
+        system: str,
+        pid: int,
+        parent_pid: int,
+        image: str,
+        command_line: str,
+        username: str,
+        integrity_level: str,
+        *,
+        os_category: str,
+        start_time: datetime | None = None,
+        logon_id: str = "",
+        lifecycle_group_id: str = "",
+        parent_lifecycle_group_id: str = "",
+    ) -> RunningProcess:
+        """Register a fixed host-native process through the canonical state boundary.
+
+        This is reserved for kernel/bootstrap identities such as Windows PID 4
+        and Linux PID 1 that cannot use the ordinary PID allocator.
+        """
+
+        with self._lock:
+            effective_start = start_time or self.state.current_time
+            if effective_start is None:
+                raise StateError("Cannot register process: current_time not set")
+            if pid < 0:
+                raise StateError("Cannot register process: PID must be non-negative")
+            if (system, pid) in self.state.running_processes:
+                raise StateError(f"Cannot register process: PID {pid} already exists on {system}")
+            if (
+                parent_pid not in {0, 4}
+                and (system, parent_pid) not in self.state.running_processes
+            ):
+                raise StateError(
+                    f"Cannot register process: parent PID {parent_pid} does not exist on {system}"
+                )
+
+            normalized_start = ensure_utc(effective_start)
+            self._initialize_pid_allocator(system, os_category)
+            if os_category == "linux":
+                self._linux_pid_used_ids.setdefault(system, set()).add(pid)
+                self._linux_pid_allocations.setdefault(system, []).append((normalized_start, pid))
+            object_id = stable_uuid(
+                "registered-process",
+                system,
+                pid,
+                parent_pid,
+                image,
+                command_line,
+                username,
+                normalized_start.isoformat(),
+                logon_id,
+            )
+            owning_session = self.get_session(logon_id) if logon_id else None
+            process = RunningProcess(
+                pid=pid,
+                parent_pid=parent_pid,
+                image=image,
+                command_line=command_line,
+                username=username,
+                system=system,
+                start_time=normalized_start,
+                integrity_level=integrity_level,
+                logon_id=logon_id,
+                ecar_object_id=object_id,
+                lifecycle_group_id=lifecycle_group_id
+                or stable_uuid("process-lifecycle", object_id),
+                parent_lifecycle_group_id=parent_lifecycle_group_id
+                or (owning_session.lifecycle_group_id if owning_session is not None else ""),
+            )
+            self.state.running_processes[(system, pid)] = process
+            self._process_object_ids[(system, pid)] = object_id
+            self._processes_by_object_id[object_id] = process
+            primary_tid = (
+                pid
+                if os_category == "linux"
+                else self._allocate_thread_id(
+                    system,
+                    object_id,
+                    pid,
+                )
+            )
+            thread = self._register_thread(
+                process,
+                tid=primary_tid,
+                kind="primary",
+                start_time=normalized_start,
+            )
+            process.primary_tid = thread.tid
+            return process
+
     def create_process(
         self,
         system: str,

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -1051,6 +1051,14 @@ class StateManager:
                 logon_id,
             )
             owning_session = self.get_session(logon_id) if logon_id else None
+            process_lifecycle_group_id = lifecycle_group_id or stable_uuid(
+                "process-lifecycle", object_id
+            )
+            process_parent_group_id = self._process_parent_lifecycle_group(
+                process_lifecycle_group_id,
+                parent_lifecycle_group_id,
+                owning_session,
+            )
             process = RunningProcess(
                 pid=pid,
                 parent_pid=parent_pid,
@@ -1062,10 +1070,8 @@ class StateManager:
                 integrity_level=integrity_level,
                 logon_id=logon_id,
                 ecar_object_id=object_id,
-                lifecycle_group_id=lifecycle_group_id
-                or stable_uuid("process-lifecycle", object_id),
-                parent_lifecycle_group_id=parent_lifecycle_group_id
-                or (owning_session.lifecycle_group_id if owning_session is not None else ""),
+                lifecycle_group_id=process_lifecycle_group_id,
+                parent_lifecycle_group_id=process_parent_group_id,
             )
             self.state.running_processes[(system, pid)] = process
             self._process_object_ids[(system, pid)] = object_id
@@ -1189,8 +1195,10 @@ class StateManager:
             process_lifecycle_group_id = lifecycle_group_id or stable_uuid(
                 "process-lifecycle", ecar_object_id
             )
-            process_parent_group_id = parent_lifecycle_group_id or (
-                owning_session.lifecycle_group_id if owning_session is not None else ""
+            process_parent_group_id = self._process_parent_lifecycle_group(
+                process_lifecycle_group_id,
+                parent_lifecycle_group_id,
+                owning_session,
             )
             process = RunningProcess(
                 pid=pid,
@@ -1229,6 +1237,27 @@ class StateManager:
             process.primary_tid = primary_thread.tid
             logger.debug(f"Created process {pid} on {system}: {image}")
             return pid
+
+    @staticmethod
+    def _process_parent_lifecycle_group(
+        lifecycle_group_id: str,
+        explicit_parent_group_id: str,
+        owning_session: ActiveSession | None,
+    ) -> str:
+        """Return process lifecycle parentage without a self-parenting group.
+
+        Ordinary processes are children of their owning session. Session-bootstrap
+        helpers intentionally share the session group so their parent is instead
+        the session's parent, if one exists.
+        """
+
+        if explicit_parent_group_id and explicit_parent_group_id != lifecycle_group_id:
+            return explicit_parent_group_id
+        if owning_session is None:
+            return ""
+        if owning_session.lifecycle_group_id == lifecycle_group_id:
+            return owning_session.parent_lifecycle_group_id
+        return owning_session.lifecycle_group_id
 
     def _allocate_thread_id(self, system: str, process_object_id: str, pid: int) -> int:
         """Allocate a deterministic host-native TID for an explicitly modeled thread."""
@@ -1973,12 +2002,24 @@ class StateManager:
         process termination) and updates (connection bytes).
         """
         with self._lock:
-            if event.event_type != "process_terminate" and event.process and event.src_host:
-                proc = self.state.running_processes.get(
-                    (event.src_host.hostname, event.process.pid)
-                )
+            process_pid = -1
+            process_host = ""
+            if event.process is not None and event.src_host is not None:
+                process_pid = event.process.pid
+                process_host = event.src_host.hostname
+            elif event.identity_plan is not None and isinstance(
+                event.identity_plan.actor, ProcessIdentity
+            ):
+                process_pid = event.identity_plan.actor.pid
+                process_host = event.identity_plan.actor.hostname
+            if event.event_type != "process_terminate" and process_pid >= 0 and process_host:
+                proc = self.state.running_processes.get((process_host, process_pid))
                 if proc is not None:
                     activity_time = ensure_utc(event.timestamp)
+                    if event.network is not None and event.network.transaction is not None:
+                        closed_at = event.network.transaction.closed_at
+                        if closed_at is not None:
+                            activity_time = max(activity_time, ensure_utc(closed_at))
                     if proc.last_activity_time is None or activity_time > proc.last_activity_time:
                         proc.last_activity_time = activity_time
 

--- a/src/evidenceforge/generation/world_model.py
+++ b/src/evidenceforge/generation/world_model.py
@@ -967,20 +967,12 @@ class WorldPlanner:
                 result.session.storyline_protected = True
             return result
 
-        logon_id = self.state_manager.create_session(
-            username=user.username,
-            system=target_system.hostname,
-            logon_type=plan.logon_type,
-            source_ip=plan.source_ip,
-            session_kind=plan.session_kind,
-        )
-        self.activity_generator.generate_logon(
+        logon_id = self.activity_generator.generate_logon(
             user=user,
             system=target_system,
             time=logon_time,
             logon_type=plan.logon_type,
             source_ip=plan.source_ip,
-            logon_id=logon_id,
         )
         session = self.state_manager.get_session(logon_id)
         if session is None:
@@ -1230,15 +1222,6 @@ class WorldPlanner:
             else "windows"
         )
         source_port = _ephemeral_port(rng, source_os)
-        logon_id = self.state_manager.create_session(
-            username=user.username,
-            system=plan.target_system.hostname,
-            logon_type=plan.logon_type,
-            source_ip=plan.source_ip,
-            source_port=source_port,
-            session_kind="ssh",
-        )
-        session_obj_id = self.state_manager.get_session_object_id(logon_id)
         min_duration = max(
             30.0,
             (activity_time - logon_time).total_seconds() + rng.uniform(2.0, 20.0),
@@ -1253,15 +1236,13 @@ class WorldPlanner:
                 min_duration,
                 (required_until - logon_time).total_seconds() + rng.uniform(20.0, 90.0),
             )
-        uid = self.activity_generator.generate_ssh_session(
+        uid, logon_id = self.activity_generator._execute_ssh_session_bundle(
             user=user,
             target_system=plan.target_system,
             time=logon_time,
             source_ip=plan.source_ip,
             source_system=plan.source_system,
             source_port=source_port,
-            logon_id=logon_id,
-            session_obj_id=session_obj_id,
             min_duration=min_duration,
         )
         session = self.state_manager.get_session(logon_id)
@@ -1313,21 +1294,13 @@ class WorldPlanner:
                 logon_time += shift
                 activity_time += shift
             source_process_factory = self._rdp_source_process_factory(rng)
-        logon_id = self.state_manager.create_session(
-            username=user.username,
-            system=plan.target_system.hostname,
-            logon_type=plan.logon_type,
-            source_ip=plan.source_ip,
-            session_kind="rdp",
-        )
-        uid = self.activity_generator.generate_rdp_session(
+        uid, logon_id = self.activity_generator._execute_rdp_session_bundle(
             user=user,
             target_system=plan.target_system,
             time=logon_time,
             source_ip=plan.source_ip,
             source_system=plan.source_system,
             source_pid=source_pid,
-            logon_id=logon_id,
             source_process_time=source_process_time if plan.source_system is not None else None,
             source_process_factory=source_process_factory,
         )

--- a/src/evidenceforge/models/state.py
+++ b/src/evidenceforge/models/state.py
@@ -79,6 +79,8 @@ class ActiveSession:
     ecar_object_id: str = ""
     storyline_protected: bool = False
     logon_guid: str = ""
+    lifecycle_group_id: str = ""
+    parent_lifecycle_group_id: str = ""
 
 
 @dataclass
@@ -112,6 +114,28 @@ class RunningProcess:
     logon_id: str = ""
     ecar_object_id: str = ""
     story_created: bool = False
+    primary_tid: int = -1
+    lifecycle_group_id: str = ""
+    parent_lifecycle_group_id: str = ""
+
+
+@dataclass
+class RunningThread:
+    """Durable state for one explicitly modeled host-native thread.
+
+    Thread identity is never keyed by PID or TID alone. The owning process
+    object's host- and start-scoped UUID is part of the canonical key, so
+    identical numeric identifiers across hosts and PID reuse cannot collide.
+    """
+
+    hostname: str
+    process_object_id: str
+    pid: int
+    tid: int
+    object_id: str
+    start_time: datetime
+    kind: str = "worker"
+    end_time: datetime | None = None
 
 
 @dataclass
@@ -178,6 +202,7 @@ class GeneratorState:
 
     active_sessions: dict[str, ActiveSession] = field(default_factory=dict)
     running_processes: dict[tuple[str, int], RunningProcess] = field(default_factory=dict)
+    running_threads: dict[tuple[str, str, int], RunningThread] = field(default_factory=dict)
     open_connections: dict[str, OpenConnection] = field(default_factory=dict)
     dns_cache: dict[str, str] = field(default_factory=dict)
     current_time: datetime | None = None

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -100,6 +100,27 @@ class TestDispatchRouting:
         sm.apply.assert_called_once_with(event)
         emitter.emit.assert_not_called()
 
+    def test_dispatch_allocates_unique_deterministic_canonical_event_ids(self):
+        """Distinct occurrences receive stable IDs before state application and rendering."""
+        first_dispatcher = EventDispatcher(state_manager=MagicMock(spec=StateManager), emitters={})
+        first_events = [
+            SecurityEvent(timestamp=_make_ts(), event_type="failed_logon") for _ in range(2)
+        ]
+        for event in first_events:
+            first_dispatcher.dispatch(event)
+
+        second_dispatcher = EventDispatcher(state_manager=MagicMock(spec=StateManager), emitters={})
+        second_events = [
+            SecurityEvent(timestamp=_make_ts(), event_type="failed_logon") for _ in range(2)
+        ]
+        for event in second_events:
+            second_dispatcher.dispatch(event)
+
+        first_ids = [event.event_id for event in first_events]
+        second_ids = [event.event_id for event in second_events]
+        assert len(set(first_ids)) == 2
+        assert first_ids == second_ids
+
     def test_dispatch_applies_storyline_cluster_provenance_only(self):
         """storyline_cluster_id marks context provenance without changing origin flag."""
         sm = MagicMock(spec=StateManager)

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -46,10 +46,10 @@ from evidenceforge.events.contexts import (
     RegistryContext,
     RemoteThreadContext,
 )
+from evidenceforge.events.identity import EventIdentityPlan, ProcessIdentity, ThreadIdentity
 from evidenceforge.events.lifecycle import ActionLifecycleContext
 from evidenceforge.formats.loader import load_format
 from evidenceforge.formats.validator import validate_event
-from evidenceforge.generation.activity.endpoint_noise import ecar_flow_identity_config
 from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
 from evidenceforge.generation.emitters.ecar import EcarEmitter
 from evidenceforge.generation.state_manager import StateManager
@@ -70,6 +70,42 @@ def emitter(tmp_path):
 @pytest.fixture
 def ts():
     return datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC)
+
+
+def _canonical_process_identity(
+    hostname: str,
+    pid: int,
+    started_at: datetime,
+    *,
+    image: str = "/usr/bin/service",
+    principal: str = "SYSTEM",
+    os_category: str = "linux",
+) -> ProcessIdentity:
+    """Build a complete immutable process identity for renderer boundary tests."""
+    object_id = f"process-{hostname}-{pid}-{started_at.isoformat()}"
+    tid = pid if os_category == "linux" else max(4, ((pid + 3) // 4) * 4)
+    thread = ThreadIdentity(
+        hostname=hostname,
+        process_object_id=object_id,
+        pid=pid,
+        tid=tid,
+        object_id=f"thread-{object_id}-{tid}",
+        started_at=started_at,
+        kind="primary",
+    )
+    return ProcessIdentity(
+        hostname=hostname,
+        object_id=object_id,
+        pid=pid,
+        parent_pid=1 if os_category == "linux" else 4,
+        image=image,
+        command_line=image,
+        principal=principal,
+        logon_id="",
+        started_at=started_at,
+        lifecycle_group_id=f"lifecycle-{object_id}",
+        primary_thread=thread,
+    )
 
 
 def test_machine_account_logon_projects_as_user_session_login(emitter, ts):
@@ -104,6 +140,63 @@ def test_machine_account_logon_projects_as_user_session_login(emitter, ts):
     assert rendered["action"] == "LOGIN"
     assert rendered["logon_id"] == "0x537dab7"
     assert rendered["objectID"] == "machine-session-object"
+
+
+def test_ecar_format_uses_explicit_identity_schema_version() -> None:
+    """eCAR 1.1 declares the optional symmetric process identity fields."""
+    format_def = load_format("ecar")
+    field_names = {field.name for field in format_def.fields}
+
+    assert format_def.version == "1.1"
+    assert {
+        "source_process_uuid",
+        "source_pid",
+        "source_tid",
+        "source_image_path",
+        "source_principal",
+        "target_process_uuid",
+        "target_pid",
+        "target_tid",
+        "target_image_path",
+        "target_principal",
+    } <= field_names
+
+
+def test_distinct_canonical_occurrences_cannot_reuse_ecar_record_ids(emitter, ts) -> None:
+    """Otherwise-identical observations retain their upstream occurrence identity."""
+    emitter.emit_event = Mock()
+    host = HostContext(
+        hostname="WS-01",
+        ip="10.0.0.10",
+        os="Windows 11",
+        os_category="windows",
+        system_type="workstation",
+    )
+    events = [
+        SecurityEvent(
+            timestamp=ts,
+            event_type="failed_logon",
+            event_id=event_id,
+            dst_host=host,
+            auth=AuthContext(
+                username="alice",
+                logon_type=3,
+                source_ip="10.0.0.20",
+                failure_reason="%%2313",
+            ),
+        )
+        for event_id in ("canonical-occurrence-one", "canonical-occurrence-two")
+    ]
+
+    for event in events:
+        emitter.emit(event)
+
+    records = [
+        json.loads(emitter._render_event(call.args[0]))
+        for call in emitter.emit_event.call_args_list
+    ]
+    assert records[0]["id"] != records[1]["id"]
+    assert records[0]["objectID"] != records[1]["objectID"]
 
 
 class TestPidEmission:
@@ -654,7 +747,7 @@ class TestSessionOutcomeRendering:
             edr=EdrContext(object_id="flow-1"),
         )
         session_event = SecurityEvent(
-            timestamp=ts,
+            timestamp=ts + timedelta(seconds=2),
             event_type="ssh_session",
             dst_host=host,
             auth=AuthContext(
@@ -703,7 +796,7 @@ class TestSessionOutcomeRendering:
             edr=EdrContext(object_id="flow-1"),
         )
         session_event = SecurityEvent(
-            timestamp=ts,
+            timestamp=ts + timedelta(seconds=2),
             event_type="logon",
             dst_host=host,
             auth=AuthContext(
@@ -856,8 +949,8 @@ class TestChronologicalOutput:
         ]
         assert [row["timestamp_ms"] for row in rows] == sorted(row["timestamp_ms"] for row in rows)
 
-    def test_close_removes_semantic_duplicate_events(self, tmp_path, ts):
-        """UUID-only duplicate eCAR facts should collapse during final flush."""
+    def test_close_preserves_distinct_canonical_events(self, tmp_path, ts):
+        """Flush must not semantically deduplicate distinct canonical events."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -883,7 +976,7 @@ class TestChronologicalOutput:
             json.loads(line)
             for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
         ]
-        assert len(rows) == 1
+        assert {row["id"] for row in rows} == {"event-one", "event-two"}
 
     def test_close_does_not_apply_output_window_admission(self, tmp_path, ts):
         """Direct eCAR rendering leaves output-window admission to the dispatcher."""
@@ -913,8 +1006,8 @@ class TestChronologicalOutput:
         ]
         assert [row["pid"] for row in rows] == [105, 110, 111]
 
-    def test_close_moves_process_terminate_after_later_references(self, tmp_path, ts):
-        """eCAR output should not terminate a process before later same-process telemetry."""
+    def test_close_does_not_repair_process_terminate_order(self, tmp_path, ts):
+        """Lifecycle ordering is owned upstream and flush preserves supplied timestamps."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -969,10 +1062,11 @@ class TestChronologicalOutput:
             for row in rows
             if row["object"] == "PROCESS" and row["action"] == "TERMINATE"
         )
-        assert terminate_ts > module_ts
+        assert terminate_ts < module_ts
+        assert terminate_ts == int(ts.replace(second=2).timestamp() * 1000)
 
-    def test_close_drops_stale_module_after_process_terminate(self, tmp_path, ts):
-        """Long-stale process-owned module rows should not drag termination forward."""
+    def test_close_preserves_stale_module_without_filtering(self, tmp_path, ts):
+        """Stale-reference admission is owned upstream, not by eCAR flush."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -1021,7 +1115,7 @@ class TestChronologicalOutput:
             json.loads(line)
             for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
         ]
-        assert {row["object"] for row in rows} == {"PROCESS"}
+        assert {row["object"] for row in rows} == {"PROCESS", "MODULE"}
         terminate_ts = next(
             row["timestamp_ms"]
             for row in rows
@@ -1029,8 +1123,8 @@ class TestChronologicalOutput:
         )
         assert terminate_ts < int((ts + timedelta(minutes=5)).timestamp() * 1000)
 
-    def test_close_drops_minute_scale_module_after_process_terminate(self, tmp_path, ts):
-        """Minute-scale module rows should not keep a terminated process alive."""
+    def test_close_preserves_minute_scale_module_without_filtering(self, tmp_path, ts):
+        """Flush serializes minute-scale stale input without semantic filtering."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -1079,7 +1173,7 @@ class TestChronologicalOutput:
             json.loads(line)
             for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
         ]
-        assert {row["object"] for row in rows} == {"PROCESS"}
+        assert {row["object"] for row in rows} == {"PROCESS", "MODULE"}
         terminate_ts = next(
             row["timestamp_ms"]
             for row in rows
@@ -1087,8 +1181,8 @@ class TestChronologicalOutput:
         )
         assert terminate_ts < int((ts + timedelta(seconds=30)).timestamp() * 1000)
 
-    def test_close_scrubs_stale_flow_process_identity_after_process_terminate(self, tmp_path, ts):
-        """Late FLOW rows should keep transport evidence without stale PID attribution."""
+    def test_close_does_not_scrub_stale_flow_process_identity(self, tmp_path, ts):
+        """Canonical planning owns stale attribution; flush cannot rewrite identity."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -1141,14 +1235,14 @@ class TestChronologicalOutput:
             for line in (tmp_path / "ws01.example.org" / "ecar.json").read_text().splitlines()
         ]
         flow = next(row for row in rows if row["object"] == "FLOW")
-        assert "actorID" not in flow
-        assert "pid" not in flow
-        assert "tid" not in flow
-        assert "principal" not in flow
-        assert "image_path" not in flow["properties"]
+        assert flow["actorID"] == process_id
+        assert flow["pid"] == 100
+        assert flow["tid"] == 144
+        assert flow["principal"] == "alice"
+        assert flow["properties"]["image_path"] == r"C:\Program Files\App\app.exe"
 
-    def test_close_scrubs_flow_actor_without_visible_process_create(self, tmp_path, ts):
-        """FLOW rows should not claim actors absent from the same host stream."""
+    def test_close_does_not_scrub_unresolved_flow_actor(self, tmp_path, ts):
+        """Flush preserves identity and leaves actor admission to canonical planning."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -1186,12 +1280,12 @@ class TestChronologicalOutput:
         ]
         flow = next(row for row in rows if row["object"] == "FLOW")
         assert flow["objectID"] == "flow-123"
-        assert "actorID" not in flow
-        assert "pid" not in flow
-        assert "tid" not in flow
-        assert "principal" not in flow
-        assert "image_path" not in flow["properties"]
-        assert "command_line" not in flow["properties"]
+        assert flow["actorID"] == "missing-process"
+        assert flow["pid"] == 1234
+        assert flow["tid"] == 1280
+        assert flow["principal"] == "alice"
+        assert flow["properties"]["image_path"] == r"C:\Program Files\App\app.exe"
+        assert flow["properties"]["command_line"] == (r'"C:\Program Files\App\app.exe" --sync')
         assert flow["properties"]["dst_port"] == "443"
 
     def test_close_preserves_flow_actor_with_visible_process_create(self, tmp_path, ts):
@@ -1822,7 +1916,10 @@ class TestChronologicalOutput:
                 conn_state="SF",
                 history="ShADadfF",
                 initiating_pid=-1,
-                responding_pid=child_pid,
+                responding_pid=listener_pid,
+            ),
+            identity_plan=EventIdentityPlan(
+                target=state_manager.get_process_identity("linux01", listener_pid)
             ),
         )
 
@@ -1950,16 +2047,7 @@ class TestChronologicalOutput:
         assert "principal" not in outbound
 
     def test_outbound_flow_can_render_user_principal(self, emitter, monkeypatch, ts):
-        """User-owned FLOW records should be able to carry mixed principal attribution."""
-        monkeypatch.setattr(
-            "evidenceforge.generation.emitters.ecar.ecar_flow_identity_config",
-            lambda: {
-                "user_process_probability": 1.0,
-                "service_process_probability": 0.0,
-                "root_process_probability": 0.0,
-                "inbound_listener_probability": 0.0,
-            },
-        )
+        """User-owned FLOW records render the canonical principal group."""
         emitted: list[dict] = []
         monkeypatch.setattr(emitter, "emit_event", emitted.append)
         event = SecurityEvent(
@@ -1989,6 +2077,16 @@ class TestChronologicalOutput:
                 protocol="tcp",
                 initiating_pid=1234,
             ),
+            identity_plan=EventIdentityPlan(
+                actor=_canonical_process_identity(
+                    "ws01",
+                    1234,
+                    ts,
+                    image=r"C:\Program Files\Mozilla Firefox\firefox.exe",
+                    principal="alice",
+                    os_category="windows",
+                )
+            ),
         )
 
         emitter._render_connection(event)
@@ -1998,19 +2096,10 @@ class TestChronologicalOutput:
         assert emitted[0]["principal"] == "alice"
         record = json.loads(emitter._render_event(emitted[0]))
         assert record["properties"]["image_path"] == event.process.image
-        assert record["properties"]["command_line"] == event.process.command_line
+        assert record["properties"]["command_line"] == event.identity_plan.actor.command_line
 
-    def test_service_flow_can_omit_principal(self, emitter, monkeypatch, ts):
-        """Service-owned FLOW records should still model vendor attribution gaps."""
-        monkeypatch.setattr(
-            "evidenceforge.generation.emitters.ecar.ecar_flow_identity_config",
-            lambda: {
-                "user_process_probability": 1.0,
-                "service_process_probability": 0.0,
-                "root_process_probability": 0.0,
-                "inbound_listener_probability": 0.0,
-            },
-        )
+    def test_service_flow_keeps_canonical_principal_group(self, emitter, monkeypatch, ts):
+        """A known canonical FLOW actor renders as one complete identity group."""
         emitted: list[dict] = []
         monkeypatch.setattr(emitter, "emit_event", emitted.append)
         event = SecurityEvent(
@@ -2040,69 +2129,88 @@ class TestChronologicalOutput:
                 protocol="tcp",
                 initiating_pid=444,
             ),
+            identity_plan=EventIdentityPlan(
+                actor=_canonical_process_identity(
+                    "dc01",
+                    444,
+                    ts,
+                    image=r"C:\Windows\System32\svchost.exe",
+                    principal="SYSTEM",
+                    os_category="windows",
+                )
+            ),
         )
 
         emitter._render_connection(event)
 
-        assert "principal" not in emitted[0]
+        assert emitted[0]["principal"] == "SYSTEM"
 
-    def test_service_flow_default_policy_keeps_known_principal_visible(self, emitter, ts):
-        """Default service FLOW policy should not create high-volume principal flips."""
-        cfg = ecar_flow_identity_config()
-        assert cfg["service_process_probability"] >= 0.98
-        assert cfg["root_process_probability"] >= 0.96
-        assert cfg["inbound_listener_probability"] >= 0.92
-
+    def test_paired_flow_projects_only_each_host_local_actor(self, emitter, monkeypatch, ts):
+        """Endpoint FLOW rows must not expose the remote host's process identity."""
+        emitted: list[dict] = []
+        monkeypatch.setattr(emitter, "emit_event", emitted.append)
+        source = _canonical_process_identity(
+            "client01",
+            4100,
+            ts - timedelta(seconds=2),
+            image="/usr/bin/curl",
+            principal="alice",
+            os_category="linux",
+        )
+        target = _canonical_process_identity(
+            "server01",
+            5200,
+            ts - timedelta(seconds=5),
+            image="/usr/sbin/nginx",
+            principal="www-data",
+            os_category="linux",
+        )
         event = SecurityEvent(
             timestamp=ts,
             event_type="connection",
             src_host=HostContext(
-                hostname="dc01",
+                hostname="client01",
                 ip="10.0.0.10",
-                os="Windows Server 2022",
-                os_category="windows",
-                system_type="domain_controller",
-                fqdn="dc01.example.org",
+                os="Ubuntu 24.04",
+                os_category="linux",
+                system_type="workstation",
+                fqdn="client01.example.org",
             ),
-            process=ProcessContext(
-                pid=444,
-                parent_pid=4,
-                image=r"C:\Windows\System32\svchost.exe",
-                command_line="svchost.exe -k netsvcs",
-                username="SYSTEM",
-                start_time=ts,
+            dst_host=HostContext(
+                hostname="server01",
+                ip="10.0.0.20",
+                os="Ubuntu 24.04",
+                os_category="linux",
+                system_type="server",
+                fqdn="server01.example.org",
             ),
             network=NetworkContext(
                 src_ip="10.0.0.10",
-                src_port=49153,
+                src_port=50123,
                 dst_ip="10.0.0.20",
-                dst_port=88,
+                dst_port=443,
                 protocol="tcp",
-                initiating_pid=444,
+                duration=1.5,
+                conn_state="SF",
+                history="ShADadfF",
+                initiating_pid=source.pid,
+                responding_pid=target.pid,
             ),
+            identity_plan=EventIdentityPlan(actor=source, target=target),
         )
 
-        assert (
-            emitter._flow_principal_for_process(
-                event,
-                event.src_host,
-                event.process,
-                "OUTBOUND",
-            )
-            == "SYSTEM"
-        )
+        emitter._render_connection(event)
+
+        outbound = next(row for row in emitted if row["direction"] == "OUTBOUND")
+        inbound = next(row for row in emitted if row["direction"] == "INBOUND")
+        assert outbound["actorID"] == source.object_id
+        assert inbound["actorID"] == target.object_id
+        for row in (outbound, inbound):
+            assert "source_process_uuid" not in row
+            assert "target_process_uuid" not in row
 
     def test_actor_linked_user_flow_preserves_principal(self, emitter, monkeypatch, ts):
         """Actor-linked user FLOW rows should not drop a known user principal."""
-        monkeypatch.setattr(
-            "evidenceforge.generation.emitters.ecar.ecar_flow_identity_config",
-            lambda: {
-                "user_process_probability": 0.0,
-                "service_process_probability": 0.0,
-                "root_process_probability": 0.0,
-                "inbound_listener_probability": 0.0,
-            },
-        )
         emitted: list[dict] = []
         monkeypatch.setattr(emitter, "emit_event", emitted.append)
         event = SecurityEvent(
@@ -2136,19 +2244,35 @@ class TestChronologicalOutput:
                 object_id="11111111-2222-3333-4444-555555555555",
                 actor_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             ),
+            identity_plan=EventIdentityPlan(
+                actor=_canonical_process_identity(
+                    "WS-MCHEN-01",
+                    6124,
+                    ts,
+                    image=r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+                    principal="marcus.chen",
+                    os_category="windows",
+                )
+            ),
         )
 
         emitter._render_connection(event)
 
         assert emitted[0]["direction"] == "OUTBOUND"
-        assert emitted[0]["actorID"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert emitted[0]["actorID"] == event.identity_plan.actor.object_id
         assert emitted[0]["principal"] == "marcus.chen"
 
     def test_inbound_flow_uses_destination_listener_pid(self, emitter, monkeypatch, ts):
         """Inbound host observations should use the local listener PID when known."""
         emitted: list[dict] = []
         monkeypatch.setattr(emitter, "emit_event", emitted.append)
-        emitter._system_pids = {"WEB-EXT-01": {"apache2": 24118}}
+        listener = _canonical_process_identity(
+            "WEB-EXT-01",
+            24118,
+            ts - timedelta(hours=1),
+            image="/usr/sbin/apache2",
+            principal="www-data",
+        )
         event = SecurityEvent(
             timestamp=ts,
             event_type="connection",
@@ -2167,8 +2291,10 @@ class TestChronologicalOutput:
                 dst_port=443,
                 protocol="tcp",
                 initiating_pid=-1,
+                responding_pid=listener.pid,
             ),
             edr=EdrContext(object_id="flow-1", actor_id=""),
+            identity_plan=EventIdentityPlan(target=listener),
         )
 
         emitter._render_connection(event)
@@ -2202,7 +2328,14 @@ class TestChronologicalOutput:
         """Infrastructure listener FLOW rows should use destination-local owners."""
         emitted: list[dict] = []
         monkeypatch.setattr(emitter, "emit_event", emitted.append)
-        emitter._system_pids = {"DC-01": system_pids}
+        listener = _canonical_process_identity(
+            "DC-01",
+            expected_pid,
+            ts - timedelta(hours=1),
+            image=r"C:\Windows\System32\service.exe",
+            principal="SYSTEM",
+            os_category="windows",
+        )
         event = SecurityEvent(
             timestamp=ts,
             event_type="connection",
@@ -2223,8 +2356,10 @@ class TestChronologicalOutput:
                 conn_state="SF",
                 history="ShADadF" if proto == "tcp" else "Dd",
                 initiating_pid=-1,
+                responding_pid=expected_pid,
             ),
             edr=EdrContext(object_id="flow-1", actor_id=""),
+            identity_plan=EventIdentityPlan(target=listener),
         )
 
         emitter._render_connection(event)
@@ -2271,8 +2406,10 @@ class TestChronologicalOutput:
                 conn_state="SF",
                 history="Dd",
                 initiating_pid=-1,
+                responding_pid=dns_pid,
             ),
             edr=EdrContext(object_id="flow-1", actor_id=""),
+            identity_plan=EventIdentityPlan(target=state.get_process_identity("DC-01", dns_pid)),
         )
 
         emitter._render_connection(event)
@@ -2318,6 +2455,9 @@ class TestChronologicalOutput:
                 responding_pid=listener_pid,
             ),
             edr=EdrContext(object_id="flow-1", actor_id=""),
+            identity_plan=EventIdentityPlan(
+                target=state.get_process_identity("APP-INT-01", listener_pid)
+            ),
         )
 
         emitter._render_connection(event)
@@ -2328,15 +2468,6 @@ class TestChronologicalOutput:
 
     def test_inbound_listener_flow_can_render_principal(self, emitter, monkeypatch, ts):
         """Observed listener-side FLOW rows can carry local service principal context."""
-        monkeypatch.setattr(
-            "evidenceforge.generation.emitters.ecar.ecar_flow_identity_config",
-            lambda: {
-                "user_process_probability": 0.0,
-                "service_process_probability": 0.0,
-                "root_process_probability": 0.0,
-                "inbound_listener_probability": 1.0,
-            },
-        )
         emitted: list[dict] = []
         monkeypatch.setattr(emitter, "emit_event", emitted.append)
         state = StateManager()
@@ -2369,7 +2500,9 @@ class TestChronologicalOutput:
                 dst_port=443,
                 protocol="tcp",
                 initiating_pid=-1,
+                responding_pid=pid,
             ),
+            identity_plan=EventIdentityPlan(target=state.get_process_identity("WEB-EXT-01", pid)),
         )
 
         emitter._render_connection(event)
@@ -2545,8 +2678,8 @@ class TestChronologicalOutput:
             ("REGISTRY", "MODIFY"),
         ]
 
-    def test_close_moves_child_process_create_after_visible_parent(self, tmp_path, ts):
-        """Visible eCAR child PROCESS/CREATE rows should not precede parent creates."""
+    def test_close_preserves_preordered_child_and_parent_timestamps(self, tmp_path, ts):
+        """Flush sorts but does not repair a planner-supplied parent inversion."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -2587,11 +2720,10 @@ class TestChronologicalOutput:
         ]
         parent_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "parent-process")
         child_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "child-process")
-        assert child_ms > parent_ms
-        assert 18 <= child_ms - parent_ms <= 150
+        assert child_ms < parent_ms
 
-    def test_close_moves_parent_termination_after_visible_child_termination(self, tmp_path, ts):
-        """Visible eCAR parents should not terminate before foreground children."""
+    def test_close_preserves_parent_and_child_termination_timestamps(self, tmp_path, ts):
+        """Parent/child closure ordering remains a lifecycle-planner responsibility."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -2663,7 +2795,7 @@ class TestChronologicalOutput:
             for row in rows
             if row["objectID"] == "debian-sa1-process" and row["action"] == "TERMINATE"
         )
-        assert shell_ms > child_ms
+        assert shell_ms < child_ms
 
     def test_close_does_not_drag_parent_termination_past_long_lived_child(self, tmp_path, ts):
         """A long-lived child should not keep a finished parent alive for hours."""
@@ -2740,8 +2872,8 @@ class TestChronologicalOutput:
         assert parent_ms < child_ms
         assert parent_ms < int((ts + timedelta(minutes=15)).timestamp() * 1000)
 
-    def test_close_moves_dependent_telemetry_after_reordered_process_create(self, tmp_path, ts):
-        """Dependent eCAR records should follow a process create shifted after its parent."""
+    def test_close_preserves_dependent_telemetry_timestamps(self, tmp_path, ts):
+        """Flush does not shift dependent rows when canonical input is inverted."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -2795,10 +2927,10 @@ class TestChronologicalOutput:
         parent_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "parent-process")
         child_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "child-process")
         file_ms = next(row["timestamp_ms"] for row in rows if row["object"] == "FILE")
-        assert parent_ms < child_ms < file_ms
+        assert file_ms < child_ms < parent_ms
 
-    def test_close_moves_child_process_create_after_parent_pid_without_actor_id(self, tmp_path, ts):
-        """Visible eCAR child creates should also respect ppid when actorID is absent."""
+    def test_close_preserves_ppid_only_child_timestamp(self, tmp_path, ts):
+        """Flush does not infer lifecycle order from ppid-only serialized rows."""
         fmt = Mock()
         fmt.output.template = "{}"
         fmt.output.header_template = None
@@ -2838,277 +2970,25 @@ class TestChronologicalOutput:
         ]
         parent_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "parent-process")
         child_ms = next(row["timestamp_ms"] for row in rows if row["objectID"] == "child-process")
-        assert child_ms > parent_ms
-        assert 18 <= child_ms - parent_ms <= 150
-
-    def test_parent_order_skips_self_parented_pid_without_hanging(self):
-        """Raw eCAR self-parented PID records should not loop forever."""
-        line = json.dumps(
-            {
-                "timestamp_ms": 1000,
-                "object": "PROCESS",
-                "action": "CREATE",
-                "objectID": "self-parent",
-                "pid": 123,
-                "ppid": 123,
-            },
-            separators=(",", ":"),
-        )
-
-        normalized = EcarEmitter._normalize_process_parent_order([line])
-
-        row = json.loads(normalized[0])
-        assert row["timestamp_ms"] == 1000
-
-    def test_linux_pid_morphology_rewrites_later_lower_process_pids(self):
-        """Linux eCAR PID rendering should not move backward over source time."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "parent",
-                    "pid": 500,
-                    "tid": 500,
-                    "properties": {"image_path": "/bin/sh"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "shell",
-                    "pid": 450,
-                    "tid": 450,
-                    "properties": {"image_path": "/usr/bin/journalctl"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2100,
-                    "object": "FILE",
-                    "action": "READ",
-                    "actorID": "shell",
-                    "pid": 450,
-                    "properties": {"file_path": "/var/log/syslog"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2200,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "child",
-                    "actorID": "shell",
-                    "pid": 440,
-                    "tid": 440,
-                    "ppid": 450,
-                    "properties": {"image_path": "/usr/bin/tail"},
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line) for line in EcarEmitter._normalize_linux_pid_morphology(lines)
-        ]
-
-        parent = next(row for row in normalized if row.get("objectID") == "parent")
-        shell = next(row for row in normalized if row.get("objectID") == "shell")
-        file_row = next(row for row in normalized if row.get("object") == "FILE")
-        child = next(row for row in normalized if row.get("objectID") == "child")
-        assert shell["pid"] > parent["pid"]
-        assert file_row["pid"] == shell["pid"]
-        assert child["pid"] > shell["pid"]
-        assert child["ppid"] == shell["pid"]
-
-    def test_linux_pid_morphology_keeps_process_create_tid_as_main_thread(self):
-        """Linux eCAR PROCESS/CREATE PID rewrites should keep TID as the main thread."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "parent",
-                    "pid": 500,
-                    "tid": 503,
-                    "properties": {"image_path": "/bin/sh"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "child",
-                    "pid": 450,
-                    "tid": 455,
-                    "ppid": 500,
-                    "properties": {"image_path": "/usr/bin/tail"},
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line) for line in EcarEmitter._normalize_linux_pid_morphology(lines)
-        ]
-
-        child = next(row for row in normalized if row.get("objectID") == "child")
-        assert child["pid"] > 500
-        assert child["tid"] == child["pid"]
-
-    def test_linux_pid_morphology_preserves_cron_group_canonical_pids(self):
-        """Cron-correlated eCAR rows keep PIDs shared with CRON syslog."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "other",
-                    "pid": 500,
-                    "tid": 500,
-                    "properties": {"image_path": "/usr/bin/bash"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "cron-shell",
-                    "actorID": "cron-daemon",
-                    "pid": 450,
-                    "tid": 450,
-                    "ppid": 200,
-                    "_concurrency_group_id": "cron:WEB-EXT-01:debian-sa1:1710766860000",
-                    "properties": {"image_path": "/bin/sh"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2100,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "cron-workload",
-                    "actorID": "cron-shell",
-                    "pid": 451,
-                    "tid": 451,
-                    "ppid": 450,
-                    "_concurrency_group_id": "cron:WEB-EXT-01:debian-sa1:1710766860000",
-                    "properties": {"image_path": "/usr/lib/sysstat/debian-sa1"},
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line) for line in EcarEmitter._normalize_linux_pid_morphology(lines)
-        ]
-
-        shell = next(row for row in normalized if row.get("objectID") == "cron-shell")
-        workload = next(row for row in normalized if row.get("objectID") == "cron-workload")
-        assert shell["pid"] == 450
-        assert shell["tid"] == 450
-        assert workload["pid"] == 451
-        assert workload["tid"] == 451
-        assert workload["ppid"] == 450
-
-    def test_linux_pid_morphology_preserves_process_open_actor_pid(self):
-        """PROCESS/OPEN top-level pid should track actorID (source), not objectID target."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "source",
-                    "pid": 500,
-                    "tid": 500,
-                    "properties": {"image_path": "/usr/bin/bash"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "target",
-                    "pid": 400,
-                    "tid": 400,
-                    "properties": {"image_path": "/usr/bin/ssh"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2100,
-                    "object": "PROCESS",
-                    "action": "OPEN",
-                    "objectID": "target",
-                    "actorID": "source",
-                    "pid": 500,
-                    "tid": 500,
-                    "properties": {"target_pid": 400, "target_process_uuid": "target"},
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line) for line in EcarEmitter._normalize_linux_pid_morphology(lines)
-        ]
-
-        source_create = next(row for row in normalized if row.get("objectID") == "source")
-        target_create = next(row for row in normalized if row.get("objectID") == "target")
-        process_open = next(
-            row
-            for row in normalized
-            if row.get("object") == "PROCESS" and row.get("action") == "OPEN"
-        )
-
-        assert target_create["pid"] > source_create["pid"]
-        assert process_open["pid"] == source_create["pid"]
-        assert process_open["properties"]["target_pid"] == target_create["pid"]
+        assert child_ms < parent_ms
 
     def test_linux_process_lifecycle_tid_uses_main_thread(self, ts):
         """Linux PROCESS/CREATE and PROCESS/TERMINATE rows should share main-thread TID."""
-        pid = 3200
+        process = _canonical_process_identity("linux-01", 3200, ts)
+        create_plan = EventIdentityPlan(subject=process)
+        terminate_plan = EventIdentityPlan(subject=process)
 
-        create_tid = EcarEmitter._stable_tid("linux-01", pid, ts, "process_create", "linux")
-        terminate_tid = EcarEmitter._stable_tid(
-            "linux-01",
-            pid,
-            ts + timedelta(seconds=5),
-            "process_terminate",
-            "linux",
-        )
-
-        assert create_tid == pid
-        assert terminate_tid == pid
+        assert create_plan.canonical_tid == 3200
+        assert terminate_plan.canonical_tid == 3200
 
     def test_linux_dependent_tids_default_to_process_leader(self, ts):
         """Linux dependent rows should not invent threads absent canonical identity."""
-        tids = {
-            EcarEmitter._stable_tid("linux-01", 3200, ts + timedelta(seconds=i), salt, "linux")
-            for i, salt in enumerate(["flow_inbound", "flow_outbound", "file", "module"])
-        }
+        process = _canonical_process_identity("linux-01", 3200, ts)
 
-        assert tids == {3200}
+        assert EventIdentityPlan(actor=process).canonical_tid == -1
 
-    def test_linux_flow_preserves_explicit_canonical_tid(self, emitter, monkeypatch, ts):
-        """An explicit modeled Linux thread should override leader-thread inference."""
+    def test_linux_flow_ignores_noncanonical_compatibility_tid(self, emitter, monkeypatch, ts):
+        """Dependent FLOW rows omit TID unless the identity plan selects a thread."""
         emitted: list[dict] = []
         monkeypatch.setattr(emitter, "emit_event", emitted.append)
         event = SecurityEvent(
@@ -3139,591 +3019,21 @@ class TestChronologicalOutput:
                 initiating_pid=3200,
             ),
             edr=EdrContext(tid=3207),
+            identity_plan=EventIdentityPlan(
+                actor=_canonical_process_identity(
+                    "linux-01",
+                    3200,
+                    ts,
+                    image="/usr/bin/wget",
+                    principal="root",
+                )
+            ),
         )
 
         emitter._render_connection(event)
 
         assert emitted[0]["pid"] == 3200
-        assert emitted[0]["tid"] == 3207
-
-    def test_flow_principal_visibility_is_stable_for_same_process_and_direction(self, ts):
-        """FLOW principal attribution should be a process-level source decision."""
-        host = HostContext(
-            hostname="PROXY-01",
-            ip="10.10.3.20",
-            os="Ubuntu 22.04",
-            os_category="linux",
-            system_type="server",
-        )
-        process = ProcessContext(
-            pid=18750,
-            parent_pid=1,
-            image="/usr/sbin/nginx",
-            command_line="nginx: worker process",
-            username="www-data",
-            start_time=ts,
-        )
-        first = SecurityEvent(
-            timestamp=ts,
-            event_type="connection",
-            src_host=host,
-            process=process,
-            network=NetworkContext(
-                src_ip="10.10.3.20",
-                src_port=40001,
-                dst_ip="203.0.113.10",
-                dst_port=443,
-                protocol="tcp",
-            ),
-        )
-        second = SecurityEvent(
-            timestamp=ts + timedelta(seconds=30),
-            event_type="connection",
-            src_host=host,
-            process=process,
-            network=NetworkContext(
-                src_ip="10.10.3.20",
-                src_port=40002,
-                dst_ip="203.0.113.11",
-                dst_port=443,
-                protocol="tcp",
-            ),
-        )
-        emitter = object.__new__(EcarEmitter)
-
-        assert emitter._flow_principal_for_process(first, host, process, "OUTBOUND") == (
-            emitter._flow_principal_for_process(second, host, process, "OUTBOUND")
-        )
-
-    def test_flow_principal_visibility_is_stable_across_directions(self, ts):
-        """FLOW principal attribution should not flip for the same local process."""
-        host = HostContext(
-            hostname="PROXY-01",
-            ip="10.10.3.20",
-            os="Ubuntu 22.04",
-            os_category="linux",
-            system_type="server",
-        )
-        process = ProcessContext(
-            pid=18750,
-            parent_pid=1,
-            image="/usr/sbin/squid",
-            command_line="/usr/sbin/squid --foreground -YC",
-            username="proxy",
-            start_time=ts,
-        )
-        event = SecurityEvent(
-            timestamp=ts,
-            event_type="connection",
-            src_host=host,
-            dst_host=host,
-            process=process,
-            network=NetworkContext(
-                src_ip="10.10.3.20",
-                src_port=40001,
-                dst_ip="10.10.3.20",
-                dst_port=8080,
-                protocol="tcp",
-            ),
-        )
-        emitter = object.__new__(EcarEmitter)
-
-        assert emitter._flow_principal_for_process(event, host, process, "OUTBOUND") == (
-            emitter._flow_principal_for_process(event, host, process, "INBOUND")
-        )
-
-    def test_parent_order_skips_pid_parent_cycles_without_hanging(self):
-        """Raw eCAR cyclic ppid records should not loop forever."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "first",
-                    "pid": 123,
-                    "ppid": 456,
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 1000,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "second",
-                    "pid": 456,
-                    "ppid": 123,
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = EcarEmitter._normalize_process_parent_order(lines)
-
-        rows = [json.loads(line) for line in normalized]
-        assert [row["timestamp_ms"] for row in rows] == [1000, 1000]
-
-    def test_user_session_logout_shifted_after_login(self):
-        """Short network sessions must not render USER_SESSION LOGOUT before LOGIN."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1710768759642,
-                    "object": "USER_SESSION",
-                    "action": "LOGOUT",
-                    "objectID": "session-object",
-                    "hostname": "WS-01",
-                    "principal": "evelyn.brooks",
-                    "properties": {
-                        "logon_id": "0xa445274",
-                        "logon_type": "3",
-                        "src_ip": "10.10.1.34",
-                        "src_port": "60409",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 1710768760347,
-                    "object": "FLOW",
-                    "action": "CONNECT",
-                    "objectID": "flow-object",
-                    "hostname": "WS-01",
-                    "properties": {
-                        "src_ip": "10.10.1.34",
-                        "src_port": "60409",
-                        "dst_ip": "10.10.1.33",
-                        "dst_port": "445",
-                        "direction": "INBOUND",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 1710768760419,
-                    "object": "USER_SESSION",
-                    "action": "LOGIN",
-                    "objectID": "session-object",
-                    "hostname": "WS-01",
-                    "principal": "evelyn.brooks",
-                    "properties": {
-                        "outcome": "success",
-                        "logon_id": "0xa445274",
-                        "logon_type": "3",
-                        "src_ip": "10.10.1.34",
-                        "src_port": "60409",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line) for line in EcarEmitter._normalize_user_session_lifecycle_order(lines)
-        ]
-        login = next(
-            row
-            for row in normalized
-            if row["object"] == "USER_SESSION" and row["action"] == "LOGIN"
-        )
-        logout = next(
-            row
-            for row in normalized
-            if row["object"] == "USER_SESSION" and row["action"] == "LOGOUT"
-        )
-        flow = next(row for row in normalized if row["object"] == "FLOW")
-
-        assert flow["timestamp_ms"] == 1710768760347
-        assert login["timestamp_ms"] == 1710768760419
-        assert logout["timestamp_ms"] > login["timestamp_ms"]
-
-    def test_user_session_logout_shifted_after_same_session_dependents(self):
-        """USER_SESSION LOGOUT must trail visible same-logon endpoint activity."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "USER_SESSION",
-                    "action": "LOGOUT",
-                    "objectID": "session-object",
-                    "hostname": "WS-01",
-                    "properties": {"logon_id": "0xabc", "session_id": "2"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2600,
-                    "object": "PROCESS",
-                    "action": "TERMINATE",
-                    "objectID": "process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {"logon_id": "0xabc", "session_id": "2"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2800,
-                    "object": "FILE",
-                    "action": "CREATE",
-                    "objectID": "file-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {"logon_id": "0xabc", "file_path": r"C:\Users\alice\a.txt"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 3200,
-                    "object": "FLOW",
-                    "action": "CONNECT",
-                    "objectID": "flow-object",
-                    "hostname": "WS-01",
-                    "properties": {
-                        "logon_id": "0xabc",
-                        "src_ip": "10.10.1.20",
-                        "dst_ip": "10.10.2.20",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 5000,
-                    "object": "PROCESS",
-                    "action": "TERMINATE",
-                    "objectID": "system-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4,
-                    "properties": {"logon_id": "0x3e7"},
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line)
-            for line in EcarEmitter._normalize_user_session_logout_after_dependents(lines)
-        ]
-        logout = next(row for row in normalized if row["object"] == "USER_SESSION")
-        latest_dependent_ms = max(
-            row["timestamp_ms"]
-            for row in normalized
-            if row["object"] in {"PROCESS", "FILE", "FLOW"}
-            and row["properties"].get("logon_id") == "0xabc"
-        )
-
-        assert logout["timestamp_ms"] > latest_dependent_ms
-        assert logout["timestamp_ms"] < 5000
-
-    def test_remote_thread_shifted_after_matching_process_open(self):
-        """THREAD/REMOTE_CREATE must not precede its PROCESS/OPEN prerequisite."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "THREAD",
-                    "action": "REMOTE_CREATE",
-                    "objectID": "thread-object",
-                    "actorID": "source-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {
-                        "target_pid": "500",
-                        "target_process_uuid": "target-process-object",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2600,
-                    "object": "PROCESS",
-                    "action": "OPEN",
-                    "objectID": "target-process-object",
-                    "actorID": "source-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {
-                        "target_pid": "500",
-                        "target_process_uuid": "target-process-object",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 1800,
-                    "object": "PROCESS",
-                    "action": "OPEN",
-                    "objectID": "other-target-process-object",
-                    "actorID": "source-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {
-                        "target_pid": "501",
-                        "target_process_uuid": "other-target-process-object",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line)
-            for line in EcarEmitter._normalize_remote_thread_after_process_open(lines)
-        ]
-        remote_thread = next(row for row in normalized if row["object"] == "THREAD")
-        matching_open = next(
-            row
-            for row in normalized
-            if row["object"] == "PROCESS" and row["objectID"] == "target-process-object"
-        )
-        other_open = next(
-            row
-            for row in normalized
-            if row["object"] == "PROCESS" and row["objectID"] == "other-target-process-object"
-        )
-
-        assert remote_thread["timestamp_ms"] > matching_open["timestamp_ms"]
-        assert other_open["timestamp_ms"] == 1800
-
-    def test_remote_thread_uses_pid_fallback_for_process_open_order(self):
-        """PID-only eCAR rows should still preserve access-before-thread ordering."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 4000,
-                    "object": "THREAD",
-                    "action": "REMOTE_CREATE",
-                    "objectID": "thread-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {"target_pid": "500"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 4300,
-                    "object": "PROCESS",
-                    "action": "OPEN",
-                    "objectID": "target-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {"target_pid": "500"},
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line)
-            for line in EcarEmitter._normalize_remote_thread_after_process_open(lines)
-        ]
-        remote_thread = next(row for row in normalized if row["object"] == "THREAD")
-        process_open = next(row for row in normalized if row["object"] == "PROCESS")
-
-        assert remote_thread["timestamp_ms"] > process_open["timestamp_ms"]
-
-    def test_remote_thread_preserves_existing_prior_process_open_order(self):
-        """A valid prior PROCESS/OPEN should not be shifted by a later matching row."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1900,
-                    "object": "PROCESS",
-                    "action": "OPEN",
-                    "objectID": "target-process-object",
-                    "actorID": "source-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {
-                        "target_pid": "500",
-                        "target_process_uuid": "target-process-object",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "THREAD",
-                    "action": "REMOTE_CREATE",
-                    "objectID": "thread-object",
-                    "actorID": "source-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {
-                        "target_pid": "500",
-                        "target_process_uuid": "target-process-object",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 2600,
-                    "object": "PROCESS",
-                    "action": "OPEN",
-                    "objectID": "target-process-object",
-                    "actorID": "source-process-object",
-                    "hostname": "WS-01",
-                    "pid": 4300,
-                    "properties": {
-                        "target_pid": "500",
-                        "target_process_uuid": "target-process-object",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line)
-            for line in EcarEmitter._normalize_remote_thread_after_process_open(lines)
-        ]
-        remote_thread = next(row for row in normalized if row["object"] == "THREAD")
-
-        assert remote_thread["timestamp_ms"] == 2000
-
-    def test_remote_user_session_login_shifted_after_late_inbound_flow(self):
-        """Remote eCAR LOGIN rows should not precede same-tuple inbound FLOW rows."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1710764221308,
-                    "object": "USER_SESSION",
-                    "action": "LOGIN",
-                    "objectID": "session-object",
-                    "hostname": "MAIL-EDGE-01",
-                    "principal": "marcus.chen",
-                    "properties": {
-                        "outcome": "success",
-                        "session_type": "ssh",
-                        "src_ip": "10.10.1.34",
-                        "src_port": "61712",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 1710764222532,
-                    "object": "FLOW",
-                    "action": "CONNECT",
-                    "objectID": "flow-object",
-                    "hostname": "MAIL-EDGE-01",
-                    "properties": {
-                        "src_ip": "10.10.1.34",
-                        "src_port": "61712",
-                        "dst_ip": "10.10.2.25",
-                        "dst_port": "22",
-                        "protocol": "tcp",
-                        "direction": "INBOUND",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line)
-            for line in EcarEmitter._normalize_remote_session_transport_order(lines)
-        ]
-        login = next(row for row in normalized if row["object"] == "USER_SESSION")
-        flow = next(row for row in normalized if row["object"] == "FLOW")
-
-        assert login["timestamp_ms"] > flow["timestamp_ms"]
-
-    def test_linux_login_shell_create_shifted_after_session_login(self):
-        """Interactive Linux shell PROCESS/CREATE rows should not predate session LOGIN."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 1710765140391,
-                    "object": "PROCESS",
-                    "action": "CREATE",
-                    "objectID": "shell-object",
-                    "hostname": "MAIL-EDGE-01",
-                    "principal": "aisha.johnson",
-                    "pid": 601049,
-                    "tid": 601049,
-                    "properties": {
-                        "command_line": "-bash",
-                        "image_path": "/bin/bash",
-                        "parent_image_path": "/usr/lib/systemd/systemd",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 1710765142724,
-                    "object": "USER_SESSION",
-                    "action": "LOGIN",
-                    "objectID": "session-object",
-                    "hostname": "MAIL-EDGE-01",
-                    "principal": "aisha.johnson",
-                    "properties": {
-                        "outcome": "success",
-                        "session_type": "ssh",
-                        "src_ip": "10.10.2.20",
-                        "src_port": "64417",
-                    },
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line)
-            for line in EcarEmitter._normalize_linux_login_shell_session_order(lines)
-        ]
-        shell = next(row for row in normalized if row["object"] == "PROCESS")
-        login = next(row for row in normalized if row["object"] == "USER_SESSION")
-
-        assert shell["timestamp_ms"] > login["timestamp_ms"]
-
-    def test_failed_user_session_login_does_not_anchor_logout_order(self):
-        """Failed USER_SESSION LOGIN attempts should not become session start anchors."""
-        lines = [
-            json.dumps(
-                {
-                    "timestamp_ms": 2000,
-                    "object": "USER_SESSION",
-                    "action": "LOGOUT",
-                    "objectID": "session-object",
-                    "hostname": "WS-01",
-                    "properties": {"logon_id": "0x999"},
-                },
-                separators=(",", ":"),
-            ),
-            json.dumps(
-                {
-                    "timestamp_ms": 3000,
-                    "object": "USER_SESSION",
-                    "action": "LOGIN",
-                    "objectID": "session-object",
-                    "hostname": "WS-01",
-                    "properties": {"logon_id": "0x999", "outcome": "failure"},
-                },
-                separators=(",", ":"),
-            ),
-        ]
-
-        normalized = [
-            json.loads(line) for line in EcarEmitter._normalize_user_session_lifecycle_order(lines)
-        ]
-
-        logout = next(row for row in normalized if row["action"] == "LOGOUT")
-        assert logout["timestamp_ms"] == 2000
+        assert "tid" not in emitted[0]
 
 
 class TestTidEmission:
@@ -3763,6 +3073,14 @@ class TestTidEmission:
         )
         emitter.emit_event = Mock()
 
+        process_identity = _canonical_process_identity(
+            "WS-01",
+            4321,
+            ts,
+            image=r"C:\Windows\System32\cmd.exe",
+            principal="alice",
+            os_category="windows",
+        )
         emitter._render_process_create(
             SecurityEvent(
                 timestamp=ts,
@@ -3775,6 +3093,7 @@ class TestTidEmission:
                     command_line="cmd.exe",
                     username="alice",
                 ),
+                identity_plan=EventIdentityPlan(subject=process_identity),
             )
         )
 
@@ -3794,6 +3113,13 @@ class TestTidEmission:
         )
         emitter.emit_event = Mock()
 
+        process_identity = _canonical_process_identity(
+            "APP-01",
+            14233,
+            ts,
+            image="/usr/bin/mysql",
+            principal="root",
+        )
         emitter._render_process_create(
             SecurityEvent(
                 timestamp=ts,
@@ -3806,6 +3132,7 @@ class TestTidEmission:
                     command_line="mysql -u root",
                     username="root",
                 ),
+                identity_plan=EventIdentityPlan(subject=process_identity),
             )
         )
 

--- a/tests/unit/test_ecar_thread_process_access.py
+++ b/tests/unit/test_ecar_thread_process_access.py
@@ -35,6 +35,7 @@ from evidenceforge.events.contexts import (
     ProcessAccessContext,
     ProcessContext,
 )
+from evidenceforge.events.identity import EventIdentityPlan, ProcessIdentity, ThreadIdentity
 from evidenceforge.generation.emitters.ecar import EcarEmitter
 
 
@@ -101,6 +102,39 @@ class TestCreateRemoteThread:
 
     def test_source_target_pids_in_properties(self, emitter, ts, windows_host, tmp_path):
         """Properties should include src_pid and target_pid as strings."""
+        source = ProcessIdentity(
+            hostname="WKS-01",
+            object_id="source-process",
+            pid=2120,
+            parent_pid=572,
+            image=r"C:\Program Files\VMware\VMware Tools\vmtoolsd.exe",
+            command_line="",
+            principal="SYSTEM",
+            logon_id="",
+            started_at=ts,
+            lifecycle_group_id="source-lifecycle",
+        )
+        target = ProcessIdentity(
+            hostname="WKS-01",
+            object_id="target-process",
+            pid=4,
+            parent_pid=0,
+            image=r"C:\Windows\System32\svchost.exe",
+            command_line="",
+            principal="SYSTEM",
+            logon_id="",
+            started_at=ts,
+            lifecycle_group_id="target-lifecycle",
+        )
+        thread = ThreadIdentity(
+            hostname="WKS-01",
+            process_object_id=target.object_id,
+            pid=target.pid,
+            tid=840,
+            object_id="target-thread",
+            started_at=ts,
+            kind="remote",
+        )
         event = SecurityEvent(
             timestamp=ts,
             event_type="create_remote_thread",
@@ -117,6 +151,7 @@ class TestCreateRemoteThread:
                 target_server=r"C:\Windows\System32\svchost.exe",
                 source_port=4,
             ),
+            identity_plan=EventIdentityPlan(subject=thread, actor=source, target=target),
         )
         emitter.emit(event)
         emitter.close()
@@ -126,7 +161,10 @@ class TestCreateRemoteThread:
         props = record["properties"]
         assert props["src_pid"] == "2120"
         assert props["target_pid"] == "4"
-        assert "target_process_uuid" in props
+        assert props["target_process_uuid"] == "target-process"
+        assert props["source_process_uuid"] == "source-process"
+        assert props["target_tid"] == "840"
+        assert "tid" not in record
         assert "start_address" in props
 
     def test_top_level_pid_is_source(self, emitter, ts, windows_host, tmp_path):
@@ -298,6 +336,66 @@ class TestProcessAccess:
         assert props["command_line"] == r"MsMpEng.exe -Scan"
         assert props["target_pid"] == "672"
         assert props["target_image_path"] == r"C:\Windows\System32\lsass.exe"
+
+    def test_process_open_renders_canonical_source_and_target_roles(
+        self, emitter, ts, windows_host, tmp_path
+    ):
+        """PROCESS/OPEN object and actor fields must preserve both canonical sides."""
+        source = ProcessIdentity(
+            hostname="WKS-01",
+            object_id="source-process",
+            pid=2064,
+            parent_pid=556,
+            image=r"C:\ProgramData\Microsoft\Windows Defender\Platform\MsMpEng.exe",
+            command_line="MsMpEng.exe -Scan",
+            principal="SYSTEM",
+            logon_id="",
+            started_at=ts,
+            lifecycle_group_id="source-lifecycle",
+        )
+        target = ProcessIdentity(
+            hostname="WKS-01",
+            object_id="target-process",
+            pid=672,
+            parent_pid=4,
+            image=r"C:\Windows\System32\lsass.exe",
+            command_line="lsass.exe",
+            principal="SYSTEM",
+            logon_id="",
+            started_at=ts,
+            lifecycle_group_id="target-lifecycle",
+        )
+        event = SecurityEvent(
+            timestamp=ts,
+            event_type="process_access",
+            src_host=windows_host,
+            process=ProcessContext(
+                pid=source.pid,
+                parent_pid=source.parent_pid,
+                image=source.image,
+                command_line=source.command_line,
+                username=source.principal,
+            ),
+            auth=AuthContext(username="SYSTEM"),
+            process_access=self._access_context(),
+            identity_plan=EventIdentityPlan(subject=target, actor=source, target=target),
+        )
+
+        emitter.emit(event)
+        emitter.close()
+
+        output_file = tmp_path / "WKS-01.corp.local" / "ecar.json"
+        record = json.loads(output_file.read_text().strip())
+        props = record["properties"]
+        assert record["objectID"] == target.object_id
+        assert record["actorID"] == source.object_id
+        assert record["pid"] == source.pid
+        assert "tid" not in record
+        assert props["source_process_uuid"] == source.object_id
+        assert props["source_pid"] == str(source.pid)
+        assert props["source_tid"] == "4321"
+        assert props["target_process_uuid"] == target.object_id
+        assert props["target_pid"] == str(target.pid)
 
     def test_process_open_parent_image_uses_source_parent(
         self, emitter, ts, windows_host, tmp_path

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -46,6 +46,30 @@ from evidenceforge.models.scenario import ConnectionEventSpec
 from evidenceforge.output_targets import OUTPUT_TARGET_FILENAME
 
 
+def _mock_activity_generator_factory(mock_instance: Mock):
+    """Bind mocked generation to the bundle-owned session postcondition."""
+
+    def factory(**kwargs):
+        state_manager = kwargs["state_manager"]
+
+        def generate_logon(**request):
+            state_manager.set_current_time(request["time"])
+            return state_manager.create_session(
+                username=request["user"].username,
+                system=request["system"].hostname,
+                logon_type=request.get("logon_type", 2),
+                source_ip=request.get("source_ip") or "-",
+                start_time=request["time"],
+                session_kind="interactive",
+                lifecycle_group_id="mock-logon-bundle",
+            )
+
+        mock_instance.generate_logon.side_effect = generate_logon
+        return mock_instance
+
+    return factory
+
+
 def test_service_wrapper_storyline_process_lifetimes_are_source_native():
     """Remote service wrappers should use the lifecycle of the modeled tool."""
     assert _estimate_process_lifetime(
@@ -619,7 +643,7 @@ class TestGenerationEngine:
 
         mock_activity_instance = Mock()
         mock_activity_instance.get_baseline_pattern.return_value = []
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(minimal_scenario, tmp_path)
         engine._initialize()
@@ -675,7 +699,7 @@ class TestGenerationEngine:
 
         mock_activity_instance = Mock()
         mock_activity_instance.get_baseline_pattern.return_value = []
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(minimal_scenario, tmp_path)
         engine._initialize()
@@ -783,7 +807,7 @@ class TestGenerationEngine:
         mock_activity_instance.get_baseline_pattern.return_value = []
         mock_activity_instance.generate_process.return_value = 1234
         mock_activity_instance.generate_logon.return_value = "0x12345"
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(scenario_with_storyline, tmp_path)
         engine._initialize()
@@ -844,7 +868,7 @@ class TestGenerationEngine:
         mock_activity_instance.get_baseline_pattern.return_value = []
         mock_activity_instance.generate_process.return_value = 1234
         mock_activity_instance.generate_logon.return_value = "0x12345"
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         mock_gt_instance = Mock()
         mock_gt_gen.return_value = mock_gt_instance
@@ -904,7 +928,7 @@ class TestGenerationEngine:
 
         mock_activity_instance = Mock()
         mock_activity_instance.get_baseline_pattern.return_value = []
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         mock_gt_instance = Mock()
         mock_gt_gen.return_value = mock_gt_instance
@@ -964,7 +988,7 @@ class TestGenerationEngine:
 
         mock_activity_instance = Mock()
         mock_activity_instance.get_baseline_pattern.return_value = []
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(minimal_scenario, tmp_path)
         engine.generate()
@@ -1097,7 +1121,7 @@ class TestGenerationEngine:
 
         mock_activity_instance = Mock()
         mock_activity_instance.get_baseline_pattern.return_value = []
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         callback = Mock()
         engine = GenerationEngine(minimal_scenario, tmp_path, progress_callback=callback)
@@ -1159,7 +1183,7 @@ class TestGenerationEngine:
 
         mock_activity_instance = Mock()
         mock_activity_instance.get_baseline_pattern.return_value = []
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         # No progress_callback provided
         engine = GenerationEngine(minimal_scenario, tmp_path)
@@ -1224,7 +1248,7 @@ class TestGenerationEngine:
 
         mock_activity_instance = Mock()
         mock_activity_instance.generate_logon.return_value = "0x12345"
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(scenario_with_storyline, tmp_path)
         engine._initialize()
@@ -1288,7 +1312,7 @@ class TestGenerationEngine:
         mock_activity_instance = Mock()
         mock_activity_instance.generate_connection.return_value = "UID123"
         mock_activity_instance.generate_logon.return_value = "0x12345"
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(scenario_with_storyline, tmp_path)
         engine._initialize()
@@ -1359,7 +1383,7 @@ class TestGenerationEngine:
         mock_activity_instance = Mock()
         mock_activity_instance.get_baseline_pattern.return_value = [("logon", 1.0)]
         mock_activity_instance.execute_baseline_activity.return_value = None
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(minimal_scenario, tmp_path)
         engine._initialize()
@@ -1428,7 +1452,7 @@ class TestGenerationEngine:
         mock_load_format.return_value = mock_format_def
 
         mock_activity_instance = Mock()
-        mock_activity_gen.return_value = mock_activity_instance
+        mock_activity_gen.side_effect = _mock_activity_generator_factory(mock_activity_instance)
 
         engine = GenerationEngine(scenario_with_storyline, tmp_path)
         engine._initialize()

--- a/tests/unit/test_identity_contract.py
+++ b/tests/unit/test_identity_contract.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Focused tests for immutable event identity roles and compatibility projections."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from evidenceforge.events.contexts import EdrContext
+from evidenceforge.events.identity import EventIdentityPlan, ProcessIdentity, ThreadIdentity
+
+
+def _process_identity() -> ProcessIdentity:
+    started_at = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+    thread = ThreadIdentity(
+        hostname="WS-01",
+        process_object_id="process-1",
+        pid=4100,
+        tid=8124,
+        object_id="thread-1",
+        started_at=started_at,
+        kind="primary",
+    )
+    return ProcessIdentity(
+        hostname="WS-01",
+        object_id="process-1",
+        pid=4100,
+        parent_pid=1200,
+        image=r"C:\Windows\System32\cmd.exe",
+        command_line="cmd.exe /c whoami",
+        principal="analyst",
+        logon_id="0x1234",
+        started_at=started_at,
+        lifecycle_group_id="process-group-1",
+        parent_lifecycle_group_id="session-group-1",
+        primary_thread=thread,
+    )
+
+
+def test_edr_compatibility_projection_accepts_canonical_identity() -> None:
+    process = _process_identity()
+    plan = EventIdentityPlan(subject=process)
+
+    EdrContext(
+        object_id=process.object_id,
+        tid=process.primary_thread.tid,
+    ).validate_identity_plan(plan)
+
+
+@pytest.mark.parametrize(
+    ("context", "message"),
+    [
+        (EdrContext(object_id="wrong"), "object_id"),
+        (EdrContext(actor_id="wrong"), "actor_id"),
+        (EdrContext(tid=9999), "tid"),
+    ],
+)
+def test_edr_compatibility_projection_rejects_contradictions(
+    context: EdrContext,
+    message: str,
+) -> None:
+    process = _process_identity()
+    plan = EventIdentityPlan(subject=process, actor=process)
+
+    with pytest.raises(ValueError, match=message):
+        context.validate_identity_plan(plan)
+
+
+def test_dependent_process_plan_has_no_implicit_tid() -> None:
+    process = _process_identity()
+    plan = EventIdentityPlan(actor=process)
+
+    assert plan.canonical_tid == -1

--- a/tests/unit/test_identity_lifecycle.py
+++ b/tests/unit/test_identity_lifecycle.py
@@ -141,6 +141,33 @@ def test_process_create_and_terminate_share_identity_and_primary_thread() -> Non
     assert terminate.edr.tid == create.edr.tid
 
 
+def test_system_process_create_uses_canonical_process_and_primary_thread() -> None:
+    state, planner, logon_id, parent_pid, child_pid = _identity_state()
+    child = state.get_process_identity("WS-01", child_pid)
+    assert child is not None
+    assert child.primary_thread is not None
+    event = SecurityEvent(
+        timestamp=child.started_at,
+        event_type="system_process_create",
+        src_host=_host(),
+        auth=AuthContext(username="analyst", logon_id=logon_id),
+        process=_process_context(child_pid, parent_pid, logon_id),
+        edr=EdrContext(),
+    )
+
+    planner.plan(event)
+
+    assert event.identity_plan is not None
+    assert event.identity_plan.subject == child
+    assert isinstance(event.identity_plan.actor, ProcessIdentity)
+    assert event.identity_plan.actor.pid == parent_pid
+    assert event.edr is not None
+    assert event.edr.tid == child.primary_thread.tid
+    assert event.lifecycle is not None
+    assert event.lifecycle.group_id == "child-process-group"
+    assert event.lifecycle.phase == "start"
+
+
 def test_dependent_process_event_keeps_object_semantics_without_synthesized_tid() -> None:
     state, planner, logon_id, parent_pid, child_pid = _identity_state()
     event = SecurityEvent(
@@ -271,6 +298,30 @@ def test_session_start_unlock_child_and_logoff_lifecycle() -> None:
     assert logoff.lifecycle is not None
     assert logoff.lifecycle.group_id == logon.lifecycle.group_id
     assert logoff.lifecycle.phase == "closure"
+
+
+def test_ssh_and_machine_logons_start_their_durable_session_lifecycle() -> None:
+    state, planner, logon_id, _parent_pid, _child_pid = _identity_state()
+    session = state.get_session_identity(logon_id)
+    assert session is not None
+
+    for event_type in ("ssh_session", "machine_logon"):
+        start = SecurityEvent(
+            timestamp=session.started_at,
+            event_type=event_type,
+            dst_host=_host(),
+            auth=AuthContext(username="analyst", logon_id=logon_id, logon_type=10),
+            edr=EdrContext(),
+        )
+        planner.plan(start)
+
+        assert start.identity_plan is not None
+        assert start.identity_plan.subject == session
+        assert start.edr is not None
+        assert start.edr.object_id == session.object_id
+        assert start.lifecycle is not None
+        assert start.lifecycle.group_id == session.lifecycle_group_id
+        assert start.lifecycle.phase == "start"
 
 
 def test_flow_actor_is_canonical_or_omitted_as_complete_group() -> None:

--- a/tests/unit/test_identity_lifecycle.py
+++ b/tests/unit/test_identity_lifecycle.py
@@ -1,0 +1,312 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for upstream identity-role and lifecycle planning."""
+
+from datetime import UTC, datetime, timedelta
+
+from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.contexts import (
+    AuthContext,
+    EdrContext,
+    FileContext,
+    HostContext,
+    NetworkContext,
+    ProcessAccessContext,
+    ProcessContext,
+    RemoteThreadContext,
+)
+from evidenceforge.events.identity import ProcessIdentity, SessionIdentity, ThreadIdentity
+from evidenceforge.generation.identity_lifecycle import IdentityLifecyclePlanner
+from evidenceforge.generation.state_manager import StateManager
+
+
+def _host() -> HostContext:
+    return HostContext(
+        hostname="WS-01",
+        ip="10.0.0.10",
+        os="Windows 11",
+        os_category="windows",
+        system_type="workstation",
+    )
+
+
+def _process_context(pid: int, parent_pid: int, logon_id: str) -> ProcessContext:
+    return ProcessContext(
+        pid=pid,
+        parent_pid=parent_pid,
+        image=rf"C:\Windows\System32\process-{pid}.exe",
+        command_line=f"process-{pid}.exe",
+        username="analyst",
+        logon_id=logon_id,
+    )
+
+
+def _identity_state() -> tuple[StateManager, IdentityLifecyclePlanner, str, int, int]:
+    start = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+    state = StateManager()
+    state.set_current_time(start)
+    logon_id = state.create_session(
+        "analyst",
+        "WS-01",
+        2,
+        "-",
+        lifecycle_group_id="session-group",
+    )
+    parent_pid = state.create_process(
+        "WS-01",
+        0,
+        r"C:\Windows\explorer.exe",
+        "explorer.exe",
+        "analyst",
+        "Medium",
+        logon_id,
+        lifecycle_group_id="parent-process-group",
+    )
+    state.set_current_time(start + timedelta(seconds=1))
+    child_pid = state.create_process(
+        "WS-01",
+        parent_pid,
+        r"C:\Windows\System32\cmd.exe",
+        "cmd.exe /c whoami",
+        "analyst",
+        "Medium",
+        logon_id,
+        lifecycle_group_id="child-process-group",
+    )
+    return state, IdentityLifecyclePlanner(state), logon_id, parent_pid, child_pid
+
+
+def test_process_create_and_terminate_share_identity_and_primary_thread() -> None:
+    state, planner, logon_id, parent_pid, child_pid = _identity_state()
+    child = state.get_process_identity("WS-01", child_pid)
+    assert child is not None
+    create = SecurityEvent(
+        timestamp=child.started_at,
+        event_type="process_create",
+        src_host=_host(),
+        auth=AuthContext(username="analyst", logon_id=logon_id),
+        process=_process_context(child_pid, parent_pid, logon_id),
+        edr=EdrContext(),
+    )
+    planner.plan(create)
+
+    assert create.identity_plan is not None
+    assert create.identity_plan.subject == child
+    assert isinstance(create.identity_plan.actor, ProcessIdentity)
+    assert create.identity_plan.actor.pid == parent_pid
+    assert isinstance(create.identity_plan.session, SessionIdentity)
+    assert create.lifecycle is not None
+    assert create.lifecycle.group_id == "child-process-group"
+    assert create.lifecycle.parent_group_id == "session-group"
+    assert create.lifecycle.phase == "start"
+    assert child.primary_thread is not None
+    assert create.edr is not None
+    assert create.edr.tid == child.primary_thread.tid
+
+    terminate = SecurityEvent(
+        timestamp=child.started_at + timedelta(seconds=10),
+        event_type="process_terminate",
+        src_host=_host(),
+        auth=AuthContext(username="analyst", logon_id=logon_id),
+        process=_process_context(child_pid, parent_pid, logon_id),
+        edr=EdrContext(),
+    )
+    planner.plan(terminate)
+    assert terminate.identity_plan is not None
+    assert terminate.identity_plan.subject == child
+    assert terminate.lifecycle is not None
+    assert terminate.lifecycle.group_id == create.lifecycle.group_id
+    assert terminate.lifecycle.phase == "closure"
+    assert terminate.edr is not None
+    assert terminate.edr.tid == create.edr.tid
+
+
+def test_dependent_process_event_keeps_object_semantics_without_synthesized_tid() -> None:
+    state, planner, logon_id, parent_pid, child_pid = _identity_state()
+    event = SecurityEvent(
+        timestamp=state.get_process("WS-01", child_pid).start_time + timedelta(seconds=2),
+        event_type="file_create",
+        src_host=_host(),
+        auth=AuthContext(username="analyst", logon_id=logon_id),
+        process=_process_context(child_pid, parent_pid, logon_id),
+        file=FileContext(path=r"C:\Temp\out.txt", action="create"),
+        edr=EdrContext(object_id="file-object"),
+    )
+    planner.plan(event)
+
+    assert event.identity_plan is not None
+    assert event.identity_plan.subject is None
+    assert isinstance(event.identity_plan.actor, ProcessIdentity)
+    assert event.identity_plan.actor.pid == child_pid
+    assert event.edr is not None
+    assert event.edr.object_id == "file-object"
+    assert event.edr.actor_id == event.identity_plan.actor.object_id
+    assert event.edr.tid == -1
+    assert event.lifecycle is not None
+    assert event.lifecycle.phase == "dependent"
+    assert event.lifecycle.group_id == "child-process-group"
+
+
+def test_cross_process_roles_and_registered_remote_thread_are_explicit() -> None:
+    state, planner, logon_id, parent_pid, child_pid = _identity_state()
+    parent = state.get_process_identity("WS-01", parent_pid)
+    child = state.get_process_identity("WS-01", child_pid)
+    assert parent is not None
+    assert child is not None
+
+    access = SecurityEvent(
+        timestamp=child.started_at + timedelta(seconds=2),
+        event_type="process_access",
+        src_host=_host(),
+        process=_process_context(child_pid, parent_pid, logon_id),
+        process_access=ProcessAccessContext(
+            source_pid=child_pid,
+            source_image=child.image,
+            target_pid=parent_pid,
+            target_image=parent.image,
+            target_process_object_id=parent.object_id,
+            granted_access="0x1010",
+        ),
+        edr=EdrContext(object_id=parent.object_id, actor_id=child.object_id),
+    )
+    planner.plan(access)
+    assert access.identity_plan is not None
+    assert access.identity_plan.subject == parent
+    assert access.identity_plan.actor == child
+    assert access.identity_plan.target == parent
+    assert access.edr is not None
+    assert access.edr.tid == -1
+
+    remote_thread = state.create_thread(
+        "WS-01",
+        parent.object_id,
+        tid=7300,
+        kind="remote",
+        start_time=access.timestamp,
+    )
+    remote = SecurityEvent(
+        timestamp=access.timestamp,
+        event_type="create_remote_thread",
+        src_host=_host(),
+        process=_process_context(child_pid, parent_pid, logon_id),
+        remote_thread=RemoteThreadContext(
+            target_pid=parent_pid,
+            target_image=parent.image,
+            new_thread_id=remote_thread.tid,
+            start_address=0x7FF600001000,
+            target_process_object_id=parent.object_id,
+            thread_object_id=remote_thread.object_id,
+        ),
+        edr=EdrContext(),
+    )
+    planner.plan(remote)
+    assert remote.identity_plan is not None
+    assert isinstance(remote.identity_plan.subject, ThreadIdentity)
+    assert remote.identity_plan.subject == remote_thread
+    assert remote.identity_plan.actor == child
+    assert remote.identity_plan.target == parent
+
+
+def test_session_start_unlock_child_and_logoff_lifecycle() -> None:
+    state, planner, logon_id, _parent_pid, _child_pid = _identity_state()
+    session = state.get_session_identity(logon_id)
+    assert session is not None
+    logon = SecurityEvent(
+        timestamp=session.started_at,
+        event_type="logon",
+        dst_host=_host(),
+        auth=AuthContext(username="analyst", logon_id=logon_id, logon_type=2),
+        edr=EdrContext(),
+    )
+    planner.plan(logon)
+    assert logon.identity_plan is not None
+    assert logon.identity_plan.subject == session
+    assert logon.lifecycle is not None
+    assert logon.lifecycle.group_id == "session-group"
+    assert logon.lifecycle.phase == "start"
+
+    unlock = SecurityEvent(
+        timestamp=session.started_at + timedelta(hours=1),
+        event_type="logon",
+        dst_host=_host(),
+        auth=AuthContext(username="analyst", logon_id=logon_id, logon_type=7),
+        edr=EdrContext(),
+    )
+    planner.plan(unlock)
+    assert unlock.identity_plan is not None
+    assert unlock.identity_plan.subject != session
+    assert unlock.identity_plan.actor == session
+    assert unlock.lifecycle is not None
+    assert unlock.lifecycle.group_id != session.lifecycle_group_id
+    assert unlock.lifecycle.parent_group_id == session.lifecycle_group_id
+
+    logoff = SecurityEvent(
+        timestamp=session.started_at + timedelta(hours=8),
+        event_type="logoff",
+        dst_host=_host(),
+        auth=AuthContext(username="analyst", logon_id=logon_id, logon_type=2),
+        edr=EdrContext(),
+    )
+    planner.plan(logoff)
+    assert logoff.lifecycle is not None
+    assert logoff.lifecycle.group_id == logon.lifecycle.group_id
+    assert logoff.lifecycle.phase == "closure"
+
+
+def test_flow_actor_is_canonical_or_omitted_as_complete_group() -> None:
+    state, planner, _logon_id, _parent_pid, child_pid = _identity_state()
+    flow = SecurityEvent(
+        timestamp=state.get_process("WS-01", child_pid).start_time + timedelta(seconds=1),
+        event_type="connection",
+        src_host=_host(),
+        network=NetworkContext(
+            src_ip="10.0.0.10",
+            src_port=51000,
+            dst_ip="198.51.100.20",
+            dst_port=443,
+            protocol="tcp",
+            initiating_pid=child_pid,
+        ),
+    )
+    planner.plan(flow)
+    assert flow.identity_plan is not None
+    assert isinstance(flow.identity_plan.actor, ProcessIdentity)
+    assert flow.identity_plan.actor.pid == child_pid
+
+    state.end_process("WS-01", child_pid, flow.timestamp + timedelta(seconds=1))
+    stale_flow = SecurityEvent(
+        timestamp=flow.timestamp + timedelta(seconds=2),
+        event_type="connection",
+        src_host=_host(),
+        network=NetworkContext(
+            src_ip="10.0.0.10",
+            src_port=51001,
+            dst_ip="198.51.100.20",
+            dst_port=443,
+            protocol="tcp",
+            initiating_pid=child_pid,
+        ),
+    )
+    planner.plan(stale_flow)
+    assert stale_flow.identity_plan is None
+    assert stale_flow.edr is None

--- a/tests/unit/test_improve_loop_fixes.py
+++ b/tests/unit/test_improve_loop_fixes.py
@@ -302,9 +302,39 @@ class TestSessionKindMatching:
         wm = WorldModel(scenario, "corp.local")
         state = StateManager()
         ag = Mock()
-        ag.generate_logon = Mock(return_value="0x1234")
-        ag.generate_ssh_session = Mock(return_value="CxUID1")
-        ag.generate_rdp_session = Mock(return_value="CxUID2")
+
+        def create_session(*, session_kind, logon_type, time, source_ip):
+            state.set_current_time(time)
+            return state.create_session(
+                username="admin",
+                system="SRV-01",
+                logon_type=logon_type,
+                source_ip=source_ip,
+                start_time=time,
+                session_kind=session_kind,
+                lifecycle_group_id=f"mock-{session_kind}-{time.isoformat()}",
+            )
+
+        def generate_logon(**kwargs):
+            logon_type = kwargs.get("logon_type", 2)
+            return create_session(
+                session_kind="network" if logon_type == 3 else "interactive",
+                logon_type=logon_type,
+                time=kwargs["time"],
+                source_ip=kwargs.get("source_ip") or "-",
+            )
+
+        def execute_ssh_session_bundle(**kwargs):
+            logon_id = create_session(
+                session_kind="ssh",
+                logon_type=10,
+                time=kwargs["time"],
+                source_ip=kwargs["source_ip"],
+            )
+            return "CxUID1", logon_id
+
+        ag.generate_logon.side_effect = generate_logon
+        ag._execute_ssh_session_bundle.side_effect = execute_ssh_session_bundle
         planner = WorldPlanner(
             world_model=wm,
             state_manager=state,

--- a/tests/unit/test_phase5_logoff.py
+++ b/tests/unit/test_phase5_logoff.py
@@ -173,6 +173,99 @@ class TestLogoffWindows:
         assert event.event_type == "logoff"
         assert event.auth.username == "alice.smith"
 
+    def test_logoff_closes_all_session_processes_before_session_closure(
+        self, activity_gen, test_user, win_system, timestamp, state_manager, mock_emitters
+    ):
+        """The session bundle owns child-first process teardown before durable logout."""
+        state_manager.set_current_time(timestamp)
+        logon_id = activity_gen.generate_logon(test_user, win_system, timestamp)
+        state_manager.set_current_time(timestamp + timedelta(minutes=1))
+        child_pid = state_manager.create_process(
+            win_system.hostname,
+            0,
+            r"C:\Windows\System32\OpenSSH\ssh.exe",
+            "ssh.exe server",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        state_manager.update_process_activity_time(
+            win_system.hostname,
+            child_pid,
+            timestamp + timedelta(minutes=8),
+        )
+        mock_emitters["ecar"].reset_mock()
+
+        activity_gen.generate_logoff(
+            test_user,
+            win_system,
+            timestamp + timedelta(minutes=2),
+            logon_id,
+        )
+
+        emitted = [call.args[0] for call in mock_emitters["ecar"].emit.call_args_list]
+        child_terminate = next(
+            event
+            for event in emitted
+            if event.event_type == "process_terminate" and event.process.pid == child_pid
+        )
+        logoff = next(event for event in emitted if event.event_type == "logoff")
+        visible_terminate = activity_gen.process_source_terminate_time(
+            win_system.hostname,
+            child_pid,
+        )
+        assert visible_terminate is not None
+        assert child_terminate.timestamp > timestamp + timedelta(minutes=8)
+        assert logoff.timestamp > visible_terminate
+        assert all(proc.logon_id != logon_id for proc in state_manager.list_running_processes())
+
+    def test_logoff_follows_preplanned_session_process_termination(
+        self, activity_gen, test_user, win_system, timestamp, state_manager, mock_emitters
+    ):
+        """A held process close remains part of its session lifecycle after state teardown."""
+        state_manager.set_current_time(timestamp)
+        logon_id = activity_gen.generate_logon(test_user, win_system, timestamp)
+        state_manager.set_current_time(timestamp + timedelta(minutes=1))
+        pid = state_manager.create_process(
+            win_system.hostname,
+            0,
+            r"C:\Windows\System32\OpenSSH\ssh.exe",
+            "ssh.exe server",
+            test_user.username,
+            "Medium",
+            logon_id,
+        )
+        state_manager.update_process_activity_time(
+            win_system.hostname,
+            pid,
+            timestamp + timedelta(minutes=12),
+        )
+        activity_gen.generate_process_termination(
+            test_user,
+            win_system,
+            timestamp + timedelta(minutes=2),
+            pid,
+            r"C:\Windows\System32\OpenSSH\ssh.exe",
+            logon_id,
+        )
+        visible_terminate = activity_gen.process_source_terminate_time(win_system.hostname, pid)
+        assert visible_terminate is not None
+        mock_emitters["ecar"].reset_mock()
+
+        activity_gen.generate_logoff(
+            test_user,
+            win_system,
+            timestamp + timedelta(minutes=3),
+            logon_id,
+        )
+
+        logoff = next(
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type == "logoff"
+        )
+        assert logoff.timestamp > visible_terminate
+
 
 class TestLogoffLinux:
     """Test logoff event generation on Linux systems."""
@@ -368,10 +461,10 @@ class TestLogoffLinux:
         assert syslog_event.timestamp == close_time + expected_delta
         assert ecar_event.timestamp == close_time + expected_delta
 
-    def test_storyline_ssh_logoff_preserves_time_before_transport_close(
+    def test_storyline_ssh_logoff_waits_for_transport_close(
         self, activity_gen, test_user, linux_system, timestamp, state_manager, mock_emitters
     ):
-        """Storyline logout should stay authored when the SSH transport is still open."""
+        """Storyline logout cannot close a durable SSH session before its transport."""
         state_manager.set_current_time(timestamp)
         logon_id = state_manager.create_session(
             username=test_user.username,
@@ -399,8 +492,12 @@ class TestLogoffLinux:
 
         syslog_event = _emitted_pam_close_event(mock_emitters)
         ecar_event = mock_emitters["ecar"].emit.call_args[0][0]
-        assert syslog_event.timestamp == logoff_time
-        assert ecar_event.timestamp == logoff_time
+        expected_delta = sample_timing_delta(
+            "windows.logoff_after_last_activity",
+            seed_parts=(linux_system.hostname, logon_id, close_time),
+        )
+        assert syslog_event.timestamp == close_time + expected_delta
+        assert ecar_event.timestamp == close_time + expected_delta
 
     def test_linux_type10_logoff_gets_pam_close_even_when_kind_was_not_preserved(
         self, activity_gen, test_user, linux_system, timestamp, state_manager, mock_emitters

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -12,11 +12,13 @@ from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import (
     AuthContext,
     DnsContext,
+    FileContext,
     HostContext,
     NetworkContext,
     ProcessAccessContext,
     ProcessContext,
 )
+from evidenceforge.events.identity import EventIdentityPlan, ProcessIdentity, ThreadIdentity
 from evidenceforge.events.lifecycle import ActionLifecycleContext
 from evidenceforge.formats import load_format
 from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
@@ -93,6 +95,51 @@ def _process_context(start_time: datetime) -> ProcessContext:
     )
 
 
+def _process_identity(
+    *,
+    hostname: str,
+    pid: int,
+    parent_pid: int,
+    started_at: datetime,
+    image: str,
+) -> ProcessIdentity:
+    object_id = f"process-{hostname}-{pid}-{started_at.isoformat()}"
+    primary_thread = ThreadIdentity(
+        hostname=hostname,
+        process_object_id=object_id,
+        pid=pid,
+        tid=max(4, ((pid + 3) // 4) * 4),
+        object_id=f"thread-{object_id}",
+        started_at=started_at,
+        kind="primary",
+    )
+    return ProcessIdentity(
+        hostname=hostname,
+        object_id=object_id,
+        pid=pid,
+        parent_pid=parent_pid,
+        image=image,
+        command_line=image,
+        principal=r"CORP\alice",
+        logon_id="0x12345",
+        started_at=started_at,
+        lifecycle_group_id=f"lifecycle-{object_id}",
+        primary_thread=primary_thread,
+    )
+
+
+def _context_from_identity(identity: ProcessIdentity) -> ProcessContext:
+    return ProcessContext(
+        pid=identity.pid,
+        parent_pid=identity.parent_pid,
+        image=identity.image,
+        command_line=identity.command_line,
+        username=identity.principal,
+        logon_id=identity.logon_id,
+        start_time=identity.started_at,
+    )
+
+
 def test_source_time_is_deterministic() -> None:
     """The same event/source/seed should produce the same planned source time."""
     planner = SourceTimingPlanner()
@@ -112,6 +159,88 @@ def test_source_time_is_deterministic() -> None:
     )
 
     assert first == second
+
+
+def test_ecar_identity_plan_preserves_parent_create_dependent_terminate_order(
+    tmp_path: Path,
+) -> None:
+    """Dispatcher timing owns visible process lifecycle order before serialization."""
+
+    base = _base_time()
+    host = _host_context()
+    parent = _process_identity(
+        hostname=host.hostname,
+        pid=3000,
+        parent_pid=4,
+        started_at=base,
+        image=r"C:\Windows\explorer.exe",
+    )
+    child = _process_identity(
+        hostname=host.hostname,
+        pid=4242,
+        parent_pid=parent.pid,
+        started_at=base + timedelta(milliseconds=15),
+        image=r"C:\Windows\System32\cmd.exe",
+    )
+    parent_event = SecurityEvent(
+        timestamp=parent.started_at,
+        event_type="process_create",
+        src_host=host,
+        process=_context_from_identity(parent),
+        identity_plan=EventIdentityPlan(subject=parent),
+    )
+    child_event = SecurityEvent(
+        timestamp=child.started_at,
+        event_type="process_create",
+        src_host=host,
+        process=_context_from_identity(child),
+        identity_plan=EventIdentityPlan(subject=child, actor=parent),
+    )
+    file_event = SecurityEvent(
+        timestamp=child.started_at + timedelta(milliseconds=25),
+        event_type="file_create",
+        src_host=host,
+        process=_context_from_identity(child),
+        file=FileContext(
+            path=r"C:\Users\alice\AppData\Local\Temp\result.txt",
+            action="create",
+            pid=child.pid,
+        ),
+        identity_plan=EventIdentityPlan(actor=child),
+    )
+    terminate_event = SecurityEvent(
+        timestamp=child.started_at + timedelta(seconds=2),
+        event_type="process_terminate",
+        src_host=host,
+        process=_context_from_identity(child),
+        identity_plan=EventIdentityPlan(subject=child),
+    )
+    planner = SourceTimingPlanner()
+    for event in (parent_event, child_event, file_event, terminate_event):
+        planner.plan_event(event, format_name="ecar")
+
+    emitter = EcarEmitter(load_format("ecar"), tmp_path, threaded=False)
+    for event in (parent_event, child_event, file_event, terminate_event):
+        emitter.emit(event)
+    emitter.close()
+
+    rows = [
+        json.loads(line) for line in (tmp_path / host.fqdn / "ecar.json").read_text().splitlines()
+    ]
+    parent_create = next(row for row in rows if row.get("objectID") == parent.object_id)
+    child_create = next(
+        row for row in rows if row.get("objectID") == child.object_id and row["action"] == "CREATE"
+    )
+    file_create = next(row for row in rows if row["object"] == "FILE")
+    child_terminate = next(
+        row
+        for row in rows
+        if row.get("objectID") == child.object_id and row["action"] == "TERMINATE"
+    )
+
+    assert parent_create["timestamp_ms"] < child_create["timestamp_ms"]
+    assert child_create["timestamp_ms"] < file_create["timestamp_ms"]
+    assert file_create["timestamp_ms"] < child_terminate["timestamp_ms"]
 
 
 def test_nested_action_children_share_host_local_source_offset() -> None:
@@ -512,174 +641,14 @@ def test_ecar_dependent_timestamp_follows_process_create(tmp_path: Path) -> None
     assert dependent_time > process_time
 
 
-def test_ecar_session_dependents_shift_after_visible_login() -> None:
-    """eCAR PROCESS/FILE/MODULE rows should not precede their same LogonID login."""
-    login_ms = 1_710_781_261_000
-    rows = [
-        {
-            "timestamp_ms": login_ms - 200,
-            "id": "process-event",
-            "hostname": "FILE-SRV-01",
-            "object": "PROCESS",
-            "action": "CREATE",
-            "objectID": "process-object",
-            "pid": 4242,
-            "principal": "MERIDIANHCS\\svc_mhsync",
-            "properties": {"logon_id": "0xf88578c", "image_path": "powershell.exe"},
-        },
-        {
-            "timestamp_ms": login_ms,
-            "id": "session-event",
-            "hostname": "FILE-SRV-01",
-            "object": "USER_SESSION",
-            "action": "LOGIN",
-            "objectID": "session-object",
-            "principal": "MERIDIANHCS\\svc_mhsync",
-            "properties": {
-                "logon_id": "0xf88578c",
-                "outcome": "success",
-                "logon_type": "3",
-            },
-        },
-        {
-            "timestamp_ms": login_ms + 50,
-            "id": "other-process",
-            "hostname": "FILE-SRV-01",
-            "object": "PROCESS",
-            "action": "CREATE",
-            "objectID": "other-object",
-            "pid": 5000,
-            "principal": "NT AUTHORITY\\SYSTEM",
-            "properties": {"logon_id": "0x3e7", "image_path": "svchost.exe"},
-        },
-    ]
-    normalized = EcarEmitter._normalize_session_dependents_after_login(
-        [json.dumps(row, separators=(",", ":")) for row in rows]
-    )
-    process = json.loads(normalized[0])
-    system_process = json.loads(normalized[2])
-
-    assert process["timestamp_ms"] > login_ms
-    assert process["properties"]["logon_id"] == "0xf88578c"
-    assert system_process["timestamp_ms"] == login_ms + 50
-
-
-def test_ecar_type7_unlock_does_not_reanchor_session_dependents() -> None:
-    """Type 7 unlock reauth rows are not original eCAR session creation anchors."""
-    unlock_ms = 1_710_770_188_500
-    rows = [
-        {
-            "timestamp_ms": unlock_ms - 60 * 60 * 1000,
-            "id": "process-event",
-            "hostname": "WS-AJOHNSON-01",
-            "object": "PROCESS",
-            "action": "CREATE",
-            "objectID": "process-object",
-            "pid": 5536,
-            "principal": "aisha.johnson",
-            "properties": {
-                "logon_id": "0x24de089",
-                "logon_type": "7",
-                "session_id": "2",
-                "image_path": r"C:\Windows\System32\mstsc.exe",
-            },
-        },
-        {
-            "timestamp_ms": unlock_ms,
-            "id": "unlock-session",
-            "hostname": "WS-AJOHNSON-01",
-            "object": "USER_SESSION",
-            "action": "LOGIN",
-            "objectID": "session-object",
-            "principal": "aisha.johnson",
-            "properties": {
-                "logon_id": "0x24de089",
-                "outcome": "success",
-                "logon_type": "7",
-                "session_id": "2",
-            },
-        },
-    ]
-
-    normalized = EcarEmitter._normalize_session_dependents_after_login(
-        [json.dumps(row, separators=(",", ":")) for row in rows]
-    )
-    process = json.loads(normalized[0])
-
-    assert process["timestamp_ms"] == unlock_ms - 60 * 60 * 1000
-
-
-def test_ecar_original_login_anchors_dependents_without_later_unlock() -> None:
-    """Original session logons still anchor dependents when a later type 7 row exists."""
-    login_ms = 1_710_770_000_000
-    unlock_ms = login_ms + 60 * 60 * 1000
-    rows = [
-        {
-            "timestamp_ms": login_ms - 200,
-            "id": "process-event",
-            "hostname": "WS-AJOHNSON-01",
-            "object": "PROCESS",
-            "action": "CREATE",
-            "objectID": "process-object",
-            "pid": 5536,
-            "principal": "aisha.johnson",
-            "properties": {
-                "logon_id": "0x24de089",
-                "session_id": "2",
-                "image_path": r"C:\Windows\System32\mstsc.exe",
-            },
-        },
-        {
-            "timestamp_ms": login_ms,
-            "id": "interactive-session",
-            "hostname": "WS-AJOHNSON-01",
-            "object": "USER_SESSION",
-            "action": "LOGIN",
-            "objectID": "session-object",
-            "principal": "aisha.johnson",
-            "properties": {
-                "logon_id": "0x24de089",
-                "outcome": "success",
-                "logon_type": "2",
-                "session_id": "2",
-            },
-        },
-        {
-            "timestamp_ms": unlock_ms,
-            "id": "unlock-session",
-            "hostname": "WS-AJOHNSON-01",
-            "object": "USER_SESSION",
-            "action": "LOGIN",
-            "objectID": "session-object",
-            "principal": "aisha.johnson",
-            "properties": {
-                "logon_id": "0x24de089",
-                "outcome": "success",
-                "logon_type": "7",
-                "session_id": "2",
-            },
-        },
-    ]
-
-    normalized = EcarEmitter._normalize_session_dependents_after_login(
-        [json.dumps(row, separators=(",", ":")) for row in rows]
-    )
-    process = json.loads(normalized[0])
-
-    assert login_ms < process["timestamp_ms"] < unlock_ms
-
-
-def test_ecar_type3_login_timestamp_follows_matching_inbound_flow(tmp_path: Path) -> None:
-    """eCAR type-3 USER_SESSION rows should not visibly precede same-tuple FLOW rows."""
+def test_ecar_type3_login_uses_upstream_canonical_transport_order(tmp_path: Path) -> None:
+    """eCAR preserves bundle-owned transport-before-auth canonical ordering."""
     emitter = EcarEmitter(load_format("ecar"), tmp_path, threaded=False)
     base = _base_time()
     host = _host_context()
     flow_time = base + timedelta(milliseconds=750)
-    emitter._remote_inbound_flow_times[(host.hostname, "10.0.0.30", 50123, host.ip, 445)] = (
-        flow_time
-    )
     event = SecurityEvent(
-        timestamp=base,
+        timestamp=flow_time + timedelta(milliseconds=1),
         event_type="logon",
         dst_host=host,
         auth=AuthContext(
@@ -719,680 +688,41 @@ def test_ecar_dependent_timestamp_for_long_running_process_uses_event_time(
 
 
 def test_ecar_process_terminate_preserves_rendered_lifetime(tmp_path: Path) -> None:
-    """eCAR process-create latency should not collapse visible command duration."""
+    """Canonical source timing preserves visible process lifetime before rendering."""
     emitter = EcarEmitter(load_format("ecar"), tmp_path, threaded=False)
     base = _base_time()
     host = _host_context()
-    proc = _process_context(base)
+    identity = _process_identity(
+        hostname=host.hostname,
+        pid=4242,
+        parent_pid=888,
+        started_at=base,
+        image=r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+    )
+    proc = _context_from_identity(identity)
     create_event = SecurityEvent(
         timestamp=base,
         event_type="process_create",
         src_host=host,
         process=proc,
+        identity_plan=EventIdentityPlan(subject=identity),
     )
     terminate_event = SecurityEvent(
         timestamp=base + timedelta(seconds=6),
         event_type="process_terminate",
         src_host=host,
         process=proc,
+        identity_plan=EventIdentityPlan(subject=identity),
     )
+    planner = SourceTimingPlanner()
+    planner.plan_event(create_event, format_name="ecar")
+    planner.plan_event(terminate_event, format_name="ecar")
 
-    process_time = emitter._process_create_timestamp(create_event, proc)
-    terminate_time = emitter._process_terminate_timestamp(terminate_event, proc)
+    process_time = emitter._process_create_timestamp(create_event, identity)
+    terminate_time = emitter._process_terminate_timestamp(terminate_event, identity)
 
     assert terminate_time >= process_time + timedelta(seconds=6)
     assert terminate_time < process_time + timedelta(seconds=12)
-
-
-def test_ecar_process_create_normalization_preserves_canonical_order() -> None:
-    """eCAR PROCESS/CREATE rows should not invert canonical same-chain process order."""
-    first = {
-        "timestamp_ms": 1_710_783_739_979,
-        "_canonical_ms": 1_710_783_736_520,
-        "id": "event-a",
-        "hostname": "dc-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "proc-a",
-        "actorID": "parent",
-        "pid": 6340,
-        "ppid": 6200,
-    }
-    second = {
-        "timestamp_ms": 1_710_783_737_093,
-        "_canonical_ms": 1_710_783_737_022,
-        "id": "event-b",
-        "hostname": "dc-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "proc-b",
-        "actorID": "parent",
-        "pid": 6352,
-        "ppid": 6200,
-    }
-
-    normalized = EcarEmitter._normalize_process_create_canonical_order(
-        [
-            json.dumps(first, separators=(",", ":")),
-            json.dumps(second, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[1]["timestamp_ms"] > rows[0]["timestamp_ms"]
-    assert 3 <= rows[1]["timestamp_ms"] - rows[0]["timestamp_ms"] <= 49
-    assert "_canonical_ms" not in rows[0]
-    assert "_canonical_ms" not in rows[1]
-
-
-def test_ecar_process_create_normalization_does_not_batch_linux_rows() -> None:
-    """Linux process-create rows keep their source-native timestamp texture."""
-    first = {
-        "timestamp_ms": 1_710_783_755_003,
-        "_canonical_ms": 1_710_777_592_000,
-        "id": "event-sshd-a",
-        "hostname": "WEB-EXT-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "proc-sshd-a",
-        "actorID": "init-process",
-        "pid": 779693,
-        "ppid": 500,
-        "properties": {"image_path": "/usr/sbin/sshd"},
-    }
-    second = {
-        "timestamp_ms": 1_710_777_613_250,
-        "_canonical_ms": 1_710_777_613_000,
-        "id": "event-sshd-b",
-        "hostname": "WEB-EXT-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "proc-sshd-b",
-        "actorID": "init-process",
-        "pid": 779701,
-        "ppid": 500,
-        "properties": {"image_path": "/usr/sbin/sshd"},
-    }
-
-    normalized = EcarEmitter._normalize_process_create_canonical_order(
-        [
-            json.dumps(first, separators=(",", ":")),
-            json.dumps(second, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[0]["timestamp_ms"] == first["timestamp_ms"]
-    assert rows[1]["timestamp_ms"] == second["timestamp_ms"]
-    assert rows[1]["timestamp_ms"] < rows[0]["timestamp_ms"]
-    assert "_canonical_ms" not in rows[0]
-    assert "_canonical_ms" not in rows[1]
-
-
-def test_ecar_linux_shell_foreground_order_serializes_visible_commands() -> None:
-    """eCAR should not show one shell foreground command starting before the prior exits."""
-    editor_create = {
-        "timestamp_ms": 1_710_780_154_204,
-        "id": "event-editor-create",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "editor-process",
-        "actorID": "bash-process",
-        "pid": 785286,
-        "ppid": 33760,
-        "principal": "lina.nguyen",
-        "properties": {
-            "image_path": "/usr/bin/emacs",
-            "command_line": "emacs -nw deploy.sh",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    next_create = {
-        "timestamp_ms": 1_710_780_209_982,
-        "id": "event-npm-create",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "npm-process",
-        "actorID": "bash-process",
-        "pid": 785296,
-        "ppid": 33760,
-        "principal": "lina.nguyen",
-        "properties": {
-            "image_path": "/usr/bin/npm",
-            "command_line": "npm install",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    editor_terminate = {
-        "timestamp_ms": 1_710_780_284_534,
-        "id": "event-editor-terminate",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "editor-process",
-        "pid": 785286,
-        "principal": "lina.nguyen",
-        "properties": {"image_path": "/usr/bin/emacs"},
-    }
-    next_terminate = {
-        "timestamp_ms": 1_710_780_230_000,
-        "id": "event-npm-terminate",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "npm-process",
-        "pid": 785296,
-        "principal": "lina.nguyen",
-        "properties": {"image_path": "/usr/bin/npm"},
-    }
-    third_create = {
-        "timestamp_ms": 1_710_780_235_000,
-        "id": "event-vim-create",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "vim-process",
-        "actorID": "bash-process",
-        "pid": 785297,
-        "ppid": 33760,
-        "principal": "lina.nguyen",
-        "properties": {
-            "image_path": "/usr/bin/vim",
-            "command_line": "vim config.yaml",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    third_terminate = {
-        "timestamp_ms": 1_710_780_245_000,
-        "id": "event-vim-terminate",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "vim-process",
-        "pid": 785297,
-        "principal": "lina.nguyen",
-        "properties": {"image_path": "/usr/bin/vim"},
-    }
-
-    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
-        [
-            json.dumps(editor_create, separators=(",", ":")),
-            json.dumps(next_create, separators=(",", ":")),
-            json.dumps(editor_terminate, separators=(",", ":")),
-            json.dumps(next_terminate, separators=(",", ":")),
-            json.dumps(third_create, separators=(",", ":")),
-            json.dumps(third_terminate, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[1]["timestamp_ms"] > rows[2]["timestamp_ms"]
-    assert rows[3]["timestamp_ms"] > rows[1]["timestamp_ms"]
-    assert rows[4]["timestamp_ms"] > rows[3]["timestamp_ms"]
-    assert rows[5]["timestamp_ms"] > rows[4]["timestamp_ms"]
-
-
-def test_ecar_linux_shell_foreground_order_covers_scp_transfer_chain() -> None:
-    """eCAR should serialize bounded foreground transfer commands from one shell."""
-    gzip_create = {
-        "timestamp_ms": 1_710_782_144_698,
-        "id": "gzip-create",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "gzip-process",
-        "actorID": "bash-process",
-        "pid": 706031,
-        "ppid": 705932,
-        "principal": "root",
-        "properties": {
-            "image_path": "/usr/bin/gzip",
-            "command_line": "gzip -9 /tmp/rpt_0318.sql",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    scp_create = {
-        "timestamp_ms": 1_710_782_165_966,
-        "id": "scp-create",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "scp-process",
-        "actorID": "bash-process",
-        "pid": 706051,
-        "ppid": 705932,
-        "principal": "root",
-        "properties": {
-            "image_path": "/usr/bin/scp",
-            "command_line": "scp /tmp/rpt_0318.sql.gz root@10.10.2.30:/tmp/rpt.sql.gz",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    gzip_terminate = {
-        "timestamp_ms": 1_710_782_173_346,
-        "id": "gzip-terminate",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "gzip-process",
-        "pid": 706031,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/gzip"},
-    }
-    scp_flow = {
-        "timestamp_ms": 1_710_782_166_500,
-        "id": "scp-flow",
-        "hostname": "DB-PROD-01",
-        "object": "FLOW",
-        "action": "START",
-        "objectID": "flow-1",
-        "actorID": "scp-process",
-        "pid": 706051,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/scp"},
-    }
-    scp_terminate = {
-        "timestamp_ms": 1_710_782_235_832,
-        "id": "scp-terminate",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "scp-process",
-        "pid": 706051,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/scp"},
-    }
-
-    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
-        [
-            json.dumps(gzip_create, separators=(",", ":")),
-            json.dumps(scp_create, separators=(",", ":")),
-            json.dumps(gzip_terminate, separators=(",", ":")),
-            json.dumps(scp_flow, separators=(",", ":")),
-            json.dumps(scp_terminate, separators=(",", ":")),
-        ]
-    )
-    normalized = EcarEmitter._normalize_process_reference_order(normalized)
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[1]["timestamp_ms"] > rows[2]["timestamp_ms"]
-    assert rows[3]["timestamp_ms"] > rows[1]["timestamp_ms"]
-    assert rows[4]["timestamp_ms"] > rows[3]["timestamp_ms"]
-
-
-def test_ecar_flow_reference_order_drops_late_process_identity() -> None:
-    """FLOW timing stays near the connection when process attribution is too late."""
-    process_create = {
-        "timestamp_ms": 1_710_789_025_000,
-        "id": "ldap-create",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "ldap-process",
-        "actorID": "bash-process",
-        "pid": 699858,
-        "ppid": 699820,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/ldapsearch"},
-    }
-    flow = {
-        "timestamp_ms": 1_710_780_340_700,
-        "id": "ldap-flow",
-        "hostname": "DB-PROD-01",
-        "object": "FLOW",
-        "action": "CONNECT",
-        "objectID": "flow-ldap",
-        "actorID": "ldap-process",
-        "pid": 699858,
-        "principal": "root",
-        "properties": {
-            "src_ip": "10.10.4.10",
-            "src_port": "42430",
-            "dst_ip": "10.10.2.10",
-            "dst_port": "389",
-            "protocol": "tcp",
-            "direction": "OUTBOUND",
-            "image_path": "/usr/bin/ldapsearch",
-            "command_line": "ldapsearch -x -H ldap://DC-01",
-        },
-    }
-
-    normalized = EcarEmitter._normalize_process_reference_order(
-        [
-            json.dumps(flow, separators=(",", ":")),
-            json.dumps(process_create, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[0]["timestamp_ms"] == flow["timestamp_ms"]
-    assert "actorID" not in rows[0]
-    assert "pid" not in rows[0]
-    assert "principal" not in rows[0]
-    assert "image_path" not in rows[0]["properties"]
-    assert "command_line" not in rows[0]["properties"]
-
-
-def test_ecar_flow_connect_keeps_network_time_for_close_process_conflict() -> None:
-    """FLOW/CONNECT drops actor identity instead of moving outside the tuple interval."""
-    process_create = {
-        "timestamp_ms": 1_710_789_025_000,
-        "id": "docker-create",
-        "hostname": "WEB-EXT-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "docker-process",
-        "actorID": "bash-process",
-        "pid": 771204,
-        "ppid": 771190,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/docker"},
-    }
-    flow = {
-        "timestamp_ms": 1_710_789_000_300,
-        "id": "proxy-flow",
-        "hostname": "WEB-EXT-01",
-        "object": "FLOW",
-        "action": "CONNECT",
-        "objectID": "flow-proxy",
-        "actorID": "docker-process",
-        "pid": 771204,
-        "principal": "root",
-        "properties": {
-            "src_ip": "10.10.3.15",
-            "src_port": "52844",
-            "dst_ip": "10.10.3.20",
-            "dst_port": "8080",
-            "protocol": "tcp",
-            "direction": "OUTBOUND",
-            "image_path": "/usr/bin/docker",
-            "command_line": "docker ps",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-
-    normalized = EcarEmitter._normalize_process_reference_order(
-        [
-            json.dumps(flow, separators=(",", ":")),
-            json.dumps(process_create, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[0]["timestamp_ms"] == flow["timestamp_ms"]
-    assert "actorID" not in rows[0]
-    assert "pid" not in rows[0]
-    assert "principal" not in rows[0]
-    assert "image_path" not in rows[0]["properties"]
-    assert "command_line" not in rows[0]["properties"]
-    assert "parent_image_path" not in rows[0]["properties"]
-
-
-def test_ecar_linux_shell_foreground_order_serializes_close_unrelated_commands() -> None:
-    """Same-shell commands without an explicit pipeline group should not overlap."""
-    sleep_create = {
-        "timestamp_ms": 1_000_000,
-        "id": "sleep-create",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "sleep-process",
-        "actorID": "bash-process",
-        "pid": 706031,
-        "ppid": 705932,
-        "principal": "root",
-        "properties": {
-            "image_path": "/usr/bin/sleep",
-            "command_line": "sleep 5",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    whoami_create = {
-        "timestamp_ms": 1_000_500,
-        "id": "whoami-create",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "whoami-process",
-        "actorID": "bash-process",
-        "pid": 706032,
-        "ppid": 705932,
-        "principal": "root",
-        "properties": {
-            "image_path": "/usr/bin/whoami",
-            "command_line": "whoami",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    sleep_terminate = {
-        "timestamp_ms": 1_005_000,
-        "id": "sleep-terminate",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "sleep-process",
-        "pid": 706031,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/sleep"},
-    }
-
-    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
-        [
-            json.dumps(sleep_create, separators=(",", ":")),
-            json.dumps(whoami_create, separators=(",", ":")),
-            json.dumps(sleep_terminate, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[1]["timestamp_ms"] > rows[2]["timestamp_ms"]
-
-
-def test_ecar_linux_shell_foreground_order_preserves_bash_history_sync() -> None:
-    """Bash-history-synchronized process rows should keep their sibling timestamp."""
-    npm_create = {
-        "timestamp_ms": 1_000_000,
-        "id": "npm-create",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "npm-process",
-        "actorID": "bash-process",
-        "pid": 781867,
-        "ppid": 780919,
-        "principal": "lina.nguyen",
-        "properties": {
-            "image_path": "/usr/bin/npm",
-            "command_line": "npm run ci",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    npm_terminate = {
-        "timestamp_ms": 1_060_000,
-        "id": "npm-terminate",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "npm-process",
-        "pid": 781867,
-        "principal": "lina.nguyen",
-        "properties": {"image_path": "/usr/bin/npm"},
-    }
-    emacs_create = {
-        "timestamp_ms": 1_020_000,
-        "id": "emacs-create",
-        "hostname": "WS-LNGUYEN-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "emacs-process",
-        "actorID": "bash-process",
-        "_concurrency_group_id": "bash-history:abc123",
-        "pid": 781901,
-        "ppid": 780919,
-        "principal": "lina.nguyen",
-        "properties": {
-            "image_path": "/usr/bin/emacs",
-            "command_line": "emacs -nw /home/lina.nguyen/repos/infra-config/requirements.txt",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-
-    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
-        [
-            json.dumps(npm_create, separators=(",", ":")),
-            json.dumps(emacs_create, separators=(",", ":")),
-            json.dumps(npm_terminate, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[1]["timestamp_ms"] == emacs_create["timestamp_ms"]
-    assert "_concurrency_group_id" not in rows[1]
-
-
-def test_ecar_linux_shell_foreground_order_keeps_pipeline_children_concurrent() -> None:
-    """Pipeline children are concurrent shell work, not sequential foreground prompts."""
-    cat_create = {
-        "timestamp_ms": 1_710_782_144_000,
-        "id": "cat-create",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "cat-process",
-        "_concurrency_group_id": "pipeline-1",
-        "actorID": "bash-process",
-        "pid": 706031,
-        "ppid": 705932,
-        "principal": "root",
-        "properties": {
-            "image_path": "/usr/bin/cat",
-            "command_line": "cat /etc/passwd",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    head_create = {
-        "timestamp_ms": 1_710_782_144_035,
-        "id": "head-create",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "head-process",
-        "_concurrency_group_id": "pipeline-1",
-        "actorID": "bash-process",
-        "pid": 706032,
-        "ppid": 705932,
-        "principal": "root",
-        "properties": {
-            "image_path": "/usr/bin/head",
-            "command_line": "head -5",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    cat_terminate = {
-        "timestamp_ms": 1_710_782_147_000,
-        "id": "cat-terminate",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "cat-process",
-        "pid": 706031,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/cat"},
-    }
-    head_terminate = {
-        "timestamp_ms": 1_710_782_146_500,
-        "id": "head-terminate",
-        "hostname": "DB-PROD-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "head-process",
-        "pid": 706032,
-        "principal": "root",
-        "properties": {"image_path": "/usr/bin/head"},
-    }
-
-    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
-        [
-            json.dumps(cat_create, separators=(",", ":")),
-            json.dumps(head_create, separators=(",", ":")),
-            json.dumps(head_terminate, separators=(",", ":")),
-            json.dumps(cat_terminate, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[1]["timestamp_ms"] == head_create["timestamp_ms"]
-    assert "_concurrency_group_id" not in rows[0]
-    assert "_concurrency_group_id" not in rows[1]
-    assert max(rows[0]["timestamp_ms"], rows[1]["timestamp_ms"]) < min(
-        rows[2]["timestamp_ms"], rows[3]["timestamp_ms"]
-    )
-
-
-def test_ecar_linux_shell_foreground_order_preserves_pipeline_stage_order() -> None:
-    """Tiny source-timing inversions should not put the pipe reader before the writer."""
-    find_create = {
-        "timestamp_ms": 1_710_780_034_167,
-        "id": "find-create",
-        "hostname": "WS-OHADDAD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "find-process",
-        "actorID": "bash-process",
-        "_concurrency_group_id": "pipeline-1",
-        "pid": 470150,
-        "ppid": 467288,
-        "principal": "omar.haddad",
-        "properties": {
-            "image_path": "/usr/bin/find",
-            "command_line": "find . -name *.csv -o -name *.xlsx",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    head_create = {
-        "timestamp_ms": 1_710_780_034_152,
-        "id": "head-create",
-        "hostname": "WS-OHADDAD-01",
-        "object": "PROCESS",
-        "action": "CREATE",
-        "objectID": "head-process",
-        "actorID": "bash-process",
-        "_concurrency_group_id": "pipeline-1",
-        "pid": 470137,
-        "ppid": 467288,
-        "principal": "omar.haddad",
-        "properties": {
-            "image_path": "/usr/bin/head",
-            "command_line": "head",
-            "parent_image_path": "/bin/bash",
-        },
-    }
-    head_terminate = {
-        "timestamp_ms": 1_710_780_038_468,
-        "id": "head-terminate",
-        "hostname": "WS-OHADDAD-01",
-        "object": "PROCESS",
-        "action": "TERMINATE",
-        "objectID": "head-process",
-        "pid": 470137,
-        "principal": "omar.haddad",
-        "properties": {"image_path": "/usr/bin/head"},
-    }
-
-    normalized = EcarEmitter._normalize_linux_shell_foreground_order(
-        [
-            json.dumps(find_create, separators=(",", ":")),
-            json.dumps(head_create, separators=(",", ":")),
-            json.dumps(head_terminate, separators=(",", ":")),
-        ]
-    )
-    rows = [json.loads(line) for line in normalized]
-
-    assert rows[0]["timestamp_ms"] < rows[1]["timestamp_ms"]
-    assert rows[1]["timestamp_ms"] == rows[0]["timestamp_ms"] + 15
-    assert rows[2]["timestamp_ms"] > rows[1]["timestamp_ms"]
 
 
 def test_ecar_logon_does_not_render_self_sourced_remote_ip(tmp_path: Path) -> None:
@@ -1474,6 +804,7 @@ def test_sysmon_process_access_timestamp_follows_process_create(tmp_path: Path) 
             target_pid=640,
             target_image=r"C:\Windows\System32\lsass.exe",
             granted_access="0x1010",
+            source_thread_id=9912,
         ),
     )
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -22,6 +22,7 @@
 
 """Unit tests for StateManager."""
 
+from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 
@@ -801,6 +802,113 @@ class TestSessionManagement:
 
         sessions = sm.list_active_sessions()
         assert len(sessions) == 2
+
+
+class TestCanonicalIdentityState:
+    """Tests for host-scoped process, session, and thread identity."""
+
+    @staticmethod
+    def _create_windows_process(sm: StateManager, system: str, pid: int = 4000) -> int:
+        sm._pid_counters[system] = pid
+        sm._pid_os[system] = "windows"
+        return sm.create_process(
+            system,
+            0,
+            rf"C:\\Windows\\System32\\{system}.exe",
+            f"{system}.exe",
+            "SYSTEM",
+            "System",
+        )
+
+    def test_identical_pid_and_tid_on_different_hosts_do_not_collide(self) -> None:
+        """Host and process object scope identical host-local numeric identifiers."""
+        sm = StateManager()
+        sm.set_current_time(datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC))
+        pid_a = self._create_windows_process(sm, "WS-01")
+        pid_b = self._create_windows_process(sm, "WS-02")
+        process_a = sm.get_process_identity("WS-01", pid_a)
+        process_b = sm.get_process_identity("WS-02", pid_b)
+        assert process_a is not None
+        assert process_b is not None
+        assert pid_a == pid_b
+        assert process_a.object_id != process_b.object_id
+
+        thread_a = sm.create_thread("WS-01", process_a.object_id, tid=9124)
+        thread_b = sm.create_thread("WS-02", process_b.object_id, tid=9124)
+        assert thread_a.tid == thread_b.tid
+        assert thread_a.canonical_key != thread_b.canonical_key
+        assert thread_a.object_id != thread_b.object_id
+
+    def test_same_host_pid_reuse_gets_new_process_and_thread_identity(self) -> None:
+        """A reused PID starts a new object scope even when a TID also repeats."""
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        sm.set_current_time(start)
+        first_pid = self._create_windows_process(sm, "WS-01")
+        first = sm.get_process_identity("WS-01", first_pid)
+        assert first is not None
+        first_thread = sm.create_thread("WS-01", first.object_id, tid=9912)
+        assert sm.end_process("WS-01", first_pid, start + timedelta(seconds=2))
+
+        sm.set_current_time(start + timedelta(minutes=1))
+        sm._pid_counters["WS-01"] = first_pid
+        second_pid = sm.create_process(
+            "WS-01",
+            0,
+            r"C:\Windows\System32\cmd.exe",
+            "cmd.exe /c whoami",
+            "analyst",
+            "Medium",
+        )
+        second = sm.get_process_identity("WS-01", second_pid)
+        assert second is not None
+        second_thread = sm.create_thread("WS-01", second.object_id, tid=9912)
+
+        assert second_pid == first_pid
+        assert second.object_id != first.object_id
+        assert second_thread.canonical_key != first_thread.canonical_key
+        assert sm.get_thread("WS-01", first.object_id, 9912) is None
+        assert sm.get_thread("WS-01", second.object_id, 9912) == second_thread
+
+    def test_primary_thread_is_deterministic_and_immutable(self) -> None:
+        """Primary-thread allocation is stable and snapshots cannot mutate runtime state."""
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        snapshots = []
+        for _ in range(2):
+            sm = StateManager()
+            sm.set_current_time(start)
+            pid = self._create_windows_process(sm, "WS-01")
+            process = sm.get_process_identity("WS-01", pid)
+            assert process is not None
+            assert process.primary_thread is not None
+            snapshots.append(process)
+
+        assert snapshots[0] == snapshots[1]
+        with pytest.raises(FrozenInstanceError):
+            snapshots[0].primary_thread.tid = 1234
+
+    def test_linux_primary_thread_is_process_leader(self) -> None:
+        """Linux process leaders use the kernel's TID-equals-PID convention."""
+        sm = StateManager()
+        sm.set_current_time(datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC))
+        pid = sm.create_process("LINUX-01", 0, "/usr/bin/bash", "bash", "analyst", "Medium")
+        process = sm.get_process_identity("LINUX-01", pid)
+        assert process is not None
+        assert process.primary_thread is not None
+        assert process.primary_thread.tid == pid
+
+    def test_explicit_thread_requires_live_owning_process(self) -> None:
+        """Worker and remote threads cannot outlive or bypass their owning process."""
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        sm.set_current_time(start)
+        pid = self._create_windows_process(sm, "WS-01")
+        process = sm.get_process_identity("WS-01", pid)
+        assert process is not None
+        assert sm.end_process("WS-01", pid, start + timedelta(seconds=1))
+
+        with pytest.raises(StateError, match="owning process object is not live"):
+            sm.create_thread("WS-01", process.object_id, tid=7000, kind="remote")
 
 
 class TestProcessManagement:

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -30,6 +30,7 @@ import pytest
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext, ProcessContext
+from evidenceforge.events.identity import EventIdentityPlan
 from evidenceforge.generation import state_manager as state_manager_module
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.models.exceptions import StateError
@@ -1196,6 +1197,28 @@ class TestProcessManagement:
                     command_line="proc.exe",
                     username="jdoe",
                 ),
+            )
+        )
+
+        proc = sm.get_process("WS-01", pid)
+        assert proc is not None
+        assert proc.last_activity_time == activity_time
+
+    def test_apply_tracks_canonical_actor_activity_without_process_context(self):
+        """Canonical network actors extend lifetime without a compatibility process context."""
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        activity_time = start + timedelta(minutes=3)
+        sm.set_current_time(start)
+        pid = sm.create_process("WS-01", 0, "browser.exe", "browser.exe", "jdoe", "Medium")
+        actor = sm.get_process_identity("WS-01", pid)
+        assert actor is not None
+
+        sm.apply(
+            SecurityEvent(
+                timestamp=activity_time,
+                event_type="connection",
+                identity_plan=EventIdentityPlan(actor=actor),
             )
         )
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -897,6 +897,42 @@ class TestCanonicalIdentityState:
         assert process.primary_thread is not None
         assert process.primary_thread.tid == pid
 
+    @pytest.mark.parametrize(
+        ("system", "pid", "image", "os_category"),
+        [
+            ("WS-01", 4, "System", "windows"),
+            ("LINUX-01", 1, "/usr/lib/systemd/systemd", "linux"),
+        ],
+    )
+    def test_fixed_boot_process_registration_uses_canonical_identity_boundary(
+        self,
+        system: str,
+        pid: int,
+        image: str,
+        os_category: str,
+    ) -> None:
+        """Kernel-native fixed PIDs receive object, lifecycle, and primary-thread state."""
+        sm = StateManager()
+        sm.set_current_time(datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC))
+        process = sm.register_process(
+            system,
+            pid,
+            0,
+            image,
+            image,
+            "SYSTEM" if os_category == "windows" else "root",
+            "System",
+            os_category=os_category,
+        )
+        identity = sm.get_process_identity(system, pid)
+
+        assert identity is not None
+        assert identity.object_id == process.ecar_object_id
+        assert identity.lifecycle_group_id == process.lifecycle_group_id
+        assert identity.primary_thread is not None
+        if os_category == "linux":
+            assert identity.primary_thread.tid == pid
+
     def test_explicit_thread_requires_live_owning_process(self) -> None:
         """Worker and remote threads cannot outlive or bypass their owning process."""
         sm = StateManager()

--- a/tests/unit/test_syslog_family_renderer.py
+++ b/tests/unit/test_syslog_family_renderer.py
@@ -24,6 +24,9 @@
 
 from datetime import UTC, datetime
 
+from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.contexts import HostContext, SyslogContext
+from evidenceforge.formats import load_format
 from evidenceforge.generation.emitters.syslog import (
     SyslogEmitter,
     _fallback_linux_uid,
@@ -111,35 +114,43 @@ def test_rfc3164_timestamp_sort_key_handles_single_digit_day() -> None:
     )
 
 
-def test_normalize_sshd_child_pids_preserves_session_mapping_and_monotonicity() -> None:
-    lines = [
-        "<86>1 2024-03-18T12:37:10.283139Z app sshd 839794 - - Connection from 10.0.1.10 port 50000 on 10.0.2.10 port 22",
-        "<86>1 2024-03-18T12:37:11.001000Z app sshd 839794 - - Accepted password for admin from 10.0.1.10 port 50000 ssh2",
-        "<86>1 2024-03-18T12:45:43.059582Z app sshd 838687 - - Connection from 10.0.1.11 port 50001 on 10.0.2.10 port 22",
-        "<86>1 2024-03-18T12:45:44.100000Z app sshd 838687 - - Accepted password for admin from 10.0.1.11 port 50001 ssh2",
+def test_syslog_close_preserves_canonical_sshd_child_pids(tmp_path) -> None:
+    """Source rendering must not rewrite canonical sshd process identities."""
+    emitter = SyslogEmitter(load_format("syslog"), tmp_path, threaded=False)
+    host = HostContext(
+        hostname="app",
+        ip="10.0.2.10",
+        os="Ubuntu 24.04",
+        os_category="linux",
+        system_type="server",
+        fqdn="app.example",
+    )
+    rows = [
+        (datetime(2024, 3, 18, 12, 37, 10, tzinfo=UTC), 839794, "10.0.1.10", 50000),
+        (datetime(2024, 3, 18, 12, 45, 43, tzinfo=UTC), 838687, "10.0.1.11", 50001),
     ]
+    for timestamp, pid, source_ip, source_port in rows:
+        emitter.emit(
+            SecurityEvent(
+                timestamp=timestamp,
+                event_type="syslog",
+                src_host=host,
+                syslog=SyslogContext(
+                    app_name="sshd",
+                    pid=pid,
+                    facility=10,
+                    severity=6,
+                    message=(
+                        f"Connection from {source_ip} port {source_port} on 10.0.2.10 port 22"
+                    ),
+                ),
+            )
+        )
+    emitter.close()
 
-    normalized = SyslogEmitter._normalize_sshd_child_pids_for_lines(lines, "app.example")
-
-    pids = [int(line.split(" sshd ")[1].split(" ")[0]) for line in normalized]
-    assert pids[0] == pids[1]
-    assert pids[2] == pids[3]
-    assert pids[2] > pids[0]
-
-
-def test_normalize_sshd_child_pids_does_not_let_orphan_closes_rewrite_session_open() -> None:
-    lines = [
-        "<86>1 2024-03-18T15:51:34.963802Z app sshd 784323 - - Connection from 10.0.1.33 port 63690 on 10.0.2.10 port 22",
-        "<86>1 2024-03-18T15:51:35.491983Z app sshd 784323 - - Accepted publickey for user from 10.0.1.33 port 63690 ssh2",
-        "<86>1 2024-03-18T15:52:24.705921Z app sshd 784329 - - pam_unix(sshd:session): session closed for user other",
-        "<86>1 2024-03-18T15:54:22.189035Z app sshd 784327 - - Connection from 10.0.1.31 port 63843 on 10.0.2.10 port 22",
-        "<86>1 2024-03-18T15:54:23.876283Z app sshd 784327 - - Accepted password for user from 10.0.1.31 port 63843 ssh2",
-    ]
-
-    normalized = SyslogEmitter._normalize_sshd_child_pids_for_lines(lines, "app.example")
-
-    pids = [int(line.split(" sshd ")[1].split(" ")[0]) for line in normalized]
-    assert pids == [784323, 784323, 784329, 784327, 784327]
+    lines = (tmp_path / "app.example" / "syslog.log").read_text().splitlines()
+    pids = [int(line.split(" sshd ")[1].split(" ")[0]) for line in lines]
+    assert pids == [839794, 838687]
 
 
 def test_normalize_logind_session_ids_preserves_monotonic_canonical_ids() -> None:
@@ -261,16 +272,3 @@ def test_normalize_sudo_session_lifecycles_preserves_non_rfc5424_order() -> None
     normalized = SyslogEmitter._normalize_sudo_session_lifecycles_for_lines(lines)
 
     assert normalized == lines
-
-
-def test_normalize_sshd_child_pids_skips_oversized_pid_without_crashing() -> None:
-    huge_pid = "9" * 5000
-    lines = [
-        f"<86>1 2024-03-18T12:37:10.283139Z app sshd {huge_pid} - - Connection from 10.0.1.10 port 50000 on 10.0.2.10 port 22",
-        "<86>1 2024-03-18T12:37:11.001000Z app sshd 100 - - Accepted password for admin from 10.0.1.10 port 50000 ssh2",
-    ]
-
-    normalized = SyslogEmitter._normalize_sshd_child_pids_for_lines(lines, "app.example")
-
-    assert normalized[0] == lines[0]
-    assert " sshd 100 " in normalized[1]

--- a/tests/unit/test_sysmon_emitter.py
+++ b/tests/unit/test_sysmon_emitter.py
@@ -520,8 +520,8 @@ class TestSysmonEventEmitter:
         assert "2024-01-15 15:44:49.138" not in event5
         assert '<Data Name="UtcTime">2024-01-15 16:32:44.' in event5
 
-    def test_interactive_process_create_uses_nonzero_terminal_session(self, format_def, tmp_path):
-        """Interactive user process creates should not all render TerminalSessionId 0."""
+    def test_interactive_process_without_canonical_session_uses_zero(self, format_def, tmp_path):
+        """Sysmon must not invent a terminal session when canonical state is unavailable."""
         from evidenceforge.events.base import SecurityEvent
         from evidenceforge.events.contexts import AuthContext, HostContext, ProcessContext
 
@@ -560,7 +560,7 @@ class TestSysmonEventEmitter:
         content = (output_dir / "WKS-01.corp.local" / "windows_event_sysmon.xml").read_text()
         match = re.search(r'<Data Name="TerminalSessionId">(\d+)</Data>', content)
         assert match is not None
-        assert int(match.group(1)) > 0
+        assert int(match.group(1)) == 0
 
     def test_process_create_prefers_canonical_auth_session_id(self, format_def, tmp_path):
         """Sysmon TerminalSessionId should reuse the StateManager-owned session ID."""
@@ -653,7 +653,7 @@ class TestSysmonEventEmitter:
                 username="jsmith",
                 logon_id=logon_id,
             ),
-            auth=AuthContext(username="jsmith", logon_id=logon_id, session_id=4, logon_type=2),
+            auth=AuthContext(username="jsmith", logon_id=logon_id, session_id=2, logon_type=2),
         )
 
         emitter.emit(parent)
@@ -663,6 +663,53 @@ class TestSysmonEventEmitter:
         content = (output_dir / "WKS-01.corp.local" / "windows_event_sysmon.xml").read_text()
         session_ids = re.findall(r'<Data Name="TerminalSessionId">(\d+)</Data>', content)
         assert session_ids == ["2", "2"]
+
+    def test_canonical_session_supersedes_earlier_unknown_value(self, format_def, tmp_path):
+        """A later canonical session ID must not be masked by emitter fallback state."""
+        from evidenceforge.events.base import SecurityEvent
+        from evidenceforge.events.contexts import AuthContext, HostContext, ProcessContext
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        emitter = SysmonEventEmitter(format_def, output_dir, buffer_size=1)
+        host = HostContext(
+            hostname="WKS-01",
+            ip="10.0.0.50",
+            os="Windows 10",
+            os_category="windows",
+            system_type="workstation",
+            domain="corp.local",
+            fqdn="WKS-01.corp.local",
+            netbios_domain="CORP",
+        )
+        logon_id = "0xabc123"
+        for index, session_id in enumerate((0, 4)):
+            emitter.emit(
+                SecurityEvent(
+                    timestamp=datetime(2024, 1, 15, 10, 30, index, tzinfo=UTC),
+                    event_type="process_create",
+                    src_host=host,
+                    process=ProcessContext(
+                        pid=8052 + (index * 4),
+                        parent_pid=4200,
+                        image=r"C:\Windows\System32\whoami.exe",
+                        command_line="whoami /all",
+                        username="jsmith",
+                        logon_id=logon_id,
+                    ),
+                    auth=AuthContext(
+                        username="jsmith",
+                        logon_id=logon_id,
+                        session_id=session_id,
+                        logon_type=10,
+                    ),
+                )
+            )
+        emitter.close()
+
+        content = (output_dir / "WKS-01.corp.local" / "windows_event_sysmon.xml").read_text()
+        session_ids = re.findall(r'<Data Name="TerminalSessionId">(\d+)</Data>', content)
+        assert session_ids == ["0", "4"]
 
     def test_process_create_renders_current_directory_from_context(self, format_def, tmp_path):
         """Sysmon Event 1 should preserve the process working directory."""

--- a/tests/unit/test_sysmon_process_access.py
+++ b/tests/unit/test_sysmon_process_access.py
@@ -132,7 +132,7 @@ class TestSysmonProcessAccess:
         assert event.process_access is not None
         assert event.process_access.target_image == r"C:\Windows\System32\lsass.exe"
         assert event.process_access.granted_access == "0x1010"
-        assert event.process_access.source_thread_id % 4 == 0
+        assert event.process_access.source_thread_id == -1
 
     def test_create_remote_thread_ids_are_windows_aligned(
         self, state_manager, activity_gen, mock_emitters, windows_system, test_user
@@ -159,7 +159,7 @@ class TestSysmonProcessAccess:
         event = mock_emitters["windows_event_sysmon"].emit.call_args[0][0]
         assert event.remote_thread is not None
         assert event.remote_thread.new_thread_id % 4 == 0
-        assert event.remote_thread.source_thread_id % 4 == 0
+        assert event.remote_thread.source_thread_id == -1
         assert event.remote_thread.target_thread_id % 4 == 0
 
     def test_process_access_skips_missing_target_pid(

--- a/tests/unit/test_sysmon_process_access.py
+++ b/tests/unit/test_sysmon_process_access.py
@@ -132,7 +132,9 @@ class TestSysmonProcessAccess:
         assert event.process_access is not None
         assert event.process_access.target_image == r"C:\Windows\System32\lsass.exe"
         assert event.process_access.granted_access == "0x1010"
-        assert event.process_access.source_thread_id == -1
+        source_thread = state_manager.get_primary_thread(windows_system.hostname, source_pid)
+        assert source_thread is not None
+        assert event.process_access.source_thread_id == source_thread.tid
 
     def test_create_remote_thread_ids_are_windows_aligned(
         self, state_manager, activity_gen, mock_emitters, windows_system, test_user
@@ -159,7 +161,9 @@ class TestSysmonProcessAccess:
         event = mock_emitters["windows_event_sysmon"].emit.call_args[0][0]
         assert event.remote_thread is not None
         assert event.remote_thread.new_thread_id % 4 == 0
-        assert event.remote_thread.source_thread_id == -1
+        source_thread = state_manager.get_primary_thread(windows_system.hostname, source_pid)
+        assert source_thread is not None
+        assert event.remote_thread.source_thread_id == source_thread.tid
         assert event.remote_thread.target_thread_id % 4 == 0
 
     def test_process_access_skips_missing_target_pid(

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -1138,6 +1138,15 @@ def test_linux_local_session_shell_has_visible_terminal_parent(
     parent_proc = state_manager.get_process(system.hostname, shell_proc.parent_pid)
     assert parent_proc is not None
     assert parent_proc.image in {"/bin/login", "/usr/libexec/gnome-terminal-server"}
+    user_manager = state_manager.get_process(system.hostname, parent_proc.parent_pid)
+    session = state_manager.get_session(logon_id)
+    assert user_manager is not None
+    assert session is not None
+    assert {
+        user_manager.lifecycle_group_id,
+        parent_proc.lifecycle_group_id,
+        shell_proc.lifecycle_group_id,
+    } == {session.lifecycle_group_id}
 
 
 def test_find_user_session_handles_mixed_timezone_start_times(

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -317,15 +317,26 @@ def test_world_model_ssh_admin_roster_is_role_and_group_scoped(scenario: Scenari
     assert {"alice.admin", "helpdesk.user"} <= web_roster
 
 
-def test_world_planner_preallocates_sessions_before_logon_emission(
+def test_world_planner_delegates_session_allocation_to_logon_bundle(
     world_model: WorldModel,
     state_manager: StateManager,
     systems: dict[str, System],
     users: dict[str, User],
 ) -> None:
-    """Planner-owned session state should not depend on generator side effects."""
+    """World planning requests session intent without allocating shadow state."""
     activity_generator = Mock()
-    activity_generator.generate_logon.return_value = "0xdeadbeef"
+
+    def generate_logon(**kwargs):
+        return state_manager.create_session(
+            username=kwargs["user"].username,
+            system=kwargs["system"].hostname,
+            logon_type=kwargs["logon_type"],
+            source_ip=kwargs["source_ip"],
+            start_time=kwargs["time"],
+            lifecycle_group_id="bundle-owned-session",
+        )
+
+    activity_generator.generate_logon.side_effect = generate_logon
     planner = WorldPlanner(world_model, state_manager, activity_generator)
 
     result = planner.bootstrap_user_session(
@@ -337,10 +348,10 @@ def test_world_planner_preallocates_sessions_before_logon_emission(
         allow_existing=False,
     )
 
-    assert result.session.logon_id != "0xdeadbeef"
     assert state_manager.get_session(result.session.logon_id) is result.session
+    assert result.session.lifecycle_group_id == "bundle-owned-session"
     call_kwargs = activity_generator.generate_logon.call_args.kwargs
-    assert call_kwargs["logon_id"] == result.session.logon_id
+    assert "logon_id" not in call_kwargs
     assert call_kwargs["logon_type"] == 2
 
 


### PR DESCRIPTION
## Summary

Implements the explicit identity and lifecycle contract across three reviewable milestone commits:

1. Adds canonical process, thread, and session identities with durable host/start-scoped state.
2. Centralizes process/session lifecycle ownership, grouping, actor attribution, and source timing.
3. Extends eCAR 1.1 roles, reduces eCAR flush to serialization, preserves canonical SSH/Sysmon identity, and makes endpoint FLOW identity host-local.

No feature-branch version bump.

## Root-cause fixes

- Process objects are host- and start-scoped; thread keys are `(hostname, process_object_id, tid)`.
- Linux leaders use `tid == pid`; Windows primary threads use deterministic host-native TIDs.
- Process/session action bundles own allocation and lifecycle transitions.
- eCAR consumes frozen identity plans and no longer invents, repairs, scrubs, or deduplicates identity during flush.
- ProcessAccess and remote-thread rows expose explicit source and target roles with canonical TIDs.
- Session closure waits for all session-owned process evidence; network activity protects actor lifetimes through close.
- Sysmon trusts canonical terminal-session state and rejects missing ProcessAccess source TIDs.
- Host-local eCAR FLOW rows expose only the local process actor.
- Syslog finalization no longer rewrites SSH child PIDs.

## Validation

- `uv run pytest --no-cov -q`: 4,948 passed, 19 skipped.
- Focused identity/eCAR/Sysmon/syslog/SSH/RDP/source-timing set: 302 passed.
- Ruff check and format check: clean.
- Config validation: 87 files, zero findings.
- `iteration-test-expanded`: valid with 26 pre-existing topology/storyline warnings.
- Evaluation: 95.3421 overall across 86,294 records.
  - Parseability 100.00
  - Plausibility 97.27
  - Causality 88.02
  - Timing 95.10

Rendered hard probes found zero duplicate IDs, PID/TID ownership mismatches, post-termination references, session-object mismatches, terminal-session mismatches, cross-host FLOW actors, remote identity leakage, or SSH PID collisions.

## Blind panel

The corrected data-only four-reviewer panel completed the required anonymized reconciliation round. All four verdicts were Inconclusive and all four explicitly passed the identity/lifecycle contract:

| Role | Synthetic confidence | Realism | Identity/lifecycle |
|---|---:|---:|---:|
| Threat hunter | 48 | 89 | 96 |
| Detection engineer | 47 | 88 | 95 |
| Network forensics | 47 | 88 | 95 |
| Host/EDR forensics | 47 | 89 | 95 |

Residual findings concern timing/distribution, record-counter, scan, and collection-manifest texture and remain outside this phase.
