### PR TITLE
feat: add Windows remote-auth observation contract

### DIFF
--- a/docs/worklog/2026-07-16-windows-remote-auth-observation-contract.md
+++ b/docs/worklog/2026-07-16-windows-remote-auth-observation-contract.md
@@ -1,0 +1,111 @@
+# Windows Remote-Authentication Observation Contract
+
+## Objective
+
+Make Windows remote authentication a canonical multi-event action whose transports, target
+authentication, optional session, and source-visible ordering are correlated before rendering.
+
+## Family Contract
+
+- **Classification:** `family_level`, correcting a dataset-wide source-visible causality defect
+  and the sibling failure-path defect that emits authentication before transport.
+- **Owning abstractions:** the Windows remote-authentication action planner owns protocol phases
+  and exact participating transports; the network transaction contract owns each tuple and
+  interval; the dispatcher `SourceTimingPlanner` owns source-visible FLOW/WFP/auth ordering;
+  observation policy owns missingness; emitters render finalized source truth.
+- **Invariant:** for one remote-authentication action, every role-labelled transport has a unique
+  transaction identity and exact tuple. When both target-side transport and authentication are
+  visible in one source, the transport precedes authentication by the configured source-native
+  gap. A failed attempt never creates a durable session, and missing observations are never
+  fabricated to satisfy correlation.
+- **Entry paths:** successful and failed Windows Type 3 logons, machine/service-account network
+  authentication, RDP Type 10 compatibility, Kerberos/NTLM validation, and Windows remote-admin
+  actions that create SMB/RPC/management transports.
+- **Consumers:** StateManager session identity, network transaction planning, identity/lifecycle
+  planning, observation and output-window admission, Windows Security, eCAR, Zeek/firewall
+  rendering, evaluator probes, and storyline trace evaluation.
+- **Layer rationale:** source ports, target service, outcome, and phase order are action truth
+  shared by several sources. Emitter-local timestamp repair cannot identify the correct transport
+  under concurrent attempts or tuple reuse and would leave failed-logon canonical order wrong.
+- **Sibling risks:** RDP and SSH already have specialized transport/session contracts; RDP will
+  adapt to the common Windows remote-auth plan without regressing SSH. Observation loss remains
+  independent, and no scenario schema is added.
+
+## Milestones
+
+1. Add immutable remote-authentication types and a planner that owns Windows Type 3 success and
+   failure transports, action grouping, and session parentage.
+2. Finalize eCAR FLOW/session and Windows WFP/logon ordering in dispatcher source timing; reduce
+   eCAR to consuming finalized timestamps.
+3. Route sibling Windows authentication and remote-admin paths through the contract, add rendered
+   family probes, and complete expanded-scenario and blind-panel acceptance.
+
+## Acceptance Targets
+
+- Zero exact-tuple eCAR remote-login-before-inbound-FLOW inversions, including SMB/445 and
+  Kerberos/88 families.
+- Zero matching Windows 4624/4625-before-5156 inversions when both rows are visible.
+- No RDP or SSH ordering regression, no cross-host/port-reuse mis-correlation, and no synthesized
+  companion evidence.
+- Default tests, configuration validation, Ruff checks, `iteration-test-expanded` evaluation, one
+  four-reviewer blind panel, and three reviewable milestone commits.
+
+## Implementation Progress
+
+- Milestone 1 (`d5fe4f68`) added immutable authentication/transport plans, routed successful and
+  failed Type 3, RDP Type 10, and machine-account Kerberos paths through the action bundle, and
+  parented network/session lifecycles to one stable remote-authentication group.
+- Milestone 2 (`a66c363d`) moved exact action/transaction/host/tuple correlation and 8–140 ms
+  source-local ordering into `SourceTimingPlanner`, applied admission after final source timing,
+  and removed eCAR plus Windows-flush remote-authentication timestamp repair.
+- Milestone 3 routes compatibility SMB, anonymous NTLM, machine-account, RDP, and remote-admin
+  siblings through the common bundle and adds a rendered evaluator probe. Exact canonical
+  transaction identity remains internal to planning and source timing; eCAR renders only
+  source-native tuple and lifecycle fields. Missing FLOWs are exempt, while visible exact-tuple
+  matches must be within the bounded authentication interval.
+
+## Acceptance Corrections
+
+- Time-aware session lookup and authoritative session-end checks prevent a stale or already-ended
+  session from owning later network or authentication activity.
+- `OpenConnection` retains canonical transaction identity so compatibility SMB paths can name the
+  exact transport without timestamp-nearest fallback.
+- Anonymous NTLM/SMB and machine-account authentication now enter the action bundle instead of
+  bypassing lifecycle and source-timing ownership.
+- SSH target-side FLOW/session timing uses the same source-planning principle as a regression
+  reference, without changing SSH canonical chronology.
+- The first blind panel identified a branch-introduced eCAR generator fingerprint: the internal
+  `network_transaction_id` had leaked into rendered FLOW rows. The fix removed that field from the
+  format and emitter, retained it only as canonical planner metadata, and changed the rendered
+  evaluator to require host plus full tuple within a five-second correlation interval. A reused
+  tuple outside that interval cannot hide a nearby inversion.
+
+## Verification Log
+
+- Milestone 1 focused authentication/RDP/machine-account tests: passed.
+- Milestone 2 source-timing, eCAR, Windows emitter, dispatcher, and SSH regression tests:
+  400 passed.
+- Milestone 3 format, evaluator, exact-tuple rendering, and probe tests: passed.
+- Configuration validation: 0 issues across 87 files.
+- Repository Ruff and formatting gates: passed.
+- Focused remote-authentication/network/source-timing/eCAR/RDP regression suite: 727 passed,
+  1 skipped.
+- Complete default suite after the source-native eCAR correction: 4,974 passed, 19 skipped.
+- Expanded scenario: 82,102 records; automated score 95.6297; all hard acceptance criteria pass;
+  causal ordering and storyline trace coverage are both 100%.
+- Rendered eCAR probe: 706 visible exact-tuple remote-auth pairs, zero inversions, including
+  249 Kerberos/88, 445 SMB/445, and 12 RDP/3389 pairs. Six logins have independently omitted FLOW
+  companions. Gaps span 8–140 ms with 133 distinct values.
+- Rendered Windows probe: 721 visible 5156/auth pairs, zero inversions; one independently omitted
+  companion. Six visible failed authentications follow transport and create no session.
+- SSH regression probe: 98/98 visible pairs, zero inversions.
+- Final replacement four-reviewer panel synthetic-confidence scores: Threat Hunter 74, Detection
+  Engineer 72, Network Forensics 88, Host/EDR 78; average 78.0 (`likely synthetic`). All verdicts
+  were Synthetic, average verdict confidence was 91, and score spread was 16, so no deliberation
+  trigger applied.
+- Reviewers consistently rated the branch-owned network chronology, traffic accounting, independent
+  sensor identity/timing, target-side remote-auth ordering, and endpoint identity as strong. No
+  reviewer found the original remote-login-before-inbound-FLOW defect.
+- Highest-leverage remaining groups belong to other contracts: standards-valid OCSP/DKIM payloads;
+  explicit-credential/Event 4648 transport and field semantics; PsExec/file/process/SSH lifecycle
+  ownership; source-native process timing and Sysmon content; and baseline/certificate texture.

--- a/src/evidenceforge/evaluation/pillars/causality.py
+++ b/src/evidenceforge/evaluation/pillars/causality.py
@@ -1643,6 +1643,16 @@ class CausalityScorer(DimensionScorer):
             total_pairs += rule_total
             correct_pairs += rule_correct
 
+        remote_total, remote_correct, remote_failures = self._score_ecar_remote_auth_ordering(
+            records.get("ecar", [])
+        )
+        total_pairs += remote_total
+        correct_pairs += remote_correct
+        for failure in remote_failures:
+            if len(failures) >= 10:
+                break
+            failures.append(failure)
+
         score = (100.0 * correct_pairs / total_pairs) if total_pairs > 0 else 100.0
         return SubScore(
             name="Causal Ordering",
@@ -1651,6 +1661,89 @@ class CausalityScorer(DimensionScorer):
             score=score,
             details=f"{correct_pairs}/{total_pairs} causal pairs correctly ordered",
             sample_failures=failures,
+        )
+
+    @classmethod
+    def _score_ecar_remote_auth_ordering(
+        cls,
+        records: list[ParsedRecord],
+    ) -> tuple[int, int, list[str]]:
+        """Score exact-tuple remote logins after the closest visible inbound FLOW."""
+
+        flows: dict[tuple[str, ...], list[ParsedRecord]] = defaultdict(list)
+        for record in records:
+            fields = record.fields
+            if (
+                record.timestamp is None
+                or fields.get("object") != "FLOW"
+                or fields.get("action") != "CONNECT"
+                or str(fields.get("direction") or "").upper() != "INBOUND"
+            ):
+                continue
+            key = cls._ecar_remote_auth_transport_key(fields)
+            if key is not None:
+                flows[key].append(record)
+
+        total = 0
+        correct = 0
+        failures: list[str] = []
+        for record in records:
+            fields = record.fields
+            if (
+                record.timestamp is None
+                or fields.get("object") != "USER_SESSION"
+                or fields.get("action") != "LOGIN"
+                or str(fields.get("logon_type") or "") not in {"3", "10"}
+            ):
+                continue
+            key = cls._ecar_remote_auth_transport_key(fields)
+            matching_flows = flows.get(key, []) if key is not None else []
+            if not matching_flows:
+                continue
+            login_time = _normalize_ts(record.timestamp)
+            bounded_flows = [
+                flow
+                for flow in matching_flows
+                if flow.timestamp is not None
+                and abs((_normalize_ts(flow.timestamp) - login_time).total_seconds()) <= 5.0
+            ]
+            if not bounded_flows:
+                continue
+            nearest_flow = min(
+                bounded_flows,
+                key=lambda flow: abs((_normalize_ts(flow.timestamp) - login_time).total_seconds()),
+            )
+            total += 1
+            if _normalize_ts(nearest_flow.timestamp) < login_time:
+                correct += 1
+            elif len(failures) < 10:
+                failures.append(
+                    "Rule 'eCAR remote FLOW before login': USER_SESSION at line "
+                    f"{record.line_number} precedes its exact inbound FLOW"
+                )
+        return total, correct, failures
+
+    @staticmethod
+    def _ecar_remote_auth_transport_key(fields: dict[str, Any]) -> tuple[str, ...] | None:
+        """Return an exact host-local tuple correlation key."""
+
+        required = (
+            "hostname",
+            "src_ip",
+            "src_port",
+            "dst_ip",
+            "dst_port",
+            "protocol",
+        )
+        if any(fields.get(name) in {None, "", "-"} for name in required):
+            return None
+        return (
+            str(fields["hostname"]).lower(),
+            str(fields["src_ip"]).removeprefix("::ffff:").lower(),
+            str(fields["src_port"]),
+            str(fields["dst_ip"]).removeprefix("::ffff:").lower(),
+            str(fields["dst_port"]),
+            str(fields["protocol"]).lower(),
         )
 
     # --- Sub-score 2: Event Presence ---

