### PR TITLE
fix: enforce explicit session closure contract

### DIFF
--- a/docs/worklog/2026-07-15-session-closure-lifecycle-contract.md
+++ b/docs/worklog/2026-07-15-session-closure-lifecycle-contract.md
@@ -1,0 +1,158 @@
+# Explicit Session Closure Contract
+
+## Objective
+
+Make an explicit storyline `logoff` authoritative for the identity and canonical end of its
+durable session. Session-owned processes and transports must respect that end; source-specific
+observation delay must not rewrite it.
+
+## Family Contract
+
+- **Classification:** `family_level`, correcting an `exact_regression` in session lifecycle
+  ownership with a sibling defect in process-owned network lifetimes.
+- **Owning abstractions:** storyline intent planning binds a logoff to its durable session;
+  authentication/session action bundles and canonical session state own the end plan; process and
+  network action bundles consume the plan; `SourceTimingPlanner` owns bounded source-visible tails.
+- **Invariant:** an explicit session end at `T` closes the intended storyline session at canonical
+  time `T`. Non-detached session processes and their transports end no later than `T`; SSH close
+  evidence stays tuple- and identity-coherent; RDP may disconnect before `T`; renderers never move
+  canonical time or invent a replacement session.
+- **Entry paths:** typed storyline `ssh_session`, `rdp_session`, successful `logon`, and `logoff`;
+  WorldPlanner session bootstrap and spill-session recovery; direct SSH/RDP/logon/logoff adapters;
+  process-owned canonical connections; baseline-generated session closure.
+- **Consumers:** StateManager identity/lifecycle state, process and network transaction planners,
+  dispatcher lifecycle admission, SourceTimingPlanner, Windows/Sysmon/eCAR/syslog/Zeek emitters,
+  ground truth, and evaluation storyline matching.
+- **Layer rationale:** the requested session and end time are explicit intent, while the dependent
+  lifetime relationships are bundle/state truth shared by several sources. Emitter repair would
+  hide contradictions rather than prevent them.
+- **Sibling risks:** simultaneous author-controlled sessions for one actor/host remain implicitly
+  paired because the scenario schema has no `session_ref`; deterministic storyline planning and an
+  ordered runtime registry must handle existing scenarios without adding that schema in this PR.
+
+## Milestones
+
+1. Add canonical session-end state and exact storyline session binding.
+2. Enforce the deadline across SSH/RDP transports, process-owned network transactions, and process
+   teardown while preserving generated baseline behavior.
+3. Keep bounded closure delay in source timing, validate `iteration-test-expanded`, and run one
+   final four-reviewer blind panel.
+
+## Acceptance Evidence
+
+### Milestone 1 — Canonical session end and explicit pairing
+
+- Added immutable `SessionEndPlan` state with canonical time, authority, and storyline event
+  identity, exposed through `StateManager` planning and lookup APIs.
+- Pre-planned each explicit logoff against the latest preceding successful storyline logon, SSH
+  session, or RDP session for the same actor and host. The runtime registry retains ordered
+  storyline sessions, and the pairing records the allocated LogonID rather than resolving the
+  newest live session at logoff time.
+- Preserved authoritative session validity across an early SSH/RDP transport disconnect so later
+  commands cannot create a replacement session that steals the explicit close.
+
+The expanded scenario exposed an important compatibility case after the initial implementation:
+`evt-022` is an explicit successful Type 3 logon with a later `evt-034` logoff. Static pairing now
+includes every explicit successful logon type, not only durable interactive types; generated
+baseline sessions remain outside the storyline registry.
+
+### Milestone 2 — Authoritative dependent-lifetime bounds
+
+- Passed the end plan through World planning and the SSH, RDP, generic logon, process, and network
+  action contracts.
+- Durable SSH closes its transport 100–1500 ms before an explicit deadline. RDP may disconnect
+  earlier, but an otherwise-open transport is capped before the session end.
+- `NetworkTransactionPlanner` rejects process-owned connections beginning at or after an
+  authoritative session end and re-finalizes capped transactions so every protocol and sensor
+  projection consumes the corrected canonical duration.
+- Process creation rejects post-deadline dependent activity. Explicit logoff teardown terminates
+  session-owned processes children-first in the final 250–3000 ms and asserts that canonical
+  process/connection holds do not survive the deadline.
+- Generated baseline logoffs retain their prior stochastic after-last-activity behavior.
+
+### Milestone 3 — Source-visible closure timing
+
+- `SourceTimingPlanner` now tracks the latest dependent time per source and lifecycle group.
+- eCAR and Windows logoff observations follow same-source dependent termination by 125–750 ms and
+  remain within a 15-second tail of canonical end without rewriting canonical time.
+- SSH PAM close follows transport close by 120–2500 ms; logind removal follows by 120–999 ms and
+  remains within four seconds of canonical end.
+- eCAR and Windows emitters no longer invoke explicit-logoff timestamp repair. They serialize the
+  lifecycle and source timing already finalized by the dispatcher.
+
+### Engineering validation
+
+- Focused session, storyline, process-lifetime, network-contract, and source-timing sets: 214
+  passed during implementation; the final storyline/logoff/network regression set passed 103.
+- `uv run pytest --no-cov`: 4,954 passed, 19 skipped in 306.88 seconds after the final Type 3
+  pairing correction.
+- `uv run eforge validate-config`: 87 files valid with zero findings.
+- `uv run eforge validate scenarios/iteration-test-expanded/scenario.yaml`: valid with the
+  scenario's 26 pre-existing topology and pivot warnings.
+- `uv run ruff check .`, `uv run ruff format --check .`, `git diff --check`, and JSON artifact
+  parsing: clean.
+
+### Expanded-scenario acceptance
+
+`iteration-test-expanded` generated 83,906 records across 21 evaluated source families. Automated
+evaluation passed at 95.5434 overall: Parseability 100.00, Plausibility 97.31, Causality 88.66,
+and Timing 95.26. All 60/60 expected format traces were recovered, all 11,688 causal-order pairs
+were correctly ordered, and all 12,404 rate-plausibility checks passed.
+
+The rendered closure probe recovered the two previously missing logoff traces and the additional
+explicit Type 3 close:
+
+| Storyline event | Session | Source-visible delay | Identity/tuple result |
+|---|---|---:|---|
+| `evt-033` / trace 43 | Aisha Type 10/RDP | 2.575 s | Same session object, LogonID, and source tuple |
+| `evt-034` | `svc_mhsync` Type 3 | 2.190 s | Same session object, LogonID, and source tuple |
+| `evt-035` / trace 45 | APP-INT root SSH | 2.532 s | Same session object, LogonID, and `10.10.3.10:41880` tuple |
+
+The APP-INT SSH observation closed 475 ms before the canonical logoff; both RDP and SSH transports
+closed before their deadlines. No source-visible process belonging to any of the three sessions
+appeared after its logout. Focused state/planner tests separately assert that canonical processes
+and process-owned connections never extend beyond the authoritative end; source-visible process
+termination may trail canonical time only inside its bounded source-delay window and still precedes
+the source-visible logout.
+
+Machine-readable acceptance artifacts are retained under
+`scenarios/iteration-test-expanded/blind-test/session-closure-lifecycle-contract/`.
+
+### Blind panel
+
+The single independent four-reviewer data-only panel produced these initial scores (lower
+synthetic confidence is better):
+
+| Reviewer | Verdict | Verdict confidence | Synthetic confidence |
+|---|---|---:|---:|
+| Threat hunter | Synthetic | 87 | 79 |
+| Detection engineer | Real | 78 | 34 |
+| Network forensics | Real | 78 | 28 |
+| Host/EDR forensics | Synthetic | 86 | 78 |
+
+The initial synthetic-confidence average was 54.75 (`mixed/inconclusive`). The 51-point spread
+triggered the assessment protocol's reconciliation pass, not another panel or A/B run. The final
+facilitated positions were 83, 63, 44, and 84 respectively, averaging 68.5 (`likely synthetic`).
+
+No reviewer found the intended explicit RDP or APP-INT SSH logoff delayed, rebound to a shadow
+session, or retaining a child beyond its authored end. The higher scores instead exposed five
+broader residual contracts:
+
+1. 560/811 exact-tuple Windows eCAR remote logins precede their source-visible inbound FLOW,
+   concentrated in SMB and Kerberos while SSH ordering remains correct.
+2. Three non-authoritative SSH sessions gracefully close before the collection boundary but omit
+   their PAM/eCAR/per-connection-process terminal group.
+3. 34/279 duration-bearing Zeek file rows end 1–2 ms after their parent connection.
+4. Three coherent post-window ASA teardowns conflict with the collection profile's perimeter-tail
+   wording.
+5. Two distinct Windows 4625 failures share one eCAR authentication object identity.
+
+These findings do not invalidate the explicit-deadline contract in this branch. They belong to
+Windows remote-auth source timing, generated/implicit SSH terminal completeness, file-transfer
+parent duration, source-family admission policy, and authentication-attempt identity respectively.
+The next improvement effort should start with the Windows FLOW-before-login ordering because it is
+the broadest reproducible defect and has the largest expected score leverage.
+
+The complete reports, corrected detection review, reconciliation, score artifact, automated eval,
+and rendered contract probe are retained under
+`scenarios/iteration-test-expanded/blind-test/session-closure-lifecycle-contract/`.

--- a/src/evidenceforge/config/activity/timing_profiles.yaml
+++ b/src/evidenceforge/config/activity/timing_profiles.yaml
@@ -176,6 +176,16 @@ relationships:
     position: after
     min_ms: 1800
     max_ms: 2800
+  source.windows_security_session_logout:
+    class: teardown
+    position: after
+    min_ms: 125
+    max_ms: 750
+  source.syslog_session_logout:
+    class: teardown
+    position: after
+    min_ms: 120
+    max_ms: 2500
   source.ecar_ssh_session_after_accept:
     class: source_latency
     position: after

--- a/src/evidenceforge/events/lifecycle.py
+++ b/src/evidenceforge/events/lifecycle.py
@@ -10,6 +10,32 @@ from datetime import datetime
 from typing import Literal
 
 LifecyclePhase = Literal["start", "dependent", "closure"]
+SessionEndAuthority = Literal["explicit_storyline", "generated"]
+
+
+@dataclass(frozen=True, slots=True)
+class SessionEndPlan:
+    """Canonical intent for one durable session end.
+
+    Explicit storyline plans are authoritative deadlines. Generated plans may
+    still be moved after later activity by the owning session bundle.
+    """
+
+    canonical_end: datetime
+    authority: SessionEndAuthority
+    storyline_event_id: str = ""
+
+    @property
+    def is_authoritative(self) -> bool:
+        """Return whether dependents must be bounded by this end time."""
+
+        return self.authority == "explicit_storyline"
+
+    def __post_init__(self) -> None:
+        """Require explicit plans to retain their storyline owner."""
+
+        if self.authority == "explicit_storyline" and not self.storyline_event_id:
+            raise ValueError("Explicit session end plans require a storyline_event_id")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/evidenceforge/generation/actions/auth_session.py
+++ b/src/evidenceforge/generation/actions/auth_session.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
 
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.actions.base import ActionAnchor
 from evidenceforge.models.scenario import System, User
 from evidenceforge.utils.rng import _stable_seed
@@ -48,6 +49,7 @@ class LogonRequest:
     emit_network_evidence: bool = True
     logon_id: str | None = None
     lifecycle_group_id: str = ""