--- a/src/evidenceforge/events/__init__.py
+++ b/src/evidenceforge/events/__init__.py
@@ -26,6 +26,10 @@ This package provides the intermediate representation layer between
 ActivityGenerator (which builds events) and emitters (which render them).
 """
 
+from evidenceforge.events.authentication import (
+    RemoteAuthenticationPlan,
+    RemoteAuthenticationTransportPlan,
+)
 from evidenceforge.events.base import RawLogEntry, SecurityEvent
 from evidenceforge.events.contexts import (
     AuthContext,
@@ -49,6 +53,8 @@ from evidenceforge.events.contexts import (
 __all__ = [
     "SecurityEvent",
     "RawLogEntry",
+    "RemoteAuthenticationPlan",
+    "RemoteAuthenticationTransportPlan",
     "HostContext",
     "AuthContext",
     "ProcessContext",

--- a/src/evidenceforge/events/authentication.py
+++ b/src/evidenceforge/events/authentication.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Immutable canonical Windows remote-authentication types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from evidenceforge.events.network import NetworkTuple
+
+RemoteAuthenticationOutcome = Literal["success", "failure"]
+RemoteAuthenticationTransportRole = Literal[
+    "target_service",
+    "kerberos_validation",
+    "ntlm_validation",
+    "rdp",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteAuthenticationTransportPlan:
+    """One role-labelled transport participating in remote authentication."""
+
+    role: RemoteAuthenticationTransportRole
+    transaction_id: str
+    tuple: NetworkTuple
+    started_at: datetime
+    closed_at: datetime | None
+    primary: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate transport identity and interval semantics."""
+
+        if not self.transaction_id:
+            raise ValueError("Remote-authentication transports require a transaction ID")
+        if self.closed_at is not None and self.closed_at < self.started_at:
+            raise ValueError("Remote-authentication transport close cannot precede its start")
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteAuthenticationPlan:
+    """Final canonical phase and correlation truth for one remote authentication."""
+
+    stable_id: str
+    source_hostname: str
+    target_hostname: str
+    logon_type: int
+    auth_protocol: str
+    outcome: RemoteAuthenticationOutcome
+    canonical_auth_time: datetime
+    transports: tuple[RemoteAuthenticationTransportPlan, ...] = ()
+    session_object_id: str = ""
+    logon_id: str = ""
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous transport ownership and invalid session outcomes."""
+
+        if not self.stable_id or not self.target_hostname:
+            raise ValueError("Remote-authentication plans require stable and target identities")
+        transaction_ids = [transport.transaction_id for transport in self.transports]
+        if len(transaction_ids) != len(set(transaction_ids)):
+            raise ValueError("Remote-authentication transaction IDs must be unique")
+        primary_transports = [transport for transport in self.transports if transport.primary]
+        if len(primary_transports) > 1:
+            raise ValueError("Remote-authentication plans permit at most one primary transport")
+        if self.outcome == "failure" and (self.session_object_id or self.logon_id):
+            raise ValueError("Failed remote authentication cannot own a durable session")
+
+    @property
+    def primary_transport(self) -> RemoteAuthenticationTransportPlan | None:
+        """Return the target transport that anchors source-visible authentication."""
+
+        return next((transport for transport in self.transports if transport.primary), None)

--- a/src/evidenceforge/events/base.py
+++ b/src/evidenceforge/events/base.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from evidenceforge.events.authentication import RemoteAuthenticationPlan
 from evidenceforge.events.contexts import (
     AccountManagementContext,
     AuthContext,
@@ -97,6 +98,7 @@ class SecurityEvent:
     src_host: HostContext | None = None
     dst_host: HostContext | None = None
     auth: AuthContext | None = None
+    remote_auth: RemoteAuthenticationPlan | None = None
     process: ProcessContext | None = None
     network: NetworkContext | None = None
     dns: DnsContext | None = None

--- a/src/evidenceforge/events/dispatcher.py
+++ b/src/evidenceforge/events/dispatcher.py
@@ -216,6 +216,7 @@ class EventDispatcher:
         if self._is_suppressed(event.timestamp):
             self._record_observation(event, "all", "out_of_window")
             return
+        self.source_timing_planner.initialize_event(event)
         matching_emitters = self._get_matching_emitters(event)
         decisions = {
             format_name: self.observation_policy.decide(format_name, event)
@@ -255,6 +256,10 @@ class EventDispatcher:
             if not self._admit_source_event(event_to_emit, format_name):
                 self._record_observation(event, format_name, "out_of_window")
                 continue
+            self.source_timing_planner.record_admitted_source_event(
+                event_to_emit,
+                format_name,
+            )
             self._record_admitted_network_identifier(event_to_emit, format_name)
             if (
                 event_to_emit.event_type != "process_terminate"

--- a/src/evidenceforge/generation/actions/__init__.py
+++ b/src/evidenceforge/generation/actions/__init__.py
@@ -169,6 +169,11 @@ from evidenceforge.generation.actions.windows_remote_admin import (
     WindowsServiceInstallActionBundle,
     WindowsServiceInstallRequest,
 )
+from evidenceforge.generation.actions.windows_remote_authentication import (
+    WindowsRemoteAuthenticationActionBundle,
+    WindowsRemoteAuthenticationPlanner,
+    WindowsRemoteAuthenticationRequest,
+)
 
 __all__ = [
     "AccountChangedActionBundle",
@@ -277,6 +282,9 @@ __all__ = [
     "ExplicitCredentialUseRequest",
     "WindowsServiceInstallActionBundle",
     "WindowsServiceInstallRequest",
+    "WindowsRemoteAuthenticationActionBundle",
+    "WindowsRemoteAuthenticationPlanner",
+    "WindowsRemoteAuthenticationRequest",
     "WorkstationLockActionBundle",
     "WorkstationLockRequest",
     "WorkstationUnlockActionBundle",

--- a/src/evidenceforge/generation/actions/auth_session.py
+++ b/src/evidenceforge/generation/actions/auth_session.py
@@ -52,6 +52,7 @@ class LogonRequest:
     lifecycle_group_id: str = ""
     session_end_plan: SessionEndPlan | None = None
     remote_authentication_plan: RemoteAuthenticationPlan | None = None
+    remote_authentication_transport_id: str = ""
     source: str = "activity_generator"
 
     @property
@@ -72,6 +73,7 @@ class LogonRequest:
             f"{self.logon_id or ''}:{source_host}:{self.source}"
             f":{self.lifecycle_group_id}:{end_time}"
             f":{self.remote_authentication_plan.stable_id if self.remote_authentication_plan else ''}"
+            f":{self.remote_authentication_transport_id}"
         )
         return f"logon-{seed:016x}"
 

--- a/src/evidenceforge/generation/actions/auth_session.py
+++ b/src/evidenceforge/generation/actions/auth_session.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
 
+from evidenceforge.events.authentication import RemoteAuthenticationPlan
 from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.actions.base import ActionAnchor
 from evidenceforge.models.scenario import System, User
@@ -50,6 +51,7 @@ class LogonRequest:
     logon_id: str | None = None
     lifecycle_group_id: str = ""
     session_end_plan: SessionEndPlan | None = None
+    remote_authentication_plan: RemoteAuthenticationPlan | None = None
     source: str = "activity_generator"
 
     @property
@@ -69,6 +71,7 @@ class LogonRequest:
             f"{self.emit_transport_syslog}:{self.emit_network_evidence}:"
             f"{self.logon_id or ''}:{source_host}:{self.source}"
             f":{self.lifecycle_group_id}:{end_time}"
+            f":{self.remote_authentication_plan.stable_id if self.remote_authentication_plan else ''}"
         )
         return f"logon-{seed:016x}"
 

--- a/src/evidenceforge/generation/actions/network_transaction_planner.py
+++ b/src/evidenceforge/generation/actions/network_transaction_planner.py
@@ -2508,6 +2508,8 @@ class NetworkTransactionPlanner:
                 protocol=proto,
                 pid=pid,
                 application=wfp_application,
+                transport_transaction_id=request.stable_id,
+                parent_action_group_id=parent_action_group_id,
             )
 
         if (
@@ -2533,6 +2535,8 @@ class NetworkTransactionPlanner:
                 protocol=proto,
                 pid=inbound_pid,
                 application=inbound_application,
+                transport_transaction_id=request.stable_id,
+                parent_action_group_id=parent_action_group_id,
             )
 
         if pid > 0 and resolved_source_system is not None and process_ctx is not None:

--- a/src/evidenceforge/generation/actions/network_transaction_planner.py
+++ b/src/evidenceforge/generation/actions/network_transaction_planner.py
@@ -144,10 +144,17 @@ class NetworkTransactionPlanner:
         canonical_start = ensure_utc(start)
         deadline = ensure_utc(end_plan.canonical_end)
         if canonical_start >= deadline:
+            process = self._executor.state_manager.get_process(source_system.hostname, pid)
+            process_detail = (
+                f" image={process.image!r} logon_id={process.logon_id}"
+                if process is not None
+                else ""
+            )
             raise StateError(
                 "Process-owned network activity cannot begin at or after its authoritative "
                 f"session end: {source_system.hostname} pid={pid} "
                 f"start={canonical_start.isoformat()} end={deadline.isoformat()}"
+                f"{process_detail}"
             )
         close_gap_ms = 100 + (
             _stable_seed(
@@ -226,6 +233,7 @@ class NetworkTransactionPlanner:
 
         executor._last_connection_effective_tuple = None
         executor._last_connection_effective_time = None
+        executor._last_connection_effective_transaction_id = ""
 
         if http is not None:
             http = generator_module._normalize_http_context_for_source_native_response(http)
@@ -703,6 +711,30 @@ class NetworkTransactionPlanner:
                 pid = -1
                 resolved_process = None
                 drop_explicit_pid_without_inference = caller_supplied_pid
+            elif (
+                not caller_supplied_pid
+                and (
+                    inferred_end_plan := executor.state_manager.process_session_end_plan(
+                        resolved_source_system.hostname,
+                        pid,
+                    )
+                )
+                is not None
+                and inferred_end_plan.is_authoritative
+                and ensure_utc(time) >= ensure_utc(inferred_end_plan.canonical_end)
+            ):
+                generator_module.logger.debug(
+                    "Dropping inferred connection PID after its owning session ended: "
+                    "host=%s pid=%s session_end=%s connection_time=%s dst=%s:%s",
+                    resolved_source_system.hostname,
+                    pid,
+                    inferred_end_plan.canonical_end,
+                    time,
+                    dst_ip,
+                    dst_port,
+                )
+                pid = -1
+                resolved_process = None
             elif (
                 resolved_process
                 and resolved_process.start_time
@@ -2471,6 +2503,7 @@ class NetworkTransactionPlanner:
                 event.network.protocol,
             )
             executor._last_connection_effective_time = event.timestamp
+            executor._last_connection_effective_transaction_id = event.network.transaction.stable_id
         executor.dispatcher.dispatch(event)
         if generic_ssh_preauth_pid is not None and target_system is not None:
             executor._emit_generic_ssh_preauth_failure_syslog(

--- a/src/evidenceforge/generation/actions/rdp_session.py
+++ b/src/evidenceforge/generation/actions/rdp_session.py
@@ -30,7 +30,6 @@ activity generator as the runtime adapter for shared state and dispatch.
 
 from __future__ import annotations
 
-import math
 import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -38,13 +37,18 @@ from typing import Any, Protocol
 
 from evidenceforge.events.dispatcher import EventDispatcher
 from evidenceforge.events.lifecycle import SessionEndPlan
-from evidenceforge.generation.actions.base import (
-    ActionAnchor,
-    endpoint_clock_difference,
-    source_observation_delay_difference,
+from evidenceforge.events.network import NetworkTuple
+from evidenceforge.generation.actions.base import ActionAnchor
+from evidenceforge.generation.actions.network_connection import (
+    NetworkConnectionActionBundle,
+    NetworkConnectionRequest,
+)
+from evidenceforge.generation.actions.windows_remote_authentication import (
+    WindowsRemoteAuthenticationPlanner,
+    WindowsRemoteAuthenticationRequest,
 )
 from evidenceforge.generation.activity.helpers import _get_os_category, _get_rng
-from evidenceforge.generation.activity.timing_profiles import get_timing_window, sample_timing_delta
+from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.timing import TemporalConstraintGraph
@@ -232,7 +236,27 @@ class RdpSessionActionBundle:
                 self._executor._os_for_ip(source_ip),
             )
 
-        uid = self._executor.generate_connection(
+        logon_time = self._target_logon_time(
+            rng=rng,
+            source_ip=source_ip,
+            src_port=src_port,
+            transport_start_time=self._request.time,
+        )
+        remote_request = WindowsRemoteAuthenticationRequest(
+            target_system=self._request.target_system,
+            time=logon_time,
+            source_ip=source_ip,
+            source_port=src_port,
+            logon_type=10,
+            auth_protocol="Negotiate",
+            outcome="success",
+            destination_port=3389,
+            source_system=source_system,
+            logon_id=self._request.logon_id,
+            transport_role="rdp",
+            source="rdp_session",
+        )
+        network_request = NetworkConnectionRequest(
             src_ip=source_ip,
             dst_ip=self._request.target_system.ip,
             time=self._request.time,
@@ -247,7 +271,12 @@ class RdpSessionActionBundle:
             source_system=source_system,
             pid=source_pid,
             conn_state="SF",
+            parent_action_group_id=remote_request.stable_id,
+            preserve_start_time=True,
+            source="rdp_session",
         )
+        transaction_id = network_request.stable_id
+        uid = NetworkConnectionActionBundle(self._executor, network_request).execute()
         network_start_time, network_close_time = self._transport_interval(
             uid,
             fallback_start=self._request.time,
@@ -259,12 +288,20 @@ class RdpSessionActionBundle:
             network_close_time=network_close_time,
         )
 
-        logon_time = self._target_logon_time(
-            rng=rng,
-            source_ip=source_ip,
-            src_port=src_port,
-            transport_start_time=network_start_time,
-            source_system=source_system,
+        remote_authentication_plan = WindowsRemoteAuthenticationPlanner(
+            self._executor
+        ).from_existing_transport(
+            remote_request,
+            transaction_id=transaction_id,
+            tuple_view=NetworkTuple(
+                src_ip=source_ip,
+                src_port=src_port,
+                dst_ip=self._request.target_system.ip,
+                dst_port=3389,
+                protocol="tcp",
+            ),
+            started_at=network_start_time,
+            closed_at=network_close_time,
         )
         logon_id = self._request.logon_id
         if logon_id:
@@ -297,6 +334,7 @@ class RdpSessionActionBundle:
             logon_id=logon_id or None,
             lifecycle_group_id=self._request.stable_id,
             session_end_plan=self._request.session_end_plan,
+            remote_authentication_plan=remote_authentication_plan,
         )
         self._rendered_logon_id = rendered_logon_id
         self._executor.state_manager.update_session_metadata(
@@ -444,9 +482,8 @@ class RdpSessionActionBundle:
         source_ip: str,
         src_port: int,
         transport_start_time: datetime | None = None,
-        source_system: System | None = None,
     ) -> datetime:
-        """Resolve target 4624 timing after source-visible network evidence."""
+        """Resolve canonical target authentication after the RDP transport starts."""
 
         observed_connection_time = transport_start_time
         if observed_connection_time is None:
@@ -476,52 +513,13 @@ class RdpSessionActionBundle:
         graph.constrain_after(
             "target_logon",
             "transport_observed",
-            min_gap=timedelta(
-                milliseconds=self._endpoint_flow_visible_gap_ms(
-                    source_system=source_system,
-                    timestamp=observed_connection_time,
-                )
-                + 25
-            ),
+            min_gap=timedelta(milliseconds=900),
         )
         return graph.resolved_time("target_logon")
-
-    def _endpoint_flow_visible_gap_ms(
-        self,
-        *,
-        source_system: System | None = None,
-        timestamp: datetime | None = None,
-    ) -> int:
-        """Return the latest expected same-tuple endpoint FLOW observation delay."""
-        flow_window = get_timing_window(
-            "source.ecar_flow",
-            default_min_ms=40,
-            default_max_ms=300,
-            default_position="after",
-            default_class="source_latency",
-        )
-        observation_delay = source_observation_delay_difference(
-            self._executor,
-            earlier_source="ecar",
-            later_source="windows_security",
-        )
-        clock_delay = timedelta(0)
-        if source_system is not None and timestamp is not None:
-            clock_delay = endpoint_clock_difference(
-                self._executor,
-                earlier_host=source_system.hostname,
-                earlier_os="windows",
-                later_host=self._request.target_system.hostname,
-                later_os="windows",
-                timestamp=timestamp,
-            )
-        return flow_window.max_ms + math.ceil(
-            (observation_delay + clock_delay).total_seconds() * 1000
-        )
 
     def _target_logon_gap_after_transport(self, rng: random.Random) -> int:
         """Choose an RDP target logon gap after endpoint transport visibility."""
         return max(
             rng.randint(900, 1600),
-            self._endpoint_flow_visible_gap_ms() + rng.randint(75, 260),
+            900,
         )

--- a/src/evidenceforge/generation/actions/windows_remote_authentication.py
+++ b/src/evidenceforge/generation/actions/windows_remote_authentication.py
@@ -137,6 +137,40 @@ class WindowsRemoteAuthenticationPlanner:
         )
         return self._plan(request, transports=(transport,))
 
+    def from_existing_transaction(
+        self,
+        request: WindowsRemoteAuthenticationRequest,
+        transaction_id: str,
+    ) -> RemoteAuthenticationPlan | None:
+        """Bind authentication to one explicitly identified exact-tuple transaction."""
+
+        candidates = [
+            connection
+            for connection in self._executor.state_manager.list_open_connections()
+            if connection.transaction_id == transaction_id
+            and connection.src_ip == request.source_ip
+            and connection.src_port == request.source_port
+            and connection.dst_ip == request.target_system.ip
+            and connection.dst_port == request.destination_port
+            and connection.protocol.lower() == "tcp"
+        ]
+        if len(candidates) != 1:
+            return None
+        connection = candidates[0]
+        return self.from_existing_transport(
+            request,
+            transaction_id=transaction_id,
+            tuple_view=NetworkTuple(
+                src_ip=connection.src_ip,
+                src_port=connection.src_port,
+                dst_ip=connection.dst_ip,
+                dst_port=connection.dst_port,
+                protocol=connection.protocol,
+            ),
+            started_at=connection.start_time,
+            closed_at=connection.close_time,
+        )
+
     @staticmethod
     def _plan(
         request: WindowsRemoteAuthenticationRequest,

--- a/src/evidenceforge/generation/actions/windows_remote_authentication.py
+++ b/src/evidenceforge/generation/actions/windows_remote_authentication.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Canonical Windows remote-authentication action planning."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Protocol
+
+from evidenceforge.events.authentication import (
+    RemoteAuthenticationOutcome,
+    RemoteAuthenticationPlan,
+    RemoteAuthenticationTransportPlan,
+    RemoteAuthenticationTransportRole,
+)
+from evidenceforge.events.network import NetworkTuple
+from evidenceforge.generation.actions.base import ActionAnchor
+from evidenceforge.generation.actions.network_connection import (
+    NetworkConnectionActionBundle,
+    NetworkConnectionRequest,
+)
+from evidenceforge.models.scenario import System
+from evidenceforge.utils.rng import _stable_seed
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsRemoteAuthenticationRequest:
+    """Intent for one Windows remote-authentication occurrence."""
+
+    target_system: System
+    time: datetime
+    source_ip: str
+    source_port: int
+    logon_type: int
+    auth_protocol: str
+    outcome: RemoteAuthenticationOutcome
+    destination_port: int
+    source_system: System | None = None
+    session_object_id: str = ""
+    logon_id: str = ""
+    emit_transport: bool = True
+    transport_role: RemoteAuthenticationTransportRole = "target_service"
+    source: str = "activity_generator"
+
+    @property
+    def stable_id(self) -> str:
+        """Return the durable action-group identity."""
+
+        source_hostname = self.source_system.hostname if self.source_system is not None else ""
+        seed = _stable_seed(
+            "action_bundle:windows_remote_authentication:"
+            f"{self.target_system.hostname}:{self.time.isoformat()}:{self.source_ip}:"
+            f"{self.source_port}:{self.logon_type}:{self.auth_protocol}:{self.outcome}:"
+            f"{self.destination_port}:{source_hostname}:{self.logon_id}:{self.source}"
+        )
+        return f"windows-remote-auth-{seed:016x}"
+
+
+class WindowsRemoteAuthenticationExecutor(Protocol):
+    """Services required by the remote-authentication action planner."""
+
+    state_manager: object
+
+
+class WindowsRemoteAuthenticationPlanner:
+    """Plan and execute one Windows transport-to-authentication occurrence."""
+
+    def __init__(self, executor: WindowsRemoteAuthenticationExecutor) -> None:
+        self._executor = executor
+
+    def execute(self, request: WindowsRemoteAuthenticationRequest) -> RemoteAuthenticationPlan:
+        """Emit the primary transport and return frozen canonical authentication truth."""
+
+        if not request.emit_transport:
+            return self.without_transport(request)
+
+        network_request = self._network_request(request)
+        transaction_id = network_request.stable_id
+        uid = NetworkConnectionActionBundle(self._executor, network_request).execute()
+        connection = next(
+            (
+                candidate
+                for candidate in self._executor.state_manager.list_open_connections()
+                if candidate.zeek_uid == uid
+            ),
+            None,
+        )
+        if connection is None:
+            raise ValueError(
+                "Remote-authentication transport did not persist canonical connection state"
+            )
+        transport = RemoteAuthenticationTransportPlan(
+            role=request.transport_role,
+            transaction_id=transaction_id,
+            tuple=NetworkTuple(
+                src_ip=connection.src_ip,
+                src_port=connection.src_port,
+                dst_ip=connection.dst_ip,
+                dst_port=connection.dst_port,
+                protocol=connection.protocol,
+            ),
+            started_at=connection.start_time,
+            closed_at=connection.close_time,
+            primary=True,
+        )
+        return self._plan(request, transports=(transport,))
+
+    def without_transport(
+        self,
+        request: WindowsRemoteAuthenticationRequest,
+    ) -> RemoteAuthenticationPlan:
+        """Return canonical authentication truth when collection models no transport."""
+
+        return self._plan(request, transports=())
+
+    def from_existing_transport(
+        self,
+        request: WindowsRemoteAuthenticationRequest,
+        *,
+        transaction_id: str,
+        tuple_view: NetworkTuple,
+        started_at: datetime,
+        closed_at: datetime | None,
+    ) -> RemoteAuthenticationPlan:
+        """Adapt an already-executed specialized transport such as RDP."""
+
+        transport = RemoteAuthenticationTransportPlan(
+            role=request.transport_role,
+            transaction_id=transaction_id,
+            tuple=tuple_view,
+            started_at=started_at,
+            closed_at=closed_at,
+            primary=True,
+        )
+        return self._plan(request, transports=(transport,))
+
+    @staticmethod
+    def _plan(
+        request: WindowsRemoteAuthenticationRequest,
+        *,
+        transports: tuple[RemoteAuthenticationTransportPlan, ...],
+    ) -> RemoteAuthenticationPlan:
+        return RemoteAuthenticationPlan(
+            stable_id=request.stable_id,
+            source_hostname=(
+                request.source_system.hostname if request.source_system is not None else ""
+            ),
+            target_hostname=request.target_system.hostname,
+            logon_type=request.logon_type,
+            auth_protocol=request.auth_protocol,
+            outcome=request.outcome,
+            canonical_auth_time=request.time,
+            transports=transports,
+            session_object_id=(request.session_object_id if request.outcome == "success" else ""),
+            logon_id=request.logon_id if request.outcome == "success" else "",
+        )
+
+    def _network_request(
+        self,
+        request: WindowsRemoteAuthenticationRequest,
+    ) -> NetworkConnectionRequest:
+        seed = _stable_seed(
+            "windows_remote_auth_transport:"
+            f"{request.stable_id}:{request.source_ip}:{request.source_port}:"
+            f"{request.target_system.ip}:{request.destination_port}"
+        )
+        rng = random.Random(seed)
+        if request.outcome == "success":
+            start_gap_ms = rng.randint(150, 900)
+            duration = rng.uniform(1.5, 45.0)
+            conn_state = "SF"
+            orig_bytes = rng.randint(800, 8000)
+            resp_bytes = rng.randint(500, 12000)
+        else:
+            start_gap_ms = rng.randint(20, 250)
+            duration = rng.uniform(0.02, 1.5)
+            conn_state = rng.choices(["SF", "RSTR"], weights=[70, 30], k=1)[0]
+            orig_bytes = rng.randint(120, 900)
+            resp_bytes = rng.randint(0, 500)
+
+        started_at = request.time - timedelta(milliseconds=start_gap_ms)
+        if request.outcome == "success":
+            minimum_duration = (request.time - started_at).total_seconds() + 0.25
+            duration = max(duration, minimum_duration)
+        service = {
+            88: "kerberos",
+            389: "ldap",
+            445: "smb",
+            3389: "rdp",
+        }.get(request.destination_port)
+        return NetworkConnectionRequest(
+            src_ip=request.source_ip,
+            dst_ip=request.target_system.ip,
+            time=started_at,
+            dst_port=request.destination_port,
+            proto="tcp",
+            service=service,
+            duration=duration,
+            orig_bytes=orig_bytes,
+            resp_bytes=resp_bytes,
+            src_port=request.source_port,
+            source_system=request.source_system,
+            conn_state=conn_state,
+            parent_action_group_id=request.stable_id,
+            preserve_start_time=True,
+            source="windows_remote_authentication",
+        )
+
+
+class WindowsRemoteAuthenticationActionBundle:
+    """Expand one remote-authentication intent through its canonical planner."""
+
+    def __init__(
+        self,
+        executor: WindowsRemoteAuthenticationExecutor,
+        request: WindowsRemoteAuthenticationRequest,
+    ) -> None:
+        self._planner = WindowsRemoteAuthenticationPlanner(executor)
+        self._request = request
+
+    @property
+    def anchor(self) -> ActionAnchor:
+        """Return the stable action anchor."""
+
+        return ActionAnchor(
+            family="windows_remote_authentication",
+            stable_id=self._request.stable_id,
+            source=self._request.source,
+        )
+
+    def execute(self) -> RemoteAuthenticationPlan:
+        """Emit the planned transport and return canonical action truth."""
+
+        return self._planner.execute(self._request)

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -4231,6 +4231,7 @@ class ActivityGenerator:
         self._last_connection_effective_dst_ip = ""
         self._last_connection_effective_tuple: tuple[str, int, str, int, str] | None = None
         self._last_connection_effective_time: datetime | None = None
+        self._last_connection_effective_transaction_id = ""
 
     def _process_termination_recorded(
         self,
@@ -5388,6 +5389,27 @@ class ActivityGenerator:
         ):
             return last_src_port
         return None
+
+    def _last_effective_connection_transaction_id(
+        self,
+        *,
+        src_ip: str,
+        src_port: int,
+        dst_ip: str,
+        dst_port: int,
+        proto: str = "tcp",
+    ) -> str:
+        """Return the transaction identity for the exact last emitted transport."""
+
+        if self._last_connection_effective_tuple != (
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+            proto,
+        ):
+            return ""
+        return self._last_connection_effective_transaction_id
 
     @staticmethod
     def _kerberos_port_key(source_ip: str, dc_hostname: str) -> tuple[str, str]:
@@ -7425,7 +7447,10 @@ class ActivityGenerator:
         known_users = getattr(self, "_users_by_username", {})
         sessions = [
             session
-            for session in self.state_manager.get_sessions_on_system(source_system.hostname)
+            for session in self.state_manager.get_sessions_on_system_at(
+                source_system.hostname,
+                time,
+            )
             if session.username in known_users
             and session.username not in _SYSTEM_ACCOUNTS
             and not session.username.endswith("$")
@@ -8984,6 +9009,7 @@ class ActivityGenerator:
         lifecycle_group_id: str = "",
         session_end_plan: SessionEndPlan | None = None,
         remote_authentication_plan: RemoteAuthenticationPlan | None = None,
+        remote_authentication_transport_id: str = "",
     ) -> str:
         """Generate logon event across all applicable log formats.
 
@@ -9017,6 +9043,7 @@ class ActivityGenerator:
             lifecycle_group_id=lifecycle_group_id,
             session_end_plan=session_end_plan,
             remote_authentication_plan=remote_authentication_plan,
+            remote_authentication_transport_id=remote_authentication_transport_id,
         )
         return LogonActionBundle(self, request).execute()
 
@@ -9034,6 +9061,7 @@ class ActivityGenerator:
         logon_id = request.logon_id
         lifecycle_group_id = request.lifecycle_group_id or request.stable_id
         remote_authentication_plan = request.remote_authentication_plan
+        remote_authentication_transport_id = request.remote_authentication_transport_id
 
         self.state_manager.set_current_time(time)
         os_cat = _get_os_category(system.os)
@@ -9349,11 +9377,20 @@ class ActivityGenerator:
                 emit_transport=emit_network_evidence,
             )
             planner = WindowsRemoteAuthenticationPlanner(self)
-            remote_authentication_plan = (
-                WindowsRemoteAuthenticationActionBundle(self, remote_request).execute()
-                if emit_network_evidence
-                else planner.without_transport(remote_request)
-            )
+            if emit_network_evidence:
+                remote_authentication_plan = WindowsRemoteAuthenticationActionBundle(
+                    self,
+                    remote_request,
+                ).execute()
+            else:
+                remote_authentication_plan = (
+                    planner.from_existing_transaction(
+                        remote_request,
+                        remote_authentication_transport_id,
+                    )
+                    if remote_authentication_transport_id
+                    else None
+                ) or planner.without_transport(remote_request)
             event.remote_auth = remote_authentication_plan
         if remote_authentication_plan is not None:
             self.state_manager.update_session_metadata(
@@ -21621,7 +21658,7 @@ class ActivityGenerator:
                     phase="dependent",
                     parent_group_id=parent_action_group_id,
                 )
-                if transport_transaction_id and parent_action_group_id
+                if transport_transaction_id
                 else None
             ),
         )
@@ -23497,20 +23534,6 @@ class ActivityGenerator:
             source_port = _ephemeral_port(rng, "windows")
             source_system = getattr(self, "_ip_to_system", {}).get(source_ip)
             workstation_name = source_system.hostname if source_system else "-"
-            self.generate_connection(
-                src_ip=source_ip,
-                dst_ip=system.ip,
-                time=time - timedelta(milliseconds=rng.randint(150, 900)),
-                dst_port=445,
-                proto="tcp",
-                service="smb",
-                duration=rng.uniform(0.2, 4.0),
-                orig_bytes=rng.randint(250, 2600),
-                resp_bytes=rng.randint(350, 4200),
-                src_port=source_port,
-                conn_state="SF",
-                source_system=source_system,
-            )
         logon_id = self.state_manager.allocate_logon_id(system.hostname, time)
         session_obj_id = stable_uuid(
             "anonymous-network-session",
@@ -23519,6 +23542,30 @@ class ActivityGenerator:
             source_ip,
             source_port,
             time.isoformat(),
+        )
+        remote_authentication_plan = None
+        if source_ip != "-":
+            remote_authentication_plan = WindowsRemoteAuthenticationActionBundle(
+                self,
+                WindowsRemoteAuthenticationRequest(
+                    target_system=system,
+                    time=time,
+                    source_ip=source_ip,
+                    source_port=source_port,
+                    logon_type=3,
+                    auth_protocol="NTLM",
+                    outcome="success",
+                    destination_port=445,
+                    source_system=source_system,
+                    session_object_id=session_obj_id,
+                    logon_id=logon_id,
+                    source="anonymous_logon",
+                ),
+            ).execute()
+        primary_transport = (
+            remote_authentication_plan.primary_transport
+            if remote_authentication_plan is not None
+            else None
         )
         event = SecurityEvent(
             timestamp=time,
@@ -23542,6 +23589,18 @@ class ActivityGenerator:
                 workstation_name=workstation_name,
             ),
             edr=EdrContext(object_id=session_obj_id),
+            remote_auth=remote_authentication_plan,
+            lifecycle=(
+                ActionLifecycleContext(
+                    group_id=remote_authentication_plan.stable_id,
+                    canonical_start=(
+                        primary_transport.started_at if primary_transport is not None else time
+                    ),
+                    phase="start",
+                )
+                if remote_authentication_plan is not None
+                else None
+            ),
         )
         self.dispatcher.dispatch(event)
         logoff_delay = rng.uniform(1.0, 30.0)
@@ -23561,6 +23620,17 @@ class ActivityGenerator:
                     workstation_name=workstation_name,
                 ),
                 edr=EdrContext(object_id=session_obj_id),
+                lifecycle=(
+                    ActionLifecycleContext(
+                        group_id=remote_authentication_plan.stable_id,
+                        canonical_start=(
+                            primary_transport.started_at if primary_transport is not None else time
+                        ),
+                        phase="closure",
+                    )
+                    if remote_authentication_plan is not None
+                    else None
+                ),
             )
         )
 

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -55,6 +55,7 @@ import yaml
 from evidenceforge.events.artifacts_manifest import (
     ARTIFACTS_MANIFEST_SCHEMA_VERSION,
 )
+from evidenceforge.events.authentication import RemoteAuthenticationPlan
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import (
     AuthContext,
@@ -160,6 +161,9 @@ from evidenceforge.generation.actions import (
     ServiceLogonRequest,
     SshSessionActionBundle,
     SshSessionRequest,
+    WindowsRemoteAuthenticationActionBundle,
+    WindowsRemoteAuthenticationPlanner,
+    WindowsRemoteAuthenticationRequest,
     WindowsServiceInstallActionBundle,
     WindowsServiceInstallRequest,
     WorkstationLockActionBundle,
@@ -8979,6 +8983,7 @@ class ActivityGenerator:
         logon_id: str | None = None,
         lifecycle_group_id: str = "",
         session_end_plan: SessionEndPlan | None = None,
+        remote_authentication_plan: RemoteAuthenticationPlan | None = None,
     ) -> str:
         """Generate logon event across all applicable log formats.
 
@@ -9011,6 +9016,7 @@ class ActivityGenerator:
             logon_id=logon_id,
             lifecycle_group_id=lifecycle_group_id,
             session_end_plan=session_end_plan,
+            remote_authentication_plan=remote_authentication_plan,
         )
         return LogonActionBundle(self, request).execute()
 
@@ -9027,6 +9033,7 @@ class ActivityGenerator:
         emit_network_evidence = request.emit_network_evidence
         logon_id = request.logon_id
         lifecycle_group_id = request.lifecycle_group_id or request.stable_id
+        remote_authentication_plan = request.remote_authentication_plan
 
         self.state_manager.set_current_time(time)
         os_cat = _get_os_category(system.os)
@@ -9318,7 +9325,41 @@ class ActivityGenerator:
                 reporting_pid=self._get_system_pid(system.hostname, "lsass", 0x2E0),
             ),
             edr=EdrContext(object_id=session_obj_id, actor_id=session_actor_id),
+            remote_auth=remote_authentication_plan,
         )
+
+        is_windows_remote_auth = (
+            os_cat == "windows"
+            and logon_type in {3, 10}
+            and auth_source_ip not in {"", "-", system.ip}
+        )
+        if is_windows_remote_auth and remote_authentication_plan is None:
+            remote_request = WindowsRemoteAuthenticationRequest(
+                target_system=system,
+                time=time,
+                source_ip=auth_source_ip,
+                source_port=source_port or 0,
+                logon_type=logon_type,
+                auth_protocol=auth_pkg.get("AuthenticationPackageName", "Negotiate"),
+                outcome="success",
+                destination_port=3389 if logon_type == 10 else 445,
+                source_system=source_system or self._ip_to_system.get(auth_source_ip),
+                session_object_id=session_obj_id,
+                logon_id=logon_id,
+                emit_transport=emit_network_evidence,
+            )
+            planner = WindowsRemoteAuthenticationPlanner(self)
+            remote_authentication_plan = (
+                WindowsRemoteAuthenticationActionBundle(self, remote_request).execute()
+                if emit_network_evidence
+                else planner.without_transport(remote_request)
+            )
+            event.remote_auth = remote_authentication_plan
+        if remote_authentication_plan is not None:
+            self.state_manager.update_session_metadata(
+                logon_id,
+                parent_lifecycle_group_id=remote_authentication_plan.stable_id,
+            )
 
         # Attach SyslogContext for Linux SSH sessions only (not network/interactive)
         session_for_syslog = self.state_manager.get_session(logon_id) if logon_id else None
@@ -9381,16 +9422,6 @@ class ActivityGenerator:
             and source_ip != "-"
         ):
             self._emit_dc_ntlm_for_logon(user, system, time, source_ip)
-
-        if emit_network_evidence:
-            self._maybe_emit_remote_logon_network_connection(
-                system=system,
-                time=time,
-                logon_type=logon_type,
-                source_ip=source_ip,
-                source_port=source_port or 0,
-                auth_package=auth_package_name,
-            )
 
         if os_cat == "windows" and logon_type == 3 and auth_source_ip not in {"", "-", system.ip}:
             ready_time = ensure_utc(time) + sample_timing_delta(
@@ -9516,6 +9547,7 @@ class ActivityGenerator:
                 source_ip="-",
             ),
         )
+
         self._linux_local_logon_syslog_sessions.add(logon_id)
 
     def _emit_dc_ntlm_for_logon(
@@ -9820,6 +9852,42 @@ class ActivityGenerator:
             ),
         )
 
+        is_windows_remote_auth = (
+            _get_os_category(system.os) == "windows"
+            and logon_type == 3
+            and auth_source_ip not in {"", "-", system.ip}
+        )
+        if is_windows_remote_auth:
+            emit_probability = float(failed_profile.get("emit_network_probability", 0.0))
+            emit_transport = emit_probability > 0 and rng.random() <= emit_probability
+            remote_request = WindowsRemoteAuthenticationRequest(
+                target_system=system,
+                time=time,
+                source_ip=auth_source_ip,
+                source_port=int(failed_profile["source_port"]),
+                logon_type=logon_type,
+                auth_protocol=str(failed_profile["auth_package"]),
+                outcome="failure",
+                destination_port=int(failed_profile.get("network_port", 445)),
+                source_system=self._ip_to_system.get(auth_source_ip),
+                emit_transport=emit_transport,
+            )
+            remote_planner = WindowsRemoteAuthenticationPlanner(self)
+            remote_authentication_plan = (
+                WindowsRemoteAuthenticationActionBundle(self, remote_request).execute()
+                if emit_transport
+                else remote_planner.without_transport(remote_request)
+            )
+            event.remote_auth = remote_authentication_plan
+            primary_transport = remote_authentication_plan.primary_transport
+            event.lifecycle = ActionLifecycleContext(
+                group_id=remote_authentication_plan.stable_id,
+                canonical_start=(
+                    primary_transport.started_at if primary_transport is not None else time
+                ),
+                phase="dependent",
+            )
+
         # Attach SyslogContext for Linux local auth failures. Remote SSH failures
         # emit a tuple-scoped sshd lifecycle below so "Connection from" can
         # precede authentication results and share the transport responder PID.
@@ -9908,15 +9976,6 @@ class ActivityGenerator:
                     status="0x18",  # KDC_ERR_PREAUTH_FAILED
                     emit_connection=True,
                 )
-
-        self._maybe_emit_failed_logon_network_connection(
-            system=system,
-            time=time,
-            logon_type=logon_type,
-            source_ip=source_ip,
-            profile=failed_profile,
-            rng=rng,
-        )
 
         logger.debug(f"Generated failed logon: {user.username} on {system.hostname}")
 
@@ -10196,41 +10255,6 @@ class ActivityGenerator:
                 facility=10,
                 severity=severity,
             )
-
-    def _maybe_emit_failed_logon_network_connection(
-        self,
-        system: System,
-        time: datetime,
-        logon_type: int,
-        source_ip: str,
-        profile: dict[str, Any],
-        rng: random.Random,
-    ) -> None:
-        """Emit visible network evidence for remote failed-auth attempts when appropriate."""
-        if logon_type != 3 or not source_ip or source_ip == "-":
-            return
-        if _get_os_category(system.os) != "windows":
-            return
-        probability = float(profile.get("emit_network_probability", 0.0))
-        if probability <= 0 or rng.random() > probability:
-            return
-        dst_port = int(profile.get("network_port", 445))
-        service = "smb" if dst_port == 445 else "rdp" if dst_port == 3389 else None
-        self.generate_connection(
-            src_ip=source_ip,
-            dst_ip=system.ip,
-            time=time - timedelta(milliseconds=rng.randint(20, 250)),
-            dst_port=dst_port,
-            proto="tcp",
-            service=service,
-            duration=rng.uniform(0.02, 1.5),
-            orig_bytes=rng.randint(120, 900),
-            resp_bytes=rng.randint(0, 500),
-            src_port=int(
-                profile.get("source_port") or _ephemeral_port(rng, self._os_for_ip(source_ip))
-            ),
-            conn_state=rng.choices(["SF", "RSTR"], weights=[70, 30], k=1)[0],
-        )
 
     def _is_known_failed_logon_account(self, username: str, actor: User) -> bool:
         """Return whether a failed-logon target is a known account in this scenario."""
@@ -20734,6 +20758,33 @@ class ActivityGenerator:
             time=tgs_time,
             source_port=source_port,
         )
+        target_system = self._ip_to_system.get(dc_ip)
+        if target_system is None:
+            target_system = System(
+                hostname=dc_hostname,
+                ip=dc_ip,
+                os="Windows Server 2022",
+                type="domain_controller",
+            )
+        remote_request = WindowsRemoteAuthenticationRequest(
+            target_system=target_system,
+            time=time,
+            source_ip=source_ip,
+            source_port=source_port,
+            logon_type=3,
+            auth_protocol="Kerberos",
+            outcome="success",
+            destination_port=88,
+            source_system=self._ip_to_system.get(source_ip),
+            session_object_id=session_obj_id,
+            logon_id=logon_id,
+            transport_role="kerberos_validation",
+            source="machine_account_logon",
+        )
+        remote_authentication_plan = WindowsRemoteAuthenticationActionBundle(
+            self,
+            remote_request,
+        ).execute()
         event = SecurityEvent(
             timestamp=time,
             event_type="machine_logon",
@@ -20755,8 +20806,9 @@ class ActivityGenerator:
                 subject_logon_id="0x3e7",
             ),
             edr=EdrContext(object_id=session_obj_id),
+            remote_auth=remote_authentication_plan,
             lifecycle=ActionLifecycleContext(
-                group_id=request.stable_id,
+                group_id=remote_authentication_plan.stable_id,
                 canonical_start=time,
                 phase="start",
             ),
@@ -20777,26 +20829,12 @@ class ActivityGenerator:
             ),
             edr=EdrContext(object_id=session_obj_id),
             lifecycle=ActionLifecycleContext(
-                group_id=request.stable_id,
+                group_id=remote_authentication_plan.stable_id,
                 canonical_start=time,
                 phase="closure",
             ),
         )
         self.dispatcher.dispatch(logoff_event)
-
-        # Also generate the Kerberos network connection to DC
-        self.generate_connection(
-            src_ip=source_ip,
-            dst_ip=dc_ip,
-            time=time,
-            dst_port=88,
-            proto="tcp",
-            service="kerberos",
-            duration=rng.uniform(0.001, 0.03),
-            orig_bytes=rng.randint(200, 1000),
-            resp_bytes=rng.randint(200, 1500),
-            src_port=source_port,
-        )
 
     def generate_kerberos_tgt(
         self,
@@ -21513,6 +21551,8 @@ class ActivityGenerator:
         protocol: str,
         pid: int = 4,
         application: str | None = None,
+        transport_transaction_id: str = "",
+        parent_action_group_id: str | None = None,
     ) -> None:
         """Generate WFP connection permitted event (5156) on Windows host.
 
@@ -21574,6 +21614,16 @@ class ActivityGenerator:
                 initiating_pid=pid,
             ),
             process=process,
+            lifecycle=(
+                ActionLifecycleContext(
+                    group_id=transport_transaction_id,
+                    canonical_start=time,
+                    phase="dependent",
+                    parent_group_id=parent_action_group_id,
+                )
+                if transport_transaction_id and parent_action_group_id
+                else None
+            ),
         )
         self.dispatcher.dispatch(event)
 
@@ -24576,42 +24626,6 @@ class ActivityGenerator:
         if not isinstance(privileges, list) or not privileges:
             privileges = ["SeChangeNotifyPrivilege"]
         return "\n\t\t\t".join(str(privilege) for privilege in privileges)
-
-    def _maybe_emit_remote_logon_network_connection(
-        self,
-        system: System,
-        time: datetime,
-        logon_type: int,
-        source_ip: str | None,
-        source_port: int,
-        auth_package: str,
-    ) -> None:
-        """Emit established network evidence for remote Windows logons when needed."""
-        if logon_type not in (3, 10):
-            return
-        if not source_ip or source_ip == "-" or source_port <= 0:
-            return
-        source_ip = source_ip.removeprefix("::ffff:")
-        if source_ip == system.ip:
-            return
-        if _get_os_category(system.os) != "windows":
-            return
-        rng = _get_rng()
-        dst_port = 3389 if logon_type == 10 else 445
-        service = "rdp" if dst_port == 3389 else "smb"
-        self.generate_connection(
-            src_ip=source_ip,
-            dst_ip=system.ip,
-            time=time - timedelta(milliseconds=rng.randint(150, 900)),
-            dst_port=dst_port,
-            proto="tcp",
-            service=service,
-            duration=rng.uniform(1.5, 45.0) if auth_package != "NTLM" else rng.uniform(0.4, 8.0),
-            orig_bytes=rng.randint(700, 6500),
-            resp_bytes=rng.randint(900, 12000),
-            src_port=source_port,
-            conn_state="SF",
-        )
 
     def _get_system_pid(self, hostname: str, role: str, fallback: int) -> int:
         """Get a seeded system process PID by role name."""

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -31,8 +31,13 @@ from evidenceforge.events.contexts import HostContext, NetworkContext
 from evidenceforge.events.identity import ProcessIdentity, ThreadIdentity
 from evidenceforge.generation.activity.timing_profiles import get_timing_window
 from evidenceforge.generation.emitters.host_base import HostMultiplexEmitter
-from evidenceforge.generation.source_timing import SourceTimingPlanner
-from evidenceforge.utils.rng import _stable_seed, stable_uuid
+from evidenceforge.generation.source_timing import (
+    SourceTimingPlanner,
+    ecar_flow_identity_key,
+    ecar_flow_render_key,
+    ecar_session_render_key,
+)
+from evidenceforge.utils.rng import stable_uuid
 
 _ECAR_SORT_PRIORITY = {
     ("USER_SESSION", "LOGIN"): 0,
@@ -461,31 +466,13 @@ class EcarEmitter(HostMultiplexEmitter):
         lifecycle: str,
     ) -> datetime:
         """Return the eCAR render timestamp for a user-session observation."""
-        if lifecycle == "logout":
+        plan = event.source_timing
+        if plan is None:
             return event.timestamp
-        auth = event.auth
-        edr = event.edr
-        canonical_timestamp = (
-            event.source_timing.canonical_timestamp
-            if event.source_timing is not None
-            else event.timestamp
+        return plan.finalized_times.get(
+            ecar_session_render_key(lifecycle),
+            event.timestamp,
         )
-        timestamp = _SOURCE_TIMING.source_time(
-            event,
-            "source.ecar_session",
-            seed_parts=(
-                lifecycle,
-                self._host_name(host),
-                getattr(auth, "username", ""),
-                getattr(auth, "source_ip", ""),
-                getattr(auth, "source_port", ""),
-                getattr(auth, "logon_id", ""),
-                getattr(auth, "logon_type", ""),
-                getattr(edr, "object_id", ""),
-                canonical_timestamp,
-            ),
-        )
-        return timestamp
 
     def _render_process_create(self, event: SecurityEvent) -> None:
         """Render eCAR PROCESS/CREATE event (logged on src_host)."""
@@ -763,203 +750,24 @@ class EcarEmitter(HostMultiplexEmitter):
         drop_late_process_identity: bool = False,
         paired_endpoint: bool = False,
     ) -> tuple[datetime, bool]:
-        """Return a FLOW timestamp bounded by the canonical connection interval.
+        """Return the dispatcher-finalized FLOW time and identity decision."""
 
-        If a very short connection cannot also satisfy source-visible process-create
-        ordering, omit the process identity from that FLOW row instead of moving the
-        endpoint observation after the network close.
-        """
-
-        interval_start, not_after = self._flow_interval(event, seed_parts)
-        lifecycle = event.lifecycle
-        if (
-            lifecycle is not None
-            and lifecycle.parent_group_id is not None
-            and lifecycle.parent_group_id.startswith("proxy-transaction-")
-        ):
-            host_key = str(seed_parts[1]) if len(seed_parts) > 1 else ""
-            flow_time = _SOURCE_TIMING.lifecycle_child_source_time(
-                event,
-                "source.ecar_flow",
-                host_key=host_key,
-                seed_parts=seed_parts,
-                within=(interval_start, not_after) if not_after is not None else None,
-            )
-            if flow_time is not None:
-                process_identity_safe = not_before is None or not_before <= flow_time
-                return flow_time, process_identity_safe
-        if drop_late_process_identity and not_before is not None:
-            flow_time = _SOURCE_TIMING.source_time(
-                event,
-                "source.ecar_flow",
-                seed_parts=seed_parts,
-                within=(interval_start, not_after) if not_after is not None else None,
-            )
-            flow_time = self._paired_flow_observation_time(
-                event,
-                flow_time,
-                seed_parts=seed_parts,
-                interval_start=interval_start,
-                not_before=None,
-                not_after=not_after,
-                enabled=paired_endpoint,
-            )
-            if not_before > flow_time:
-                return flow_time, False
-            return flow_time, True
-
-        process_identity_safe = not_before is None or not_after is None or not_before <= not_after
-        flow_time = _SOURCE_TIMING.source_time(
-            event,
-            "source.ecar_flow",
-            seed_parts=seed_parts,
-            not_before=not_before if process_identity_safe else None,
-            within=(interval_start, not_after) if not_after is not None else None,
-        )
-        flow_time = self._paired_flow_observation_time(
-            event,
-            flow_time,
-            seed_parts=seed_parts,
-            interval_start=interval_start,
-            not_before=not_before if process_identity_safe else None,
-            not_after=not_after,
-            enabled=paired_endpoint,
-        )
-        if process_identity_safe and not_before is not None and flow_time < not_before:
-            process_identity_safe = False
-        return (
-            flow_time,
-            process_identity_safe,
-        )
-
-    @staticmethod
-    def _paired_flow_observation_time(
-        event: SecurityEvent,
-        timestamp: datetime,
-        *,
-        seed_parts: tuple[Any, ...],
-        interval_start: datetime,
-        not_before: datetime | None,
-        not_after: datetime | None,
-        enabled: bool,
-    ) -> datetime:
-        """Add host-local texture to paired endpoint FLOW observations."""
-        if not enabled:
-            return timestamp
-        if not_after is None:
-            return EcarEmitter._unbounded_paired_flow_observation_time(
-                event,
-                seed_parts=seed_parts,
-                not_before=not_before,
-            )
-
-        short_interval = not_after <= interval_start + timedelta(milliseconds=5)
-        lower_bound = not_before
-        if not short_interval and not_after > interval_start:
-            lower_bound = (
-                interval_start if lower_bound is None else max(lower_bound, interval_start)
-            )
-        min_offset_ms = EcarEmitter._flow_min_endpoint_offset_ms(event, seed_parts)
-        if min_offset_ms > 0:
-            min_observation_time = interval_start + timedelta(milliseconds=min_offset_ms)
-            if min_observation_time <= not_after:
-                lower_bound = (
-                    min_observation_time
-                    if lower_bound is None
-                    else max(lower_bound, min_observation_time)
-                )
-
-        seed = _stable_seed(
-            "ecar_paired_flow_observation:"
-            + ":".join(str(part) for part in (*seed_parts, event.timestamp.isoformat()))
-        )
+        del drop_late_process_identity, paired_endpoint
         direction = str(seed_parts[0]) if seed_parts else ""