+    session_end_plan: SessionEndPlan | None = None
     source: str = "activity_generator"
 
     @property
@@ -55,13 +57,18 @@ class LogonRequest:
         """Return a deterministic intent identifier for durable references."""
 
         source_host = self.source_system.hostname if self.source_system is not None else ""
+        end_time = (
+            self.session_end_plan.canonical_end.isoformat()
+            if self.session_end_plan is not None
+            else ""
+        )
         seed = _stable_seed(
             "action_bundle:logon:"
             f"{self.user.username}:{self.system.hostname}:{self.time.isoformat()}:"
             f"{self.logon_type}:{self.source_ip or ''}:{self.source_port or ''}:"
             f"{self.emit_transport_syslog}:{self.emit_network_evidence}:"
             f"{self.logon_id or ''}:{source_host}:{self.source}"
-            f":{self.lifecycle_group_id}"
+            f":{self.lifecycle_group_id}:{end_time}"
         )
         return f"logon-{seed:016x}"
 
@@ -76,6 +83,7 @@ class LogoffRequest:
     logon_id: str
     logon_type: int = 2
     from_storyline: bool = False
+    session_end_plan: SessionEndPlan | None = None
     source: str = "activity_generator"
 
     @property
@@ -85,7 +93,9 @@ class LogoffRequest:
         seed = _stable_seed(
             "action_bundle:logoff:"
             f"{self.user.username}:{self.system.hostname}:{self.time.isoformat()}:"
-            f"{self.logon_id}:{self.logon_type}:{self.from_storyline}:{self.source}"
+            f"{self.logon_id}:{self.logon_type}:{self.from_storyline}:"
+            f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
+            f"{self.source}"
         )
         return f"logoff-{seed:016x}"
 

--- a/src/evidenceforge/generation/actions/network_transaction_planner.py
+++ b/src/evidenceforge/generation/actions/network_transaction_planner.py
@@ -29,6 +29,10 @@ from datetime import datetime, timedelta
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
+from evidenceforge.models.exceptions import StateError
+from evidenceforge.utils.rng import _stable_seed
+from evidenceforge.utils.time import ensure_utc
+
 if TYPE_CHECKING:
     from evidenceforge.events.base import SecurityEvent
     from evidenceforge.generation.actions.network_connection import NetworkConnectionRequest
@@ -117,6 +121,47 @@ class NetworkTransactionPlanner:
 
     def __init__(self, executor: ActivityGenerator) -> None:
         self._executor = executor
+
+    def _cap_to_owning_session(
+        self,
+        *,
+        start: datetime,
+        duration: float | None,
+        source_system: Any,
+        pid: int,
+        stable_id: str,
+    ) -> float | None:
+        """Bound process-owned transport lifetime by an authoritative session end."""
+
+        if source_system is None or pid <= 0:
+            return duration
+        end_plan = self._executor.state_manager.process_session_end_plan(
+            source_system.hostname,
+            pid,
+        )
+        if end_plan is None or not end_plan.is_authoritative:
+            return duration
+        canonical_start = ensure_utc(start)
+        deadline = ensure_utc(end_plan.canonical_end)
+        if canonical_start >= deadline:
+            raise StateError(
+                "Process-owned network activity cannot begin at or after its authoritative "
+                f"session end: {source_system.hostname} pid={pid} "
+                f"start={canonical_start.isoformat()} end={deadline.isoformat()}"
+            )
+        close_gap_ms = 100 + (
+            _stable_seed(
+                "network_before_authoritative_session_end:"
+                f"{stable_id}:{source_system.hostname}:{pid}:{deadline.isoformat()}"
+            )
+            % 1401
+        )
+        latest_duration = (
+            deadline - timedelta(milliseconds=close_gap_ms) - canonical_start
+        ).total_seconds()
+        if latest_duration <= 0:
+            latest_duration = max(0.001, (deadline - canonical_start).total_seconds() / 2)
+        return latest_duration if duration is None else min(duration, latest_duration)
 
     def execute(self, request: NetworkConnectionRequest) -> str:
         """Expand one network connection request into canonical evidence."""
@@ -1268,6 +1313,13 @@ class NetworkTransactionPlanner:
                 time,
             )
         else:
+            duration = self._cap_to_owning_session(
+                start=time,
+                duration=duration,
+                source_system=resolved_source_system,
+                pid=pid,
+                stable_id=request.stable_id,
+            )
             executor._remember_connection_tuple(
                 src_ip,
                 src_port,
@@ -2327,6 +2379,13 @@ class NetworkTransactionPlanner:
         # payload, and process-visibility adjustment has settled. Dispatch creates
         # source-local event copies with collection delay, so the immutable interval
         # must live on NetworkContext rather than be re-derived from those copies.
+        event.network.duration = self._cap_to_owning_session(
+            start=event.timestamp,
+            duration=event.network.duration,
+            source_system=resolved_source_system,
+            pid=pid,
+            stable_id=request.stable_id,
+        )
         event.network.source_visible_start_time = event.timestamp
         event.network.source_visible_close_time = (
             event.timestamp + generator_module.timedelta(seconds=max(0.0, event.network.duration))

--- a/src/evidenceforge/generation/actions/process_execution.py
+++ b/src/evidenceforge/generation/actions/process_execution.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
 
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.actions.base import ActionAnchor
 from evidenceforge.models.scenario import System, User
 from evidenceforge.utils.rng import _stable_seed
@@ -82,6 +83,7 @@ class ProcessTerminationRequest:
     process_name: str
     logon_id: str
     from_storyline: bool = False
+    session_end_plan: SessionEndPlan | None = None
     source: str = "activity_generator"
 
     @property
@@ -92,6 +94,7 @@ class ProcessTerminationRequest:
             "action_bundle:process_termination:"
             f"{self.user.username}:{self.system.hostname}:{self.time.isoformat()}:"
             f"{self.pid}:{self.process_name}:{self.logon_id}:{self.from_storyline}:"
+            f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
             f"{self.source}"
         )
         return f"process-termination-{seed:016x}"

--- a/src/evidenceforge/generation/actions/rdp_session.py
+++ b/src/evidenceforge/generation/actions/rdp_session.py
@@ -37,6 +37,7 @@ from datetime import datetime, timedelta
 from typing import Any, Protocol
 
 from evidenceforge.events.dispatcher import EventDispatcher
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.actions.base import (
     ActionAnchor,
     endpoint_clock_difference,
@@ -47,6 +48,7 @@ from evidenceforge.generation.activity.timing_profiles import get_timing_window,
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.timing import TemporalConstraintGraph
+from evidenceforge.models.exceptions import StateError
 from evidenceforge.models.scenario import System, User
 from evidenceforge.utils.rng import _stable_seed
 
@@ -65,6 +67,7 @@ class RdpSessionRequest:
     source_process_time: datetime | None = None
     logon_id: str = ""
     preserve_explicit_source: bool = False
+    session_end_plan: SessionEndPlan | None = None
     source: str = "activity_generator"
 
     @property
@@ -78,7 +81,9 @@ class RdpSessionRequest:
             f"{self.source_port or ''}:{self.preserve_explicit_source}:"
             f"{self.source_process_time.isoformat() if self.source_process_time else ''}:"
             f"{self.target_system.hostname}:{self.target_system.ip}:"
-            f"{self.logon_id}:{self.source}:{self.time.isoformat()}"
+            f"{self.logon_id}:"
+            f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
+            f"{self.source}:{self.time.isoformat()}"
         )
         return f"rdp-session-{seed:016x}"
 
@@ -194,6 +199,23 @@ class RdpSessionActionBundle:
         )
         source_ip, source_system, source_pid = self._resolve_source(rng, user)
         duration = rng.uniform(60.0, 3600.0)
+        end_plan = self._request.session_end_plan
+        if end_plan is not None and end_plan.is_authoritative:
+            close_gap_ms = 100 + (
+                _stable_seed(
+                    "rdp_transport_before_explicit_logoff:"
+                    f"{self._request.stable_id}:{end_plan.canonical_end.isoformat()}"
+                )
+                % 1401
+            )
+            latest_close = end_plan.canonical_end - timedelta(milliseconds=close_gap_ms)
+            if latest_close <= self._request.time:
+                raise StateError(
+                    "Explicit RDP session end must follow transport open: "
+                    f"{self._request.target_system.hostname} at "
+                    f"{end_plan.canonical_end.isoformat()}"
+                )
+            duration = min(duration, (latest_close - self._request.time).total_seconds())
         source_pid = self._materialize_source_process(
             user=user,
             source_system=source_system,
@@ -274,6 +296,7 @@ class RdpSessionActionBundle:
             emit_network_evidence=False,
             logon_id=logon_id or None,
             lifecycle_group_id=self._request.stable_id,
+            session_end_plan=self._request.session_end_plan,
         )
         self._rendered_logon_id = rendered_logon_id
         self._executor.state_manager.update_session_metadata(

--- a/src/evidenceforge/generation/actions/ssh_session.py
+++ b/src/evidenceforge/generation/actions/ssh_session.py
@@ -45,6 +45,7 @@ from evidenceforge.events.contexts import (
     SyslogContext,
 )
 from evidenceforge.events.dispatcher import EventDispatcher
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.actions.base import (
     ActionAnchor,
     source_observation_delay_difference,
@@ -59,6 +60,7 @@ from evidenceforge.generation.identity import IdentityDirectory, default_linux_u
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.timing import TemporalConstraintGraph
+from evidenceforge.models.exceptions import StateError
 from evidenceforge.models.scenario import System, User
 from evidenceforge.utils.rng import _stable_seed, stable_uuid
 from evidenceforge.utils.time import ensure_utc
@@ -119,6 +121,7 @@ class SshSessionRequest:
     public_key_type: str = ""
     public_key_hash: str = ""
     emit_session_close: bool = False
+    session_end_plan: SessionEndPlan | None = None
     source: str = "activity_generator"
 
     @property
@@ -135,7 +138,9 @@ class SshSessionRequest:
             f"{self.min_duration or ''}:{self.duration or ''}:"
             f"{self.orig_bytes or ''}:{self.resp_bytes or ''}:"
             f"{self.auth_method}:{self.public_key_type}:{self.public_key_hash}:"
-            f"{self.emit_session_close}:{self.source}:{self.time.isoformat()}"
+            f"{self.emit_session_close}:"
+            f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
+            f"{self.source}:{self.time.isoformat()}"
         )
         return f"ssh-session-{seed:016x}"
 
@@ -151,6 +156,7 @@ class SshSessionRequest:
             f"{self.logon_id}:{self.session_obj_id}:{self.min_duration or ''}:"
             f"{self.duration or ''}:{self.orig_bytes or ''}:{self.resp_bytes or ''}:"
             f"{self.auth_method}:{self.public_key_type}:{self.public_key_hash}:"
+            f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
             f"{self.emit_session_close}:{self.source}:{self.time.isoformat()}"
         )
         return f"ssh-session-exec-{seed:016x}"
@@ -428,12 +434,6 @@ class SshSessionActionBundle:
             self._source_os(),
             time=request.time,
         )
-        if request.duration is not None:
-            duration = max(1.0, request.duration)
-        else:
-            duration = rng.uniform(30.0, 3600.0)
-        if request.min_duration is not None and request.duration is None:
-            duration = max(duration, request.min_duration)
         transport_open_time = request.time + sample_packet_timing_delta(
             "network.connection_start_jitter",
             seed_parts=(
@@ -446,6 +446,30 @@ class SshSessionActionBundle:
                 request.time,
             ),
         )
+        if request.duration is not None:
+            duration = max(1.0, request.duration)
+        else:
+            duration = rng.uniform(30.0, 3600.0)
+        if request.min_duration is not None and request.duration is None:
+            duration = max(duration, request.min_duration)
+        end_plan = request.session_end_plan
+        if end_plan is not None and end_plan.is_authoritative:
+            close_gap_ms = 100 + (
+                _stable_seed(
+                    "ssh_transport_before_explicit_logoff:"
+                    f"{request.stable_id}:{end_plan.canonical_end.isoformat()}"
+                )
+                % 1401
+            )
+            planned_close = ensure_utc(end_plan.canonical_end) - timedelta(
+                milliseconds=close_gap_ms
+            )
+            if planned_close <= ensure_utc(transport_open_time):
+                raise StateError(
+                    "Explicit SSH session end must follow transport open: "
+                    f"{request.target_system.hostname} at {end_plan.canonical_end.isoformat()}"
+                )
+            duration = (planned_close - ensure_utc(transport_open_time)).total_seconds()
         orig_bytes = (
             request.orig_bytes if request.orig_bytes is not None else rng.randint(2000, 50000)
         )
@@ -494,6 +518,8 @@ class SshSessionActionBundle:
             )
         if not state.session_obj_id:
             state.session_obj_id = executor.state_manager.get_session_object_id(state.logon_id)
+        if request.session_end_plan is not None:
+            executor.state_manager.plan_session_end(state.logon_id, request.session_end_plan)
 
     def _open_transport(self, state: _SshTransportState, responding_pid: int | None) -> None:
         """Delegate SSH TCP transport to the canonical network connection contract."""

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -82,7 +82,7 @@ from evidenceforge.events.contexts import (
     X509Context,
 )
 from evidenceforge.events.dispatcher import EventDispatcher, expand_formats
-from evidenceforge.events.lifecycle import ActionLifecycleContext
+from evidenceforge.events.lifecycle import ActionLifecycleContext, SessionEndPlan
 from evidenceforge.generation.actions import (
     AccountChangedActionBundle,
     AccountChangedRequest,
@@ -204,6 +204,7 @@ from evidenceforge.generation.identity import IdentityDirectory, default_linux_u
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.timing import TemporalConstraintGraph
+from evidenceforge.models.exceptions import StateError
 from evidenceforge.models.scenario import EmailMessageEventSpec, ProxyAuthPolicyConfig, System, User
 from evidenceforge.models.state import ActiveSession, RunningProcess
 from evidenceforge.utils.ids import generate_stable_zeek_uid
@@ -4252,6 +4253,25 @@ class ActivityGenerator:
         if pid <= 0 or close_time is None:
             return
         close_time = ensure_utc(close_time)
+        end_plan = self.state_manager.process_session_end_plan(system.hostname, pid)
+        if end_plan is not None and end_plan.is_authoritative:
+            deadline = ensure_utc(end_plan.canonical_end)
+            close_gap_ms = 100 + (
+                _stable_seed(
+                    "process_hold_before_authoritative_session_end:"
+                    f"{system.hostname}:{pid}:{deadline.isoformat()}"
+                )
+                % 1401
+            )
+            latest_hold = deadline - timedelta(milliseconds=close_gap_ms)
+            process = self.state_manager.get_process(system.hostname, pid)
+            if (
+                process is not None
+                and process.last_activity_time is not None
+                and latest_hold <= ensure_utc(process.last_activity_time)
+            ):
+                latest_hold = deadline - timedelta(milliseconds=1)
+            close_time = min(close_time, latest_hold)
         key = (system.hostname, pid)
         previous = self._process_connection_hold_until.get(key)
         if previous is None or close_time > previous:
@@ -8958,6 +8978,7 @@ class ActivityGenerator:
         emit_network_evidence: bool = True,
         logon_id: str | None = None,
         lifecycle_group_id: str = "",
+        session_end_plan: SessionEndPlan | None = None,
     ) -> str:
         """Generate logon event across all applicable log formats.
 
@@ -8989,6 +9010,7 @@ class ActivityGenerator:
             emit_network_evidence=emit_network_evidence,
             logon_id=logon_id,
             lifecycle_group_id=lifecycle_group_id,
+            session_end_plan=session_end_plan,
         )
         return LogonActionBundle(self, request).execute()
 
@@ -9052,6 +9074,7 @@ class ActivityGenerator:
                 source_port=source_port,
                 logon_id=logon_id,
                 preserve_explicit_source=True,
+                session_end_plan=request.session_end_plan,
             )
             return rendered_logon_id
         if logon_id is None and os_cat == "windows" and logon_type in (2, 11):
@@ -9159,6 +9182,7 @@ class ActivityGenerator:
                 source_port=source_port,
                 logon_id=logon_id,
                 session_obj_id=session_obj_id,
+                session_end_plan=request.session_end_plan,
                 source="linux_logon_compat",
             )
             session = self.state_manager.get_session(logon_id)
@@ -9213,6 +9237,9 @@ class ActivityGenerator:
             ):
                 time = existing_session.start_time
                 self.state_manager.set_current_time(time)
+
+        if request.session_end_plan is not None:
+            self.state_manager.plan_session_end(logon_id, request.session_end_plan)
 
         requires_logon_guid = auth_pkg.get("LogonGuid") != "{00000000-0000-0000-0000-000000000000}"
         auth_logon_guid = self.state_manager.get_or_create_session_logon_guid(
@@ -10236,6 +10263,7 @@ class ActivityGenerator:
         logon_id: str,
         logon_type: int = 2,
         from_storyline: bool = False,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> None:
         """Generate logoff event across all applicable log formats.
 
@@ -10259,6 +10287,7 @@ class ActivityGenerator:
             logon_id=logon_id,
             logon_type=logon_type,
             from_storyline=from_storyline,
+            session_end_plan=session_end_plan,
         )
         LogoffActionBundle(self, request).execute()
 
@@ -10270,6 +10299,15 @@ class ActivityGenerator:
         logon_id = request.logon_id
         logon_type = request.logon_type
         from_storyline = request.from_storyline
+        session_end_plan = request.session_end_plan
+        authoritative_end_plan = (
+            session_end_plan
+            if session_end_plan is not None and session_end_plan.is_authoritative
+            else None
+        )
+        if authoritative_end_plan is not None:
+            time = ensure_utc(authoritative_end_plan.canonical_end)
+            self.state_manager.plan_session_end(logon_id, authoritative_end_plan)
 
         # Terminate session-specific processes before ending session
         session = self.state_manager.get_session(logon_id)
@@ -10284,7 +10322,7 @@ class ActivityGenerator:
                 if is_ssh_session and session.network_close_time is not None
                 else None
             )
-            if ssh_transport_close_time is not None:
+            if ssh_transport_close_time is not None and authoritative_end_plan is None:
                 transport_logoff_time = ssh_transport_close_time + sample_timing_delta(
                     "windows.logoff_after_last_activity",
                     seed_parts=(system.hostname, logon_id, ssh_transport_close_time),
@@ -10358,7 +10396,14 @@ class ActivityGenerator:
                 key=lambda proc: (_session_process_depth(proc.pid), proc.start_time, proc.pid),
                 reverse=True,
             )
-            termination_span = timedelta(milliseconds=max(500, 50 * (len(session_processes) + 1)))
+            if authoritative_end_plan is not None:
+                termination_span = timedelta(
+                    milliseconds=min(3000, max(250, 100 * (len(session_processes) + 1)))
+                )
+            else:
+                termination_span = timedelta(
+                    milliseconds=max(500, 50 * (len(session_processes) + 1))
+                )
             termination_start = time - termination_span
             prior_visible_termination = self._session_process_source_terminate_times.get(
                 (session.system, logon_id)
@@ -10367,9 +10412,22 @@ class ActivityGenerator:
                 [prior_visible_termination] if prior_visible_termination is not None else []
             )
             for ordinal, session_process in enumerate(session_processes):
-                requested_termination_time = termination_start + timedelta(
-                    milliseconds=50 * ordinal
-                )
+                if authoritative_end_plan is not None:
+                    slot_ms = (
+                        termination_span.total_seconds()
+                        * 1000
+                        / max(
+                            1,
+                            len(session_processes) + 1,
+                        )
+                    )
+                    requested_termination_time = termination_start + timedelta(
+                        milliseconds=slot_ms * ordinal
+                    )
+                else:
+                    requested_termination_time = termination_start + timedelta(
+                        milliseconds=50 * ordinal
+                    )
                 self.generate_process_termination(
                     user=user,
                     system=system,
@@ -10378,6 +10436,7 @@ class ActivityGenerator:
                     process_name=session_process.image,
                     logon_id=logon_id,
                     from_storyline=from_storyline,
+                    session_end_plan=authoritative_end_plan,
                 )
                 visible_termination_time = self.process_source_terminate_time(
                     session.system,
@@ -10385,13 +10444,33 @@ class ActivityGenerator:
                 )
                 if visible_termination_time is not None:
                     visible_termination_times.append(visible_termination_time)
-            if visible_termination_times:
+            if visible_termination_times and authoritative_end_plan is None:
                 latest_visible_termination = max(visible_termination_times)
                 minimum_logoff_time = latest_visible_termination + sample_timing_delta(
                     "windows.logoff_after_rendered_dependents",
                     seed_parts=(system.hostname, logon_id, latest_visible_termination),
                 )
                 time = max(time, minimum_logoff_time)
+
+            if authoritative_end_plan is not None:
+                remaining_processes = [
+                    proc
+                    for proc in self.state_manager.list_running_processes()
+                    if proc.system == session.system and proc.logon_id == logon_id
+                ]
+                if remaining_processes:
+                    raise StateError(
+                        "Authoritative session closure left running processes: "
+                        f"{system.hostname} logon_id={logon_id} "
+                        f"pids={[proc.pid for proc in remaining_processes]}"
+                    )
+                if ssh_transport_close_time is not None and ssh_transport_close_time >= ensure_utc(
+                    authoritative_end_plan.canonical_end
+                ):
+                    raise StateError(
+                        "SSH transport extends beyond authoritative session end: "
+                        f"{system.hostname} logon_id={logon_id}"
+                    )
 
         # Build SecurityEvent (StateManager.apply() handles end_session)
         session_obj_id = self.state_manager.get_session_object_id(logon_id)
@@ -10415,6 +10494,16 @@ class ActivityGenerator:
             ),
             edr=EdrContext(object_id=session_obj_id),
             storyline_origin=from_storyline,
+            lifecycle=(
+                ActionLifecycleContext(
+                    group_id=session.lifecycle_group_id,
+                    canonical_start=session.start_time,
+                    phase="closure",
+                    parent_group_id=session.parent_lifecycle_group_id or None,
+                )
+                if session is not None
+                else None
+            ),
         )
 
         # Attach SyslogContext for Linux SSH sessions only (sshd session closed).
@@ -10453,6 +10542,43 @@ class ActivityGenerator:
                     message=f"pam_unix(sshd:session): session closed for user {user.username}",
                 )
 