-        if short_interval and direction == "inbound":
-            min_jitter_ms = 22
-            max_jitter_ms = 55
-        elif short_interval and direction == "outbound":
-            min_jitter_ms = 1
-            max_jitter_ms = 16
-        elif direction == "inbound":
-            min_jitter_ms = 75
-            max_jitter_ms = 540
-        elif direction == "outbound":
-            min_jitter_ms = 12
-            max_jitter_ms = 220
-        else:
-            min_jitter_ms = 12
-            max_jitter_ms = 360
-
-        jitter_ms = min_jitter_ms + (seed % (max_jitter_ms - min_jitter_ms + 1))
-        candidate = timestamp - timedelta(milliseconds=jitter_ms)
-        if lower_bound is not None and candidate < lower_bound:
-            available_ms = int((timestamp - lower_bound).total_seconds() * 1000)
-            if available_ms <= 0:
-                return timestamp
-            if available_ms < min_jitter_ms:
-                if direction == "inbound" and available_ms >= 4:
-                    slice_min_ms = max(1, (available_ms * 2) // 3)
-                    slice_max_ms = available_ms
-                elif direction == "outbound" and available_ms >= 4:
-                    slice_min_ms = 1
-                    slice_max_ms = max(1, available_ms // 3)
-                else:
-                    slice_min_ms = 1
-                    slice_max_ms = available_ms
-                bounded_jitter_ms = slice_min_ms + (seed % (slice_max_ms - slice_min_ms + 1))
-            else:
-                bounded_jitter_ms = min_jitter_ms + (seed % (available_ms - min_jitter_ms + 1))
-            candidate = timestamp - timedelta(milliseconds=bounded_jitter_ms)
-        if not_after is not None and candidate > not_after:
-            return not_after
-        return candidate
-
-    @staticmethod
-    def _unbounded_paired_flow_observation_time(
-        event: SecurityEvent,
-        *,
-        seed_parts: tuple[Any, ...],
-        not_before: datetime | None,
-    ) -> datetime:
-        """Return coordinated host-local timing for paired FLOWs with no close bound."""
-        net = event.network
-        if net is None:
-            return event.timestamp
-
-        tuple_seed = _stable_seed(
-            "ecar_paired_flow_base:"
-            + ":".join(
-                str(part)
-                for part in (
-                    net.src_ip,
-                    net.src_port,
-                    net.dst_ip,
-                    net.dst_port,
-                    net.protocol,
-                    event.timestamp.isoformat(),
-                )
-            )
+        hostname = str(seed_parts[1]) if len(seed_parts) > 1 else ""
+        plan = event.source_timing
+        if plan is None:
+            timestamp = event.network.source_visible_start_time or event.timestamp
+            return timestamp, not_before is None or not_before <= timestamp
+        timestamp = plan.finalized_times.get(
+            ecar_flow_render_key(direction, hostname),
+            event.network.source_visible_start_time or event.timestamp,
         )
-        base_delay_ms = 220 + (tuple_seed % 900)
-
-        direction = str(seed_parts[0]) if seed_parts else ""
-        host = str(seed_parts[1]) if len(seed_parts) > 1 else ""
-        offset_seed = _stable_seed(
-            "ecar_paired_flow_host_offset:"
-            + ":".join(str(part) for part in (direction, host, *seed_parts))
+        identity_safe = plan.finalized_flags.get(
+            ecar_flow_identity_key(direction, hostname),
+            not_before is None or not_before <= timestamp,
         )
-        if direction == "inbound":
-            offset_ms = 300 + (offset_seed % 360)
-        elif direction == "outbound":
-            offset_ms = 20 + (offset_seed % 180)
-        else:
-            offset_ms = 80 + (offset_seed % 420)
-
-        candidate = event.timestamp + timedelta(milliseconds=base_delay_ms + offset_ms)
-        if not_before is not None and candidate < not_before:
-            gap_ms = 6 + (offset_seed % 180)
-            candidate = not_before + timedelta(milliseconds=gap_ms)
-        return candidate
+        return timestamp, identity_safe
 
     @staticmethod
     def _flow_identity_deadline(event: SecurityEvent) -> datetime:
@@ -973,56 +781,6 @@ class EcarEmitter(HostMultiplexEmitter):
             default_class="source_latency",
         )
         return event.timestamp + timedelta(milliseconds=window.max_ms + 1)
-
-    @staticmethod
-    def _flow_interval(
-        event: SecurityEvent,
-        seed_parts: tuple[Any, ...],
-    ) -> tuple[datetime, datetime | None]:
-        """Return the finalized canonical interval for an endpoint FLOW observation."""
-
-        net = event.network
-        if net is None:
-            return event.timestamp, None
-        start_time = net.source_visible_start_time or event.timestamp
-        if net.duration is None:
-            if net.conn_state in {"S0", "REJ", "RSTO", "RSTR", "SH", "SHR"}:
-                seed = _stable_seed(
-                    "ecar_failed_flow_not_after:"
-                    + ":".join(str(part) for part in (*seed_parts, start_time.isoformat()))
-                )
-                return start_time, start_time + timedelta(milliseconds=45 + (seed % 620))
-            return start_time, None
-        close_time = net.source_visible_close_time or (
-            start_time + timedelta(seconds=max(0.0, net.duration))
-        )
-        if close_time <= start_time:
-            return start_time, close_time
-        duration_us = int((close_time - start_time).total_seconds() * 1_000_000)
-        seed = _stable_seed("ecar_flow_not_after:" + ":".join(str(part) for part in seed_parts))
-        margin_us = 1000 + (seed % 4000)
-        if duration_us <= margin_us:
-            margin_us = max(0, duration_us // 2)
-        return start_time, close_time - timedelta(microseconds=margin_us)
-
-    @staticmethod
-    def _flow_min_endpoint_offset_ms(event: SecurityEvent, seed_parts: tuple[Any, ...]) -> int:
-        """Return minimum FLOW observation separation from the network timestamp."""
-        net = event.network
-        if net is None:
-            return 0
-        applies = False
-        if net.duration is None:
-            applies = net.conn_state in {"S0", "REJ", "RSTO", "RSTR", "SH", "SHR"}
-        else:
-            applies = 0 <= net.duration < 0.1
-        if not applies:
-            return 0
-        seed = _stable_seed(
-            "ecar_flow_min_endpoint_offset:"
-            + ":".join(str(part) for part in (*seed_parts, event.timestamp.isoformat()))
-        )
-        return 18 + (seed % 65)
 
     @staticmethod
     def _flow_connection_failed(net: NetworkContext | None) -> bool:

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -116,6 +116,23 @@ def _ecar_flow_endpoint_properties(
     return properties
 
 
+def _ecar_remote_auth_transport_properties(event: SecurityEvent) -> dict[str, Any]:
+    """Return the exact primary transport view for a remote authentication."""
+
+    remote_auth = event.remote_auth
+    transport = remote_auth.primary_transport if remote_auth is not None else None
+    if transport is None:
+        return {}
+    tuple_view = transport.tuple
+    return {
+        "src_ip": tuple_view.src_ip,
+        "src_port": tuple_view.src_port,
+        "dst_ip": tuple_view.dst_ip,
+        "dst_port": tuple_view.dst_port,
+        "protocol": tuple_view.protocol,
+    }
+
+
 def _ecar_non_windows_session_type(event: SecurityEvent) -> str:
     """Return an OS-native session label for non-Windows eCAR sessions."""
     if event.event_type == "ssh_session":
@@ -402,6 +419,7 @@ class EcarEmitter(HostMultiplexEmitter):
         }
         if event_data["src_ip"] != "-" and event.auth.source_port:
             event_data["src_port"] = event.auth.source_port
+        event_data.update(_ecar_remote_auth_transport_properties(event))
         if getattr(host, "os_category", "") == "windows":
             event_data["logon_type"] = event.auth.logon_type
         else:
@@ -456,6 +474,7 @@ class EcarEmitter(HostMultiplexEmitter):
             event_data["sub_status"] = event.auth.failure_substatus
         else:
             event_data["session_type"] = _ecar_non_windows_session_type(event)
+        event_data.update(_ecar_remote_auth_transport_properties(event))
         self._apply_edr_context(event_data, event)
         self._emit_canonical_event(event_data, event)
 

--- a/src/evidenceforge/generation/emitters/windows.py
+++ b/src/evidenceforge/generation/emitters/windows.py
@@ -2303,7 +2303,6 @@ class WindowsEventEmitter(LogEmitter):
         if self._spooled_count:
             self._spool_event_dicts_unlocked()
             self._shift_spooled_kerberos_tgts_before_service_tickets_unlocked()
-            self._shift_spooled_network_logons_after_transport_unlocked()
             self._shift_spooled_process_creates_after_logons_unlocked()
             self._shift_spooled_process_creates_after_visible_parent_unlocked()
             self._shift_spooled_process_dependents_after_create_unlocked()
@@ -2313,7 +2312,6 @@ class WindowsEventEmitter(LogEmitter):
             events = self._iter_spooled_events_unlocked()
         else:
             self._shift_kerberos_tgts_before_service_tickets()
-            self._shift_network_logons_after_transport()
             self._shift_process_creates_after_logons()
             self._shift_process_creates_after_visible_parent()
             self._shift_process_dependents_after_create()

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -814,6 +814,16 @@ def _session_activity_deadline(
     if logoff_time is not None:
         deadline = min(deadline, logoff_time)
 
+    end_plan = getattr(session, "end_plan", None)
+    if end_plan is not None:
+        canonical_end = end_plan.canonical_end
+        canonical_end = (
+            canonical_end.replace(tzinfo=UTC)
+            if canonical_end.tzinfo is None
+            else canonical_end.astimezone(UTC)
+        )
+        deadline = min(deadline, canonical_end)
+
     network_close_time = getattr(session, "network_close_time", None)
     if network_close_time is not None:
         network_close_time = (
@@ -6088,6 +6098,7 @@ class BaselineMixin:
         self,
         target_system: System,
         rng: random.Random,
+        at_time: datetime | None = None,
     ) -> tuple[User, System] | None:
         """Pick a baseline SSH user and source host that agree with each other."""
         roster = self._get_baseline_ssh_users(target_system)
@@ -6095,8 +6106,18 @@ class BaselineMixin:
             return None
         for user in rng.sample(roster, k=len(roster)):
             source_system = self._baseline_ssh_source_system_for_user(user, target_system, rng)
-            if source_system is not None:
-                return user, source_system
+            if source_system is None:
+                continue
+            if (
+                at_time is not None
+                and self.state_manager.authoritative_session_end_blocks_rebootstrap(
+                    user.username,
+                    source_system.hostname,
+                    at_time,
+                )
+            ):
+                continue
+            return user, source_system
         return None
 
     def _linux_remote_admin_hour_probability(self, system: Any) -> float:
@@ -6318,6 +6339,21 @@ class BaselineMixin:
             logon_kwargs["source_port"] = source_port
         if not emit_network_evidence:
             logon_kwargs["emit_network_evidence"] = False
+            transaction_matcher = getattr(
+                self.activity_generator,
+                "_last_effective_connection_transaction_id",
+                None,
+            )
+            if transaction_matcher is not None and source_port is not None:
+                transaction_id = transaction_matcher(
+                    src_ip=source_ip,
+                    src_port=source_port,
+                    dst_ip=file_server.ip,
+                    dst_port=445,
+                    proto="tcp",
+                )
+                if isinstance(transaction_id, str) and transaction_id:
+                    logon_kwargs["remote_authentication_transport_id"] = transaction_id
 
         logon_id = self.activity_generator.generate_logon(
             **logon_kwargs,
@@ -8138,12 +8174,12 @@ class BaselineMixin:
 
                     num_ssh = self._linux_remote_admin_session_count(rng, system)
                     for _ in range(num_ssh):
-                        ssh_identity = self._pick_baseline_ssh_identity(system, rng)
+                        offset = rng.uniform(0, 3599)
+                        ts = current_hour + timedelta(seconds=offset)
+                        ssh_identity = self._pick_baseline_ssh_identity(system, rng, at_time=ts)
                         if ssh_identity is None:
                             continue
                         ssh_user, source_system = ssh_identity
-                        offset = rng.uniform(0, 3599)
-                        ts = current_hour + timedelta(seconds=offset)
                         hour_end = current_hour + timedelta(hours=1)
                         self.state_manager.set_current_time(ts)
                         self.world_planner.bootstrap_user_session(
@@ -8732,7 +8768,7 @@ class BaselineMixin:
                             facility=10,
                         )
                 elif source_roll < 0.32 + _LINUX_AMBIENT_SSH_NOISE_BAND and sys_type == "server":
-                    ssh_identity = self._pick_baseline_ssh_identity(system, rng)
+                    ssh_identity = self._pick_baseline_ssh_identity(system, rng, at_time=ts)
                     if ssh_identity is None:
                         continue
                     ssh_user_model, src_sys_obj = ssh_identity

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -3960,7 +3960,7 @@ class StorylineMixin:
                             actor,
                             dst_sys,
                             source_ip,
-                            time,
+                            connection_time,
                             rng,
                             source_port=smb_source_port,
                             emit_network_evidence=smb_source_port is None,

--- a/src/evidenceforge/generation/source_timing.py
+++ b/src/evidenceforge/generation/source_timing.py
@@ -76,6 +76,8 @@ def ecar_flow_identity_key(direction: str, hostname: str) -> str:
 
 _WINDOWS_WFP_RENDER_KEY = "windows.wfp_connection"
 _REMOTE_TRANSPORT_KEY = tuple[str, str, str, str, int, str, int, str]
+_TRANSACTION_TRANSPORT_KEY = tuple[str, str, str, int, str, int, str]
+_SSH_TRANSPORT_KEY = tuple[str, str, int, str, int, str]
 
 
 class SourceTimingPlanner:
@@ -87,6 +89,11 @@ class SourceTimingPlanner:
         self._latest_session_dependent_times: dict[tuple[str, str], datetime] = {}
         self._admitted_ecar_remote_transports: dict[_REMOTE_TRANSPORT_KEY, datetime] = {}
         self._admitted_windows_remote_transports: dict[_REMOTE_TRANSPORT_KEY, datetime] = {}
+        self._admitted_ecar_transport_transactions: dict[_TRANSACTION_TRANSPORT_KEY, datetime] = {}
+        self._admitted_windows_transport_transactions: dict[
+            _TRANSACTION_TRANSPORT_KEY, datetime
+        ] = {}
+        self._admitted_ecar_ssh_transports: dict[_SSH_TRANSPORT_KEY, datetime] = {}
 
     def plan_event(
         self,
@@ -122,8 +129,75 @@ class SourceTimingPlanner:
     ) -> None:
         """Publish an admitted transport anchor for later authentication siblings."""
 
-        lifecycle = event.lifecycle
         network = event.network
+        lifecycle = event.lifecycle
+        if (
+            format_name == "ecar"
+            and event.event_type == "connection"
+            and network is not None
+            and network.transaction is not None
+            and event.dst_host is not None
+        ):
+            timestamp = self._finalized_time(
+                event,
+                ecar_flow_render_key("inbound", event.dst_host.hostname),
+            )
+            if timestamp is not None:
+                self._admitted_ecar_transport_transactions[
+                    self._transaction_transport_key(
+                        network.transaction.stable_id,
+                        event.dst_host.hostname,
+                        network.src_ip,
+                        network.src_port,
+                        network.dst_ip,
+                        network.dst_port,
+                        network.protocol,
+                    )
+                ] = timestamp
+        if (
+            format_name in {"windows_security", "windows_event_security"}
+            and event.event_type == "wfp_connection"
+            and network is not None
+            and lifecycle is not None
+        ):
+            host = event.src_host or event.dst_host
+            timestamp = self._finalized_time(event, _WINDOWS_WFP_RENDER_KEY)
+            if host is not None and timestamp is not None:
+                self._admitted_windows_transport_transactions[
+                    self._transaction_transport_key(
+                        lifecycle.group_id,
+                        host.hostname,
+                        network.src_ip,
+                        network.src_port,
+                        network.dst_ip,
+                        network.dst_port,
+                        network.protocol,
+                    )
+                ] = timestamp
+        if (
+            format_name == "ecar"
+            and event.event_type == "connection"
+            and network is not None
+            and network.protocol.lower() == "tcp"
+            and network.dst_port == 22
+            and event.dst_host is not None
+        ):
+            timestamp = self._finalized_time(
+                event,
+                ecar_flow_render_key("inbound", event.dst_host.hostname),
+            )
+            if timestamp is not None:
+                self._admitted_ecar_ssh_transports[
+                    self._ssh_transport_key(
+                        event.dst_host.hostname,
+                        network.src_ip,
+                        network.src_port,
+                        network.dst_ip,
+                        network.dst_port,
+                        network.protocol,
+                    )
+                ] = timestamp
+
         if lifecycle is None or network is None or lifecycle.parent_group_id is None:
             return
         if not lifecycle.parent_group_id.startswith("windows-remote-auth-"):
@@ -222,6 +296,7 @@ class SourceTimingPlanner:
         anchor = self._remote_auth_transport_anchor(
             event,
             self._admitted_ecar_remote_transports,
+            self._admitted_ecar_transport_transactions,
         )
         if anchor is not None:
             timestamp = anchor + sample_timing_delta(
@@ -233,6 +308,23 @@ class SourceTimingPlanner:
                     lifecycle,
                 ),
             )
+        elif event.event_type == "ssh_session":
+            ssh_anchor = self._ssh_transport_anchor(event)
+            if ssh_anchor is not None:
+                timestamp = max(
+                    timestamp,
+                    ssh_anchor
+                    + sample_timing_delta(
+                        "source.ecar_ssh_session_after_accept",
+                        seed_parts=(
+                            "flow_order",
+                            getattr(host, "hostname", ""),
+                            getattr(event.auth, "source_ip", ""),
+                            getattr(event.auth, "source_port", ""),
+                            canonical_timestamp,
+                        ),
+                    ),
+                )
         plan.finalized_times[ecar_session_render_key(lifecycle)] = timestamp
 
     def _plan_windows_remote_auth_time(self, event: SecurityEvent) -> SecurityEvent:
@@ -264,6 +356,7 @@ class SourceTimingPlanner:
         anchor = self._remote_auth_transport_anchor(
             event,
             self._admitted_windows_remote_transports,
+            self._admitted_windows_transport_transactions,
         )
         if anchor is None:
             return event
@@ -279,19 +372,33 @@ class SourceTimingPlanner:
         self._ensure_plan(event).finalized_times["windows.remote_authentication"] = timestamp
         return replace(event, timestamp=timestamp)
 
-    @staticmethod
     def _remote_auth_transport_anchor(
+        self,
         event: SecurityEvent,
         registry: dict[_REMOTE_TRANSPORT_KEY, datetime],
+        transaction_registry: dict[_TRANSACTION_TRANSPORT_KEY, datetime],
     ) -> datetime | None:
         remote_auth = event.remote_auth
         if remote_auth is None or remote_auth.primary_transport is None:
             return None
         transport = remote_auth.primary_transport
         tuple_view = transport.tuple
-        return registry.get(
+        action_anchor = registry.get(
             SourceTimingPlanner._remote_transport_key(
                 remote_auth.stable_id,
+                transport.transaction_id,
+                remote_auth.target_hostname,
+                tuple_view.src_ip,
+                tuple_view.src_port,
+                tuple_view.dst_ip,
+                tuple_view.dst_port,
+                tuple_view.protocol,
+            )
+        )
+        if action_anchor is not None:
+            return action_anchor
+        return transaction_registry.get(
+            self._transaction_transport_key(
                 transport.transaction_id,
                 remote_auth.target_hostname,
                 tuple_view.src_ip,
@@ -318,6 +425,66 @@ class SourceTimingPlanner:
         return (
             action_group_id,
             transaction_id,
+            target_hostname,
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+            protocol.lower(),
+        )
+
+    @staticmethod
+    def _transaction_transport_key(
+        transaction_id: str,
+        target_hostname: str,
+        src_ip: str,
+        src_port: int,
+        dst_ip: str,
+        dst_port: int,
+        protocol: str,
+    ) -> _TRANSACTION_TRANSPORT_KEY:
+        """Return an exact source-view key independent of the parent bundle."""
+
+        return (
+            transaction_id,
+            target_hostname,
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+            protocol.lower(),
+        )
+
+    def _ssh_transport_anchor(self, event: SecurityEvent) -> datetime | None:
+        """Return the admitted exact-tuple SSH FLOW time for a session event."""
+
+        auth = event.auth
+        host = event.dst_host or event.src_host
+        if auth is None or host is None or not auth.source_ip or auth.source_port <= 0:
+            return None
+        return self._admitted_ecar_ssh_transports.get(
+            self._ssh_transport_key(
+                host.hostname,
+                auth.source_ip,
+                auth.source_port,
+                host.ip,
+                22,
+                "tcp",
+            )
+        )
+
+    @staticmethod
+    def _ssh_transport_key(
+        target_hostname: str,
+        src_ip: str,
+        src_port: int,
+        dst_ip: str,
+        dst_port: int,
+        protocol: str,
+    ) -> _SSH_TRANSPORT_KEY:
+        """Return the exact target-view key for one admitted SSH transport."""
+
+        return (
             target_hostname,
             src_ip,
             src_port,

--- a/src/evidenceforge/generation/source_timing.py
+++ b/src/evidenceforge/generation/source_timing.py
@@ -52,6 +52,30 @@ class SourceTimingPlan:
     canonical_timestamp: datetime
     clock_profile_name: str = "complete"
     source_times: dict[str, datetime] = field(default_factory=dict)
+    finalized_times: dict[str, datetime] = field(default_factory=dict)
+    finalized_flags: dict[str, bool] = field(default_factory=dict)
+
+
+def ecar_flow_render_key(direction: str, hostname: str) -> str:
+    """Return the finalized-plan key for one host-local eCAR FLOW row."""
+
+    return f"ecar.flow.{direction.lower()}.{hostname}"
+
+
+def ecar_session_render_key(lifecycle: str) -> str:
+    """Return the finalized-plan key for one eCAR USER_SESSION row."""
+
+    return f"ecar.session.{lifecycle}"
+
+
+def ecar_flow_identity_key(direction: str, hostname: str) -> str:
+    """Return the finalized-plan key for FLOW process-attribution safety."""
+
+    return f"ecar.flow_identity_safe.{direction.lower()}.{hostname}"
+
+
+_WINDOWS_WFP_RENDER_KEY = "windows.wfp_connection"
+_REMOTE_TRANSPORT_KEY = tuple[str, str, str, str, int, str, int, str]
 
 
 class SourceTimingPlanner:
@@ -61,6 +85,8 @@ class SourceTimingPlanner:
         self.clock_profile_name = clock_profile_name or "complete"
         self._ecar_process_create_times: dict[str, datetime] = {}
         self._latest_session_dependent_times: dict[tuple[str, str], datetime] = {}
+        self._admitted_ecar_remote_transports: dict[_REMOTE_TRANSPORT_KEY, datetime] = {}
+        self._admitted_windows_remote_transports: dict[_REMOTE_TRANSPORT_KEY, datetime] = {}
 
     def plan_event(
         self,
@@ -71,9 +97,567 @@ class SourceTimingPlanner:
         self._ensure_plan(event)
         if format_name in {None, "ecar"}:
             self._plan_ecar_identity_times(event)
+        if format_name == "ecar":
+            self._plan_ecar_render_times(event)
+        if format_name in {"windows_security", "windows_event_security"}:
+            event = self._plan_windows_remote_auth_time(event)
         if format_name is not None:
             event = self._plan_session_lifecycle_time(event, format_name)
         return event
+
+    def initialize_event(self, event: SecurityEvent) -> None:
+        """Retain canonical time before source observation delay is applied.
+
+        Initialization deliberately does not plan identities or render timestamps;
+        those decisions belong to the visible source path selected by the
+        dispatcher.
+        """
+
+        self._ensure_plan(event)
+
+    def record_admitted_source_event(
+        self,
+        event: SecurityEvent,
+        format_name: str,
+    ) -> None:
+        """Publish an admitted transport anchor for later authentication siblings."""
+
+        lifecycle = event.lifecycle
+        network = event.network
+        if lifecycle is None or network is None or lifecycle.parent_group_id is None:
+            return
+        if not lifecycle.parent_group_id.startswith("windows-remote-auth-"):
+            return
+        target_host = event.dst_host or event.src_host
+        target_hostname = getattr(target_host, "hostname", "")
+        if not target_hostname:
+            return
+        if event.event_type == "connection" and network.transaction is not None:
+            transaction_id = network.transaction.stable_id
+            if format_name == "ecar" and event.dst_host is not None:
+                timestamp = self._finalized_time(
+                    event,
+                    ecar_flow_render_key("inbound", event.dst_host.hostname),
+                )
+                if timestamp is not None:
+                    self._admitted_ecar_remote_transports[
+                        self._remote_transport_key(
+                            lifecycle.parent_group_id,
+                            transaction_id,
+                            target_hostname,
+                            network.src_ip,
+                            network.src_port,
+                            network.dst_ip,
+                            network.dst_port,
+                            network.protocol,
+                        )
+                    ] = timestamp
+            return
+        if event.event_type != "wfp_connection" or format_name not in {
+            "windows_security",
+            "windows_event_security",
+        }:
+            return
+        host = event.src_host or event.dst_host
+        if host is None or network.dst_ip != host.ip:
+            return
+        timestamp = self._finalized_time(event, _WINDOWS_WFP_RENDER_KEY)
+        if timestamp is not None:
+            self._admitted_windows_remote_transports[
+                self._remote_transport_key(
+                    lifecycle.parent_group_id,
+                    lifecycle.group_id,
+                    host.hostname,
+                    network.src_ip,
+                    network.src_port,
+                    network.dst_ip,
+                    network.dst_port,
+                    network.protocol,
+                )
+            ] = timestamp
+
+    def _plan_ecar_render_times(self, event: SecurityEvent) -> None:
+        """Finalize eCAR FLOW and USER_SESSION times before emitter admission."""
+
+        if event.event_type == "connection" and event.network is not None:
+            self._plan_ecar_flow_times(event)
+            return
+        if event.auth is None or event.event_type not in {
+            "logon",
+            "machine_logon",
+            "ssh_session",
+            "failed_logon",
+            "logoff",
+        }:
+            return
+        lifecycle = (
+            "logout"
+            if event.event_type == "logoff"
+            else "failed_login"
+            if event.event_type == "failed_logon"
+            else "login"
+        )
+        plan = self._ensure_plan(event)
+        if lifecycle == "logout":
+            plan.finalized_times[ecar_session_render_key(lifecycle)] = event.timestamp
+            return
+        host = event.dst_host or event.src_host
+        canonical_timestamp = plan.canonical_timestamp
+        seed_parts = (
+            lifecycle,
+            getattr(host, "hostname", ""),
+            getattr(event.auth, "username", ""),
+            getattr(event.auth, "source_ip", ""),
+            getattr(event.auth, "source_port", ""),
+            getattr(event.auth, "logon_id", ""),
+            getattr(event.auth, "logon_type", ""),
+            getattr(event.edr, "object_id", ""),
+            canonical_timestamp,
+        )
+        timestamp = self.source_time(
+            event,
+            "source.ecar_session",
+            seed_parts=seed_parts,
+        )
+        anchor = self._remote_auth_transport_anchor(
+            event,
+            self._admitted_ecar_remote_transports,
+        )
+        if anchor is not None:
+            timestamp = anchor + sample_timing_delta(
+                "windows.network_logon_after_transport",
+                seed_parts=(
+                    "ecar",
+                    event.remote_auth.stable_id,
+                    event.remote_auth.primary_transport.transaction_id,
+                    lifecycle,
+                ),
+            )
+        plan.finalized_times[ecar_session_render_key(lifecycle)] = timestamp
+
+    def _plan_windows_remote_auth_time(self, event: SecurityEvent) -> SecurityEvent:
+        """Finalize source-local WFP-before-authentication ordering."""
+
+        if event.event_type == "wfp_connection" and event.network is not None:
+            host = event.src_host or event.dst_host
+            timestamp = self.source_time(
+                event,
+                "source.windows_wfp_connection",
+                seed_parts=(
+                    getattr(host, "hostname", ""),
+                    event.network.initiating_pid if event.network.initiating_pid > 0 else 4,
+                    event.network.src_ip,
+                    event.network.src_port,
+                    event.network.dst_ip,
+                    event.network.dst_port,
+                    event.timestamp,
+                ),
+                not_before=event.timestamp,
+            )
+            self._ensure_plan(event).finalized_times[_WINDOWS_WFP_RENDER_KEY] = timestamp
+            return event
+        if (
+            event.event_type not in {"logon", "machine_logon", "failed_logon"}
+            or event.remote_auth is None
+        ):
+            return event
+        anchor = self._remote_auth_transport_anchor(
+            event,
+            self._admitted_windows_remote_transports,
+        )
+        if anchor is None:
+            return event
+        timestamp = anchor + sample_timing_delta(
+            "windows.network_logon_after_transport",
+            seed_parts=(
+                "windows_security",
+                event.remote_auth.stable_id,
+                event.remote_auth.primary_transport.transaction_id,
+                event.event_type,
+            ),
+        )
+        self._ensure_plan(event).finalized_times["windows.remote_authentication"] = timestamp
+        return replace(event, timestamp=timestamp)
+
+    @staticmethod
+    def _remote_auth_transport_anchor(
+        event: SecurityEvent,
+        registry: dict[_REMOTE_TRANSPORT_KEY, datetime],
+    ) -> datetime | None:
+        remote_auth = event.remote_auth
+        if remote_auth is None or remote_auth.primary_transport is None:
+            return None
+        transport = remote_auth.primary_transport
+        tuple_view = transport.tuple
+        return registry.get(
+            SourceTimingPlanner._remote_transport_key(
+                remote_auth.stable_id,
+                transport.transaction_id,
+                remote_auth.target_hostname,
+                tuple_view.src_ip,
+                tuple_view.src_port,
+                tuple_view.dst_ip,
+                tuple_view.dst_port,
+                tuple_view.protocol,
+            )
+        )
+
+    @staticmethod
+    def _remote_transport_key(
+        action_group_id: str,
+        transaction_id: str,
+        target_hostname: str,
+        src_ip: str,
+        src_port: int,
+        dst_ip: str,
+        dst_port: int,
+        protocol: str,
+    ) -> _REMOTE_TRANSPORT_KEY:
+        """Return the exact source-view key for one remote-auth transport."""
+
+        return (
+            action_group_id,
+            transaction_id,
+            target_hostname,
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+            protocol.lower(),
+        )
+
+    @staticmethod
+    def _finalized_time(event: SecurityEvent, key: str) -> datetime | None:
+        plan = event.source_timing
+        return plan.finalized_times.get(key) if plan is not None else None
+
+    def _plan_ecar_flow_times(self, event: SecurityEvent) -> None:
+        """Finalize every host-local FLOW timestamp and attribution decision."""
+
+        network = event.network
+        if network is None:
+            return
+        identity_plan = event.identity_plan
+        source_identity = (
+            identity_plan.actor
+            if identity_plan is not None and isinstance(identity_plan.actor, ProcessIdentity)
+            else None
+        )
+        target_identity = (
+            identity_plan.target
+            if identity_plan is not None and isinstance(identity_plan.target, ProcessIdentity)
+            else None
+        )
+        plan = self._ensure_plan(event)
+        paired_endpoint = event.src_host is not None and event.dst_host is not None
+        if event.src_host is not None:
+            direction = "outbound"
+            hostname = event.src_host.hostname
+            not_before = (
+                self._ecar_process_identity_not_before(event, source_identity)
+                if source_identity is not None
+                else None
+            )
+            timestamp, identity_safe = self._ecar_flow_source_time(
+                event,
+                seed_parts=(
+                    direction,
+                    hostname,
+                    network.initiating_pid,
+                    network.src_ip,
+                    network.src_port,
+                    network.dst_ip,
+                    network.dst_port,
+                    event.timestamp,
+                ),
+                not_before=not_before,
+                drop_late_process_identity=(
+                    network.protocol == "tcp" and network.dst_port in {22, 3389}
+                ),
+                paired_endpoint=paired_endpoint,
+            )
+            plan.finalized_times[ecar_flow_render_key(direction, hostname)] = timestamp
+            plan.finalized_flags[ecar_flow_identity_key(direction, hostname)] = identity_safe
+        if event.dst_host is not None:
+            direction = "inbound"
+            hostname = event.dst_host.hostname
+            not_before = (
+                self._ecar_process_identity_not_before(event, target_identity)
+                if target_identity is not None
+                else None
+            )
+            timestamp, identity_safe = self._ecar_flow_source_time(
+                event,
+                seed_parts=(
+                    direction,
+                    hostname,
+                    network.initiating_pid,
+                    network.src_ip,
+                    network.src_port,
+                    network.dst_ip,
+                    network.dst_port,
+                    event.timestamp,
+                ),
+                not_before=not_before,
+                drop_late_process_identity=(
+                    network.protocol == "tcp" and network.dst_port in {22, 3389}
+                ),
+                paired_endpoint=paired_endpoint,
+            )
+            plan.finalized_times[ecar_flow_render_key(direction, hostname)] = timestamp
+            plan.finalized_flags[ecar_flow_identity_key(direction, hostname)] = identity_safe
+
+    def _ecar_process_identity_not_before(
+        self,
+        event: SecurityEvent,
+        identity: ProcessIdentity,
+    ) -> datetime:
+        """Return the earliest FLOW time that can safely claim a process."""
+
+        if event.timestamp - identity.started_at >= timedelta(seconds=5):
+            return identity.started_at
+        create_time = self._prime_ecar_process_create_time(event, identity)
+        return create_time + _SOURCE_EPSILON
+
+    def _ecar_flow_source_time(
+        self,
+        event: SecurityEvent,
+        *,
+        seed_parts: tuple[Any, ...],
+        not_before: datetime | None,
+        drop_late_process_identity: bool,
+        paired_endpoint: bool,
+    ) -> tuple[datetime, bool]:
+        """Return a finalized FLOW time bounded by its canonical interval."""
+
+        interval_start, not_after = self._ecar_flow_interval(event, seed_parts)
+        lifecycle = event.lifecycle
+        if (
+            lifecycle is not None
+            and lifecycle.parent_group_id is not None
+            and lifecycle.parent_group_id.startswith("proxy-transaction-")
+        ):
+            host_key = str(seed_parts[1]) if len(seed_parts) > 1 else ""
+            flow_time = self.lifecycle_child_source_time(
+                event,
+                "source.ecar_flow",
+                host_key=host_key,
+                seed_parts=seed_parts,
+                within=(interval_start, not_after) if not_after is not None else None,
+            )
+            if flow_time is not None:
+                return flow_time, not_before is None or not_before <= flow_time
+
+        if drop_late_process_identity and not_before is not None:
+            flow_time = self.source_time(
+                event,
+                "source.ecar_flow",
+                seed_parts=seed_parts,
+                within=(interval_start, not_after) if not_after is not None else None,
+            )
+            flow_time = self._paired_ecar_flow_observation_time(
+                event,
+                flow_time,
+                seed_parts=seed_parts,
+                interval_start=interval_start,
+                not_before=None,
+                not_after=not_after,
+                enabled=paired_endpoint,
+            )
+            return flow_time, not_before <= flow_time
+
+        identity_safe = not_before is None or not_after is None or not_before <= not_after
+        flow_time = self.source_time(
+            event,
+            "source.ecar_flow",
+            seed_parts=seed_parts,
+            not_before=not_before if identity_safe else None,
+            within=(interval_start, not_after) if not_after is not None else None,
+        )
+        flow_time = self._paired_ecar_flow_observation_time(
+            event,
+            flow_time,
+            seed_parts=seed_parts,
+            interval_start=interval_start,
+            not_before=not_before if identity_safe else None,
+            not_after=not_after,
+            enabled=paired_endpoint,
+        )
+        if identity_safe and not_before is not None and flow_time < not_before:
+            identity_safe = False
+        return flow_time, identity_safe
+
+    @staticmethod
+    def _paired_ecar_flow_observation_time(
+        event: SecurityEvent,
+        timestamp: datetime,
+        *,
+        seed_parts: tuple[Any, ...],
+        interval_start: datetime,
+        not_before: datetime | None,
+        not_after: datetime | None,
+        enabled: bool,
+    ) -> datetime:
+        """Add deterministic host-local texture to paired endpoint FLOWs."""
+
+        if not enabled:
+            return timestamp
+        if not_after is None:
+            return SourceTimingPlanner._unbounded_paired_ecar_flow_time(
+                event,
+                seed_parts=seed_parts,
+                not_before=not_before,
+            )
+        short_interval = not_after <= interval_start + timedelta(milliseconds=5)
+        lower_bound = not_before
+        if not short_interval and not_after > interval_start:
+            lower_bound = (
+                interval_start if lower_bound is None else max(lower_bound, interval_start)
+            )
+        min_offset_ms = SourceTimingPlanner._ecar_flow_min_endpoint_offset_ms(
+            event,
+            seed_parts,
+        )
+        if min_offset_ms > 0:
+            minimum_time = interval_start + timedelta(milliseconds=min_offset_ms)
+            if minimum_time <= not_after:
+                lower_bound = (
+                    minimum_time if lower_bound is None else max(lower_bound, minimum_time)
+                )
+
+        seed = _stable_seed(
+            "ecar_paired_flow_observation:"
+            + ":".join(str(part) for part in (*seed_parts, event.timestamp.isoformat()))
+        )
+        direction = str(seed_parts[0]) if seed_parts else ""
+        if short_interval and direction == "inbound":
+            minimum_jitter_ms, maximum_jitter_ms = 22, 55
+        elif short_interval and direction == "outbound":
+            minimum_jitter_ms, maximum_jitter_ms = 1, 16
+        elif direction == "inbound":
+            minimum_jitter_ms, maximum_jitter_ms = 75, 540
+        elif direction == "outbound":
+            minimum_jitter_ms, maximum_jitter_ms = 12, 220
+        else:
+            minimum_jitter_ms, maximum_jitter_ms = 12, 360
+        jitter_ms = minimum_jitter_ms + (seed % (maximum_jitter_ms - minimum_jitter_ms + 1))
+        candidate = timestamp - timedelta(milliseconds=jitter_ms)
+        if lower_bound is not None and candidate < lower_bound:
+            available_ms = int((timestamp - lower_bound).total_seconds() * 1000)
+            if available_ms <= 0:
+                return timestamp
+            if available_ms < minimum_jitter_ms:
+                if direction == "inbound" and available_ms >= 4:
+                    slice_min_ms, slice_max_ms = max(1, (available_ms * 2) // 3), available_ms
+                elif direction == "outbound" and available_ms >= 4:
+                    slice_min_ms, slice_max_ms = 1, max(1, available_ms // 3)
+                else:
+                    slice_min_ms, slice_max_ms = 1, available_ms
+                bounded_jitter_ms = slice_min_ms + (seed % (slice_max_ms - slice_min_ms + 1))
+            else:
+                bounded_jitter_ms = minimum_jitter_ms + (
+                    seed % (available_ms - minimum_jitter_ms + 1)
+                )
+            candidate = timestamp - timedelta(milliseconds=bounded_jitter_ms)
+        return min(candidate, not_after)
+
+    @staticmethod
+    def _unbounded_paired_ecar_flow_time(
+        event: SecurityEvent,
+        *,
+        seed_parts: tuple[Any, ...],
+        not_before: datetime | None,
+    ) -> datetime:
+        """Return coordinated paired FLOW timing when no close bound exists."""
+
+        network = event.network
+        if network is None:
+            return event.timestamp
+        tuple_seed = _stable_seed(
+            "ecar_paired_flow_base:"
+            + ":".join(
+                str(part)
+                for part in (
+                    network.src_ip,
+                    network.src_port,
+                    network.dst_ip,
+                    network.dst_port,
+                    network.protocol,
+                    event.timestamp.isoformat(),
+                )
+            )
+        )
+        base_delay_ms = 220 + (tuple_seed % 900)
+        direction = str(seed_parts[0]) if seed_parts else ""
+        host = str(seed_parts[1]) if len(seed_parts) > 1 else ""
+        offset_seed = _stable_seed(
+            "ecar_paired_flow_host_offset:"
+            + ":".join(str(part) for part in (direction, host, *seed_parts))
+        )
+        if direction == "inbound":
+            offset_ms = 300 + (offset_seed % 360)
+        elif direction == "outbound":
+            offset_ms = 20 + (offset_seed % 180)
+        else:
+            offset_ms = 80 + (offset_seed % 420)
+        candidate = event.timestamp + timedelta(milliseconds=base_delay_ms + offset_ms)
+        if not_before is not None and candidate < not_before:
+            candidate = not_before + timedelta(milliseconds=6 + (offset_seed % 180))
+        return candidate
+
+    @staticmethod
+    def _ecar_flow_interval(
+        event: SecurityEvent,
+        seed_parts: tuple[Any, ...],
+    ) -> tuple[datetime, datetime | None]:
+        """Return the finalized canonical interval for an endpoint FLOW."""
+
+        network = event.network
+        if network is None:
+            return event.timestamp, None
+        start_time = network.source_visible_start_time or event.timestamp
+        if network.duration is None:
+            if network.conn_state in {"S0", "REJ", "RSTO", "RSTR", "SH", "SHR"}:
+                seed = _stable_seed(
+                    "ecar_failed_flow_not_after:"
+                    + ":".join(str(part) for part in (*seed_parts, start_time.isoformat()))
+                )
+                return start_time, start_time + timedelta(milliseconds=45 + (seed % 620))
+            return start_time, None
+        close_time = network.source_visible_close_time or (
+            start_time + timedelta(seconds=max(0.0, network.duration))
+        )
+        if close_time <= start_time:
+            return start_time, close_time
+        duration_us = int((close_time - start_time).total_seconds() * 1_000_000)
+        seed = _stable_seed("ecar_flow_not_after:" + ":".join(str(part) for part in seed_parts))
+        margin_us = 1000 + (seed % 4000)
+        if duration_us <= margin_us:
+            margin_us = max(0, duration_us // 2)
+        return start_time, close_time - timedelta(microseconds=margin_us)
+
+    @staticmethod
+    def _ecar_flow_min_endpoint_offset_ms(
+        event: SecurityEvent,
+        seed_parts: tuple[Any, ...],
+    ) -> int:
+        """Return the minimum endpoint delay for very short FLOWs."""
+
+        network = event.network
+        if network is None:
+            return 0
+        applies = (
+            network.conn_state in {"S0", "REJ", "RSTO", "RSTR", "SH", "SHR"}
+            if network.duration is None
+            else 0 <= network.duration < 0.1
+        )
+        if not applies:
+            return 0
+        seed = _stable_seed(
+            "ecar_flow_min_endpoint_offset:"
+            + ":".join(str(part) for part in (*seed_parts, event.timestamp.isoformat()))
+        )
+        return 18 + (seed % 65)
 
     def _plan_session_lifecycle_time(
         self,
@@ -310,6 +894,21 @@ class SourceTimingPlanner:
     def admission_time(self, event: SecurityEvent, format_name: str) -> datetime:
         """Return the finalized source-visible timestamp used for window admission."""
 
+        if event.source_timing is not None:
+            if format_name == "ecar":
+                ecar_times = [
+                    timestamp
+                    for key, timestamp in event.source_timing.finalized_times.items()
+                    if key.startswith("ecar.flow.") or key.startswith("ecar.session.")
+                ]
+                if ecar_times:
+                    return max(ecar_times)
+            if format_name in {"windows_security", "windows_event_security"}:
+                windows_time = event.source_timing.finalized_times.get(
+                    "windows.remote_authentication"
+                ) or event.source_timing.finalized_times.get(_WINDOWS_WFP_RENDER_KEY)
+                if windows_time is not None:
+                    return windows_time
         if format_name == "proxy_access" and event.proxy is not None:
             transaction = event.proxy.transaction
             if transaction is not None:
@@ -336,26 +935,6 @@ class SourceTimingPlanner:
             ]
             if observed:
                 return min(observed)
-        if format_name == "ecar" and event.network is not None:
-            return self.source_time(
-                event,
-                "source.ecar_flow",
-                seed_parts=(
-                    "dispatcher-admission",
-                    event.network.zeek_uid,
-                    event.network.src_ip,
-                    event.network.src_port,
-                    event.network.dst_ip,
-                    event.network.dst_port,
-                ),
-                within=(
-                    event.network.source_visible_start_time,
-                    event.network.source_visible_close_time,
-                )
-                if event.network.source_visible_start_time is not None
-                and event.network.source_visible_close_time is not None
-                else None,
-            )
         return event.timestamp
 
     def source_time(

--- a/src/evidenceforge/generation/state_manager.py
+++ b/src/evidenceforge/generation/state_manager.py
@@ -444,6 +444,35 @@ class StateManager:
                     sessions[session.logon_id] = session
             return list(sessions.values())
 
+    def authoritative_session_end_blocks_rebootstrap(
+        self,
+        username: str,
+        system: str,
+        at_time: datetime,
+    ) -> bool:
+        """Return whether an explicit end leaves no session able to own later activity."""
+
+        cutoff = ensure_utc(at_time)
+        with self._lock:
+            sessions: dict[str, ActiveSession] = {
+                session.logon_id: session
+                for session in self.state.active_sessions.values()
+                if session.username == username and session.system == system
+            }
+            for session, _end_time in self._ended_sessions.values():
+                if session.username == username and session.system == system:
+                    sessions[session.logon_id] = session
+
+            has_expired_authoritative_plan = any(
+                session.end_plan is not None
+                and session.end_plan.is_authoritative
+                and ensure_utc(session.end_plan.canonical_end) <= cutoff
+                for session in sessions.values()
+            )
+            if not has_expired_authoritative_plan:
+                return False
+            return not any(_session_valid_at(session, cutoff) for session in sessions.values())
+
     def get_sessions_on_system(self, system: str) -> list[ActiveSession]:
         """Get all active sessions on a system.
 
@@ -455,6 +484,28 @@ class StateManager:
         """
         with self._lock:
             return [s for s in self.state.active_sessions.values() if s.system == system]
+
+    def get_sessions_on_system_at(
+        self,
+        system: str,
+        at_time: datetime,
+    ) -> list[ActiveSession]:
+        """Get sessions that may own activity on a system at a specific time."""
+
+        cutoff = ensure_utc(at_time)
+        with self._lock:
+            sessions: dict[str, ActiveSession] = {}
+            for session in self.state.active_sessions.values():
+                if session.system == system and _session_valid_at(session, cutoff):
+                    sessions[session.logon_id] = session
+            for session, end_time in self._ended_sessions.values():
+                if (
+                    session.system == system
+                    and _session_valid_at(session, cutoff)
+                    and cutoff < end_time
+                ):
+                    sessions[session.logon_id] = session
+            return list(sessions.values())
 
     def register_session(
         self,
@@ -2088,6 +2139,7 @@ class StateManager:
                     if conn is not None:
                         transaction = event.network.transaction
                         if transaction is not None:
+                            conn.transaction_id = transaction.stable_id
                             if event.network.application_layer_only:
                                 conn.traffic_ledger = conn.traffic_ledger.accumulate(
                                     transaction.traffic

--- a/src/evidenceforge/models/state.py
+++ b/src/evidenceforge/models/state.py
@@ -179,6 +179,7 @@ class OpenConnection:
     bytes_sent: int = 0
     bytes_received: int = 0
     traffic_ledger: NetworkTrafficLedger = field(default_factory=NetworkTrafficLedger)
+    transaction_id: str = ""
     conn_state: str = ""
     history: str = ""
     duration: float | None = None

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -3010,6 +3010,99 @@ class TestActivityGenerator:
         assert session is not None
         assert session.parent_lifecycle_group_id == logon_event.remote_auth.stable_id
 
+    def test_remote_logon_reuses_existing_exact_transport_without_duplicate_flow(
+        self, activity_gen, test_user, test_system, state_manager, mock_emitters
+    ):
+        """Compatibility SMB paths bind the prior transaction into remote-auth timing."""
+
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        source_ip = "10.0.0.50"
+        source_port = 52595
+        state_manager.set_current_time(timestamp)
+        activity_gen.generate_connection(
+            src_ip=source_ip,
+            src_port=source_port,
+            dst_ip=test_system.ip,
+            dst_port=445,
+            proto="tcp",
+            service="smb",
+            time=timestamp,
+            duration=5.0,
+            conn_state="SF",
+        )
+        network_event = next(
+            call[0][0]
+            for call in mock_emitters["zeek_conn"].emit.call_args_list
+            if call[0][0].event_type == "connection"
+        )
+        transaction_id = network_event.network.transaction.stable_id
+
+        activity_gen.generate_logon(
+            test_user,
+            test_system,
+            timestamp,
+            logon_type=3,
+            source_ip=source_ip,
+            source_port=source_port,
+            emit_network_evidence=False,
+            remote_authentication_transport_id=transaction_id,
+        )
+
+        logon_event = next(
+            call[0][0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call[0][0].event_type == "logon"
+        )
+        assert logon_event.remote_auth is not None
+        assert logon_event.remote_auth.primary_transport is not None
+        assert logon_event.remote_auth.primary_transport.transaction_id == transaction_id
+        network_events = [
+            call[0][0]
+            for call in mock_emitters["zeek_conn"].emit.call_args_list
+            if call[0][0].event_type == "connection"
+        ]
+        assert len(network_events) == 1
+
+    def test_remote_logon_rejects_wrong_explicit_transport_transaction(
+        self, activity_gen, test_user, test_system, state_manager, mock_emitters
+    ):
+        """A reused tuple cannot bind authentication without its exact transaction ID."""
+
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        source_ip = "10.0.0.50"
+        source_port = 52595
+        state_manager.set_current_time(timestamp)
+        activity_gen.generate_connection(
+            src_ip=source_ip,
+            src_port=source_port,
+            dst_ip=test_system.ip,
+            dst_port=445,
+            proto="tcp",
+            service="smb",
+            time=timestamp,
+            duration=5.0,
+            conn_state="SF",
+        )
+
+        activity_gen.generate_logon(
+            test_user,
+            test_system,
+            timestamp,
+            logon_type=3,
+            source_ip=source_ip,
+            source_port=source_port,
+            emit_network_evidence=False,
+            remote_authentication_transport_id="network-connection-wrong",
+        )
+
+        logon_event = next(
+            call[0][0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call[0][0].event_type == "logon"
+        )
+        assert logon_event.remote_auth is not None
+        assert logon_event.remote_auth.primary_transport is None
+
     def test_internal_remote_successful_logon_emits_matching_network_evidence(
         self, activity_gen, test_user, test_system, state_manager, mock_emitters
     ):
@@ -6779,6 +6872,14 @@ class TestActivityGenerator:
         assert target_wfp.network.dst_ip == dc_system.ip
         assert target_wfp.network.initiating_pid == lsass_pid
         assert target_wfp.process.image.endswith("lsass.exe")
+        connection_event = next(
+            call.args[0]
+            for call in mock_emitters["zeek_conn"].emit.call_args_list
+            if call.args[0].event_type == "connection"
+        )
+        assert target_wfp.lifecycle is not None
+        assert target_wfp.lifecycle.parent_group_id is None
+        assert target_wfp.lifecycle.group_id == connection_event.network.transaction.stable_id
 
     def test_failed_inbound_windows_probe_does_not_emit_target_wfp(
         self, activity_gen, test_system, state_manager, mock_emitters

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -2999,6 +2999,16 @@ class TestActivityGenerator:
         assert network_event.network.src_port == 52595
         assert network_event.network.dst_ip == test_system.ip
         assert network_event.network.conn_state == "SF"
+        assert logon_event.remote_auth is not None
+        assert logon_event.remote_auth.primary_transport is not None
+        assert (
+            logon_event.remote_auth.primary_transport.transaction_id
+            == network_event.network.transaction.stable_id
+        )
+        assert network_event.lifecycle.parent_group_id == logon_event.remote_auth.stable_id
+        session = state_manager.get_session(logon_event.auth.logon_id)
+        assert session is not None
+        assert session.parent_lifecycle_group_id == logon_event.remote_auth.stable_id
 
     def test_internal_remote_successful_logon_emits_matching_network_evidence(
         self, activity_gen, test_user, test_system, state_manager, mock_emitters
@@ -3588,6 +3598,10 @@ class TestActivityGenerator:
             event for event in security_events if event.event_type == "machine_logon"
         )
         machine_logoff = next(event for event in security_events if event.event_type == "logoff")
+        assert machine_logon.remote_auth is not None
+        assert machine_logon.remote_auth.outcome == "success"
+        assert machine_logon.remote_auth.primary_transport is not None
+        assert machine_logon.remote_auth.primary_transport.role == "kerberos_validation"
         assert machine_logon.edr.object_id == machine_logoff.edr.object_id
         assert machine_logon.lifecycle.group_id == machine_logoff.lifecycle.group_id
         assert machine_logon.lifecycle.phase == "start"
@@ -3598,6 +3612,10 @@ class TestActivityGenerator:
             if call.args[0].event_type == "connection"
         )
         assert machine_logon.auth.source_port == kerberos_connection.network.src_port
+        assert (
+            machine_logon.remote_auth.primary_transport.transaction_id
+            == kerberos_connection.network.transaction.stable_id
+        )
         assert all(
             event.kerberos.source_port == machine_logon.auth.source_port
             for event in kerberos_events

--- a/tests/unit/test_baseline_canonical.py
+++ b/tests/unit/test_baseline_canonical.py
@@ -2002,7 +2002,9 @@ class TestAnonymousLogon:
         activity_gen.generate_anonymous_logon(system=dc, time=timestamp)
 
         win = mock_emitters["windows_event_security"]
-        event = win.emit.call_args[0][0]
+        event = next(
+            call.args[0] for call in win.emit.call_args_list if call.args[0].event_type == "logon"
+        )
         assert event.auth.source_ip == ws.ip
         assert event.auth.source_port > 0
         assert event.auth.workstation_name == ws.hostname
@@ -2015,6 +2017,15 @@ class TestAnonymousLogon:
         assert network_event.network.src_port == event.auth.source_port
         assert network_event.network.dst_ip == dc.ip
         assert network_event.network.dst_port == 445
+        assert event.remote_auth is not None
+        assert event.remote_auth.primary_transport is not None
+        assert event.remote_auth.primary_transport.transaction_id == (
+            network_event.network.transaction.stable_id
+        )
+        assert event.lifecycle is not None
+        assert event.lifecycle.group_id == event.remote_auth.stable_id
+        assert network_event.lifecycle is not None
+        assert network_event.lifecycle.parent_group_id == event.remote_auth.stable_id
 
     def test_anonymous_logon_no_session_created(
         self, activity_gen, state_manager, mock_emitters, timestamp
@@ -2031,6 +2042,33 @@ class TestAnonymousLogon:
         activity_gen.generate_anonymous_logon(system=dc, time=timestamp)
         sessions_after = len(state_manager.state.active_sessions)
         assert sessions_after == sessions_before
+
+    def test_anonymous_logon_plans_transport_without_source_host_metadata(
+        self, activity_gen, state_manager, mock_emitters, timestamp
+    ):
+        """An unmodeled private source still retains the remote transport contract."""
+        dc = System(
+            hostname="DC-01",
+            ip="10.0.10.100",
+            os="Windows Server 2019",
+            type="domain_controller",
+        )
+        activity_gen._all_system_ips = [dc.ip, "10.0.10.77"]
+        activity_gen._ip_to_system = {dc.ip: dc}
+        state_manager.set_current_time(timestamp)
+
+        activity_gen.generate_anonymous_logon(system=dc, time=timestamp)
+
+        event = next(
+            call.args[0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call.args[0].event_type == "logon"
+        )
+        assert event.auth.source_ip == "10.0.10.77"
+        assert event.auth.workstation_name == "-"
+        assert event.remote_auth is not None
+        assert event.remote_auth.primary_transport is not None
+        assert event.remote_auth.primary_transport.tuple.src_ip == "10.0.10.77"
 
     def test_anonymous_logon_emits_short_lived_logoff(
         self, activity_gen, state_manager, mock_emitters, timestamp
@@ -2068,8 +2106,46 @@ class TestAnonymousLogon:
         assert ecar_events[0].edr.object_id
         assert ecar_events[1].edr.object_id == ecar_events[0].edr.object_id
         assert ecar_events[1].auth.logon_id == ecar_events[0].auth.logon_id
+        assert ecar_events[0].lifecycle is None
+        assert ecar_events[1].lifecycle is None
         assert timestamp < win_events[1].timestamp <= timestamp + timedelta(seconds=30)
         assert len(state_manager.state.active_sessions) == sessions_before
+
+    def test_anonymous_logoff_closes_remote_authentication_group(
+        self, activity_gen, state_manager, mock_emitters, timestamp
+    ):
+        """Anonymous transport, login, and logoff share one action lifecycle."""
+        dc = System(
+            hostname="DC-01",
+            ip="10.0.10.100",
+            os="Windows Server 2019",
+            type="domain_controller",
+        )
+        ws = System(
+            hostname="WS-01",
+            ip="10.0.10.50",
+            os="Windows 11",
+            type="workstation",
+        )
+        activity_gen._all_system_ips = [dc.ip, ws.ip]
+        activity_gen._ip_to_system = {ws.ip: ws, dc.ip: dc}
+        state_manager.set_current_time(timestamp)
+
+        activity_gen.generate_anonymous_logon(system=dc, time=timestamp)
+
+        events = [
+            call.args[0]
+            for call in mock_emitters["windows_event_security"].emit.call_args_list
+            if call.args[0].event_type in {"logon", "logoff"}
+        ]
+        assert len(events) == 2
+        assert events[0].remote_auth is not None
+        assert events[0].lifecycle is not None
+        assert events[1].lifecycle is not None
+        assert events[0].lifecycle.group_id == events[0].remote_auth.stable_id
+        assert events[1].lifecycle.group_id == events[0].lifecycle.group_id
+        assert events[0].lifecycle.phase == "start"
+        assert events[1].lifecycle.phase == "closure"
 
 
 class TestNoInternalGenerateRaw:
@@ -2126,7 +2202,8 @@ class TestBaselineSshTiming:
         assert 'source_roll < 0.32 + _LINUX_AMBIENT_SSH_NOISE_BAND and sys_type == "server"' in (
             source
         )
-        assert "ssh_identity = self._pick_baseline_ssh_identity(system, rng)" in source
+        assert "ssh_identity = self._pick_baseline_ssh_identity" in source
+        assert "at_time=ts" in source
         assert "ssh_user_model, src_sys_obj = ssh_identity" in source
         assert "ssh_user = ssh_user_model.username" in source
 

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -35,6 +35,10 @@ from unittest.mock import Mock
 
 import pytest
 
+from evidenceforge.events.authentication import (
+    RemoteAuthenticationPlan,
+    RemoteAuthenticationTransportPlan,
+)
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import (
     AuthContext,
@@ -48,6 +52,7 @@ from evidenceforge.events.contexts import (
 )
 from evidenceforge.events.identity import EventIdentityPlan, ProcessIdentity, ThreadIdentity
 from evidenceforge.events.lifecycle import ActionLifecycleContext
+from evidenceforge.events.network import NetworkTuple
 from evidenceforge.formats.loader import load_format
 from evidenceforge.formats.validator import validate_event
 from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
@@ -175,6 +180,90 @@ def test_ecar_format_uses_explicit_identity_schema_version() -> None:
         "target_image_path",
         "target_principal",
     } <= field_names
+
+
+def test_remote_auth_login_and_flow_render_exact_tuple_without_internal_id(emitter, ts) -> None:
+    """Remote eCAR siblings expose the tuple without leaking canonical planner IDs."""
+
+    emitter.emit_event = Mock()
+    host = HostContext(
+        hostname="FILE-SRV-01",
+        fqdn="FILE-SRV-01.example.local",
+        ip="10.0.2.20",
+        os="Windows Server 2022",
+        os_category="windows",
+        system_type="server",
+    )
+    network = NetworkContext(
+        src_ip="10.0.1.10",
+        src_port=55222,
+        dst_ip=host.ip,
+        dst_port=445,
+        protocol="tcp",
+        service="smb",
+        duration=4.0,
+        source_visible_start_time=ts,
+        source_visible_close_time=ts + timedelta(seconds=4),
+        conn_state="SF",
+        history="ShADadFf",
+    )
+    network.finalize_transaction("network-remote-auth-test")
+    transport = RemoteAuthenticationTransportPlan(
+        role="target_service",
+        transaction_id="network-remote-auth-test",
+        tuple=NetworkTuple(
+            src_ip=network.src_ip,
+            src_port=network.src_port,
+            dst_ip=network.dst_ip,
+            dst_port=network.dst_port,
+            protocol=network.protocol,
+        ),
+        started_at=ts,
+        closed_at=ts + timedelta(seconds=4),
+        primary=True,
+    )
+    remote_auth = RemoteAuthenticationPlan(
+        stable_id="windows-remote-auth-test",
+        source_hostname="WS-01",
+        target_hostname=host.hostname,
+        logon_type=3,
+        auth_protocol="NTLM",
+        outcome="success",
+        canonical_auth_time=ts + timedelta(milliseconds=500),
+        transports=(transport,),
+        session_object_id="session-test",
+        logon_id="0x123",
+    )
+    flow_event = SecurityEvent(
+        timestamp=ts,
+        event_type="connection",
+        dst_host=host,
+        network=network,
+    )
+    login_event = SecurityEvent(
+        timestamp=remote_auth.canonical_auth_time,
+        event_type="logon",
+        dst_host=host,
+        auth=AuthContext(
+            username="alice",
+            logon_id="0x123",
+            logon_type=3,
+            source_ip=network.src_ip,
+            source_port=network.src_port,
+        ),
+        edr=EdrContext(object_id="session-test"),
+        remote_auth=remote_auth,
+    )
+
+    emitter._render_connection(flow_event)
+    flow = emitter.emit_event.call_args.args[0]
+    emitter._render_logon(login_event)
+    login = emitter.emit_event.call_args.args[0]
+
+    for field in ("src_ip", "src_port", "dst_ip", "dst_port", "protocol"):
+        assert login[field] == flow[field]
+    assert "network_transaction_id" not in flow
+    assert "network_transaction_id" not in login
 
 
 def test_distinct_canonical_occurrences_cannot_reuse_ecar_record_ids(emitter, ts) -> None:

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -52,6 +52,7 @@ from evidenceforge.formats.loader import load_format
 from evidenceforge.formats.validator import validate_event
 from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
 from evidenceforge.generation.emitters.ecar import EcarEmitter
+from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
 
 
@@ -64,6 +65,20 @@ def emitter(tmp_path):
     format_def.output.footer_template = None
     format_def.output.encoding = "utf-8"
     e = EcarEmitter(format_def, tmp_path, threaded=False)
+    planner = SourceTimingPlanner()
+    for method_name in (
+        "_render_connection",
+        "_render_logon",
+        "_render_logoff",
+        "_render_failed_logon",
+    ):
+        renderer = getattr(e, method_name)
+
+        def planned_renderer(event, renderer=renderer):
+            planner.plan_event(event, "ecar")
+            return renderer(event)
+
+        setattr(e, method_name, planned_renderer)
     return e
 
 

--- a/tests/unit/test_emitters.py
+++ b/tests/unit/test_emitters.py
@@ -1239,10 +1239,10 @@ class TestWindowsEventEmitter:
         assert logon["TimeCreated"] == expected_logon_time
         assert privilege["TimeCreated"] == expected_logon_time + expected_privilege_delta
 
-    def test_flush_repairs_transport_shifted_logon_before_process_create(
+    def test_flush_does_not_repair_remote_auth_transport_ordering(
         self, format_def, temp_output, monkeypatch
     ):
-        """Flush should move remote 4624 rows before repairing same-session 4688 rows."""
+        """Remote-auth ordering is finalized before Windows emitter flush."""
         emitter = WindowsEventEmitter(format_def, temp_output, buffer_size=10)
         logon_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         process_time = logon_time + timedelta(milliseconds=250)
@@ -1297,7 +1297,8 @@ class TestWindowsEventEmitter:
 
         emitter._flush_unlocked()
 
-        assert calls.index("network") < calls.index("process")
+        assert "network" not in calls
+        assert "process" in calls
         logon = next(event for event in rendered if event["EventID"] == 4624)
         process = next(event for event in rendered if event["EventID"] == 4688)
         assert process["TimeCreated"] > logon["TimeCreated"]

--- a/tests/unit/test_eval_temporal.py
+++ b/tests/unit/test_eval_temporal.py
@@ -119,6 +119,74 @@ class TestUsernameExtraction:
         assert _extract_username(r) is None
 
 
+class TestRemoteAuthenticationOrderingProbe:
+    """Rendered eCAR remote-authentication transaction ordering probes."""
+
+    @staticmethod
+    def _fields(object_name: str, *, src_port: int = 55222) -> dict:
+        return {
+            "object": object_name,
+            "action": "CONNECT" if object_name == "FLOW" else "LOGIN",
+            "direction": "INBOUND" if object_name == "FLOW" else "",
+            "logon_type": "3" if object_name == "USER_SESSION" else "",
+            "hostname": "FILE-SRV-01",
+            "src_ip": "10.0.1.10",
+            "src_port": str(src_port),
+            "dst_ip": "10.0.2.20",
+            "dst_port": "445",
+            "protocol": "tcp",
+        }
+
+    def test_scores_exact_flow_before_login(self):
+        flow = _record("ecar", self._fields("FLOW"), ts=T0)
+        login = _record(
+            "ecar",
+            self._fields("USER_SESSION"),
+            ts=T0 + timedelta(milliseconds=25),
+        )
+
+        assert CausalityScorer._score_ecar_remote_auth_ordering([flow, login])[:2] == (1, 1)
+
+    def test_reports_exact_flow_login_inversion(self):
+        flow = _record(
+            "ecar",
+            self._fields("FLOW"),
+            ts=T0 + timedelta(milliseconds=25),
+        )
+        login = _record("ecar", self._fields("USER_SESSION"), ts=T0)
+
+        total, correct, failures = CausalityScorer._score_ecar_remote_auth_ordering([login, flow])
+
+        assert (total, correct) == (1, 0)
+        assert failures
+
+    def test_skips_missing_or_wrong_tuple_companion(self):
+        flow = _record("ecar", self._fields("FLOW", src_port=55223), ts=T0)
+        login = _record(
+            "ecar",
+            self._fields("USER_SESSION"),
+            ts=T0 + timedelta(milliseconds=25),
+        )
+
+        assert CausalityScorer._score_ecar_remote_auth_ordering([flow, login])[:2] == (0, 0)
+
+    def test_distant_reused_tuple_does_not_mask_nearby_inversion(self):
+        old_flow = _record("ecar", self._fields("FLOW"), ts=T0 - timedelta(minutes=10))
+        inverted_flow = _record(
+            "ecar",
+            self._fields("FLOW"),
+            ts=T0 + timedelta(milliseconds=25),
+        )
+        login = _record("ecar", self._fields("USER_SESSION"), ts=T0)
+
+        total, correct, failures = CausalityScorer._score_ecar_remote_auth_ordering(
+            [old_flow, login, inverted_flow]
+        )
+
+        assert (total, correct) == (1, 0)
+        assert failures
+
+
 class TestHumanBurstiness:
     def test_bursty_events(self):
         """Events with varied inter-event gaps should score well."""

--- a/tests/unit/test_file_server_logon.py
+++ b/tests/unit/test_file_server_logon.py
@@ -63,11 +63,15 @@ class TestEmitSmbLogonPair:
         obj = MagicMock()
         obj.activity_generator = MagicMock()
         obj.activity_generator.generate_logon.return_value = "0x54321"
+        obj.activity_generator._last_effective_connection_transaction_id.return_value = (
+            "network-connection-000000001234abcd"
+        )
         method = BaselineMixin._emit_smb_logon_pair.__get__(obj)
 
         user = MagicMock()
         file_server = MagicMock()
         file_server.os = "Windows Server 2019"
+        file_server.ip = "10.10.10.20"
         ts = datetime(2024, 3, 15, 10, 0, 0, tzinfo=UTC)
         rng = random.Random(42)
 
@@ -80,6 +84,13 @@ class TestEmitSmbLogonPair:
             source_port=50001,
             emit_network_evidence=False,
         )
+        obj.activity_generator._last_effective_connection_transaction_id.assert_called_once_with(
+            src_ip="10.10.10.50",
+            src_port=50001,
+            dst_ip="10.10.10.20",
+            dst_port=445,
+            proto="tcp",
+        )
 
         assert logon_id == "0x54321"
         obj.activity_generator.generate_logon.assert_called_once_with(
@@ -90,6 +101,7 @@ class TestEmitSmbLogonPair:
             source_ip="10.10.10.50",
             source_port=50001,
             emit_network_evidence=False,
+            remote_authentication_transport_id="network-connection-000000001234abcd",
         )
         obj.activity_generator.generate_logoff.assert_called_once()
 

--- a/tests/unit/test_network_transaction_contract.py
+++ b/tests/unit/test_network_transaction_contract.py
@@ -305,3 +305,62 @@ def test_process_owned_connection_is_capped_before_authoritative_session_end() -
     process = state.get_process(source.hostname, pid)
     assert process is not None
     assert process.last_activity_time < deadline
+
+
+def test_inferred_connection_pid_is_omitted_after_owning_session_end() -> None:
+    """Stale inference must not turn later traffic into a session dependent."""
+    state = StateManager()
+    start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    deadline = start + timedelta(hours=1)
+    source = System(
+        hostname="WKS-01",
+        ip="10.0.0.10",
+        os="Windows 11",
+        type="workstation",
+    )
+    state.set_current_time(start)
+    logon_id = state.create_session(
+        username="alice",
+        system=source.hostname,
+        logon_type=2,
+        source_ip="-",
+        start_time=start,
+        session_kind="interactive",
+    )
+    state.plan_session_end(
+        logon_id,
+        SessionEndPlan(deadline, "explicit_storyline", "interactive-close"),
+    )
+    pid = state.create_process(
+        source.hostname,
+        4,
+        r"C:\Windows\System32\OpenSSH\ssh.exe",
+        "ssh app@example",
+        "alice",
+        "Medium",
+        logon_id=logon_id,
+    )
+    emitter = Mock()
+    emitter.can_handle.return_value = True
+    generator = ActivityGenerator(state, {"zeek_conn": emitter})
+    generator._ip_to_system = {source.ip: source}
+    generator._system_pids = {source.hostname: {"sshd": pid}}
+
+    generator.generate_connection(
+        src_ip=source.ip,
+        dst_ip="203.0.113.20",
+        time=deadline + timedelta(seconds=30),
+        dst_port=22,
+        proto="tcp",
+        service="ssh",
+        duration=15.0,
+        source_system=source,
+        conn_state="SF",
+    )
+
+    event = next(
+        call.args[0]
+        for call in emitter.emit.call_args_list
+        if call.args[0].event_type == "connection"
+    )
+    assert event.network.initiating_pid == -1

--- a/tests/unit/test_phase5_failed_logon.py
+++ b/tests/unit/test_phase5_failed_logon.py
@@ -487,6 +487,23 @@ class TestFailedLogonDC:
         ]
         assert network_events
         assert all(event.network.conn_state != "S0" for event in network_events)
+        failed_event = next(
+            call[0][0]
+            for call in mock_emitters["ecar"].emit.call_args_list
+            if call[0][0].event_type == "failed_logon"
+        )
+        assert failed_event.remote_auth is not None
+        assert failed_event.remote_auth.outcome == "failure"
+        assert failed_event.remote_auth.logon_id == ""
+        assert failed_event.remote_auth.session_object_id == ""
+        transport = failed_event.remote_auth.primary_transport
+        assert transport is not None
+        assert transport.transaction_id == network_events[0].network.transaction.stable_id
+        assert network_events[0].lifecycle.parent_group_id == failed_event.remote_auth.stable_id
+        ecar_event_types = [
+            call[0][0].event_type for call in mock_emitters["ecar"].emit.call_args_list
+        ]
+        assert ecar_event_types.index("connection") < ecar_event_types.index("failed_logon")
 
     def test_known_user_failed_logon_uses_wrong_password_substatus(
         self, state_manager, mock_emitters, timestamp

--- a/tests/unit/test_process_lifetimes.py
+++ b/tests/unit/test_process_lifetimes.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from evidenceforge.events.dispatcher import EventDispatcher
+from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.generation.activity import ActivityGenerator
 from evidenceforge.generation.activity.generator import (
     _linux_foreground_lifetime,
@@ -228,6 +229,27 @@ def test_baseline_session_activity_stops_at_network_close() -> None:
         network_close_time=close,
         system="SRV-LIN-01",
         logon_id="0x1234",
+    )
+
+    assert _session_active_at(session, close - timedelta(milliseconds=1), start, None)
+    assert not _session_active_at(session, close, start, None)
+    assert not _session_active_at(session, close + timedelta(seconds=1), start, None)
+
+
+def test_baseline_session_activity_stops_at_authoritative_end_plan() -> None:
+    """Storyline session deadlines must bound baseline dependents before dispatch."""
+    start = datetime(2024, 3, 18, 20, 20, 0, tzinfo=UTC)
+    close = start + timedelta(minutes=7)
+    session = SimpleNamespace(
+        start_time=start,
+        network_close_time=None,
+        system="WS-01",
+        logon_id="0x1234",
+        end_plan=SessionEndPlan(
+            canonical_end=close,
+            authority="explicit_storyline",
+            storyline_event_id="evt-logoff",
+        ),
     )
 
     assert _session_active_at(session, close - timedelta(milliseconds=1), start, None)

--- a/tests/unit/test_rdp_baseline_noise.py
+++ b/tests/unit/test_rdp_baseline_noise.py
@@ -236,16 +236,18 @@ class TestRDPBaselineNoise:
             engine._initialize()
 
             rdp_connections = []
-            original = engine.activity_generator.generate_connection
+            original = engine.dispatcher.dispatch
 
-            def tracking(*args, **kwargs):
-                if kwargs.get("dst_port") == 3389:
-                    rdp_connections.append(kwargs)
-                return original(*args, **kwargs)
+            def tracking(event):
+                if (
+                    event.event_type == "connection"
+                    and event.network is not None
+                    and event.network.dst_port == 3389
+                ):
+                    rdp_connections.append(event)
+                return original(event)
 
-            with patch.object(
-                engine.activity_generator, "generate_connection", side_effect=tracking
-            ):
+            with patch.object(engine.dispatcher, "dispatch", side_effect=tracking):
                 # Generate multiple hours for determinism
                 for h in range(4):
                     hour = datetime(2024, 1, 15, 10 + h, 0, 0, tzinfo=UTC)
@@ -253,9 +255,10 @@ class TestRDPBaselineNoise:
 
             assert len(rdp_connections) > 0, "No RDP baseline connections in 4 hours of generation"
             for conn in rdp_connections:
-                assert conn["dst_port"] == 3389
-                assert conn["proto"] == "tcp"
-                assert conn["service"] == "rdp"
+                assert conn.network is not None
+                assert conn.network.dst_port == 3389
+                assert conn.network.protocol == "tcp"
+                assert conn.network.service == "rdp"
 
     def test_no_rdp_noise_for_workstations_only(self):
         """Environment with only workstations should not get RDP admin connections."""
@@ -270,16 +273,18 @@ class TestRDPBaselineNoise:
             engine._initialize()
 
             rdp_connections = []
-            original = engine.activity_generator.generate_connection
+            original = engine.dispatcher.dispatch
 
-            def tracking(*args, **kwargs):
-                if kwargs.get("dst_port") == 3389:
-                    rdp_connections.append(kwargs)
-                return original(*args, **kwargs)
+            def tracking(event):
+                if (
+                    event.event_type == "connection"
+                    and event.network is not None
+                    and event.network.dst_port == 3389
+                ):
+                    rdp_connections.append(event)
+                return original(event)
 
-            with patch.object(
-                engine.activity_generator, "generate_connection", side_effect=tracking
-            ):
+            with patch.object(engine.dispatcher, "dispatch", side_effect=tracking):
                 hour = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
                 engine._generate_system_traffic(hour)
 

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -5,9 +5,14 @@
 
 import json
 import xml.etree.ElementTree as ET
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from evidenceforge.events.authentication import (
+    RemoteAuthenticationPlan,
+    RemoteAuthenticationTransportPlan,
+)
 from evidenceforge.events.base import SecurityEvent
 from evidenceforge.events.contexts import (
     AuthContext,
@@ -20,6 +25,7 @@ from evidenceforge.events.contexts import (
 )
 from evidenceforge.events.identity import EventIdentityPlan, ProcessIdentity, ThreadIdentity
 from evidenceforge.events.lifecycle import ActionLifecycleContext
+from evidenceforge.events.network import NetworkTuple
 from evidenceforge.formats import load_format
 from evidenceforge.generation.activity.timing_profiles import sample_timing_delta
 from evidenceforge.generation.emitters.ecar import EcarEmitter
@@ -27,7 +33,11 @@ from evidenceforge.generation.emitters.sysmon import SysmonEventEmitter
 from evidenceforge.generation.emitters.windows import WindowsEventEmitter
 from evidenceforge.generation.emitters.zeek import ZeekEmitter
 from evidenceforge.generation.emitters.zeek_dns import ZeekDnsEmitter
-from evidenceforge.generation.source_timing import SourceTimingPlanner
+from evidenceforge.generation.source_timing import (
+    SourceTimingPlanner,
+    ecar_flow_render_key,
+    ecar_session_render_key,
+)
 
 
 def _base_time() -> datetime:
@@ -827,6 +837,252 @@ def test_ecar_logoff_does_not_render_orphaned_self_sourced_port(tmp_path: Path) 
     assert row["action"] == "LOGOUT"
     assert "src_ip" not in row["properties"]
     assert "src_port" not in row["properties"]
+
+
+def _remote_auth_timing_events(
+    *,
+    outcome: str = "success",
+) -> tuple[SecurityEvent, SecurityEvent]:
+    """Return one correlated target transport and Windows authentication event."""
+
+    start = _base_time()
+    auth_time = start + timedelta(milliseconds=350)
+    source = _host_context()
+    target = HostContext(
+        hostname="FILE-SRV-01",
+        ip="10.0.0.40",
+        fqdn="FILE-SRV-01.corp.local",
+        os="Windows Server 2022",
+        os_category="windows",
+        system_type="server",
+        domain="corp.local",
+        netbios_domain="CORP",
+    )
+    transaction_id = "network-connection-remote-auth"
+    action_id = "windows-remote-auth-test"
+    network = NetworkContext(
+        src_ip=source.ip,
+        src_port=53123,
+        dst_ip=target.ip,
+        dst_port=445,
+        protocol="tcp",
+        service="smb",
+        zeek_uid="CremoteAuthTiming",
+        conn_id="conn-remote-auth",
+        duration=4.0,
+        source_visible_start_time=start,
+        source_visible_close_time=start + timedelta(seconds=4),
+        orig_bytes=1200,
+        resp_bytes=2400,
+        orig_pkts=4,
+        resp_pkts=5,
+        orig_ip_bytes=1360,
+        resp_ip_bytes=2600,
+        conn_state="SF",
+        history="ShADadFf",
+        local_orig=True,
+        local_resp=True,
+    )
+    network.finalize_transaction(transaction_id)
+    transport = RemoteAuthenticationTransportPlan(
+        role="target_service",
+        transaction_id=transaction_id,
+        tuple=NetworkTuple(
+            src_ip=source.ip,
+            src_port=53123,
+            dst_ip=target.ip,
+            dst_port=445,
+            protocol="tcp",
+        ),
+        started_at=start,
+        closed_at=start + timedelta(seconds=4),
+        primary=True,
+    )
+    remote_auth = RemoteAuthenticationPlan(
+        stable_id=action_id,
+        source_hostname=source.hostname,
+        target_hostname=target.hostname,
+        logon_type=3,
+        auth_protocol="NTLM",
+        outcome=outcome,
+        canonical_auth_time=auth_time,
+        transports=(transport,),
+        session_object_id="session-remote-auth" if outcome == "success" else "",
+        logon_id="0x12345" if outcome == "success" else "",
+    )
+    flow_event = SecurityEvent(
+        timestamp=start,
+        event_type="connection",
+        src_host=source,
+        dst_host=target,
+        network=network,
+        lifecycle=ActionLifecycleContext(
+            group_id=transaction_id,
+            canonical_start=start,
+            phase="start",
+            parent_group_id=action_id,
+        ),
+    )
+    auth_event = SecurityEvent(
+        timestamp=auth_time,
+        event_type="logon" if outcome == "success" else "failed_logon",
+        src_host=source,
+        dst_host=target,
+        auth=AuthContext(
+            username="alice",
+            logon_id="0x12345" if outcome == "success" else "",
+            logon_type=3,
+            result=outcome,
+            source_ip=source.ip,
+            source_port=53123,
+        ),
+        remote_auth=remote_auth,
+    )
+    return flow_event, auth_event
+
+
+def test_remote_auth_ecar_login_follows_admitted_exact_transport() -> None:
+    """Dispatcher timing should place eCAR authentication after its exact FLOW."""
+
+    planner = SourceTimingPlanner()
+    flow_event, login_event = _remote_auth_timing_events()
+
+    planner.plan_event(flow_event, "ecar")
+    planner.record_admitted_source_event(flow_event, "ecar")
+    planner.plan_event(login_event, "ecar")
+
+    flow_time = flow_event.source_timing.finalized_times[
+        ecar_flow_render_key("inbound", "FILE-SRV-01")
+    ]
+    login_time = login_event.source_timing.finalized_times[ecar_session_render_key("login")]
+    assert timedelta(milliseconds=8) <= login_time - flow_time <= timedelta(milliseconds=140)
+
+
+def test_remote_auth_failed_ecar_login_follows_transport_without_session() -> None:
+    """Failed authentication should order after FLOW without durable session identity."""
+
+    planner = SourceTimingPlanner()
+    flow_event, failed_event = _remote_auth_timing_events(outcome="failure")
+
+    planner.plan_event(flow_event, "ecar")
+    planner.record_admitted_source_event(flow_event, "ecar")
+    planner.plan_event(failed_event, "ecar")
+
+    flow_time = flow_event.source_timing.finalized_times[
+        ecar_flow_render_key("inbound", "FILE-SRV-01")
+    ]
+    failure_time = failed_event.source_timing.finalized_times[
+        ecar_session_render_key("failed_login")
+    ]
+    assert timedelta(milliseconds=8) <= failure_time - flow_time <= timedelta(milliseconds=140)
+    assert failed_event.remote_auth.session_object_id == ""
+    assert failed_event.remote_auth.logon_id == ""
+
+
+def test_remote_auth_timing_does_not_correlate_wrong_transaction() -> None:
+    """A different transaction in the same action cannot anchor authentication."""
+
+    planner = SourceTimingPlanner()
+    flow_event, login_event = _remote_auth_timing_events()
+    flow_event.network.transaction = replace(
+        flow_event.network.transaction,
+        stable_id="network-connection-unrelated",
+    )
+    flow_event.lifecycle = replace(
+        flow_event.lifecycle,
+        group_id="network-connection-unrelated",
+    )
+
+    planner.plan_event(flow_event, "ecar")
+    planner.record_admitted_source_event(flow_event, "ecar")
+    planner.plan_event(login_event, "ecar")
+
+    preferred = planner.source_time(
+        login_event,
+        "source.ecar_session",
+        seed_parts=(
+            "login",
+            "FILE-SRV-01",
+            "alice",
+            "10.0.0.20",
+            53123,
+            "0x12345",
+            3,
+            "",
+            login_event.source_timing.canonical_timestamp,
+        ),
+    )
+    assert login_event.source_timing.finalized_times[ecar_session_render_key("login")] == preferred
+
+
+def test_remote_auth_timing_does_not_correlate_wrong_exact_tuple() -> None:
+    """A reused transaction label with a different tuple cannot anchor authentication."""
+
+    planner = SourceTimingPlanner()
+    flow_event, login_event = _remote_auth_timing_events()
+    flow_event.network.src_port += 1
+
+    planner.plan_event(flow_event, "ecar")
+    planner.record_admitted_source_event(flow_event, "ecar")
+    planner.plan_event(login_event, "ecar")
+
+    preferred = planner.source_time(
+        login_event,
+        "source.ecar_session",
+        seed_parts=(
+            "login",
+            "FILE-SRV-01",
+            "alice",
+            "10.0.0.20",
+            53123,
+            "0x12345",
+            3,
+            "",
+            login_event.source_timing.canonical_timestamp,
+        ),
+    )
+    assert login_event.source_timing.finalized_times[ecar_session_render_key("login")] == preferred
+
+
+def test_remote_auth_windows_logon_follows_admitted_target_wfp() -> None:
+    """Visible target 5156 should precede the correlated Windows authentication row."""
+
+    planner = SourceTimingPlanner()
+    flow_event, login_event = _remote_auth_timing_events()
+    target = flow_event.dst_host
+    assert target is not None
+    transaction_id = flow_event.network.transaction.stable_id
+    wfp_event = SecurityEvent(
+        timestamp=flow_event.timestamp,
+        event_type="wfp_connection",
+        src_host=target,
+        network=NetworkContext(
+            src_ip=flow_event.network.src_ip,
+            src_port=flow_event.network.src_port,
+            dst_ip=flow_event.network.dst_ip,
+            dst_port=flow_event.network.dst_port,
+            protocol="tcp",
+            initiating_pid=4,
+        ),
+        lifecycle=ActionLifecycleContext(
+            group_id=transaction_id,
+            canonical_start=flow_event.timestamp,
+            phase="dependent",
+            parent_group_id=login_event.remote_auth.stable_id,
+        ),
+    )
+
+    planned_wfp = planner.plan_event(wfp_event, "windows_event_security")
+    planner.record_admitted_source_event(planned_wfp, "windows_event_security")
+    planned_login = planner.plan_event(login_event, "windows_event_security")
+
+    wfp_time = wfp_event.source_timing.finalized_times["windows.wfp_connection"]
+    assert (
+        timedelta(milliseconds=8)
+        <= planned_login.timestamp - wfp_time
+        <= timedelta(milliseconds=140)
+    )
+    assert planned_login.source_timing.canonical_timestamp == login_event.timestamp
 
 
 def test_sysmon_process_access_timestamp_follows_process_create(tmp_path: Path) -> None:

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -958,6 +958,54 @@ def test_remote_auth_ecar_login_follows_admitted_exact_transport() -> None:
     assert timedelta(milliseconds=8) <= login_time - flow_time <= timedelta(milliseconds=140)
 
 
+def test_ssh_ecar_login_follows_admitted_exact_transport() -> None:
+    """SSH remains ordered by its admitted target FLOW after source jitter."""
+
+    planner = SourceTimingPlanner()
+    start = _base_time()
+    target = _linux_host_context()
+    network = NetworkContext(
+        src_ip="10.0.0.20",
+        src_port=53124,
+        dst_ip=target.ip,
+        dst_port=22,
+        protocol="tcp",
+        service="ssh",
+        zeek_uid="CsshSourceTiming",
+        duration=30.0,
+        conn_state="SF",
+        history="ShADadFf",
+    )
+    flow_event = SecurityEvent(
+        timestamp=start,
+        event_type="connection",
+        dst_host=target,
+        network=network,
+    )
+    login_event = SecurityEvent(
+        timestamp=start + timedelta(milliseconds=100),
+        event_type="ssh_session",
+        dst_host=target,
+        auth=AuthContext(
+            username="alice",
+            source_ip=network.src_ip,
+            source_port=network.src_port,
+            logon_id="0x12345",
+            logon_type=10,
+        ),
+    )
+
+    planner.plan_event(flow_event, "ecar")
+    planner.record_admitted_source_event(flow_event, "ecar")
+    planner.plan_event(login_event, "ecar")
+
+    flow_time = flow_event.source_timing.finalized_times[
+        ecar_flow_render_key("inbound", target.hostname)
+    ]
+    login_time = login_event.source_timing.finalized_times[ecar_session_render_key("login")]
+    assert login_time > flow_time
+
+
 def test_remote_auth_failed_ecar_login_follows_transport_without_session() -> None:
     """Failed authentication should order after FLOW without durable session identity."""
 
@@ -1083,6 +1131,56 @@ def test_remote_auth_windows_logon_follows_admitted_target_wfp() -> None:
         <= timedelta(milliseconds=140)
     )
     assert planned_login.source_timing.canonical_timestamp == login_event.timestamp
+
+
+def test_remote_auth_timing_reuses_transaction_without_parent_action_metadata() -> None:
+    """An already-emitted transport remains exact-correlatable by transaction and tuple."""
+
+    planner = SourceTimingPlanner()
+    flow_event, login_event = _remote_auth_timing_events()
+    flow_event.lifecycle = replace(flow_event.lifecycle, parent_group_id=None)
+    target = flow_event.dst_host
+    assert target is not None
+    transaction_id = flow_event.network.transaction.stable_id
+    wfp_event = SecurityEvent(
+        timestamp=flow_event.timestamp,
+        event_type="wfp_connection",
+        src_host=target,
+        network=NetworkContext(
+            src_ip=flow_event.network.src_ip,
+            src_port=flow_event.network.src_port,
+            dst_ip=flow_event.network.dst_ip,
+            dst_port=flow_event.network.dst_port,
+            protocol="tcp",
+            initiating_pid=4,
+        ),
+        lifecycle=ActionLifecycleContext(
+            group_id=transaction_id,
+            canonical_start=flow_event.timestamp,
+            phase="dependent",
+        ),
+    )
+
+    planner.plan_event(flow_event, "ecar")
+    planner.record_admitted_source_event(flow_event, "ecar")
+    planner.plan_event(login_event, "ecar")
+    ecar_flow_time = flow_event.source_timing.finalized_times[
+        ecar_flow_render_key("inbound", target.hostname)
+    ]
+    ecar_login_time = login_event.source_timing.finalized_times[ecar_session_render_key("login")]
+    assert (
+        timedelta(milliseconds=8) <= ecar_login_time - ecar_flow_time <= timedelta(milliseconds=140)
+    )
+
+    planner.plan_event(wfp_event, "windows_event_security")
+    planner.record_admitted_source_event(wfp_event, "windows_event_security")
+    planned_login = planner.plan_event(login_event, "windows_event_security")
+    wfp_time = wfp_event.source_timing.finalized_times["windows.wfp_connection"]
+    assert (
+        timedelta(milliseconds=8)
+        <= planned_login.timestamp - wfp_time
+        <= timedelta(milliseconds=140)
+    )
 
 
 def test_sysmon_process_access_timestamp_follows_process_create(tmp_path: Path) -> None:

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -191,6 +191,75 @@ class TestStateManagerInit:
         ] == [logon_id]
         assert sm.get_sessions_for_user_at("alice", deadline) == []
 
+    def test_sessions_on_system_at_excludes_authoritatively_ended_session(self):
+        """Host-local activity selection must honor a preplanned session deadline."""
+
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        deadline = start + timedelta(hours=1)
+        logon_id = sm.create_session(
+            username="alice",
+            system="WS-01",
+            logon_type=2,
+            source_ip="-",
+            start_time=start,
+        )
+        assert sm.plan_session_end(
+            logon_id,
+            SessionEndPlan(deadline, "explicit_storyline", "story-logoff"),
+        )
+
+        assert [
+            session.logon_id
+            for session in sm.get_sessions_on_system_at(
+                "WS-01",
+                deadline - timedelta(milliseconds=1),
+            )
+        ] == [logon_id]
+        assert sm.get_sessions_on_system_at("WS-01", deadline) == []
+
+    def test_authoritative_end_blocks_implicit_rebootstrap_until_new_session(self):
+        """Baseline planners must not silently recreate an explicitly ended session."""
+
+        sm = StateManager()
+        start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        deadline = start + timedelta(hours=1)
+        logon_id = sm.create_session(
+            username="alice",
+            system="WS-01",
+            logon_type=2,
+            source_ip="-",
+            start_time=start,
+        )
+        assert sm.plan_session_end(
+            logon_id,
+            SessionEndPlan(deadline, "explicit_storyline", "story-logoff"),
+        )
+
+        assert not sm.authoritative_session_end_blocks_rebootstrap(
+            "alice",
+            "WS-01",
+            deadline - timedelta(milliseconds=1),
+        )
+        assert sm.authoritative_session_end_blocks_rebootstrap(
+            "alice",
+            "WS-01",
+            deadline,
+        )
+
+        sm.create_session(
+            username="alice",
+            system="WS-01",
+            logon_type=2,
+            source_ip="-",
+            start_time=deadline + timedelta(minutes=5),
+        )
+        assert not sm.authoritative_session_end_blocks_rebootstrap(
+            "alice",
+            "WS-01",
+            deadline + timedelta(minutes=6),
+        )
+
     def test_authoritative_end_plan_cannot_be_replaced(self):
         """The first explicit storyline close remains the immutable session authority."""
         sm = StateManager()

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -32,7 +32,6 @@ from evidenceforge.events.dispatcher import EventDispatcher
 from evidenceforge.events.observation import ObservationPolicy
 from evidenceforge.generation.actions.rdp_session import RdpSessionActionBundle, RdpSessionRequest
 from evidenceforge.generation.activity import ActivityGenerator
-from evidenceforge.generation.activity.timing_profiles import get_timing_window
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
 from evidenceforge.generation.world_model import WorldModel, WorldPlanner
@@ -774,8 +773,8 @@ def test_world_planner_bootstraps_rdp_session_with_owned_state(
     assert rdp_connections[0].source_system == "WKS-01"
 
 
-def test_rdp_target_logon_waits_for_endpoint_flow_visibility() -> None:
-    """RDP target logon timing should not precede same-tuple eCAR FLOW visibility."""
+def test_rdp_target_logon_uses_canonical_transport_phase_gap() -> None:
+    """RDP canonical authentication should not absorb source-observation latency."""
     scenario = _make_scenario()
     target = next(system for system in scenario.environment.systems if system.hostname == "APP-01")
     user = scenario.environment.users[0]
@@ -789,14 +788,6 @@ def test_rdp_target_logon_waits_for_endpoint_flow_visibility() -> None:
             source_ip="10.10.10.50",
         ),
     )
-    flow_window = get_timing_window(
-        "source.ecar_flow",
-        default_min_ms=40,
-        default_max_ms=300,
-        default_position="after",
-        default_class="source_latency",
-    )
-
     logon_time = bundle._target_logon_time(
         rng=random.Random(7),
         source_ip="10.10.10.50",
@@ -804,11 +795,12 @@ def test_rdp_target_logon_waits_for_endpoint_flow_visibility() -> None:
         transport_start_time=base_time,
     )
 
-    assert logon_time > base_time + timedelta(milliseconds=flow_window.max_ms)
+    assert base_time + timedelta(milliseconds=900) <= logon_time
+    assert logon_time <= base_time + timedelta(milliseconds=1600)
 
 
-def test_rdp_target_logon_budgets_observation_and_cross_host_clocks() -> None:
-    """RDP authentication should follow both rendered endpoint FLOW observations."""
+def test_rdp_target_logon_is_independent_of_observation_profile() -> None:
+    """Dispatcher source timing, not canonical RDP time, owns endpoint delay."""
 
     scenario = _make_scenario()
     source = next(system for system in scenario.environment.systems if system.hostname == "WKS-01")
@@ -834,14 +826,10 @@ def test_rdp_target_logon_budgets_observation_and_cross_host_clocks() -> None:
         source_ip=source.ip,
         src_port=52875,
         transport_start_time=base_time,
-        source_system=source,
-    )
-    required_gap_ms = bundle._endpoint_flow_visible_gap_ms(
-        source_system=source,
-        timestamp=base_time,
     )
 
-    assert logon_time > base_time + timedelta(milliseconds=required_gap_ms)
+    assert base_time + timedelta(milliseconds=900) <= logon_time
+    assert logon_time <= base_time + timedelta(milliseconds=1600)
 
 
 def test_world_planner_moves_rdp_source_after_future_workstation_session(

--- a/tests/unit/test_zeek_activity_contexts.py
+++ b/tests/unit/test_zeek_activity_contexts.py
@@ -2517,6 +2517,7 @@ class TestSslContextPopulation:
         assert ecar_login_time > accepted_event.timestamp
         assert ecar_login_time > pam_event.timestamp
         assert ecar_login_time > pam_event.timestamp + timedelta(milliseconds=250)
+        gen.dispatcher.source_timing_planner.plan_event(ssh_event, format_name="ecar")
         delayed_for_observation_profile = replace(
             ssh_event,
             timestamp=ssh_event.timestamp + timedelta(milliseconds=750),


### PR DESCRIPTION
## Summary

- add a canonical Windows remote-authentication planner and action bundle for Type 3, failed authentication, machine-account, remote-admin, and RDP paths
- correlate role-labelled network transactions to authentication by action group, exact transaction/tuple, host, and observation before rendering
- finalize eCAR and Windows source-local FLOW/auth ordering in `SourceTimingPlanner`, preserving independent missingness and post-timing output admission
- remove remote-auth timestamp invention/repair from emitters and add a rendered exact-tuple evaluator probe
- retain internal network transaction identity only in canonical planning; source-native eCAR output does not expose it

## Milestones

1. `d5fe4f68` — canonical remote-authentication planning
2. `a66c363d` — source timing and emitter simplification
3. `b9dfde31` — family completion, rendered probes, and acceptance evidence

## Validation

- focused remote-auth/network/source-timing/eCAR/RDP suite: 727 passed, 1 skipped
- default suite: 4,974 passed, 19 skipped
- configuration validation: 87 files, 0 issues
- Ruff check and format check: passed
- `iteration-test-expanded`: 82,102 records, score 95.6297, all hard gates passed
- eCAR: 706 visible exact-tuple pairs, 0 inversions (249 Kerberos/88, 445 SMB/445, 12 RDP/3389)
- Windows: 721 visible 5156/auth pairs, 0 inversions
- SSH regression: 98 visible pairs, 0 inversions
- no feature-branch version bump

## Blind panel

Final independent synthetic-confidence scores (lower is more production-like):

- Threat Hunter: 74
- Detection Engineer: 72
- Network Forensics: 88
- Host/EDR: 78
- Average: 78.0

All reviewers assessed the dataset as Synthetic; no deliberation trigger applied. Reviewers consistently rated the branch-owned network chronology, transaction accounting, independent sensor behavior, target-side remote-auth ordering, and endpoint identity as strong. The remaining high-score findings are recorded in the worklog and belong primarily to OCSP/DKIM payload generation, Event 4648/explicit-credential semantics, remote-admin process/file ownership, Sysmon content/timing, and baseline texture.

The first acceptance panel exposed an eCAR-only leak of the internal canonical transaction ID. That branch-local regression was removed at the format/emitter boundary, the evaluator was changed to source-native full-tuple/time correlation, the dataset was regenerated, and the final panel above reviewed the corrected output.