+        if authoritative_end_plan is not None:
+            ecar_close_time = time + sample_timing_delta(
+                "source.ecar_session_logout",
+                seed_parts=(system.hostname, logon_id, time),
+            )
+            windows_close_time = time + sample_timing_delta(
+                "source.windows_security_session_logout",
+                seed_parts=(system.hostname, logon_id, time),
+            )
+            self._source_timing_planner.record_session_closure_source_time(
+                event,
+                "ecar",
+                ecar_close_time,
+            )
+            self._source_timing_planner.record_session_closure_source_time(
+                event,
+                "windows_event_security",
+                windows_close_time,
+            )
+            if is_ssh_session and ssh_transport_close_time is not None and event.syslog is not None:
+                pam_delay_ms = 120 + (
+                    _stable_seed(
+                        "ssh_pam_close_after_transport:"
+                        f"{system.hostname}:{logon_id}:{ssh_transport_close_time.isoformat()}"
+                    )
+                    % 2381
+                )
+                pam_close_time = min(
+                    ssh_transport_close_time + timedelta(milliseconds=pam_delay_ms),
+                    ensure_utc(authoritative_end_plan.canonical_end) + timedelta(seconds=4),
+                )
+                self._source_timing_planner.record_session_closure_source_time(
+                    event,
+                    "syslog",
+                    pam_close_time,
+                )
+
         # Phase 3: Dispatch to matching emitters
         self.dispatcher.dispatch(event)
         if event.syslog is not None and event.dst_host and event.dst_host.os_category == "linux":
@@ -10462,12 +10588,19 @@ class ActivityGenerator:
                     f"{system.hostname}:{user.username}:{logon_id}:{session_id}:"
                     f"{time.isoformat()}"
                 )
+                syslog_close_time = self._source_timing_planner.session_closure_source_time(
+                    event,
+                    "syslog",
+                )
                 self.dispatcher.dispatch(
                     SecurityEvent(
-                        timestamp=time
-                        + timedelta(
-                            milliseconds=120 + (remove_seed % 880),
-                            microseconds=701 + (remove_seed % 173),
+                        timestamp=min(
+                            syslog_close_time
+                            + timedelta(
+                                milliseconds=120 + (remove_seed % 880),
+                                microseconds=701 + (remove_seed % 173),
+                            ),
+                            ensure_utc(time) + timedelta(seconds=4),
                         ),
                         event_type="syslog",
                         src_host=event.dst_host,
@@ -10963,6 +11096,16 @@ class ActivityGenerator:
         concurrency_group_id = request.concurrency_group_id
 
         self.state_manager.set_current_time(time)
+        session_end_plan = self.state_manager.get_session_end_plan(logon_id)
+        if (
+            session_end_plan is not None
+            and session_end_plan.is_authoritative
+            and ensure_utc(time) >= ensure_utc(session_end_plan.canonical_end)
+        ):
+            raise StateError(
+                "Process activity cannot begin at or after its authoritative session end: "
+                f"{system.hostname} logon_id={logon_id} time={ensure_utc(time).isoformat()}"
+            )
         if _get_os_category(system.os) == "windows":
             process_name, command_line = _windows_script_host_process(
                 process_name,
@@ -12424,6 +12567,7 @@ class ActivityGenerator:
         process_name: str,
         logon_id: str,
         from_storyline: bool = False,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> None:
         """Generate process termination event across all applicable log formats.
 
@@ -12446,6 +12590,7 @@ class ActivityGenerator:
             process_name=process_name,
             logon_id=logon_id,
             from_storyline=from_storyline,
+            session_end_plan=session_end_plan,
         )
         ProcessTerminationActionBundle(self, request).execute()
 
@@ -12460,6 +12605,7 @@ class ActivityGenerator:
         process_name = request.process_name
         logon_id = request.logon_id
         from_storyline = request.from_storyline
+        authoritative_end_plan = request.session_end_plan
 
         running_proc = self.state_manager.get_process(system.hostname, pid)
         if self._process_termination_recorded(
@@ -12474,13 +12620,18 @@ class ActivityGenerator:
             and running_proc.last_activity_time is not None
             and time <= running_proc.last_activity_time
         ):
-            delay_rng = random.Random(
-                _stable_seed(
-                    "process_terminate_after_activity:"
-                    f"{system.hostname}:{pid}:{running_proc.last_activity_time.isoformat()}"
+            if authoritative_end_plan is not None and authoritative_end_plan.is_authoritative:
+                time = ensure_utc(running_proc.last_activity_time) + timedelta(milliseconds=25)
+            else:
+                delay_rng = random.Random(
+                    _stable_seed(
+                        "process_terminate_after_activity:"
+                        f"{system.hostname}:{pid}:{running_proc.last_activity_time.isoformat()}"
+                    )
                 )
-            )
-            time = running_proc.last_activity_time + timedelta(seconds=delay_rng.uniform(2.0, 30.0))
+                time = running_proc.last_activity_time + timedelta(
+                    seconds=delay_rng.uniform(2.0, 30.0)
+                )
         if running_proc is not None:
             process_name = running_proc.image
         process_username = running_proc.username if running_proc is not None else user.username
@@ -12499,11 +12650,29 @@ class ActivityGenerator:
                 latest_allowed = running_proc.start_time + timedelta(milliseconds=100)
             if latest_allowed < session_end_time:
                 time = min(time, latest_allowed)
-        time = self._held_process_termination_time(
-            system=system,
-            pid=pid,
-            requested_time=time,
-        )
+        if authoritative_end_plan is not None and authoritative_end_plan.is_authoritative:
+            deadline = ensure_utc(authoritative_end_plan.canonical_end)
+            hold_until = self._process_connection_hold_until.get((system.hostname, pid))
+            if hold_until is not None and ensure_utc(hold_until) >= deadline:
+                raise StateError(
+                    "Process connection hold extends beyond authoritative session end: "
+                    f"{system.hostname} pid={pid} hold={ensure_utc(hold_until).isoformat()} "
+                    f"end={deadline.isoformat()}"
+                )
+            end_margin_ms = 25 + (
+                _stable_seed(
+                    "process_terminate_before_authoritative_logoff:"
+                    f"{system.hostname}:{pid}:{process_logon_id}:{deadline.isoformat()}"
+                )
+                % 176
+            )
+            time = min(ensure_utc(time), deadline - timedelta(milliseconds=end_margin_ms))
+        else:
+            time = self._held_process_termination_time(
+                system=system,
+                pid=pid,
+                requested_time=time,
+            )
         if not process_logon_id:
             if process_username in _SYSTEM_ACCOUNTS:
                 process_logon_id = "0x3e7"
@@ -17026,6 +17195,7 @@ class ActivityGenerator:
         public_key_type: str = "",
         public_key_hash: str = "",
         emit_session_close: bool = False,
+        session_end_plan: SessionEndPlan | None = None,
         source: str = "activity_generator",
     ) -> str:
         """Generate an SSH session through the SSH action-bundle adapter.
@@ -17059,6 +17229,7 @@ class ActivityGenerator:
             public_key_type=public_key_type,
             public_key_hash=public_key_hash,
             emit_session_close=emit_session_close,
+            session_end_plan=session_end_plan,
             source=source,
         )
         return SshSessionActionBundle(request=request, executor=self).execute()
@@ -17084,6 +17255,7 @@ class ActivityGenerator:
         public_key_type: str = "",
         public_key_hash: str = "",
         emit_session_close: bool = False,
+        session_end_plan: SessionEndPlan | None = None,
         source: str = "activity_generator",
     ) -> tuple[str, str]:
         """Execute the canonical SSH bundle and return transport and session IDs."""
@@ -17108,6 +17280,7 @@ class ActivityGenerator:
             public_key_type=public_key_type,
             public_key_hash=public_key_hash,
             emit_session_close=emit_session_close,
+            session_end_plan=session_end_plan,
             source=source,
         )
         return SshSessionActionBundle(request=request, executor=self).execute_with_identity()
@@ -21417,6 +21590,7 @@ class ActivityGenerator:
         source_process_time: datetime | None = None,
         source_process_factory: RdpSourceProcessFactory | None = None,
         preserve_explicit_source: bool = False,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> str:
         """Generate RDP session: Zeek conn + 4624 type 10 + eCAR on target.
 
@@ -21435,6 +21609,7 @@ class ActivityGenerator:
             source_process_time=source_process_time,
             source_process_factory=source_process_factory,
             preserve_explicit_source=preserve_explicit_source,
+            session_end_plan=session_end_plan,
         )
         return uid
 
@@ -21451,6 +21626,7 @@ class ActivityGenerator:
         source_process_time: datetime | None = None,
         source_process_factory: RdpSourceProcessFactory | None = None,
         preserve_explicit_source: bool = False,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> tuple[str, str]:
         """Execute the canonical RDP bundle and return transport and session IDs."""
 
@@ -21467,6 +21643,7 @@ class ActivityGenerator:
                 source_process_time=source_process_time,
                 logon_id=logon_id or "",
                 preserve_explicit_source=preserve_explicit_source,
+                session_end_plan=session_end_plan,
             ),
             source_process_factory=source_process_factory,
         )

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -461,6 +461,8 @@ class EcarEmitter(HostMultiplexEmitter):
         lifecycle: str,
     ) -> datetime:
         """Return the eCAR render timestamp for a user-session observation."""
+        if lifecycle == "logout":
+            return event.timestamp
         auth = event.auth
         edr = event.edr
         canonical_timestamp = (
@@ -468,12 +470,9 @@ class EcarEmitter(HostMultiplexEmitter):
             if event.source_timing is not None
             else event.timestamp
         )
-        source_key = (
-            "source.ecar_session_logout" if lifecycle == "logout" else "source.ecar_session"
-        )
         timestamp = _SOURCE_TIMING.source_time(
             event,
-            source_key,
+            "source.ecar_session",
             seed_parts=(
                 lifecycle,
                 self._host_name(host),

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -2309,7 +2309,6 @@ class WindowsEventEmitter(LogEmitter):
             self._shift_spooled_process_dependents_after_create_unlocked()
             self._shift_spooled_special_privileges_after_logons_unlocked()
             self._shift_spooled_process_terminations_after_dependents_unlocked()
-            self._shift_spooled_logoffs_after_dependents_unlocked()
             self._suppress_spooled_duplicate_lock_unlock_transitions_unlocked()
             events = self._iter_spooled_events_unlocked()
         else:
@@ -2320,7 +2319,6 @@ class WindowsEventEmitter(LogEmitter):
             self._shift_process_dependents_after_create()
             self._shift_special_privileges_after_logons()
             self._shift_process_terminations_after_dependents()
-            self._shift_logoffs_after_dependents()
             self._suppress_duplicate_lock_unlock_transitions()
 
             def _sort_key(event: dict) -> Any:

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -1865,12 +1865,7 @@ class StorylineMixin:
             key = (storyline_event.actor, storyline_event.system)
             for spec_index, spec in enumerate(storyline_event.events):
                 spec_id = f"{storyline_event.id}:{spec_index}"
-                is_durable_logon = spec.type == "logon" and getattr(
-                    spec,
-                    "logon_type",
-                    3,
-                ) in {2, 10, 11}
-                if spec.type in {"ssh_session", "rdp_session"} or is_durable_logon:
+                if spec.type in {"ssh_session", "rdp_session", "logon"}:
                     pending.setdefault(key, []).append(spec_id)
                 elif spec.type == "logoff" and pending.get(key):
                     start_id = pending[key].pop()

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -45,6 +45,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.actions import (
     IdsAlertActionBundle,
     IdsAlertRequest,
@@ -70,6 +71,7 @@ from evidenceforge.generation.activity.http_content import (
     response_size_for_status,
 )
 from evidenceforge.generation.activity.network import _is_private_ip
+from evidenceforge.models.exceptions import StateError
 from evidenceforge.models.scenario import (
     MAX_HTTP_RESPONSE_BODY_LEN,
     BeaconHttpSequenceEntry,
@@ -1781,10 +1783,19 @@ class StorylineMixin:
         logon_id: str,
         source_ip: str | None = None,
     ) -> None:
-        """Record the latest storyline-created session by actor and target host."""
+        """Record a storyline-created session and bind any planned explicit close."""
+        self._ensure_storyline_session_end_pairs()
+        key = (actor.username, system.hostname)
+        registry = getattr(self, "_storyline_logon_registry", None)
+        if registry is None:
+            registry = self._storyline_logon_registry = {}
+        ordered_logons = registry.setdefault(key, [])
+        if logon_id not in ordered_logons:
+            ordered_logons.append(logon_id)
+
         if not hasattr(self, "_last_storyline_logon_by_actor_system"):
             self._last_storyline_logon_by_actor_system: dict[tuple[str, str], str] = {}
-        self._last_storyline_logon_by_actor_system[(actor.username, system.hostname)] = logon_id
+        self._last_storyline_logon_by_actor_system[key] = logon_id
         if source_ip is None and hasattr(self, "state_manager"):
             get_session = getattr(self.state_manager, "get_session", None)
             if callable(get_session):
@@ -1793,9 +1804,21 @@ class StorylineMixin:
         if source_ip:
             if not hasattr(self, "_last_storyline_logon_source_by_actor_system"):
                 self._last_storyline_logon_source_by_actor_system: dict[tuple[str, str], str] = {}
-            self._last_storyline_logon_source_by_actor_system[(actor.username, system.hostname)] = (
-                source_ip
-            )
+            self._last_storyline_logon_source_by_actor_system[key] = source_ip
+            if not hasattr(self, "_storyline_logon_source_by_id"):
+                self._storyline_logon_source_by_id: dict[str, str] = {}
+            self._storyline_logon_source_by_id[logon_id] = source_ip
+
+        spec_id = getattr(self, "_current_storyline_spec_id", "")
+        logoff_id = getattr(self, "_storyline_start_to_logoff", {}).get(spec_id)
+        if logoff_id:
+            plan = self._storyline_session_end_plans[logoff_id]
+            if not self.state_manager.plan_session_end(logon_id, plan):
+                raise StateError(
+                    f"Cannot bind explicit storyline close {logoff_id} to missing session "
+                    f"{logon_id}"
+                )
+            self._storyline_logoff_to_logon[logoff_id] = logon_id
 
     def _last_storyline_logon_for_actor_system(
         self,
@@ -1804,21 +1827,82 @@ class StorylineMixin:
         at_time: datetime | None = None,
     ) -> str | None:
         """Return the latest storyline-created active LogonID for this actor/host."""
-        logons = getattr(self, "_last_storyline_logon_by_actor_system", {})
-        logon_id = logons.get((actor.username, system.hostname))
-        if not logon_id:
-            return None
+        key = (actor.username, system.hostname)
+        registry = getattr(self, "_storyline_logon_registry", {})
+        ordered = registry.get(key)
+        if ordered is None:
+            latest = getattr(self, "_last_storyline_logon_by_actor_system", {}).get(key)
+            ordered = [latest] if latest else []
+        valid_ids = None
         if at_time is not None:
-            valid_sessions = self.state_manager.get_sessions_for_user_at(actor.username, at_time)
-            if not any(
-                session.logon_id == logon_id and session.system == system.hostname
-                for session in valid_sessions
+            valid_ids = {
+                session.logon_id
+                for session in self.state_manager.get_sessions_for_user_at(actor.username, at_time)
+                if session.system == system.hostname
+            }
+        for logon_id in reversed(ordered):
+            if valid_ids is not None and logon_id not in valid_ids:
+                continue
+            session = self.state_manager.get_session(logon_id)
+            if session is not None and session.system == system.hostname:
+                return logon_id
+        return None
+
+    def _ensure_storyline_session_end_pairs(self) -> None:
+        """Pair explicit logoffs with the latest preceding durable session intent."""
+        if hasattr(self, "_storyline_start_to_logoff"):
+            return
+        pending: dict[tuple[str, str], list[str]] = {}
+        start_to_logoff: dict[str, str] = {}
+        logoff_plans: dict[str, SessionEndPlan] = {}
+        scenario = getattr(self, "scenario", None)
+        for storyline_event in getattr(scenario, "storyline", []):
+            if not all(
+                hasattr(storyline_event, field)
+                for field in ("actor", "system", "id", "time", "events")
             ):
-                return None
-        session = self.state_manager.get_session(logon_id)
-        if session is None or session.system != system.hostname:
+                continue
+            key = (storyline_event.actor, storyline_event.system)
+            for spec_index, spec in enumerate(storyline_event.events):
+                spec_id = f"{storyline_event.id}:{spec_index}"
+                is_durable_logon = spec.type == "logon" and getattr(
+                    spec,
+                    "logon_type",
+                    3,
+                ) in {2, 10, 11}
+                if spec.type in {"ssh_session", "rdp_session"} or is_durable_logon:
+                    pending.setdefault(key, []).append(spec_id)
+                elif spec.type == "logoff" and pending.get(key):
+                    start_id = pending[key].pop()
+                    start_to_logoff[start_id] = spec_id
+                    end_time = self._parse_storyline_time(storyline_event.time)
+                    if end_time.tzinfo is None:
+                        end_time = end_time.replace(tzinfo=UTC)
+                    logoff_plans[spec_id] = SessionEndPlan(
+                        canonical_end=end_time.astimezone(UTC),
+                        authority="explicit_storyline",
+                        storyline_event_id=storyline_event.id,
+                    )
+        self._storyline_start_to_logoff = start_to_logoff
+        self._storyline_session_end_plans = logoff_plans
+        self._storyline_logoff_to_logon: dict[str, str] = {}
+
+    def _session_end_plan_for_current_start(self) -> SessionEndPlan | None:
+        """Return the explicit end paired with the current session-start spec."""
+        self._ensure_storyline_session_end_pairs()
+        spec_id = getattr(self, "_current_storyline_spec_id", "")
+        logoff_id = self._storyline_start_to_logoff.get(spec_id)
+        return self._storyline_session_end_plans.get(logoff_id or "")
+
+    def _session_end_plan_for_current_logoff(self) -> tuple[str, SessionEndPlan] | None:
+        """Return the exact session and close plan paired with the current logoff."""
+        self._ensure_storyline_session_end_pairs()
+        spec_id = getattr(self, "_current_storyline_spec_id", "")
+        plan = self._storyline_session_end_plans.get(spec_id)
+        logon_id = self._storyline_logoff_to_logon.get(spec_id)
+        if plan is None or logon_id is None:
             return None
-        return logon_id
+        return logon_id, plan
 
     def _resolve_storyline_process_spill_logon_id(
         self,
@@ -1858,8 +1942,6 @@ class StorylineMixin:
             return logon_id
 
         required_until = self._next_storyline_logoff_time_for_actor_system(actor, system, time)
-        if required_until is not None:
-            required_until += timedelta(minutes=2)
         plan = self.world_model.plan_session(
             user=actor,
             target_system=system,
@@ -1917,8 +1999,12 @@ class StorylineMixin:
         at_time: datetime | None = None,
     ) -> str | None:
         """Return the latest storyline network-logon source for this actor/host."""
-        if self._last_storyline_logon_for_actor_system(actor, system, at_time=at_time) is None:
+        logon_id = self._last_storyline_logon_for_actor_system(actor, system, at_time=at_time)
+        if logon_id is None:
             return None
+        by_logon = getattr(self, "_storyline_logon_source_by_id", {})
+        if logon_id in by_logon:
+            return by_logon[logon_id]
         sources = getattr(self, "_last_storyline_logon_source_by_actor_system", {})
         return sources.get((actor.username, system.hostname))
 
@@ -2685,6 +2771,8 @@ class StorylineMixin:
             self.dispatcher.storyline_cluster_id = storyline_event.id
             try:
                 for i, spec in enumerate(storyline_event.events):
+                    previous_spec_id = getattr(self, "_current_storyline_spec_id", "")
+                    self._current_storyline_spec_id = f"{storyline_event.id}:{i}"
                     event_t = event_time + timedelta(seconds=cadence_offsets[i])
                     event_t = self._apply_storyline_shell_availability(
                         actor=actor,
@@ -2693,17 +2781,20 @@ class StorylineMixin:
                         rng=rng,
                     )
                     self.state_manager.set_current_time(event_t)
-                    malicious_event = self._execute_typed_event(
-                        spec=spec,
-                        actor=actor,
-                        system=system,
-                        time=event_t,
-                        activity=storyline_event.activity,
-                        explicit_types=explicit_types,
-                        future_specs=itertools.islice(storyline_event.events, i + 1, None),
-                    )
-                    if malicious_event:
-                        self.malicious_events.append(malicious_event)
+                    try:
+                        malicious_event = self._execute_typed_event(
+                            spec=spec,
+                            actor=actor,
+                            system=system,
+                            time=event_t,
+                            activity=storyline_event.activity,
+                            explicit_types=explicit_types,
+                            future_specs=itertools.islice(storyline_event.events, i + 1, None),
+                        )
+                        if malicious_event:
+                            self.malicious_events.append(malicious_event)
+                    finally:
+                        self._current_storyline_spec_id = previous_spec_id
                 self._flush_story_process_terminations()
             finally:
                 self.dispatcher.storyline_cluster_id = previous_cluster
@@ -2752,6 +2843,8 @@ class StorylineMixin:
         self.dispatcher.storyline_cluster_id = storyline_event.id
         try:
             for i, spec in enumerate(storyline_event.events):
+                previous_spec_id = getattr(self, "_current_storyline_spec_id", "")
+                self._current_storyline_spec_id = f"{storyline_event.id}:{i}"
                 event_t = event_time + timedelta(seconds=cadence_offsets[i])
                 event_t = self._apply_storyline_shell_availability(
                     actor=actor,
@@ -2760,17 +2853,20 @@ class StorylineMixin:
                     rng=rng,
                 )
                 self.state_manager.set_current_time(event_t)
-                malicious_event = self._execute_typed_event(
-                    spec=spec,
-                    actor=actor,
-                    system=system,
-                    time=event_t,
-                    activity=storyline_event.activity,
-                    explicit_types=explicit_types,
-                    future_specs=itertools.islice(storyline_event.events, i + 1, None),
-                )
-                if malicious_event:
-                    self.malicious_events.append(malicious_event)
+                try:
+                    malicious_event = self._execute_typed_event(
+                        spec=spec,
+                        actor=actor,
+                        system=system,
+                        time=event_t,
+                        activity=storyline_event.activity,
+                        explicit_types=explicit_types,
+                        future_specs=itertools.islice(storyline_event.events, i + 1, None),
+                    )
+                    if malicious_event:
+                        self.malicious_events.append(malicious_event)
+                finally:
+                    self._current_storyline_spec_id = previous_spec_id
             self._flush_story_process_terminations()
         finally:
             self.dispatcher.storyline_cluster_id = previous_cluster
@@ -2886,12 +2982,14 @@ class StorylineMixin:
 
         if spec.type == "logon":
             source_ip = spec.source_ip or pick_external_actor_ip("logon_source_ips", rng)
+            session_end_plan = self._session_end_plan_for_current_start()
             logon_id = self.activity_generator.generate_logon(
                 user=actor,
                 system=system,
                 time=time,
                 logon_type=spec.logon_type,
                 source_ip=source_ip,
+                session_end_plan=session_end_plan,
             )
             # Protect storyline-created sessions from baseline logoff
             session = self.state_manager.get_session(logon_id)
@@ -2922,20 +3020,37 @@ class StorylineMixin:
             malicious_event["source_ip"] = source_ip
 
         elif spec.type == "logoff":
-            sessions = [
-                session
-                for session in self.state_manager.get_sessions_for_user(actor.username)
-                if session.system == system.hostname
-            ]
-            target_session = max(
-                sessions,
-                key=lambda session: session.start_time,
-                default=None,
-            )
-            if target_session:
+            paired_close = self._session_end_plan_for_current_logoff()
+            if paired_close is not None:
+                logon_id, session_end_plan = paired_close
+                target_session = self.state_manager.get_session(logon_id)
+                if target_session is None or target_session.system != system.hostname:
+                    raise StateError(
+                        f"Explicit storyline logoff {session_end_plan.storyline_event_id} "
+                        f"lost its paired session {logon_id} on {system.hostname}"
+                    )
                 self.activity_generator.generate_logoff(
-                    actor, system, time, target_session.logon_id, from_storyline=True
+                    actor,
+                    system,
+                    session_end_plan.canonical_end,
+                    logon_id,
+                    from_storyline=True,
+                    session_end_plan=session_end_plan,
                 )
+            else:
+                logon_id = self._last_storyline_logon_for_actor_system(
+                    actor,
+                    system,
+                    at_time=time,
+                )
+                if logon_id is not None:
+                    self.activity_generator.generate_logoff(
+                        actor,
+                        system,
+                        time,
+                        logon_id,
+                        from_storyline=True,
+                    )
 
         elif spec.type == "email_message":
             result = self.activity_generator.generate_email_message(
@@ -3019,8 +3134,6 @@ class StorylineMixin:
                             system,
                             time,
                         )
-                        if required_until is not None:
-                            required_until += timedelta(minutes=2)
                         # Pre-compute the session kind via the planner so reuse
                         # filtering matches the correct transport type.
                         plan = self.world_model.plan_session(
@@ -3878,6 +3991,7 @@ class StorylineMixin:
                     allow_existing=False,
                     source_ip_override=spec.source_ip,
                     storyline_protected=True,
+                    session_end_plan=self._session_end_plan_for_current_start(),
                 )
             else:
                 source_ip = spec.source_ip or system.ip
@@ -3935,6 +4049,7 @@ class StorylineMixin:
                     allow_existing=False,
                     source_ip_override=spec.source_ip,
                     storyline_protected=True,
+                    session_end_plan=self._session_end_plan_for_current_start(),
                 )
             else:
                 source_ip = spec.source_ip or system.ip

--- a/src/evidenceforge/generation/source_timing.py
+++ b/src/evidenceforge/generation/source_timing.py
@@ -22,7 +22,9 @@ from evidenceforge.generation.activity.timing_profiles import (
     sample_timing_delta,
 )
 from evidenceforge.generation.timing import TemporalConstraintGraph
+from evidenceforge.models.exceptions import StateError
 from evidenceforge.utils.rng import _stable_seed
+from evidenceforge.utils.time import ensure_utc
 
 if TYPE_CHECKING:
     from evidenceforge.events.base import SecurityEvent
@@ -35,6 +37,12 @@ _PROCESS_CREATE_SOURCE_KEYS = {
     "source.ecar_process_create",
 }
 _PROCESS_START_EVENT_TYPES = {"process_create", "system_process_create"}
+_SESSION_CLOSURE_SOURCE_KEYS = {
+    "ecar": "source.ecar_session_logout",
+    "windows_security": "source.windows_security_session_logout",
+    "windows_event_security": "source.windows_security_session_logout",
+    "syslog": "source.syslog_session_logout",
+}
 
 
 @dataclass(slots=True)
@@ -52,6 +60,7 @@ class SourceTimingPlanner:
     def __init__(self, clock_profile_name: str = "complete") -> None:
         self.clock_profile_name = clock_profile_name or "complete"
         self._ecar_process_create_times: dict[str, datetime] = {}
+        self._latest_session_dependent_times: dict[tuple[str, str], datetime] = {}
 
     def plan_event(
         self,
@@ -62,7 +71,143 @@ class SourceTimingPlanner:
         self._ensure_plan(event)
         if format_name in {None, "ecar"}:
             self._plan_ecar_identity_times(event)
+        if format_name is not None:
+            event = self._plan_session_lifecycle_time(event, format_name)
         return event
+
+    def _plan_session_lifecycle_time(
+        self,
+        event: SecurityEvent,
+        format_name: str,
+    ) -> SecurityEvent:
+        """Order same-source process termination and session closure observations."""
+
+        lifecycle = event.lifecycle
+        if lifecycle is None:
+            return event
+        if event.event_type == "process_terminate" and lifecycle.parent_group_id:
+            source_time = self._process_termination_source_time(event, format_name)
+            key = (format_name, lifecycle.parent_group_id)
+            previous = self._latest_session_dependent_times.get(key)
+            if previous is None or source_time > previous:
+                self._latest_session_dependent_times[key] = source_time
+            return event
+        if event.event_type != "logoff" or format_name not in _SESSION_CLOSURE_SOURCE_KEYS:
+            return event
+        return replace(
+            event,
+            timestamp=self.session_closure_source_time(event, format_name),
+        )
+
+    def _process_termination_source_time(
+        self,
+        event: SecurityEvent,
+        format_name: str,
+    ) -> datetime:
+        """Return the timestamp a source will render for a process termination."""
+
+        process = event.process
+        host = event.src_host
+        if process is None or host is None:
+            return event.timestamp
+        start_time = process.start_time or event.timestamp
+        if format_name in {"windows_security", "windows_event_security"}:
+            return self.source_time(
+                event,
+                "source.windows_security_process_terminate",
+                seed_parts=(host.hostname, process.pid, start_time, event.timestamp),
+                not_before=event.timestamp,
+            )
+        if format_name == "ecar":
+            identity = (
+                event.identity_plan.subject
+                if event.identity_plan is not None
+                and isinstance(event.identity_plan.subject, ProcessIdentity)
+                else None
+            )
+            process_start = identity.started_at if identity is not None else start_time
+            create_time = (
+                self._prime_ecar_process_create_time(event, identity)
+                if identity is not None
+                else process_start
+            )
+            canonical_lifetime = max(
+                timedelta(milliseconds=100),
+                event.timestamp - process_start,
+            )
+            return self.source_time(
+                event,
+                "source.ecar_process_terminate",
+                seed_parts=(host.hostname, process.pid, process_start, event.timestamp),
+                not_before=max(event.timestamp, create_time + canonical_lifetime),
+            )
+        return event.timestamp
+
+    def session_closure_source_time(
+        self,
+        event: SecurityEvent,
+        format_name: str,
+    ) -> datetime:
+        """Return the bounded source-native closure time for one session group."""
+
+        lifecycle = event.lifecycle
+        source_key = _SESSION_CLOSURE_SOURCE_KEYS.get(format_name)
+        if lifecycle is None or source_key is None:
+            return event.timestamp
+        plan = self._ensure_plan(event)
+        canonical_end = ensure_utc(plan.canonical_timestamp)
+        seed_parts = (
+            "session-closure",
+            format_name,
+            lifecycle.group_id,
+            getattr(event.auth, "logon_id", ""),
+            canonical_end,
+        )
+        cache_key = self._cache_key(source_key, seed_parts)
+        preferred = plan.source_times.get(cache_key)
+        if preferred is None:
+            preferred = canonical_end
+        latest = self._latest_session_dependent_times.get((format_name, lifecycle.group_id))
+        earliest = canonical_end
+        if latest is not None:
+            earliest = latest + sample_timing_delta(
+                "windows.logoff_after_rendered_dependents",
+                seed_parts=(format_name, lifecycle.group_id, latest),
+            )
+        tail_seconds = 4 if format_name == "syslog" else 15
+        latest_allowed = canonical_end + timedelta(seconds=tail_seconds)
+        if earliest > latest_allowed:
+            raise StateError(
+                "Source-visible session dependents exceed the closure tail bound: "
+                f"format={format_name} group={lifecycle.group_id} "
+                f"dependent={earliest.isoformat()} end={canonical_end.isoformat()}"
+            )
+        closure_time = min(max(preferred, earliest), latest_allowed)
+        plan.source_times[cache_key] = closure_time
+        return closure_time
+
+    def record_session_closure_source_time(
+        self,
+        event: SecurityEvent,
+        format_name: str,
+        timestamp: datetime,
+    ) -> None:
+        """Record a bundle-planned closure time for a source before dispatch."""
+
+        lifecycle = event.lifecycle
+        source_key = _SESSION_CLOSURE_SOURCE_KEYS.get(format_name)
+        if lifecycle is None or source_key is None:
+            return
+        plan = self._ensure_plan(event)
+        canonical_end = ensure_utc(plan.canonical_timestamp)
+        seed_parts = (
+            "session-closure",
+            format_name,
+            lifecycle.group_id,
+            getattr(event.auth, "logon_id", ""),
+            canonical_end,
+        )
+        plan.source_times[self._cache_key(source_key, seed_parts)] = ensure_utc(timestamp)
 
     def _plan_ecar_identity_times(self, event: SecurityEvent) -> None:
         """Prime stable process-create anchors for eCAR lifecycle consumers.

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -34,6 +34,7 @@ from threading import RLock
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.identity import ProcessIdentity, SessionIdentity, ThreadIdentity
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.events.network import NetworkTransactionPlan
 from evidenceforge.models.exceptions import StateError
 from evidenceforge.models.state import (
@@ -60,8 +61,17 @@ def _session_valid_at(session: ActiveSession, cutoff: datetime) -> bool:
     """Return whether a session can own visible activity at cutoff."""
     if ensure_utc(session.start_time) > cutoff:
         return False
+    end_plan = session.end_plan
+    if end_plan is not None and end_plan.is_authoritative:
+        return cutoff < ensure_utc(end_plan.canonical_end)
     network_close_time = session.network_close_time
-    if network_close_time is not None and cutoff >= ensure_utc(network_close_time):
+    if (
+        session.session_kind == "ssh"
+        and network_close_time is not None
+        and cutoff >= ensure_utc(network_close_time)
+    ):
+        return False
+    if end_plan is not None and cutoff >= ensure_utc(end_plan.canonical_end):
         return False
     return True
 
@@ -566,6 +576,50 @@ class StateManager:
             if parent_lifecycle_group_id is not None:
                 session.parent_lifecycle_group_id = parent_lifecycle_group_id
             return True
+
+    def plan_session_end(self, logon_id: str, plan: SessionEndPlan) -> bool:
+        """Attach an immutable canonical end plan to an active session.
+
+        An explicit storyline deadline cannot be silently replaced by another
+        event. Re-applying the same plan is idempotent.
+        """
+
+        with self._lock:
+            session = self.state.active_sessions.get(self._resolve_logon_id(logon_id))
+            if session is None:
+                return False
+            existing = session.end_plan
+            if existing is not None and existing != plan:
+                if existing.is_authoritative:
+                    raise StateError(
+                        "Cannot replace authoritative session end plan for "
+                        f"{logon_id}: {existing.canonical_end.isoformat()}"
+                    )
+            session.end_plan = plan
+            return True
+
+    def get_session_end_plan(self, logon_id: str) -> SessionEndPlan | None:
+        """Return the immutable end plan for an active or ended session."""
+
+        with self._lock:
+            resolved_logon_id = self._resolve_logon_id(logon_id)
+            session = self.state.active_sessions.get(resolved_logon_id)
+            if session is None:
+                ended = self._ended_sessions.get(resolved_logon_id) or self._ended_sessions.get(
+                    logon_id
+                )
+                session = ended[0] if ended is not None else None
+            return session.end_plan if session is not None else None
+
+    def process_session_end_plan(self, system: str, pid: int) -> SessionEndPlan | None:
+        """Return the owning session end plan for a live process."""
+
+        with self._lock:
+            process = self.state.running_processes.get((system, pid))
+            if process is None or not process.logon_id:
+                return None
+            session = self.state.active_sessions.get(self._resolve_logon_id(process.logon_id))
+            return session.end_plan if session is not None else None
 
     def get_session_identity(self, logon_id: str) -> SessionIdentity | None:
         """Return an immutable snapshot of an active or ended session identity."""

--- a/src/evidenceforge/generation/world_model.py
+++ b/src/evidenceforge/generation/world_model.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.activity.generator import _ephemeral_port, _linux_foreground_lifetime
 from evidenceforge.generation.activity.helpers import _get_os_category
 from evidenceforge.generation.activity.network_params import public_ntp_ips
@@ -820,6 +821,7 @@ class WorldPlanner:
         allow_existing: bool = True,
         storyline_protected: bool = False,
         required_until: datetime | None = None,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> ActiveSession:
         return self.bootstrap_user_session(
             user=user,
@@ -831,6 +833,7 @@ class WorldPlanner:
             allow_existing=allow_existing,
             storyline_protected=storyline_protected,
             required_until=required_until,
+            session_end_plan=session_end_plan,
         ).session
 
     def _find_windows_interactive_session(
@@ -869,6 +872,7 @@ class WorldPlanner:
         source_ip_override: str | None = None,
         storyline_protected: bool = False,
         required_until: datetime | None = None,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> SessionBootstrapResult:
         if allow_existing and session_kind in (None, "interactive"):
             existing_interactive = self._find_windows_interactive_session(
@@ -878,6 +882,11 @@ class WorldPlanner:
             )
             if existing_interactive is not None:
                 existing_interactive.last_activity_time = time
+                if session_end_plan is not None:
+                    self.state_manager.plan_session_end(
+                        existing_interactive.logon_id,
+                        session_end_plan,
+                    )
                 if storyline_protected:
                     existing_interactive.storyline_protected = True
                 return SessionBootstrapResult(session=existing_interactive, network_uid=None)
@@ -897,6 +906,7 @@ class WorldPlanner:
                 and required_until is not None
                 and existing.session_kind == "ssh"
                 and existing.network_close_time is not None
+                and not (existing.end_plan and existing.end_plan.is_authoritative)
             ):
                 required_until_utc = (
                     required_until.replace(tzinfo=UTC)
@@ -912,6 +922,8 @@ class WorldPlanner:
                     transport_compatible = False
             if transport_compatible:
                 existing.last_activity_time = time
+                if session_end_plan is not None:
+                    self.state_manager.plan_session_end(existing.logon_id, session_end_plan)
                 if existing.session_kind == "ssh":
                     ensure_shell = getattr(
                         self.activity_generator,
@@ -957,12 +969,20 @@ class WorldPlanner:
                 time,
                 rng,
                 required_until=required_until,
+                session_end_plan=session_end_plan,
             )
             if storyline_protected and result.session:
                 result.session.storyline_protected = True
             return result
         if plan.session_kind == "rdp":
-            result = self._bootstrap_rdp_session(user, plan, logon_time, time, rng)
+            result = self._bootstrap_rdp_session(
+                user,
+                plan,
+                logon_time,
+                time,
+                rng,
+                session_end_plan=session_end_plan,
+            )
             if storyline_protected and result.session:
                 result.session.storyline_protected = True
             return result
@@ -973,6 +993,7 @@ class WorldPlanner:
             time=logon_time,
             logon_type=plan.logon_type,
             source_ip=plan.source_ip,
+            session_end_plan=session_end_plan,
         )
         session = self.state_manager.get_session(logon_id)
         if session is None:
@@ -1215,6 +1236,7 @@ class WorldPlanner:
         activity_time: datetime,
         rng: random.Random,
         required_until: datetime | None = None,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> SessionBootstrapResult:
         source_os = (
             self.world_model.hosts[plan.source_system.hostname].os_category
@@ -1226,7 +1248,7 @@ class WorldPlanner:
             30.0,
             (activity_time - logon_time).total_seconds() + rng.uniform(2.0, 20.0),
         )
-        if required_until is not None:
+        if required_until is not None and session_end_plan is None:
             required_until = (
                 required_until.replace(tzinfo=UTC)
                 if required_until.tzinfo is None
@@ -1244,6 +1266,7 @@ class WorldPlanner:
             source_system=plan.source_system,
             source_port=source_port,
             min_duration=min_duration,
+            session_end_plan=session_end_plan,
         )
         session = self.state_manager.get_session(logon_id)
         if session is None:
@@ -1277,6 +1300,7 @@ class WorldPlanner:
         logon_time: datetime,
         activity_time: datetime,
         rng: random.Random,
+        session_end_plan: SessionEndPlan | None = None,
     ) -> SessionBootstrapResult:
         source_pid = -1
         source_process_time = logon_time - timedelta(milliseconds=rng.randint(1800, 3200))
@@ -1303,6 +1327,7 @@ class WorldPlanner:
             source_pid=source_pid,
             source_process_time=source_process_time if plan.source_system is not None else None,
             source_process_factory=source_process_factory,
+            session_end_plan=session_end_plan,
         )
         session = self.state_manager.get_session(logon_id)
         if session is None:

--- a/src/evidenceforge/models/state.py
+++ b/src/evidenceforge/models/state.py
@@ -33,6 +33,7 @@ runtime state tracking.
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.events.network import NetworkTrafficLedger
 
 
@@ -81,6 +82,7 @@ class ActiveSession:
     logon_guid: str = ""
     lifecycle_group_id: str = ""
     parent_lifecycle_group_id: str = ""
+    end_plan: SessionEndPlan | None = None
 
 
 @dataclass

--- a/tests/unit/test_network_transaction_contract.py
+++ b/tests/unit/test_network_transaction_contract.py
@@ -23,13 +23,17 @@
 """Tests for the canonical network transaction and traffic-ledger contract."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
 
 import pytest
 
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import NetworkContext
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.events.network import DirectionalTrafficLedger, NetworkTrafficLedger
+from evidenceforge.generation.activity import ActivityGenerator
 from evidenceforge.generation.state_manager import StateManager
+from evidenceforge.models import System
 
 
 def _network_context(start: datetime) -> NetworkContext:
@@ -238,3 +242,66 @@ def test_state_manager_accumulates_persistent_application_transactions() -> None
     assert connection.traffic_ledger.resp.payload_bytes == 4396
     assert connection.traffic_ledger.orig.packets == 9
     assert connection.traffic_ledger.resp.packets == 14
+
+
+def test_process_owned_connection_is_capped_before_authoritative_session_end() -> None:
+    """The network planner must shorten a child transport instead of moving logoff."""
+    state = StateManager()
+    start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    deadline = start + timedelta(hours=1)
+    source = System(
+        hostname="WKS-01",
+        ip="10.0.0.10",
+        os="Windows 11",
+        type="workstation",
+    )
+    state.set_current_time(start)
+    logon_id = state.create_session(
+        username="alice",
+        system=source.hostname,
+        logon_type=10,
+        source_ip="10.0.0.50",
+        start_time=start,
+        session_kind="rdp",
+    )
+    plan = SessionEndPlan(deadline, "explicit_storyline", "rdp-close")
+    state.plan_session_end(logon_id, plan)
+    pid = state.create_process(
+        source.hostname,
+        4,
+        r"C:\Windows\System32\OpenSSH\ssh.exe",
+        "ssh app@example",
+        "alice",
+        "Medium",
+        logon_id=logon_id,
+    )
+    emitter = Mock()
+    emitter.can_handle.return_value = True
+    generator = ActivityGenerator(state, {"zeek_conn": emitter})
+    generator._ip_to_system = {source.ip: source}
+    connection_start = deadline - timedelta(minutes=10)
+
+    generator.generate_connection(
+        src_ip=source.ip,
+        dst_ip="203.0.113.20",
+        time=connection_start,
+        dst_port=22,
+        proto="tcp",
+        service="ssh",
+        duration=3600.0,
+        source_system=source,
+        pid=pid,
+        conn_state="SF",
+    )
+
+    event = next(
+        call.args[0]
+        for call in emitter.emit.call_args_list
+        if call.args[0].event_type == "connection"
+    )
+    assert event.network.source_visible_close_time is not None
+    assert event.network.source_visible_close_time <= deadline - timedelta(milliseconds=100)
+    assert event.network.duration < 600
+    process = state.get_process(source.hostname, pid)
+    assert process is not None
+    assert process.last_activity_time < deadline

--- a/tests/unit/test_phase5_logoff.py
+++ b/tests/unit/test_phase5_logoff.py
@@ -28,6 +28,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.activity import ActivityGenerator
 from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
 from evidenceforge.generation.state_manager import StateManager
@@ -498,6 +499,63 @@ class TestLogoffLinux:
         )
         assert syslog_event.timestamp == close_time + expected_delta
         assert ecar_event.timestamp == close_time + expected_delta
+
+    def test_authoritative_ssh_deadline_owns_transport_and_source_closure(
+        self, activity_gen, test_user, linux_system, timestamp, state_manager, mock_emitters
+    ):
+        """Explicit SSH closure keeps canonical and source-native deadlines distinct."""
+        deadline = timestamp + timedelta(hours=1)
+        plan = SessionEndPlan(deadline, "explicit_storyline", "ssh-explicit-close")
+        activity_gen._ip_to_system = {linux_system.ip: linux_system}
+
+        activity_gen.generate_ssh_session(
+            user=test_user,
+            target_system=linux_system,
+            time=timestamp,
+            source_ip="10.0.10.50",
+            source_port=51111,
+            session_end_plan=plan,
+        )
+        session = next(
+            session
+            for session in state_manager.get_sessions_for_user(test_user.username)
+            if session.system == linux_system.hostname
+        )
+        assert session.end_plan == plan
+        assert session.network_close_time is not None
+        assert deadline - timedelta(milliseconds=1500) <= session.network_close_time
+        assert session.network_close_time <= deadline - timedelta(milliseconds=100)
+        mock_emitters["syslog"].reset_mock()
+        mock_emitters["ecar"].reset_mock()
+        mock_emitters["windows_event_security"].reset_mock()
+
+        activity_gen.generate_logoff(
+            test_user,
+            linux_system,
+            deadline + timedelta(minutes=20),
+            session.logon_id,
+            logon_type=10,
+            from_storyline=True,
+            session_end_plan=plan,
+        )
+
+        pam_close = _emitted_pam_close_event(mock_emitters)
+        logind_close = next(
+            event
+            for event in _emitted_syslog_events(mock_emitters)
+            if event.syslog.message.startswith("Removed session ")
+        )
+        ecar_close = next(
+            call.args[0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call.args[0].event_type == "logoff"
+        )
+        assert state_manager.get_session_end_time(session.logon_id) == deadline
+        assert timedelta(milliseconds=120) <= pam_close.timestamp - session.network_close_time
+        assert pam_close.timestamp - session.network_close_time <= timedelta(milliseconds=2500)
+        assert pam_close.source_timing.canonical_timestamp == deadline
+        assert deadline <= ecar_close.timestamp <= deadline + timedelta(seconds=15)
+        assert pam_close.timestamp < logind_close.timestamp <= deadline + timedelta(seconds=4)
 
     def test_linux_type10_logoff_gets_pam_close_even_when_kind_was_not_preserved(
         self, activity_gen, test_user, linux_system, timestamp, state_manager, mock_emitters

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -161,6 +161,58 @@ def test_source_time_is_deterministic() -> None:
     assert first == second
 
 
+def test_session_closure_follows_same_source_process_termination_with_bounded_tail() -> None:
+    """Source timing—not canonical time—orders closure after rendered dependents."""
+    planner = SourceTimingPlanner()
+    canonical_end = _base_time() + timedelta(hours=1)
+    host = _host_context()
+    process_start = canonical_end - timedelta(minutes=10)
+    process_event = SecurityEvent(
+        timestamp=canonical_end - timedelta(milliseconds=200),
+        event_type="process_terminate",
+        src_host=host,
+        process=ProcessContext(
+            pid=4242,
+            parent_pid=4,
+            image=r"C:\Windows\System32\cmd.exe",
+            command_line="",
+            username=r"CORP\alice",
+            logon_id="0x12345",
+            start_time=process_start,
+        ),
+        lifecycle=ActionLifecycleContext(
+            group_id="process-group",
+            canonical_start=process_start,
+            phase="closure",
+            parent_group_id="session-group",
+        ),
+    )
+    planner.plan_event(process_event, "windows_event_security")
+    logoff_event = SecurityEvent(
+        timestamp=canonical_end,
+        event_type="logoff",
+        dst_host=host,
+        auth=AuthContext(username=r"CORP\alice", logon_id="0x12345", logon_type=10),
+        lifecycle=ActionLifecycleContext(
+            group_id="session-group",
+            canonical_start=canonical_end - timedelta(hours=1),
+            phase="closure",
+        ),
+    )
+
+    planned = planner.plan_event(logoff_event, "windows_event_security")
+    process_source_time = planner.source_time(
+        process_event,
+        "source.windows_security_process_terminate",
+        seed_parts=(host.hostname, 4242, process_start, process_event.timestamp),
+        not_before=process_event.timestamp,
+    )
+
+    assert planned.source_timing.canonical_timestamp == canonical_end
+    assert planned.timestamp > process_source_time
+    assert planned.timestamp <= canonical_end + timedelta(seconds=15)
+
+
 def test_ecar_identity_plan_preserves_parent_create_dependent_terminate_order(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -31,6 +31,7 @@ import pytest
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import HostContext, ProcessContext
 from evidenceforge.events.identity import EventIdentityPlan
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation import state_manager as state_manager_module
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.models.exceptions import StateError
@@ -162,6 +163,58 @@ class TestStateManagerInit:
         ] == [logon_id]
         assert sm.get_sessions_for_user_at("alice", close) == []
         assert sm.get_sessions_for_user_at("alice", close + timedelta(minutes=1)) == []
+
+    def test_authoritative_end_keeps_durable_ssh_session_live_past_early_disconnect(self):
+        """An early SSH transport close must not create a shadow durable session."""
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        transport_close = start + timedelta(minutes=8)
+        deadline = start + timedelta(hours=1)
+        logon_id = sm.create_session(
+            username="alice",
+            system="linux01",
+            logon_type=10,
+            source_ip="10.0.1.50",
+            start_time=start,
+            session_kind="ssh",
+        )
+        sm.update_session_metadata(logon_id, network_close_time=transport_close)
+        plan = SessionEndPlan(deadline, "explicit_storyline", "story-logoff")
+
+        assert sm.plan_session_end(logon_id, plan)
+        assert [
+            session.logon_id
+            for session in sm.get_sessions_for_user_at(
+                "alice",
+                transport_close + timedelta(minutes=10),
+            )
+        ] == [logon_id]
+        assert sm.get_sessions_for_user_at("alice", deadline) == []
+
+    def test_authoritative_end_plan_cannot_be_replaced(self):
+        """The first explicit storyline close remains the immutable session authority."""
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        logon_id = sm.create_session(
+            username="alice",
+            system="linux01",
+            logon_type=10,
+            source_ip="10.0.1.50",
+            start_time=start,
+            session_kind="ssh",
+        )
+        first = SessionEndPlan(start + timedelta(hours=1), "explicit_storyline", "first")
+        replacement = SessionEndPlan(
+            start + timedelta(hours=2),
+            "explicit_storyline",
+            "replacement",
+        )
+
+        assert sm.plan_session_end(logon_id, first)
+        assert sm.plan_session_end(logon_id, first)
+        with pytest.raises(StateError, match="Cannot replace authoritative"):
+            sm.plan_session_end(logon_id, replacement)
+        assert sm.get_session_end_plan(logon_id) == first
 
     def test_linux_logind_session_collision_ids_avoid_elapsed_second_deltas(self):
         """Collision bumps should not recreate an exact session-time delta."""

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -298,7 +298,7 @@ class TestStorylineCommandNetworks:
         ) == datetime(2024, 3, 18, 17, 57, 0, tzinfo=UTC)
 
     def test_explicit_logoff_pair_is_not_stolen_by_later_shadow_session(self):
-        """Runtime session churn cannot replace the statically paired durable session."""
+        """Runtime session churn cannot replace an explicit successful logon pairing."""
         state = StateManager()
         start = datetime(2024, 3, 18, 14, 0, 0, tzinfo=UTC)
         actor = User(username="root", full_name="Root", email="root@example.local")
@@ -314,11 +314,11 @@ class TestStorylineCommandNetworks:
         engine.scenario = SimpleNamespace(
             storyline=[
                 SimpleNamespace(
-                    id="durable-ssh",
+                    id="explicit-logon",
                     actor="root",
                     system=system.hostname,
                     time="+1m",
-                    events=[SimpleNamespace(type="ssh_session")],
+                    events=[SimpleNamespace(type="logon", logon_type=3)],
                 ),
                 SimpleNamespace(
                     id="explicit-close",
@@ -335,9 +335,9 @@ class TestStorylineCommandNetworks:
             logon_type=10,
             source_ip="10.10.3.10",
             start_time=start + timedelta(minutes=1),
-            session_kind="ssh",
+            session_kind="network",
         )
-        engine._current_storyline_spec_id = "durable-ssh:0"
+        engine._current_storyline_spec_id = "explicit-logon:0"
         engine._record_storyline_logon(actor, system, durable_id)
         shadow_id = state.create_session(
             username=actor.username,

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -297,6 +297,67 @@ class TestStorylineCommandNetworks:
             datetime(2024, 3, 18, 17, 41, 0, tzinfo=UTC),
         ) == datetime(2024, 3, 18, 17, 57, 0, tzinfo=UTC)
 
+    def test_explicit_logoff_pair_is_not_stolen_by_later_shadow_session(self):
+        """Runtime session churn cannot replace the statically paired durable session."""
+        state = StateManager()
+        start = datetime(2024, 3, 18, 14, 0, 0, tzinfo=UTC)
+        actor = User(username="root", full_name="Root", email="root@example.local")
+        system = System(
+            hostname="APP-INT-01",
+            ip="10.10.2.30",
+            os="Ubuntu 22.04",
+            type="server",
+        )
+        engine = object.__new__(StorylineMixin)
+        engine.start_time = start
+        engine.state_manager = state
+        engine.scenario = SimpleNamespace(
+            storyline=[
+                SimpleNamespace(
+                    id="durable-ssh",
+                    actor="root",
+                    system=system.hostname,
+                    time="+1m",
+                    events=[SimpleNamespace(type="ssh_session")],
+                ),
+                SimpleNamespace(
+                    id="explicit-close",
+                    actor="root",
+                    system=system.hostname,
+                    time="+60m",
+                    events=[SimpleNamespace(type="logoff")],
+                ),
+            ]
+        )
+        durable_id = state.create_session(
+            username=actor.username,
+            system=system.hostname,
+            logon_type=10,
+            source_ip="10.10.3.10",
+            start_time=start + timedelta(minutes=1),
+            session_kind="ssh",
+        )
+        engine._current_storyline_spec_id = "durable-ssh:0"
+        engine._record_storyline_logon(actor, system, durable_id)
+        shadow_id = state.create_session(
+            username=actor.username,
+            system=system.hostname,
+            logon_type=10,
+            source_ip="10.10.3.11",
+            start_time=start + timedelta(minutes=30),
+            session_kind="ssh",
+        )
+        engine._current_storyline_spec_id = ""
+        engine._record_storyline_logon(actor, system, shadow_id)
+        engine._current_storyline_spec_id = "explicit-close:0"
+
+        paired_id, plan = engine._session_end_plan_for_current_logoff()
+
+        assert paired_id == durable_id
+        assert plan.storyline_event_id == "explicit-close"
+        assert state.get_session_end_plan(durable_id) == plan
+        assert state.get_session_end_plan(shadow_id) is None
+
     def test_linux_shell_storyline_process_renders_explicit_shell_invocation(self):
         """Bare shell control syntax should be rendered as source-native bash -c argv."""
         command_line = _linux_shell_process_command_line(


### PR DESCRIPTION
## Summary

- bind explicit storyline logoffs to their statically paired session and immutable `SessionEndPlan`
- make authoritative session deadlines cap SSH/RDP transports, process lifetimes, and process-owned network transactions
- keep bounded eCAR/Windows/PAM/logind closure tails in `SourceTimingPlanner` without moving canonical logoff time
- preserve generated baseline logoff behavior and existing scenario compatibility

## Milestone commits

1. `feat: enforce explicit session closure contract`
2. `test: cover authoritative session closure invariants`
3. `fix: finalize explicit session closure acceptance`

## Validation

- `uv run pytest --no-cov`: 4,954 passed, 19 skipped
- focused session/storyline/process/network/source-timing sets: 214 passed; final regression set: 103 passed
- `uv run ruff check .`: clean
- `uv run ruff format --check .`: clean
- `uv run eforge validate-config`: 87 files, zero findings
- `uv run eforge validate scenarios/iteration-test-expanded/scenario.yaml`: valid with 26 pre-existing warnings

## Expanded-scenario acceptance

- 83,906 records; automated evaluation 95.5434 PASS
- Parseability 100.00, Plausibility 97.31, Causality 88.66, Timing 95.26
- 60/60 storyline format traces and 11,688/11,688 causal-order pairs
- RDP, Type 3, and APP-INT SSH explicit logoffs appear 2.190–2.575 seconds after their authored times
- intended session objects, LogonIDs, and source tuples are preserved
- APP-INT SSH transport closes before the canonical deadline; no source-visible session process appears after logout

## Blind panel

Independent synthetic-confidence scores (lower is better): Threat Hunter 79, Detection Engineer 34, Network Forensics 28, Host/EDR 78; average 54.75. The required spread reconciliation produced 83, 63, 44, and 84 (average 68.5).

The panel did not find a failure of the explicit-logoff deadlines in this PR. It exposed broader residual contracts, led by Windows eCAR remote login appearing before inbound FLOW, three non-authoritative SSH terminal-group omissions, and Zeek file durations ending 1–2 ms past parent connections. These are documented and owner-classified in the worklog for follow-up.

## Scope

- target: `dev`
- no version bump
- focused worklog: `docs/worklog/2026-07-15-session-closure-lifecycle-contract.md`
