### PR TITLE
fix: address assessment realism findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Most synthetic log generators produce isolated, single-format data that experien
 
 - **Deterministic engine, LLM-assisted authoring.** Scenario creation uses Claude Code Skills for interactive, research-backed attack planning. Log generation is fully deterministic — no LLM calls, no API costs, reproducible output every time.
 
-- **Built-in quality evaluation.** A 4-pillar scoring framework (20 sub-scores) measures parseability, plausibility, causality, and timing. Know exactly how good your data is before using it.
+- **Built-in quality evaluation.** A 4-pillar scoring framework (21 sub-scores) measures parseability, plausibility, causality, and timing. Know exactly how good your data is before using it.
 
 ## Quick Start
 
@@ -82,7 +82,7 @@ For scripted or non-interactive use:
 |---------|-------------|
 | `eforge generate <scenario.yaml> -o <dir>` | Generate logs from a scenario file |
 | `eforge validate <scenario.yaml>` | Validate scenario schema and cross-references |
-| `eforge eval <output_dir> -s <scenario.yaml>` | Evaluate data quality (4 pillars, 20 sub-scores) |
+| `eforge eval <output_dir> -s <scenario.yaml>` | Evaluate data quality (4 pillars, 21 sub-scores) |
 | `eforge info [field]` | Show installation info, config paths, and data inventories. Pass a dot-path field for a specific value (e.g., `eforge info personas`). Use `--fields` to list available fields, `--json` for machine output. |
 | `eforge validate-config` | Validate config files for cross-reference integrity. Use `--json` for machine output. |
 | `eforge install-skills [--agent all\|claude\|chatgpt\|codex] [--global]` | Install project-local or user-wide agent skills; defaults to all agents (`codex` aliases `chatgpt`) |
@@ -128,7 +128,7 @@ Every generated scenario includes a `GROUND_TRUTH.md` file. Attack scenarios doc
 - **Ground truth documentation** — Every run generates a GROUND_TRUTH.md; attack scenarios include narrative, timeline, and IOCs
 - **Parallel generation** — Threaded emitters write all formats simultaneously with temporal consistency
 - **Scenario validation** — Cross-reference checking, uniqueness constraints, and network topology validation
-- **Data quality evaluation** — 4-pillar scoring framework (20 sub-scores) with acceptance criteria
+- **Data quality evaluation** — 4-pillar scoring framework (21 sub-scores) with acceptance criteria
 - **Multi-timezone support** — Pattern-based timezone overrides per system hostname
 
 ## Supported Log Formats

--- a/TODO.md
+++ b/TODO.md
@@ -220,7 +220,8 @@ further per-loop or per-PR details in worklogs or PR descriptions.
 - [ ] Storyline cadence field: `human`, `automated`, or periodic interval with
   jitter.
 - [ ] Cloud/SaaS log formats: Azure AD, AWS CloudTrail, GCP audit logs, and M365.
-- [ ] `snort_alert` typed event spec for IDS signature declarations.
+- [x] Correlated multi-SID IDS attachments on typed `connection` and `beacon`
+  events, including sensor-local Snort-style alert filtering and reporting.
 - [ ] HTTP proxy server support for Squid, Blue Coat, and Zscaler.
 - [ ] Checkpointing and resume for long-running generation.
 - [ ] Additional skills: create-persona, create-log-format, create-network, and

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # EvidenceForge Implementation Plan
 
-**Status:** Phase 8.5 (Dual src/dst HostContext) COMPLETE; Pre-MVP quality fixes ongoing
+**Status:** Phase 8.5 (Dual src/dst HostContext) COMPLETE; post-1.0 quality improvements ongoing
 **Started:** 2026-03-11
 **Last Roadmap Review:** 2026-05-26
 
@@ -21,7 +21,7 @@ ground truth documentation.
 **Phase 2: Scalability.** Parallel threaded emitters, 7 log formats, persona
 temporal distribution, network visibility modeling, and multi-OS support.
 
-**Phase 3: MVP Release.** Skill-based scenario/generate/validate/evaluate
+**Phase 3: Initial Product Release.** Skill-based scenario/generate/validate/evaluate
 workflow, prebuilt personas, skill installation, and scenario reference docs.
 
 **Phase 4: Data Quality Evaluation.** `eforge eval` with deterministic scoring,
@@ -40,7 +40,7 @@ assessment history belongs in worklogs and changelog entries, not this roadmap.
 
 ---
 
-## Pre-MVP Quality Roadmap
+## Quality Roadmap
 
 Current goal: fix analyst-rejection issues and finish remaining quality work
 without turning `TODO.md` back into a high-conflict work journal.
@@ -212,7 +212,7 @@ further per-loop or per-PR details in worklogs or PR descriptions.
 
 ---
 
-## Post-MVP Enhancements
+## Future Enhancements
 
 ### Short-Term
 
@@ -220,8 +220,16 @@ further per-loop or per-PR details in worklogs or PR descriptions.
 - [ ] Storyline cadence field: `human`, `automated`, or periodic interval with
   jitter.
 - [ ] Cloud/SaaS log formats: Azure AD, AWS CloudTrail, GCP audit logs, and M365.
-- [x] Correlated multi-SID IDS attachments on typed `connection` and `beacon`
-  events, including sensor-local Snort-style alert filtering and reporting.
+- [x] Correlated multi-SID IDS attachments on typed transport-owning events,
+  including connections, beacons, remote sessions, DHCP, scans, and DNS activity,
+  with sensor-local Snort-style alert filtering and reporting.
+- [ ] Extend correlated IDS attachments to typed `email_message` and `email_read`
+  events so asserted SIDs follow the real mail transports produced by modeled
+  routing and sensor placement. IDS sensors do not currently decrypt traffic;
+  before implementation, decide whether STARTTLS and implicit TLS suppress every
+  candidate or permit signatures classified as detectable from flow,
+  pre-encryption, or TLS metadata. Plaintext mail is eligible only when a
+  storyline or background path explicitly asserts a signature.
 - [ ] HTTP proxy server support for Squid, Blue Coat, and Zscaler.
 - [ ] Checkpointing and resume for long-running generation.
 - [ ] Additional skills: create-persona, create-log-format, create-network, and

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,8 @@ temporal distribution, network visibility modeling, and multi-OS support.
 workflow, prebuilt personas, skill installation, and scenario reference docs.
 
 **Phase 4: Data Quality Evaluation.** `eforge eval` with deterministic scoring,
-source parsers, and acceptance criteria.
+source-instance-aware parsers, inferred narrative pivots, acceptance criteria,
+and exact correlated-IDS integrity gating.
 
 **Phase 5: Data Realism Improvements.** Major generator-level realism fixes for
 identity, protocol, process, temporal, and baseline noise patterns.

--- a/commands/eforge/config.md
+++ b/commands/eforge/config.md
@@ -109,6 +109,7 @@ Also read the relevant reference doc for field schemas and conventions:
 | Evaluation rules | `references/config-evaluation.md` (read-only reference — not user-customizable) |
 | Cross-file dependencies | `references/config-dependency-graph.md` |
 | Validation checks | `references/config-validation.md` |
+| IDS signatures and alert policy | `references/config-ids.md` |
 
 ## Step 4: Interview for Completeness
 
@@ -125,6 +126,13 @@ and whether it has multiple IPs.
 duplicate names. Keep profile contents synthetic and behavior-shaped: URI shapes,
 method/status/byte ranges, User-Agent pools, and deterministic tokens are fine;
 do not encode live malware IOC paths, domains, or exact campaign payloads.
+
+**Changing IDS cadence:** Edit the project overlay at
+`.eforge/config/activity/ids_signatures.yaml`; entries merge by `sid`. Add or
+replace `alert_policy` with `detection_filter`, `event_filter`, or both, or set it
+to `every`. Do not copy the whole packaged signature unless its metadata also
+needs to change. Read `references/config-ids.md`, run `eforge validate-config`,
+and start a fresh CLI process after the edit so cached signature data is reloaded.
 
 **Adding an application:** Which OS(es)? Categories? Which personas? Image path? PE metadata? Command templates? Parent process? Children? Network traffic?
 

--- a/commands/eforge/evaluate.md
+++ b/commands/eforge/evaluate.md
@@ -27,12 +27,15 @@ in an EvidenceForge source checkout, retry the same command with
 
 For canonical IDS attachments, compare Snort row counts with the per-SID
 candidate/emitted/policy-filtered totals in `GROUND_TRUTH.json`, not with the
-number of beacon ticks alone. Treat `OBSERVATION_MANIFEST.json` as the authority
+number of authored event ticks or probes alone. Treat `OBSERVATION_MANIFEST.json` as the authority
 for intentional policy `filtered`, collection `dropped`, delayed, and
 out-of-window evidence. Verify emitted rows retain the sensor-visible timestamp,
 tuple, ephemeral source port, and NAT/PAT projection of the corresponding
 physical connection. Remember that an attachment asserts a rule match;
 EvidenceForge does not evaluate the complete Snort predicate.
+For DHCP, count only the authored transaction, not later automatic renewals; for
+DNS tunnel activity, exclude generated background cover queries. For web scans,
+account for automatic and authored SIDs and the authored-wins duplicate rule.
 
 If they don't have generated output yet, suggest using `/eforge generate` first.
 

--- a/commands/eforge/evaluate.md
+++ b/commands/eforge/evaluate.md
@@ -11,7 +11,7 @@ description: >
 
 # EvidenceForge Data Quality Evaluator
 
-You are helping the user evaluate the quality of generated synthetic security log datasets using EvidenceForge's evaluation framework. The eval command scores datasets across **4 pillars** with 20 sub-scores, all deterministic and statistical. Your job is to run the eval, interpret the results, review sample records for realism, and provide actionable improvement suggestions.
+You are helping the user evaluate the quality of generated synthetic security log datasets using EvidenceForge's evaluation framework. The eval command scores datasets across **4 pillars** with 21 sub-scores, all deterministic and statistical. Your job is to run the eval, interpret the results, review sample records for realism, and provide actionable improvement suggestions.
 
 ## Quick Start
 
@@ -25,14 +25,15 @@ Default to `eforge` for all CLI execution. If `eforge` is not found and you are
 in an EvidenceForge source checkout, retry the same command with
 `uv run eforge ...`.
 
-For canonical IDS attachments, compare Snort row counts with the per-SID
-candidate/emitted/policy-filtered totals in `GROUND_TRUTH.json`, not with the
-number of authored event ticks or probes alone. Treat `OBSERVATION_MANIFEST.json` as the authority
-for intentional policy `filtered`, collection `dropped`, delayed, and
-out-of-window evidence. Verify emitted rows retain the sensor-visible timestamp,
-tuple, ephemeral source port, and NAT/PAT projection of the corresponding
-physical connection. Remember that an attachment asserts a rule match;
-EvidenceForge does not evaluate the complete Snort predicate.
+Canonical IDS reconciliation is automated by the zero-weight
+`plausibility.ids_integrity` hard gate. It compares every per-sensor `(gid, sid)`
+count and ordered normalized digest in `GROUND_TRUTH.json` with parsed Snort
+rows, including the sensor-visible UTC timestamp, signature metadata, complete
+tuple, ephemeral source port, and NAT/PAT projection. It also reconciles policy
+filtering and observation totals and requires every emitted row to have an
+authorized authored, built-in, or raw origin. Legacy datasets without
+`ids_evaluation` skip this check with a warning, but a scenario containing
+authored `ids_alerts` fails when the summary is missing or invalid.
 For DHCP, count only the authored transaction, not later automatic renewals; for
 DNS tunnel activity, exclude generated background cover queries. For web scans,
 account for automatic and authored SIDs and the authored-wins duplicate rule.
@@ -145,12 +146,13 @@ For each pillar, explain what the score means in practical terms:
 - Cross-Source Field Agreement: When the same event appears in multiple log sources, do shared fields agree? Uses pivot-key joins defined in `cross_source_pairs.yaml` plus built-in email checks — pairs include Windows 4688 ↔ eCAR PROCESS/CREATE (same PID+host → same process name), zeek_conn ↔ Cisco ASA (same 4-tuple), web_access/proxy ↔ zeek_http (same client+URI+10s bucket → same status/method), zeek_ssl ↔ zeek_x509 (cert chain fuids → server_name ∈ SAN), and email checks where SMTP UIDs join to conn.log, visible SMTP FUIDs join to files.log, and plaintext SMTP subject metadata agrees with `ARTIFACTS_MANIFEST.json` email records. A score below 100 means real field disagreements were found.
 - User Behavioral Diversity: Do different users behave differently, or are they cookie-cutter clones?
 - Benign Anomaly Rate: Is there a realistic 1–5% rate of anomalous-but-benign events? Zero anomalies is as implausible as 50%.
+- IDS Correlation Integrity: Do sensor-local Snort rows exactly match canonical counts, ordered digests, origins, and observation totals? This is a 100% hard gate with zero scoring weight.
 
 **Pillar 3: Causality (weight 0.25)**
 - Causal Ordering: Are logon→process→logoff and lock→reauth→unlock sequences correctly ordered? DNS before TCP? Kerberos/DC TGT/TGS before domain logons? NTLM/DC validation and Windows audit/process-access companions after their owning evidence?
 - Storyline Event Presence: Are all expected-visible storyline events visible in at least one log source? For non-`complete` observation profiles with a manifest, source rows marked `dropped`, `filtered`, or `out_of_window` are excluded from this coverage denominator.
 - Indicator Accuracy: Do traces carry the correct IPs, usernames, hostnames from the scenario?
-- Pivot Linkability: Can a hunter pivot between consecutive expected-visible attack steps using shared field values?
+- Pivot Linkability: Can a hunter pivot along inferred narrative edges built from shared typed indicators such as hosts, IPs, accounts, domains, URLs, files/hashes, and artifact/message IDs? Unrelated interleaved steps are not connected, generic ports/protocols are excluded, and isolated events are reported separately.
 - Storyline Temporal Integrity: Are expected-visible attack events in the right relative order at the right times?
 - Storyline Trace Coverage: For each expected-visible log format group on each involved host, does the storyline leave a trace?
 

--- a/commands/eforge/evaluate.md
+++ b/commands/eforge/evaluate.md
@@ -25,6 +25,15 @@ Default to `eforge` for all CLI execution. If `eforge` is not found and you are
 in an EvidenceForge source checkout, retry the same command with
 `uv run eforge ...`.
 
+For canonical IDS attachments, compare Snort row counts with the per-SID
+candidate/emitted/policy-filtered totals in `GROUND_TRUTH.json`, not with the
+number of beacon ticks alone. Treat `OBSERVATION_MANIFEST.json` as the authority
+for intentional policy `filtered`, collection `dropped`, delayed, and
+out-of-window evidence. Verify emitted rows retain the sensor-visible timestamp,
+tuple, ephemeral source port, and NAT/PAT projection of the corresponding
+physical connection. Remember that an attachment asserts a rule match;
+EvidenceForge does not evaluate the complete Snort predicate.
+
 If they don't have generated output yet, suggest using `/eforge generate` first.
 
 For detailed field documentation and known limitations of each log format, use the `/eforge:references:evidence-formats` skill.

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -34,6 +34,11 @@ origin request, observation missingness, or policy cadence can all legitimately
 reduce output. Candidate spooling is disk-backed and removed on success or
 failure; a leftover EvidenceForge IDS spool indicates an interrupted process and
 may be removed once no generation process is using it.
+`GROUND_TRUTH.json` also includes the bounded `ids_evaluation` acceptance
+contract: per-sensor/SID counts, origin totals, observation totals, and an
+ordered normalized alert digest. `GROUND_TRUTH.md` renders the same information
+in its IDS Evaluation Summary. Generation accumulates this summary while Snort
+candidates finalize and does not retain alert-volume-sized state.
 
 Interpret candidates by owned transport: SSH/RDP use only their session
 connection; DHCP uses only the authored transaction and does not pass assertions

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -25,6 +25,16 @@ Default to `eforge` for all CLI execution. If `eforge` is not found and you are
 in an EvidenceForge source checkout, retry the same command with
 `uv run eforge ...`.
 
+When a scenario uses canonical `ids_alerts`, do not infer missing Snort rows from
+the authored attachment count alone. Check `GROUND_TRUTH.json`/`.md` for each
+SID's effective policy and candidate/emitted/policy-filtered sensor totals, then
+check `OBSERVATION_MANIFEST.json` for collection drops, clipping, and policy
+`filtered` status. No IDS sensor, an invisible proxy leg, a denied/cache-hit
+origin request, observation missingness, or policy cadence can all legitimately
+reduce output. Candidate spooling is disk-backed and removed on success or
+failure; a leftover EvidenceForge IDS spool indicates an interrupted process and
+may be removed once no generation process is using it.
+
 If they don't have a scenario file yet, suggest using `/eforge scenario` to create one first.
 
 ## Command Reference

--- a/commands/eforge/generate.md
+++ b/commands/eforge/generate.md
@@ -35,6 +35,12 @@ reduce output. Candidate spooling is disk-backed and removed on success or
 failure; a leftover EvidenceForge IDS spool indicates an interrupted process and
 may be removed once no generation process is using it.
 
+Interpret candidates by owned transport: SSH/RDP use only their session
+connection; DHCP uses only the authored transaction and does not pass assertions
+to automatic renewals; scans and DNS families fan out across authored
+probes/requests/queries. DNS-tunnel cover traffic is not attached. IDS sensors
+do not decrypt traffic, and email attachments remain unsupported.
+
 If they don't have a scenario file yet, suggest using `/eforge scenario` to create one first.
 
 ## Command Reference

--- a/commands/eforge/references/config-evaluation.md
+++ b/commands/eforge/references/config-evaluation.md
@@ -30,6 +30,14 @@ correctness gates such as parseability, value plausibility, field agreement, and
 ordering remain strict. Adjusted sub-scores expose `raw_score` in JSON and show `raw:<score>` in
 the text report.
 
+`plausibility.ids_integrity` is a special zero-weight 100% hard gate. It validates
+the bounded `GROUND_TRUTH.json.ids_evaluation` contract against parsed,
+sensor-provenanced Snort rows and `OBSERVATION_MANIFEST.json`. Its zero weight
+keeps the overall numeric score unchanged while any count, digest, origin, tuple,
+timestamp, filtering, or observation contradiction fails acceptance. Legacy
+ground truth without the section skips the gate unless the supplied scenario
+authors `ids_alerts`, in which case absence is a failure.
+
 ### Structure
 
 ```yaml
@@ -87,6 +95,7 @@ pillars:
 | plausibility | `field_agreement` | no |
 | plausibility | `user_diversity` | no |
 | plausibility | `anomaly_rate` | no |
+| plausibility | `ids_integrity` | yes (100%; zero weight) |
 | causality | `causal_ordering` | yes |
 | causality | `event_presence` | yes |
 | causality | `indicator_accuracy` | no |

--- a/commands/eforge/references/config-ids.md
+++ b/commands/eforge/references/config-ids.md
@@ -1,0 +1,63 @@
+# IDS Signature Configuration
+
+## File and overlay
+
+Package defaults live in `activity/ids_signatures.yaml`. Project changes belong
+in `.eforge/config/activity/ids_signatures.yaml`. Entries merge by `sid`, so an
+overlay can add a signature or replace selected fields, including its default
+alert policy. Reset/reload config state (or start a new CLI process) after edits,
+then run `eforge validate-config`.
+
+```yaml
+signatures:
+  - sid: 2002910
+    alert_policy:
+      event_filter:
+        type: both
+        track: by_src
+        count: 5
+        seconds: 60
+```
+
+Required signature fields remain `sid`, `rev`, `message`, `classification`,
+`priority`, and `proto`; the existing `dst_port`, `direction`, DNS templates,
+target service/OS, and baseline eligibility fields keep their current meanings.
+
+## `alert_policy`
+
+`alert_policy` is optional. Omission and `every` both admit every sensor-visible
+candidate. A policy object supports:
+
+```yaml
+alert_policy:
+  detection_filter:
+    track: by_src       # by_src | by_dst
+    count: 5            # positive integer
+    seconds: 60         # positive integer; half-open window
+  event_filter:
+    type: limit         # limit | threshold | both
+    track: by_src
+    count: 1
+    seconds: 300
+```
+
+`detection_filter` suppresses the first `count` rule matches and admits later
+matches while the rolling window stays above that threshold. `event_filter` is
+then applied to admitted matches: `limit` emits the first `count` per window,
+`threshold` emits every `count`th match and resets, and `both` emits once when the
+count is reached and suppresses until expiry. A timestamp exactly `seconds`
+after the window start begins a new window.
+
+Scenario attachment policies replace, rather than merge with, this default.
+Use `policy: every` on an attachment to explicitly bypass a signature default.
+EvidenceForge models alert output only: it does not parse complete Snort rules,
+apply `rate_filter`, CIDR suppressions, or IPS actions.
+
+## Validation
+
+`eforge validate-config` rejects empty policies, unknown keys, invalid
+filter/type/track values, booleans/fractions/non-positive values, and integers
+above 2,147,483,647. `eforge validate <scenario>` rejects unknown or duplicate
+attachment SIDs and conflicting effective policies for one SID. Protocol, port,
+and direction mismatches are advisory warnings because nonstandard deployments
+can be intentional.

--- a/commands/eforge/references/config-ids.md
+++ b/commands/eforge/references/config-ids.md
@@ -53,6 +53,12 @@ Use `policy: every` on an attachment to explicitly bypass a signature default.
 EvidenceForge models alert output only: it does not parse complete Snort rules,
 apply `rate_filter`, CIDR suppressions, or IPS actions.
 
+Signature defaults are inherited by attachments on typed `connection`,
+`beacon`, `ssh_session`, `rdp_session`, `dhcp_lease`, `port_scan`, `web_scan`,
+`dns_query`, `dga_queries`, and `dns_tunnel` events. Defaults never make an
+unattached tuple alert. The IDS model does not decrypt traffic, and mail-event
+attachments remain deferred.
+
 ## Validation
 
 `eforge validate-config` rejects empty policies, unknown keys, invalid

--- a/commands/eforge/references/config-validation.md
+++ b/commands/eforge/references/config-validation.md
@@ -110,6 +110,23 @@ When `eforge validate` checks a scenario:
 - `event_spacing.mode: explicit_offsets` must provide exactly one offset per child event in the parent storyline or red-herring step
 - `event_spacing.mode: interval` must include `interval`
 
+## IDS signature and attachment validation
+
+When `eforge validate-config` checks `ids_signatures.yaml`:
+
+- required signature identity/rendering fields must be present and numeric fields
+  must be positive integers;
+- `alert_policy` may be `every` or a non-empty object containing
+  `detection_filter`, `event_filter`, or both;
+- filter `track` is `by_src` or `by_dst`; event-filter `type` is `limit`,
+  `threshold`, or `both`; `count` and `seconds` are strict positive integers no
+  larger than 2,147,483,647; unknown keys are errors.
+
+When `eforge validate` checks scenario `ids_alerts`, unknown/duplicate SIDs and
+conflicting effective policies for one SID are errors. Protocol, destination
+port, and direction mismatches are advisory warnings so intentional custom rule
+deployments remain possible. See `config-ids.md` for the policy state semantics.
+
 ## Scenario Validation: traffic_rates
 
 When `eforge validate` checks a scenario with `baseline_activity.traffic_rates`:

--- a/commands/eforge/references/config-validation.md
+++ b/commands/eforge/references/config-validation.md
@@ -125,7 +125,10 @@ When `eforge validate-config` checks `ids_signatures.yaml`:
 When `eforge validate` checks scenario `ids_alerts`, unknown/duplicate SIDs and
 conflicting effective policies for one SID are errors. Protocol, destination
 port, and direction mismatches are advisory warnings so intentional custom rule
-deployments remain possible. See `config-ids.md` for the policy state semantics.
+deployments remain possible. Attachments are accepted only on typed transport
+owners: connections, beacons, SSH/RDP sessions, authored DHCP transactions,
+port/web scans, and DNS query families. Email and non-transport/composite events
+reject the field. See `config-ids.md` for the policy state semantics.
 
 ## Scenario Validation: traffic_rates
 

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -340,6 +340,15 @@ Per-user command history for Linux systems. Baseline SSH sessions to Linux serve
 
 Network intrusion detection alerts. Baseline generates false-positive alerts (e.g., ICMP PING, SSH scan, policy violations) correlated with Zeek conn records via canonical SecurityEvent dispatch. Storyline generates true-positive alerts for malicious connections. IDS signature-to-context construction is owned by the internal IDS alert action bundle so Snort/Suricata rows render canonical network/DNS/HTTP evidence rather than independently inventing alert payloads.
 
+Typed `connection` and `beacon` events may attach multiple configured SIDs with
+`ids_alerts`. The attachment asserts a match; EvidenceForge does not execute the
+full rule predicate. Filtering is deferred until sensor visibility, clock, and
+NAT/PAT projection are known, then tracked independently per sensor and visible
+source/destination IP. `GROUND_TRUTH.json`/`.md` expose effective policy and
+candidate/emitted/policy-filtered totals; policy suppression appears as
+`filtered` IDS evidence in `OBSERVATION_MANIFEST.json`. Raw Snort events are
+unchanged.
+
 Web scan events (`web_scan` storyline type) generate three layers of IDS alerts:
 1. **Scanner UA detection** — identifies the scanning tool by user-agent (non-TLS only)
 2. **Per-path content alerts** — curated SID mappings for specific probe paths (non-TLS only)
@@ -349,6 +358,8 @@ Alert format: `[gid:sid:rev]` where `gid` defaults to 1, `sid` identifies the ru
 
 **Known Limitations:**
 - IDS alert variety is limited to curated SID pools (not full ruleset simulation)
+- Attached alerts do not support rule parsing, `rate_filter`, CIDR suppression,
+  or IPS actions
 
 ---
 

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -352,6 +352,16 @@ candidate/emitted/policy-filtered totals; policy suppression appears as
 `filtered` IDS evidence in `OBSERVATION_MANIFEST.json`. Raw Snort events are
 unchanged.
 
+The optional schema-v1 `ids_evaluation` section in `GROUND_TRUTH.json` is the
+automated acceptance contract. For each sensor and `(gid, sid)` it records
+candidate, emitted, policy-filtered, visible/delayed, and authorized-origin
+totals plus a SHA-256 digest over normalized alerts in file order. Normalization
+covers sensor identity, UTC timestamp, signature metadata, protocol, full tuple,
+and the sensor-visible NAT/PAT projection. Overall IDS observation totals
+reconcile visible, delayed, dropped, filtered, and out-of-window attempts. The
+Markdown IDS Evaluation Summary renders the same counts with abbreviated
+digests.
+
 Attachments follow only owned transports: the SSH/RDP session connection, the
 authored DHCP transaction, each scan/web request, and each authored DNS-family
 query. Automatic DHCP renewals and DNS-tunnel cover queries do not inherit them.

--- a/commands/eforge/references/evidence-formats.md
+++ b/commands/eforge/references/evidence-formats.md
@@ -340,14 +340,23 @@ Per-user command history for Linux systems. Baseline SSH sessions to Linux serve
 
 Network intrusion detection alerts. Baseline generates false-positive alerts (e.g., ICMP PING, SSH scan, policy violations) correlated with Zeek conn records via canonical SecurityEvent dispatch. Storyline generates true-positive alerts for malicious connections. IDS signature-to-context construction is owned by the internal IDS alert action bundle so Snort/Suricata rows render canonical network/DNS/HTTP evidence rather than independently inventing alert payloads.
 
-Typed `connection` and `beacon` events may attach multiple configured SIDs with
-`ids_alerts`. The attachment asserts a match; EvidenceForge does not execute the
-full rule predicate. Filtering is deferred until sensor visibility, clock, and
+Typed `connection`, `beacon`, `ssh_session`, `rdp_session`, `dhcp_lease`,
+`port_scan`, `dns_query`, `dga_queries`, `dns_tunnel`, and `web_scan` events may
+attach multiple configured SIDs with `ids_alerts`. The attachment asserts a
+match; EvidenceForge does not execute the full rule predicate or decrypt
+traffic. A tuple without an explicit or built-in IDS context does not alert.
+Filtering is deferred until sensor visibility, clock, and
 NAT/PAT projection are known, then tracked independently per sensor and visible
 source/destination IP. `GROUND_TRUTH.json`/`.md` expose effective policy and
 candidate/emitted/policy-filtered totals; policy suppression appears as
 `filtered` IDS evidence in `OBSERVATION_MANIFEST.json`. Raw Snort events are
 unchanged.
+
+Attachments follow only owned transports: the SSH/RDP session connection, the
+authored DHCP transaction, each scan/web request, and each authored DNS-family
+query. Automatic DHCP renewals and DNS-tunnel cover queries do not inherit them.
+Authored web-scan SIDs coexist with automatic alerts and win duplicate
+`(gid, sid)` collisions. Email transport attachments remain deferred.
 
 Web scan events (`web_scan` storyline type) generate three layers of IDS alerts:
 1. **Scanner UA detection** — identifies the scanning tool by user-agent (non-TLS only)

--- a/commands/eforge/references/scenario-reference.md
+++ b/commands/eforge/references/scenario-reference.md
@@ -797,8 +797,8 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
 | `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent`, `ids_alerts` |
-| `ssh_session` | canonical SSH connection (Zeek conn) + syslog sshd + EDR/eCAR | | `source_ip` |
-| `rdp_session` | Zeek conn + 4624 type 10 + eCAR | | `source_ip` |
+| `ssh_session` | canonical SSH connection (Zeek conn) + syslog sshd + EDR/eCAR | | `source_ip`, `ids_alerts` |
+| `rdp_session` | Zeek conn + 4624 type 10 + eCAR | | `source_ip`, `ids_alerts` |
 | `account_created` | 4720 (on DC) | `target_username` | `target_sid` |
 | `account_deleted` | 4726 (on DC) | `target_username` | `target_sid` |
 | `group_member_added` | 4728/4732/4756 (on DC) | `group_name`, `member_name` | `scope` (global/local/universal) |
@@ -806,16 +806,16 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `scheduled_task_created` | 4698 | `task_name` | `task_content` |
 | `log_cleared` | 1102 | | |
 | `create_remote_thread` | Sysmon 8, eCAR THREAD/REMOTE_CREATE | `target_process` | |
-| `dhcp_lease` | Zeek dhcp.log | | `mac_address`, `requested_ip` |
-| `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `source_ip`, `target_count`, `ports`, `protocol`, `scan_rate` |
+| `dhcp_lease` | Zeek dhcp.log | | `mac_address`, `requested_ip`, `ids_alerts` |
+| `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `source_ip`, `target_count`, `ports`, `protocol`, `scan_rate`, `ids_alerts` |
 | `beacon` | Zeek conn/proxy/ASA/Snort (periodic connections) | `dst_ip`, `interval`, one of `end_time`/`duration`/`count` | `action` (allow/deny), `hostname`, `service`, `protocol`, `source_ip`, `method`, `uri`, `user_agent`, `referrer`, `status_code`, `orig_bytes`, `resp_bytes`, `profile`, `http_sequence`, `ids_alerts`, `jitter` (default: 0.15) |
-| `dns_query` | Zeek dns.log + conn.log, Sysmon 22 | `query` | `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR), `source_ip` |
+| `dns_query` | Zeek dns.log + conn.log, Sysmon 22 | `query` | `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR), `source_ip`, `ids_alerts` |
 | `email_message` | SMTP route evidence: Zeek conn/dns/smtp/files, artifacts, ground truth | at least one of `to`/`cc`/`bcc` | `sender`, `subject`, `body`, `corpus_id`, `artifact_id`, `user_agent`, `verdict`, `mail_action`, `outcome`, `attachments` |
 | `email_read` | Opaque TLS mailbox access: DNS + conn/ssl/x509 evidence only | | `mailbox`, `server`, `protocol` (`imaps`/`owa`), `message_ids`, `count`, `duration`, `user_agent` |
-| `web_scan` | web_access + Zeek HTTP (bulk HTTP requests) | `dst_ip`, `rate`, one of `end_time`/`duration`/`count` | `preset` (nikto/dirb/gobuster/sqlmap/nmap_http), `paths`, `hostname`, `user_agent`, `jitter` (default: 0.4) |
+| `web_scan` | web_access + Zeek HTTP (bulk HTTP requests) | `dst_ip`, `rate`, one of `end_time`/`duration`/`count` | `preset` (nikto/dirb/gobuster/sqlmap/nmap_http), `paths`, `hostname`, `user_agent`, `ids_alerts`, `jitter` (default: 0.4) |
 | `credential_spray` | Windows 4625/4776 or syslog auth | `target_accounts`, `interval`, one of `end_time`/`duration`/`count` | `pattern` (spray/brute_force/stuffing), `source_ip`, `logon_type`, `success`, `jitter` (default: 0.5) |
-| `dga_queries` | Zeek dns.log + conn.log (bulk DGA) | `interval`, one of `end_time`/`duration`/`count` | `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`, `source_ip`, `jitter` (default: 0.3) |
-| `dns_tunnel` | Zeek dns.log + conn.log (encoded exfil) | `base_domain`, `interval`, one of `end_time`/`duration`/`count` | `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`, `payload_size`, `source_ip`, `jitter` (default: 0.25) |
+| `dga_queries` | Zeek dns.log + conn.log (bulk DGA) | `interval`, one of `end_time`/`duration`/`count` | `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`, `source_ip`, `ids_alerts`, `jitter` (default: 0.3) |
+| `dns_tunnel` | Zeek dns.log + conn.log (encoded exfil) | `base_domain`, `interval`, one of `end_time`/`duration`/`count` | `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`, `payload_size`, `source_ip`, `ids_alerts`, `jitter` (default: 0.25) |
 | `explicit_credentials` | Windows 4648 (explicit credential usage) | `target_username` | `target_server`, `process_name`, `source_ip` |
 | `workstation_lock` | Windows 4800 (workstation locked) | | |
 | `workstation_unlock` | Windows 4624 type 7 re-auth followed by 4801 unlock | | |
@@ -1025,7 +1025,9 @@ Timing fields: `start_time` (optional, defaults to parent event time), `interval
 
 ### Correlated IDS attachments
 
-`connection` and `beacon` accept `ids_alerts`, a list of configured SIDs. An
+Typed `connection`, `beacon`, `ssh_session`, `rdp_session`, `dhcp_lease`,
+`port_scan`, `dns_query`, `dga_queries`, `dns_tunnel`, and `web_scan` events
+accept `ids_alerts`, a list of configured SIDs. An
 omitted policy inherits the signature's `alert_policy`; `policy: every` replaces
 it; an object replaces it with `detection_filter`, `event_filter`, or both.
 Tracking is `by_src` or `by_dst`; event-filter types are `limit`, `threshold`,
@@ -1046,6 +1048,14 @@ rule predicate. Filtering is per sensor after visibility, timing, and NAT/PAT
 projection. Explicit proxies carry candidates on both physical legs where those
 legs exist; denials and cache hits do not create origin alerts. Prefer attachments
 over raw Snort events for cross-source correlation.
+
+Attachments fan out only to transports owned by the authored event: the SSH/RDP
+session connection, the authored DHCP transaction, each scan/web request, or
+each authored DNS/DGA/tunnel query. Automatic DHCP renewals and DNS-tunnel cover
+traffic do not inherit the assertion. Authored web-scan attachments coexist with
+preset alerts and win a same-`(gid, sid)` collision. A tuple without an explicit
+or built-in IDS context never alerts. Email transports remain deferred, and IDS
+sensors do not decrypt traffic.
 
 ### DNS Query Events
 

--- a/commands/eforge/references/scenario-reference.md
+++ b/commands/eforge/references/scenario-reference.md
@@ -796,7 +796,7 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `logon` | 4624, target-host 4672 for elevated sessions, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
-| `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent` |
+| `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent`, `ids_alerts` |
 | `ssh_session` | canonical SSH connection (Zeek conn) + syslog sshd + EDR/eCAR | | `source_ip` |
 | `rdp_session` | Zeek conn + 4624 type 10 + eCAR | | `source_ip` |
 | `account_created` | 4720 (on DC) | `target_username` | `target_sid` |
@@ -808,7 +808,7 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `create_remote_thread` | Sysmon 8, eCAR THREAD/REMOTE_CREATE | `target_process` | |
 | `dhcp_lease` | Zeek dhcp.log | | `mac_address`, `requested_ip` |
 | `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `source_ip`, `target_count`, `ports`, `protocol`, `scan_rate` |
-| `beacon` | Zeek conn/proxy/ASA (periodic connections) | `dst_ip`, `interval`, one of `end_time`/`duration`/`count` | `action` (allow/deny), `hostname`, `service`, `protocol`, `source_ip`, `method`, `uri`, `user_agent`, `referrer`, `status_code`, `orig_bytes`, `resp_bytes`, `profile`, `http_sequence`, `jitter` (default: 0.15) |
+| `beacon` | Zeek conn/proxy/ASA/Snort (periodic connections) | `dst_ip`, `interval`, one of `end_time`/`duration`/`count` | `action` (allow/deny), `hostname`, `service`, `protocol`, `source_ip`, `method`, `uri`, `user_agent`, `referrer`, `status_code`, `orig_bytes`, `resp_bytes`, `profile`, `http_sequence`, `ids_alerts`, `jitter` (default: 0.15) |
 | `dns_query` | Zeek dns.log + conn.log, Sysmon 22 | `query` | `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR), `source_ip` |
 | `email_message` | SMTP route evidence: Zeek conn/dns/smtp/files, artifacts, ground truth | at least one of `to`/`cc`/`bcc` | `sender`, `subject`, `body`, `corpus_id`, `artifact_id`, `user_agent`, `verdict`, `mail_action`, `outcome`, `attachments` |
 | `email_read` | Opaque TLS mailbox access: DNS + conn/ssl/x509 evidence only | | `mailbox`, `server`, `protocol` (`imaps`/`owa`), `message_ids`, `count`, `duration`, `user_agent` |
@@ -1022,6 +1022,30 @@ Use `beacon` for periodic connections — allowed (C2 callbacks through proxy) o
 ```
 
 Timing fields: `start_time` (optional, defaults to parent event time), `interval` (required), one of `end_time`/`duration`/`count` (required), `jitter` (0.0-1.0, default: **0.15** — beacons are deliberately tight). Connection fields: all `connection` fields (dst_ip, dst_port, hostname, service, protocol, method, uri, user_agent, `referrer`, etc.). `profile` selects a behavior-shaped synthetic profile from `config/activity/beacon_profiles.yaml`; bundled profiles model broad check-in/tasking shapes, not live malware IoCs. `http_sequence` cycles explicit per-tick request shapes and can use deterministic URI tokens: `{host_id}`, `{campaign_id}`, `{tick}`, `{hex8}`, `{guid}`, and `{base64url:N}`. Sequence entries may override `method`, `uri`, `user_agent`, `referrer`, `status_code`, `response_body_len`, `orig_bytes`, and `resp_bytes`; byte fields accept either an integer or `[min, max]`. For `hostname`, use the client-facing DNS name used by the beacon, not a reverse-DNS/PTR artifact, unless that is intentionally part of the scenario. `action`: `allow` (default) or `deny`. Set `referrer` to pin the HTTP Referer header for a specific beacon URL (e.g., a phishing page that launched the download). In explicit proxy mode, HTTP/S beacons from hosts routed through a `forward_proxy` traverse the proxy; denied proxyable beacons stop at the proxy and emit proxy-denied CONNECT/GET evidence rather than direct client-to-origin network evidence.
+
+### Correlated IDS attachments
+
+`connection` and `beacon` accept `ids_alerts`, a list of configured SIDs. An
+omitted policy inherits the signature's `alert_policy`; `policy: every` replaces
+it; an object replaces it with `detection_filter`, `event_filter`, or both.
+Tracking is `by_src` or `by_dst`; event-filter types are `limit`, `threshold`,
+and `both`; counts and windows are positive integers. The same SID must have one
+effective policy throughout a scenario.
+
+```yaml
+ids_alerts:
+  - sid: 2028401
+  - sid: 2002910
+    policy:
+      detection_filter: {track: by_src, count: 5, seconds: 60}
+      event_filter: {type: limit, track: by_src, count: 1, seconds: 300}
+```
+
+Attachments assert a match; EvidenceForge does not evaluate the complete Snort
+rule predicate. Filtering is per sensor after visibility, timing, and NAT/PAT
+projection. Explicit proxies carry candidates on both physical legs where those
+legs exist; denials and cache hits do not create origin alerts. Prefer attachments
+over raw Snort events for cross-source correlation.
 
 ### DNS Query Events
 

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -146,8 +146,10 @@ Multiple attackers and parallel attack paths are supported — for example, an e
 
 **Log formats** — Which formats should be generated? Windows Event Security and Zeek are the most common pair. Add the `ecar` output format for simulated EDR visibility, syslog + bash_history for Linux systems, Snort for IDS alerts, web_access for web server logs, proxy_access for forward proxy logs (captures outbound HTTP/HTTPS with CONNECT tunnels and full URLs). Zeek includes `zeek_smtp` when a network sensor can see modeled SMTP traffic.
 
-For an authored `connection` or `beacon` that should trigger configured IDS
-signatures, use `ids_alerts` rather than a raw Snort event. Select SIDs from the
+For an authored transport-owning event (`connection`, `beacon`, `ssh_session`,
+`rdp_session`, `dhcp_lease`, `port_scan`, `dns_query`, `dga_queries`,
+`dns_tunnel`, or `web_scan`) that should trigger configured IDS signatures, use
+`ids_alerts` rather than a raw Snort event. Select SIDs from the
 merged `ids_signatures.yaml` pool. Omit `policy` to inherit the signature default,
 use `policy: every` for every visible connection, or replace the default with a
 `detection_filter`, `event_filter`, or both. Use filtering only when the intended
@@ -156,6 +158,14 @@ assert a match and do not execute the complete rule predicate. Explicit proxy
 attachments follow both real transport legs, while topology decides which IDS
 sensor sees each; denials and cache hits have no origin leg. Read
 `/eforge:references:scenario-reference` for the full policy schema.
+
+Attach only when the story explicitly asserts a signature match; a tuple alone
+never alerts, and IDS sensors do not decrypt traffic. SSH/RDP attach only to the
+session transport, authored DHCP only to that transaction (not later renewals),
+and scan/DNS families fan out to their owned probes or queries. Authored web-scan
+SIDs coexist with automatic preset alerts and win a duplicate `(gid, sid)`.
+Do not add attachments to `email_message` or `email_read`; encrypted mail
+detection surfaces are deferred.
 
 **System roles** — Assign `roles` to systems in the environment to drive both **outbound** traffic (connections the host initiates) and **inbound** traffic (connections the host receives). Roles like `web_server`, `database`, `mail_server`, `file_server`, `domain_controller` each have specific traffic profiles. For example, a `web_server` generates outbound database queries AND receives inbound HTTPS from external clients and internal users. A `database` generates outbound replication AND receives inbound SQL queries from web/app servers.
 

--- a/commands/eforge/scenario.md
+++ b/commands/eforge/scenario.md
@@ -146,6 +146,17 @@ Multiple attackers and parallel attack paths are supported — for example, an e
 
 **Log formats** — Which formats should be generated? Windows Event Security and Zeek are the most common pair. Add the `ecar` output format for simulated EDR visibility, syslog + bash_history for Linux systems, Snort for IDS alerts, web_access for web server logs, proxy_access for forward proxy logs (captures outbound HTTP/HTTPS with CONNECT tunnels and full URLs). Zeek includes `zeek_smtp` when a network sensor can see modeled SMTP traffic.
 
+For an authored `connection` or `beacon` that should trigger configured IDS
+signatures, use `ids_alerts` rather than a raw Snort event. Select SIDs from the
+merged `ids_signatures.yaml` pool. Omit `policy` to inherit the signature default,
+use `policy: every` for every visible connection, or replace the default with a
+`detection_filter`, `event_filter`, or both. Use filtering only when the intended
+rule cadence needs it; every candidate is the reasonable default. Attachments
+assert a match and do not execute the complete rule predicate. Explicit proxy
+attachments follow both real transport legs, while topology decides which IDS
+sensor sees each; denials and cache hits have no origin leg. Read
+`/eforge:references:scenario-reference` for the full policy schema.
+
 **System roles** — Assign `roles` to systems in the environment to drive both **outbound** traffic (connections the host initiates) and **inbound** traffic (connections the host receives). Roles like `web_server`, `database`, `mail_server`, `file_server`, `domain_controller` each have specific traffic profiles. For example, a `web_server` generates outbound database queries AND receives inbound HTTPS from external clients and internal users. A `database` generates outbound replication AND receives inbound SQL queries from web/app servers.
 
 Inbound traffic respects network topology: DMZ-placed `web_server` hosts attract external HTTPS, while internal `database` hosts only receive queries from other internal systems. The firewall policy determines what gets permitted vs denied — denied inbound attempts produce firewall deny records visible to analysts.

--- a/commands/eforge/validate.md
+++ b/commands/eforge/validate.md
@@ -22,7 +22,8 @@ Default to `eforge` for all CLI execution. If `eforge` is not found and you are
 in an EvidenceForge source checkout, retry the same command with
 `uv run eforge ...`.
 
-For `connection`/`beacon` `ids_alerts`, explain schema errors precisely: SIDs
+For transport-owner `ids_alerts` on connections, beacons, SSH/RDP, authored
+DHCP, scans, and DNS families, explain schema errors precisely: SIDs
 must be unique within the event and resolve through merged
 `ids_signatures.yaml`; filter counts/windows are strict positive integers;
 unknown fields and invalid `track`/`type` values are rejected. A SID must resolve
@@ -30,6 +31,9 @@ to one effective policy across the scenario. Protocol, destination-port, and
 direction mismatches are warnings, not errors, because custom sensor/rule
 deployments can be intentional. Suggest `policy: every` when a signature default
 should be explicitly replaced. See `references/scenario-reference.md`.
+Reject `ids_alerts` on non-transport/composite events and on the deferred
+`email_message`/`email_read` types. Explain that ordinary tuple-bearing events
+without an IDS context do not alert.
 
 Exit codes:
 - 0 = Valid (may include warnings)

--- a/commands/eforge/validate.md
+++ b/commands/eforge/validate.md
@@ -22,6 +22,15 @@ Default to `eforge` for all CLI execution. If `eforge` is not found and you are
 in an EvidenceForge source checkout, retry the same command with
 `uv run eforge ...`.
 
+For `connection`/`beacon` `ids_alerts`, explain schema errors precisely: SIDs
+must be unique within the event and resolve through merged
+`ids_signatures.yaml`; filter counts/windows are strict positive integers;
+unknown fields and invalid `track`/`type` values are rejected. A SID must resolve
+to one effective policy across the scenario. Protocol, destination-port, and
+direction mismatches are warnings, not errors, because custom sensor/rule
+deployments can be intentional. Suggest `policy: every` when a signature default
+should be explicitly replaced. See `references/scenario-reference.md`.
+
 Exit codes:
 - 0 = Valid (may include warnings)
 - 1 = YAML parse error or file I/O error

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -689,7 +689,7 @@ EvaluationEngine
 ├── Pillars (4 scoring modules — currently still 5 legacy scorers during transition)
 │   ├── Parseability    (30%) — spec conformance, format constraints
 │   ├── Plausibility    (25%) — OS/value correctness, co-occurrence, distributions,
-│   │                           user diversity, benign anomaly rate
+│   │                           user diversity, anomaly rate, zero-weight IDS integrity gate
 │   ├── Causality       (25%) — causal ordering, event presence, indicator accuracy,
 │   │                           pivot linkability, storyline temporal integrity
 │   └── Timing          (20%) — attack-chain timing, burstiness, diurnal patterns,
@@ -709,6 +709,15 @@ EvaluationEngine
 ```
 
 Causal ordering rules are defined in `evaluation/rules/causal_pairs.yaml`. Rules support several evaluation features:
+
+Snort finalization incrementally builds a bounded `ids_evaluation` contract in
+canonical ground truth. Evaluation preserves each parsed record's host/sensor
+source instance and exactly compares the contract's sensor-local counts and
+ordered normalized digests with rendered alerts. The check is a 100% hard gate
+but has zero score weight. Older datasets skip it explicitly unless their
+scenario authors IDS attachments. Storyline pivot linkability is inferred from
+typed stable indicators; it connects consecutive events per indicator rather
+than scoring unrelated globally consecutive steps.
 
 - **Grace period:** Events within the scenario's `logon_grace_period` (default 30m) from scenario start are exempt from causal ordering checks, since data collection begins mid-session with pre-existing user sessions.
 - **Per-rule tolerance:** Rules can specify a `tolerance` fraction (e.g., 0.03 for DNS→TCP) allowing a percentage of failures without penalty. Used for intentional direct-IP baseline connections.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -421,12 +421,20 @@ Zeek/web-access correlation. `ScheduledScanOverlapActionBundle` covers
 suspicious-but-benign scanner noise, and `NmapCommandProbeActionBundle` covers
 network probes caused by modeled nmap processes.
 
-IDS alert callers supply one data-driven signature or preset rule, and
-`IdsAlertActionBundle` builds the canonical alert context attached to network
+IDS alert callers may supply multiple data-driven signatures, and
+`IdsAlertActionBundle` builds canonical alert contexts attached to network
 evidence. The bundle owns `(gid, sid, rev)` identity,
 message/classification/priority normalization, and optional signature-owned DNS
-payload construction for DNS alerts. Snort/Suricata emitters render `IdsContext`
-only; signature choice and alert payload construction remain upstream.
+payload construction for DNS alerts. Typed `connection` and `beacon` attachments
+follow every physical canonical connection, including each existing explicit
+proxy leg. The Snort emitter first consumes frozen sensor visibility, clock, and
+NAT/PAT projections, then stores candidates in a bounded-memory SQLite spool.
+Finalization sorts by sensor-observed time and stable identity before applying
+per-sensor `(gid, sid, tracked visible IP)` detection/event filters. This avoids
+storyline insertion-order effects and keeps long beacon campaigns from retaining
+all candidates in memory. Invisible, dropped, warm-up, clipped, and nonexistent
+proxy legs never advance policy state. Raw Snort events remain an explicit
+source-local escape hatch.
 
 File-transfer callers supply transfer intent layered on top of a transport path.
 `HttpResponseFileTransferActionBundle` and `SmbFileTransferMetadataActionBundle`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -425,9 +425,15 @@ IDS alert callers may supply multiple data-driven signatures, and
 `IdsAlertActionBundle` builds canonical alert contexts attached to network
 evidence. The bundle owns `(gid, sid, rev)` identity,
 message/classification/priority normalization, and optional signature-owned DNS
-payload construction for DNS alerts. Typed `connection` and `beacon` attachments
-follow every physical canonical connection, including each existing explicit
-proxy leg. The Snort emitter first consumes frozen sensor visibility, clock, and
+payload construction for DNS alerts. Typed transport owners (`connection`,
+`beacon`, SSH/RDP sessions, authored DHCP transactions, scans, and DNS activity)
+carry attachments only on their owned physical canonical connections. Automatic
+DHCP renewals and DNS-tunnel cover traffic do not inherit authored assertions;
+web-scan automatic alerts coexist with authored attachments, with authored
+contexts winning duplicate `(gid, sid)` identities. Explicit proxy-capable
+attachments follow each existing physical proxy leg. A network tuple alone is
+never sufficient to create an alert, and the current IDS model performs no
+decryption. The Snort emitter first consumes frozen sensor visibility, clock, and
 NAT/PAT projections, then stores candidates in a bounded-memory SQLite spool.
 Finalization sorts by sensor-observed time and stable identity before applying
 per-sensor `(gid, sid, tracked visible IP)` detection/event filters. This avoids

--- a/docs/design/data-quality-prd.md
+++ b/docs/design/data-quality-prd.md
@@ -109,10 +109,19 @@ The attack storyline must actually materialize correctly in the data, within sen
 |-----------|-----------------|--------------|
 | **Event Presence** (0.25) | Storyline events that should be visible (within sensor coverage) produced at least one trace | `100 * found / expected_visible` |
 | **Indicator Accuracy** (0.25) | Present storyline events carry the correct indicators (IPs, usernames, hostnames, process names as specified in scenario) | `100 * correct_indicators / total_indicators` |
-| **Pivot Linkability** (0.25) | Consecutive storyline steps share at least one common indicator a hunter could pivot on | `100 * linkable_pairs / consecutive_pairs` |
+| **Pivot Linkability** (0.25) | Inferred narrative edges share a stable typed indicator a hunter can pivot on | `100 * linkable_edges / inferred_edges`; connect consecutive events per host/IP/account/domain/URL/file/hash/artifact indicator, exclude generic values, and report isolated events separately |
 | **Storyline Temporal Integrity** (0.25) | Storyline events appear in correct order at approximately correct times | `100 * correctly_timed / total_storyline_events` (with tolerance) |
 
 **Note**: not all storyline events need to produce traces — realistic gaps are acceptable. Acceptance threshold: Event Presence >= 90%.
+
+**IDS integrity contract:** correlated IDS output adds a zero-weight 100% hard
+gate. Generation stores bounded per-sensor/SID counts, authorized origins,
+observation totals, and ordered normalized SHA-256 digests in schema-v1
+`GROUND_TRUTH.json`. Evaluation compares that contract exactly with parsed Snort
+rows and `OBSERVATION_MANIFEST.json`. Zero weight prevents double-counting IDS in
+the composite score, while any missing, extra, mutated, misplaced, filtered, or
+tuple/timestamp-divergent alert fails acceptance. Legacy ground truth skips the
+gate unless its supplied scenario authors `ids_alerts`.
 
 ---
 
@@ -237,7 +246,7 @@ src/evidenceforge/evaluation/
     pillars/
         __init__.py
         parseability.py        # Pillar 1: spec_conformance + format_constraints
-        plausibility.py        # Pillar 2: value_plausibility, co_occurrence, distribution_fit, field_agreement, user_diversity, anomaly_rate
+        plausibility.py        # Pillar 2: value/co-occurrence/distribution/agreement/diversity/anomaly + zero-weight IDS integrity gate
         causality.py           # Pillar 3: causal_ordering, event_presence, indicator_accuracy, pivot_linkability, temporal_integrity, storyline_trace_coverage
         timing.py              # Pillar 4: attack_chain_timing, burstiness, system_regularity, diurnal_pattern, volume_adequacy, rate_plausibility
     _shared.py             # Shared helpers (field maps, username/hostname extractors, JSD)

--- a/docs/reference/CUSTOMIZING_CONFIG.md
+++ b/docs/reference/CUSTOMIZING_CONFIG.md
@@ -230,6 +230,14 @@ failing visible contradictions, parse errors, value mismatches, and missing evid
 manifest marks `visible` or `delayed`. Text and JSON reports keep the adjusted score and expose
 the raw score for affected sub-scores.
 
+IDS output has an additional zero-weight `ids_integrity` hard gate fixed at
+100%. It reconciles sensor-local Snort counts and ordered normalized digests with
+`GROUND_TRUTH.json.ids_evaluation`, then checks filtering and observation totals
+against `OBSERVATION_MANIFEST.json`. Because its weight is zero, it does not
+move the overall numeric score; any contradiction still fails acceptance.
+Legacy datasets without an IDS summary skip the check unless the supplied
+scenario contains authored `ids_alerts`.
+
 For full schema documentation for each file, see the skill reference: `/eforge:references:config-evaluation`.
 
 ## Reference Documentation

--- a/docs/reference/CUSTOMIZING_CONFIG.md
+++ b/docs/reference/CUSTOMIZING_CONFIG.md
@@ -263,3 +263,8 @@ support `detection_filter`, `event_filter`, or both; track is `by_src`/`by_dst`,
 and event-filter type is `limit`/`threshold`/`both`. Counts and seconds are strict
 positive integers. Run `eforge validate-config` after editing. See the installed
 `references/config-ids.md` skill reference for exact semantics.
+
+These defaults apply when an attachment omits `policy` on any supported typed
+transport owner (`connection`, `beacon`, SSH/RDP sessions, authored DHCP,
+port/web scans, and DNS query families). They do not cause unattached network
+events to alert and do not imply IDS decryption.

--- a/docs/reference/CUSTOMIZING_CONFIG.md
+++ b/docs/reference/CUSTOMIZING_CONFIG.md
@@ -172,6 +172,7 @@ library that should influence many scenarios.
 | Endpoint background noise | `endpoint_noise.yaml` (Windows scheduled-process trigger windows, host drift, skip probability, and DHCP registry emission policy) |
 | Host/persona/role volume realism | `host_activity_profiles.yaml` (coarse rate-family multipliers, firewall deny burst shaping, and data-driven artifact variants) |
 | Generated identity pools | `email_background.yaml`, `mail_public_identities.yaml`, `external_actor_profiles.yaml`, `suspicious_benign.yaml`, and `command_parameter_pools.yaml` (baseline email senders/recipients, reserved public mail replacements, omitted storyline external IPs, suspicious-benign DNS/connection targets, and command URL/host placeholders). Scenario-authored IPs/domains still override fallback pools. |
+| IDS signatures and default alert cadence | `ids_signatures.yaml` (`alert_policy` supports Snort-style `detection_filter` and `event_filter`; scenario `ids_alerts[].policy` replaces the signature default) |
 | Observation/source coverage | `observation_profiles.yaml` (named source-level missingness/delay profiles selected by scenario `observation_profile`; default `complete` keeps perfect coverage; non-complete decisions are coherent per source-local process, session, and same-UID network group; optional collection batching/window knobs belong here) |
 | Causal/source-native timing | `timing_profiles.yaml` (`relationships` for causal prerequisites, source latency, teardown margins, Zeek analyzer offsets and TLS duration floors, endpoint host-clock profiles shared by OS logs and host-resident eCAR, independent network sensor clock/path profiles, plus Windows/Sysmon collision spacing) |
 | Public NTP fallback servers and DNS tunnel timing | `network_params.yaml` (`public_ntp_servers`, `dns_tunnel_rtt`; scenario-defined internal/domain NTP servers still take precedence) |
@@ -243,3 +244,22 @@ For full field schemas and conventions, see the reference docs installed with th
 | Host activity (bash, systemd, syslog) | `/eforge:references:config-host-activity` |
 | Cross-file dependency map | `/eforge:references:config-dependency-graph` |
 | Validation checks | `/eforge:references:config-validation` |
+
+### IDS signature alert-policy overlays
+
+IDS signature entries merge by `sid`, so an overlay can add or replace only the
+default policy while preserving the packaged identity and metadata:
+
+```yaml
+# .eforge/config/activity/ids_signatures.yaml
+signatures:
+  - sid: 2002910
+    alert_policy:
+      event_filter: {type: both, track: by_src, count: 5, seconds: 60}
+```
+
+An omitted policy (or `every`) alerts for every visible candidate. Policy objects
+support `detection_filter`, `event_filter`, or both; track is `by_src`/`by_dst`,
+and event-filter type is `limit`/`threshold`/`both`. Counts and seconds are strict
+positive integers. Run `eforge validate-config` after editing. See the installed
+`references/config-ids.md` skill reference for exact semantics.

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -345,6 +345,20 @@ Per-user command history for Linux systems. Baseline SSH sessions to Linux serve
 
 Network intrusion detection alerts. Baseline generates false-positive alerts (e.g., ICMP PING, SSH scan, policy violations) correlated with Zeek conn records via canonical SecurityEvent dispatch. Storyline generates true-positive alerts for malicious connections. IDS signature-to-context construction is owned by the internal IDS alert action bundle so Snort/Suricata rows render canonical network/DNS/HTTP evidence rather than independently inventing alert payloads.
 
+Typed `connection` and `beacon` events can attach multiple configured SIDs with
+`ids_alerts`. Attachments assert that a signature matches; the generator does not
+run the full Snort rule predicate. Candidates are projected through sensor
+visibility, clock, and NAT/PAT views before per-sensor `detection_filter` and
+`event_filter` state is applied. Deferred candidates use a disk-backed spool and
+are deterministically ordered, so long beacons stay memory-bounded and authored
+storyline order cannot change filtering results. Raw Snort events retain their
+existing source-local behavior.
+
+`GROUND_TRUTH.json` and `.md` record each attached SID, its effective policy, and
+candidate/emitted/policy-filtered sensor totals. Policy suppression is also
+reported as `filtered` IDS evidence in `OBSERVATION_MANIFEST.json`; collection
+drops and output-window clipping are distinct and never advance filter counters.
+
 Web scan events (`web_scan` storyline type) generate three layers of IDS alerts:
 1. **Scanner UA detection** — identifies the scanning tool by user-agent (non-TLS only)
 2. **Per-path content alerts** — curated SID mappings for specific probe paths (non-TLS only)
@@ -354,6 +368,8 @@ Alert format: `[gid:sid:rev]` where `gid` defaults to 1, `sid` identifies the ru
 
 **Known Limitations:**
 - IDS alert variety is limited to curated SID pools (not full ruleset simulation)
+- Signature attachments declare matches; they do not parse or execute Snort rules,
+  `rate_filter`, CIDR suppression, or IPS actions
 
 ---
 

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -345,14 +345,25 @@ Per-user command history for Linux systems. Baseline SSH sessions to Linux serve
 
 Network intrusion detection alerts. Baseline generates false-positive alerts (e.g., ICMP PING, SSH scan, policy violations) correlated with Zeek conn records via canonical SecurityEvent dispatch. Storyline generates true-positive alerts for malicious connections. IDS signature-to-context construction is owned by the internal IDS alert action bundle so Snort/Suricata rows render canonical network/DNS/HTTP evidence rather than independently inventing alert payloads.
 
-Typed `connection` and `beacon` events can attach multiple configured SIDs with
-`ids_alerts`. Attachments assert that a signature matches; the generator does not
-run the full Snort rule predicate. Candidates are projected through sensor
+Typed `connection`, `beacon`, `ssh_session`, `rdp_session`, `dhcp_lease`,
+`port_scan`, `dns_query`, `dga_queries`, `dns_tunnel`, and `web_scan` events can
+attach multiple configured SIDs with `ids_alerts`. Attachments assert that a
+signature matches; the generator does not run the full Snort rule predicate or
+decrypt traffic. A network tuple without an explicit or built-in IDS context
+does not alert. Candidates are projected through sensor
 visibility, clock, and NAT/PAT views before per-sensor `detection_filter` and
 `event_filter` state is applied. Deferred candidates use a disk-backed spool and
 are deterministically ordered, so long beacons stay memory-bounded and authored
 storyline order cannot change filtering results. Raw Snort events retain their
 existing source-local behavior.
+
+Each attachment follows only the physical transports owned by its authored
+event. SSH/RDP attach to their session transport, DHCP only to the explicitly
+authored transaction, scans and web scans to each probe/request, and DNS families
+to their authored queries. Automatic DHCP renewals and DNS-tunnel background
+cover queries do not inherit attachments. Authored web-scan SIDs coexist with
+automatic preset/path/rate alerts and take precedence on a duplicate `(gid, sid)`.
+Email transport attachments remain deferred.
 
 `GROUND_TRUTH.json` and `.md` record each attached SID, its effective policy, and
 candidate/emitted/policy-filtered sensor totals. Policy suppression is also

--- a/docs/reference/EVIDENCE_FORMATS.md
+++ b/docs/reference/EVIDENCE_FORMATS.md
@@ -370,6 +370,16 @@ candidate/emitted/policy-filtered sensor totals. Policy suppression is also
 reported as `filtered` IDS evidence in `OBSERVATION_MANIFEST.json`; collection
 drops and output-window clipping are distinct and never advance filter counters.
 
+The optional schema-v1 `ids_evaluation` section in `GROUND_TRUTH.json` is the
+automated acceptance contract. For each sensor and `(gid, sid)` it records
+candidate, emitted, policy-filtered, visible/delayed, and authorized-origin
+totals plus a SHA-256 digest over normalized alerts in file order. Normalization
+covers sensor identity, UTC timestamp, signature metadata, protocol, full tuple,
+and the sensor-visible NAT/PAT projection. Overall observation totals reconcile
+visible, delayed, dropped, filtered, and out-of-window IDS attempts. The
+Markdown IDS Evaluation Summary renders the same counts with abbreviated
+digests.
+
 Web scan events (`web_scan` storyline type) generate three layers of IDS alerts:
 1. **Scanner UA detection** — identifies the scanning tool by user-agent (non-TLS only)
 2. **Per-path content alerts** — curated SID mappings for specific probe paths (non-TLS only)

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -796,7 +796,7 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `logon` | 4624, target-host 4672 for elevated sessions, eCAR LOGIN | | `logon_type` (default 3), `source_ip` |
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
-| `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent` |
+| `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent`, `ids_alerts` |
 | `ssh_session` | canonical SSH connection (Zeek conn) + syslog sshd + EDR/eCAR | | `source_ip` |
 | `rdp_session` | Zeek conn + 4624 type 10 + eCAR | | `source_ip` |
 | `account_created` | 4720 (on DC) | `target_username` | `target_sid` |
@@ -808,7 +808,7 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `create_remote_thread` | Sysmon 8, eCAR THREAD/REMOTE_CREATE | `target_process` | |
 | `dhcp_lease` | Zeek dhcp.log | | `mac_address`, `requested_ip` |
 | `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `source_ip`, `target_count`, `ports`, `protocol`, `scan_rate` |
-| `beacon` | Zeek conn/proxy/ASA (periodic connections) | `dst_ip`, `interval`, one of `end_time`/`duration`/`count` | `action` (allow/deny), `hostname`, `service`, `protocol`, `source_ip`, `method`, `uri`, `user_agent`, `referrer`, `status_code`, `orig_bytes`, `resp_bytes`, `profile`, `http_sequence`, `jitter` (default: 0.15) |
+| `beacon` | Zeek conn/proxy/ASA/Snort (periodic connections) | `dst_ip`, `interval`, one of `end_time`/`duration`/`count` | `action` (allow/deny), `hostname`, `service`, `protocol`, `source_ip`, `method`, `uri`, `user_agent`, `referrer`, `status_code`, `orig_bytes`, `resp_bytes`, `profile`, `http_sequence`, `ids_alerts`, `jitter` (default: 0.15) |
 | `dns_query` | Zeek dns.log + conn.log, Sysmon 22 | `query` | `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR), `source_ip` |
 | `email_message` | SMTP route evidence: Zeek conn/dns/smtp/files, artifacts, ground truth | at least one of `to`/`cc`/`bcc` | `sender`, `subject`, `body`, `corpus_id`, `artifact_id`, `user_agent`, `verdict`, `mail_action`, `outcome`, `attachments` |
 | `email_read` | Opaque TLS mailbox access: DNS + conn/ssl/x509 evidence only | | `mailbox`, `server`, `protocol` (`imaps`/`owa`), `message_ids`, `count`, `duration`, `user_agent` |
@@ -1022,6 +1022,46 @@ Use `beacon` for periodic connections — allowed (C2 callbacks through proxy) o
 ```
 
 Timing fields: `start_time` (optional, defaults to parent event time), `interval` (required), one of `end_time`/`duration`/`count` (required), `jitter` (0.0-1.0, default: **0.15** — beacons are deliberately tight). Connection fields: all `connection` fields (dst_ip, dst_port, hostname, service, protocol, method, uri, user_agent, `referrer`, etc.). `profile` selects a behavior-shaped synthetic profile from `config/activity/beacon_profiles.yaml`; bundled profiles model broad check-in/tasking shapes, not live malware IoCs. `http_sequence` cycles explicit per-tick request shapes and can use deterministic URI tokens: `{host_id}`, `{campaign_id}`, `{tick}`, `{hex8}`, `{guid}`, and `{base64url:N}`. Sequence entries may override `method`, `uri`, `user_agent`, `referrer`, `status_code`, `response_body_len`, `orig_bytes`, and `resp_bytes`; byte fields accept either an integer or `[min, max]`. For `hostname`, use the client-facing DNS name used by the beacon, not a reverse-DNS/PTR artifact, unless that is intentionally part of the scenario. `action`: `allow` (default) or `deny`. Set `referrer` to pin the HTTP Referer header for a specific beacon URL (e.g., a phishing page that launched the download). In explicit proxy mode, HTTP/S beacons from hosts routed through a `forward_proxy` traverse the proxy; denied proxyable beacons stop at the proxy and emit proxy-denied CONNECT/GET evidence rather than direct client-to-origin network evidence.
+
+### Correlated IDS attachments
+
+`connection` and `beacon` may assert one or more configured signature matches with
+`ids_alerts`. EvidenceForge resolves each SID from
+`activity/ids_signatures.yaml` and attaches it to every physical canonical
+connection produced by the event. The resulting Snort row therefore shares the
+sensor-observed timestamp, source port, tuple, and NAT/PAT view with the related
+network evidence. This is an assertion that the signature matched; EvidenceForge
+does not execute the complete Snort rule predicate.
+
+```yaml
+- type: beacon
+  dst_ip: 45.83.221.30
+  dst_port: 443
+  service: ssl
+  interval: 2m
+  duration: 45m
+  ids_alerts:
+    - sid: 2028401
+    - sid: 2002910
+      policy:
+        detection_filter: {track: by_src, count: 5, seconds: 60}
+        event_filter: {type: limit, track: by_src, count: 1, seconds: 300}
+```
+
+An omitted `policy` inherits the signature's optional `alert_policy`. Use
+`policy: every` to replace that default and alert on every visible candidate.
+A policy object replaces the signature default and may contain
+`detection_filter`, `event_filter`, or both. Filters support `track: by_src` or
+`by_dst`; event-filter types are `limit`, `threshold`, and `both`; `count` and
+`seconds` must be positive integers. The same SID must have one effective policy
+throughout a scenario.
+
+Filtering is per IDS sensor and post-NAT sensor-visible IP. Observation drops,
+invisible connections, warm-up records, and output-window clipping do not advance
+filter state. With explicit proxies, attachments follow the client-to-proxy and
+proxy-to-origin physical legs; sensor placement selects the visible side. Denials
+and cache hits do not invent an origin leg. Prefer this facility over raw Snort
+events whenever the alert must correlate with canonical network evidence.
 
 ### DNS Query Events
 

--- a/docs/reference/scenario-reference.md
+++ b/docs/reference/scenario-reference.md
@@ -797,8 +797,8 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `failed_logon` | 4625, eCAR LOGIN failure | | `source_ip`, `logon_type` (default 3) |
 | `logoff` | 4634, eCAR LOGOUT | | |
 | `connection` | Zeek conn, eCAR FLOW, + web_access/zeek_http when `service: http` | `dst_ip` | `dst_port` (default 443), `hostname` (domain for DNS/SSL SNI), `service`, `source_ip`, `method`, `uri`, `status_code`, `user_agent`, `ids_alerts` |
-| `ssh_session` | canonical SSH connection (Zeek conn) + syslog sshd + EDR/eCAR | | `source_ip` |
-| `rdp_session` | Zeek conn + 4624 type 10 + eCAR | | `source_ip` |
+| `ssh_session` | canonical SSH connection (Zeek conn) + syslog sshd + EDR/eCAR | | `source_ip`, `ids_alerts` |
+| `rdp_session` | Zeek conn + 4624 type 10 + eCAR | | `source_ip`, `ids_alerts` |
 | `account_created` | 4720 (on DC) | `target_username` | `target_sid` |
 | `account_deleted` | 4726 (on DC) | `target_username` | `target_sid` |
 | `group_member_added` | 4728/4732/4756 (on DC) | `group_name`, `member_name` | `scope` (global/local/universal) |
@@ -806,16 +806,16 @@ minutes or hours. `explicit_offsets` accepts one offset per child event, such as
 | `scheduled_task_created` | 4698 | `task_name` | `task_content` |
 | `log_cleared` | 1102 | | |
 | `create_remote_thread` | Sysmon 8, eCAR THREAD/REMOTE_CREATE | `target_process` | |
-| `dhcp_lease` | Zeek dhcp.log | | `mac_address`, `requested_ip` |
-| `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `source_ip`, `target_count`, `ports`, `protocol`, `scan_rate` |
+| `dhcp_lease` | Zeek dhcp.log | | `mac_address`, `requested_ip`, `ids_alerts` |
+| `port_scan` | ASA 106023 (bulk denies) | `target_ips` or `target_segment` | `source_ip`, `target_count`, `ports`, `protocol`, `scan_rate`, `ids_alerts` |
 | `beacon` | Zeek conn/proxy/ASA/Snort (periodic connections) | `dst_ip`, `interval`, one of `end_time`/`duration`/`count` | `action` (allow/deny), `hostname`, `service`, `protocol`, `source_ip`, `method`, `uri`, `user_agent`, `referrer`, `status_code`, `orig_bytes`, `resp_bytes`, `profile`, `http_sequence`, `ids_alerts`, `jitter` (default: 0.15) |
-| `dns_query` | Zeek dns.log + conn.log, Sysmon 22 | `query` | `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR), `source_ip` |
+| `dns_query` | Zeek dns.log + conn.log, Sysmon 22 | `query` | `qtype`, `rcode`, `ttl`, `answer` (required for NOERROR), `source_ip`, `ids_alerts` |
 | `email_message` | SMTP route evidence: Zeek conn/dns/smtp/files, artifacts, ground truth | at least one of `to`/`cc`/`bcc` | `sender`, `subject`, `body`, `corpus_id`, `artifact_id`, `user_agent`, `verdict`, `mail_action`, `outcome`, `attachments` |
 | `email_read` | Opaque TLS mailbox access: DNS + conn/ssl/x509 evidence only | | `mailbox`, `server`, `protocol` (`imaps`/`owa`), `message_ids`, `count`, `duration`, `user_agent` |
-| `web_scan` | web_access + Zeek HTTP (bulk HTTP requests) | `dst_ip`, `rate`, one of `end_time`/`duration`/`count` | `preset` (nikto/dirb/gobuster/sqlmap/nmap_http), `paths`, `hostname`, `user_agent`, `jitter` (default: 0.4) |
+| `web_scan` | web_access + Zeek HTTP (bulk HTTP requests) | `dst_ip`, `rate`, one of `end_time`/`duration`/`count` | `preset` (nikto/dirb/gobuster/sqlmap/nmap_http), `paths`, `hostname`, `user_agent`, `ids_alerts`, `jitter` (default: 0.4) |
 | `credential_spray` | Windows 4625/4776 or syslog auth | `target_accounts`, `interval`, one of `end_time`/`duration`/`count` | `pattern` (spray/brute_force/stuffing), `source_ip`, `logon_type`, `success`, `jitter` (default: 0.5) |
-| `dga_queries` | Zeek dns.log + conn.log (bulk DGA) | `interval`, one of `end_time`/`duration`/`count` | `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`, `source_ip`, `jitter` (default: 0.3) |
-| `dns_tunnel` | Zeek dns.log + conn.log (encoded exfil) | `base_domain`, `interval`, one of `end_time`/`duration`/`count` | `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`, `payload_size`, `source_ip`, `jitter` (default: 0.25) |
+| `dga_queries` | Zeek dns.log + conn.log (bulk DGA) | `interval`, one of `end_time`/`duration`/`count` | `length_range`, `charset`, `tld`, `seed`, `rcode_distribution`, `answer_ip`, `source_ip`, `ids_alerts`, `jitter` (default: 0.3) |
+| `dns_tunnel` | Zeek dns.log + conn.log (encoded exfil) | `base_domain`, `interval`, one of `end_time`/`duration`/`count` | `encoding` (base32/base64/hex), `qtype` (TXT/NULL/CNAME), `label_length`, `payload`, `payload_size`, `source_ip`, `ids_alerts`, `jitter` (default: 0.25) |
 | `explicit_credentials` | Windows 4648 (explicit credential usage) | `target_username` | `target_server`, `process_name`, `source_ip` |
 | `workstation_lock` | Windows 4800 (workstation locked) | | |
 | `workstation_unlock` | Windows 4624 type 7 re-auth followed by 4801 unlock | | |
@@ -1025,13 +1025,23 @@ Timing fields: `start_time` (optional, defaults to parent event time), `interval
 
 ### Correlated IDS attachments
 
-`connection` and `beacon` may assert one or more configured signature matches with
-`ids_alerts`. EvidenceForge resolves each SID from
+Typed `connection`, `beacon`, `ssh_session`, `rdp_session`, `dhcp_lease`,
+`port_scan`, `dns_query`, `dga_queries`, `dns_tunnel`, and `web_scan` events may
+assert one or more configured signature matches with `ids_alerts`. EvidenceForge resolves each SID from
 `activity/ids_signatures.yaml` and attaches it to every physical canonical
 connection produced by the event. The resulting Snort row therefore shares the
 sensor-observed timestamp, source port, tuple, and NAT/PAT view with the related
 network evidence. This is an assertion that the signature matched; EvidenceForge
 does not execute the complete Snort rule predicate.
+
+Attachments fan out only across transports owned by that authored event: one
+SSH/RDP session transport, the authored DHCP transaction, every scan probe or
+web request, and every authored DNS/DGA/tunnel query. Later automatic DHCP
+renewals do not inherit the assertion, and DNS-tunnel background cover traffic
+does not inherit a tunnel signature. Web-scan preset alerts coexist with
+authored alerts; an authored attachment wins if both use the same `(gid, sid)`.
+`email_message` and `email_read` do not yet accept attachments. A network tuple
+alone never creates a Snort alert, and IDS sensors do not decrypt traffic.
 
 ```yaml
 - type: beacon

--- a/docs/worklog/2026-08-04-evaluator-ids-integrity-refresh.md
+++ b/docs/worklog/2026-08-04-evaluator-ids-integrity-refresh.md
@@ -1,0 +1,41 @@
+# Evaluator IDS Integrity Refresh
+
+## Scope
+
+Refresh `eforge eval` after expanding authored IDS attachments to transport-owning
+events. The evaluator now treats correlated IDS output as an exact acceptance
+contract and updates older evidence assumptions exposed by
+`iteration-test-expanded-ids`.
+
+## Implemented
+
+- Added bounded schema-v1 `ids_evaluation` ground truth with per-sensor/SID
+  candidate, emitted, policy-filtered, observation, origin, and ordered digest
+  totals, plus Markdown parity.
+- Added zero-weight `plausibility.ids_integrity` at a 100% hard-gate threshold.
+- Preserved parser source instances, made Snort parsing scenario-year-aware and
+  IPv4/IPv6 safe, stabilized record ordering and sampling, and sourced report
+  generation time from canonical ground truth.
+- Corrected STARTTLS/IMAPS/OWA matching, appliance-hostname comparisons,
+  case-insensitive TLS name agreement, eligible bash-history expectations, and
+  process-parent PID lifetime checks.
+- Replaced global-consecutive pivot scoring with an inferred typed-indicator
+  graph and expanded event/transport trace contracts.
+
+## Calibration
+
+The regenerated `iteration-test-expanded-ids` dataset contains 87,707 parsed
+records across 20 sources. Two evaluations are identical after removing
+`evaluated_at`. IDS integrity passes 225/225 exact checks, all 46
+expected-visible storyline events are found, and the prior ASA-hostname and
+SSL/X.509 case-only false mismatches are absent. Remaining lower-scored findings
+are reported as calibration signals rather than acceptance failures.
+
+## Verification
+
+- Focused evaluator, parser, generation, ground-truth, observation, email,
+  network, IDS, documentation, and installer tests pass.
+- Default suite: 5,077 passed, 19 skipped.
+- Slow-inclusive suite: 5,090 passed, 6 skipped.
+- Ruff lint/format, generated-skill `quick_validate.py`, temporary Claude and
+  ChatGPT/Codex installations, and `git diff --check` pass.

--- a/src/evidenceforge/cli/install_skills.py
+++ b/src/evidenceforge/cli/install_skills.py
@@ -39,6 +39,7 @@ _CHATGPT_REFERENCES_BY_SKILL = {
         "references/config-evaluation.md",
         "references/config-formats.md",
         "references/config-host-activity.md",
+        "references/config-ids.md",
         "references/config-personas.md",
         "references/config-validation.md",
     ),

--- a/src/evidenceforge/cli/validate_config.py
+++ b/src/evidenceforge/cli/validate_config.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from pydantic import ValidationError
 
 from evidenceforge.config import (
     get_activity_directory,
@@ -40,6 +41,7 @@ from evidenceforge.config import (
     get_formats_directory,
     get_personas_directory,
 )
+from evidenceforge.models.ids import IdsAlertPolicySpec
 
 VALID_RISK_PROFILES = frozenset({"low", "medium", "high"})
 VALID_BROWSING_INTENSITIES = frozenset({"light", "normal", "heavy"})
@@ -980,6 +982,18 @@ def validate_config() -> ValidationResult:
                     f"Signature {sid} baseline_fp_allowed must be a boolean",
                 )
             )
+        alert_policy = sig.get("alert_policy")
+        if alert_policy is not None and alert_policy != "every":
+            try:
+                IdsAlertPolicySpec.model_validate(alert_policy)
+            except ValidationError as exc:
+                result.issues.append(
+                    Issue(
+                        "ERROR",
+                        "ids_signatures.yaml",
+                        f"Signature {sid} has invalid alert_policy: {exc.errors(include_url=False)}",
+                    )
+                )
         gid = sig.get("gid", 1)
         _validate_ids_numeric_field(
             "ids_signatures.yaml", f"Signature {sid}", sig, "sid", required=True

--- a/src/evidenceforge/config/activity/ids_signatures.yaml
+++ b/src/evidenceforge/config/activity/ids_signatures.yaml
@@ -30,13 +30,13 @@ signatures:
   # Policy violations: common enterprise noise from legitimate browsing/tools
   - {sid: 2013028, rev: 4, message: "ET POLICY curl User-Agent Outbound", classification: "policy-violation", priority: 3, proto: tcp, dst_port: 80, direction: out}
   - {sid: 2010935, rev: 3, message: "ET POLICY Outgoing Basic Auth Base64 HTTP Password detected", classification: "policy-violation", priority: 2, proto: tcp, dst_port: 80, direction: out}
-  - {sid: 2025331, rev: 5, message: "ET POLICY SSLv3 Outbound Connection Detected", classification: "policy-violation", priority: 2, proto: tcp, dst_port: 443, direction: out}
+  - {sid: 2025331, rev: 5, message: "ET POLICY SSLv3 Outbound Connection Detected", classification: "policy-violation", priority: 2, proto: tcp, dst_port: 443, direction: out, baseline_fp_allowed: false}
   - {sid: 2013504, rev: 3, message: "ET POLICY GNU/Linux APT User-Agent Outbound likely related to package management", classification: "policy-violation", priority: 3, proto: tcp, dst_port: 80, direction: out, target_os: [linux]}
   - {sid: 2018959, rev: 4, message: "ET POLICY PE EXE or DLL Windows file download HTTP", classification: "policy-violation", priority: 2, proto: tcp, dst_port: 80, direction: out}
-  - {sid: 2000419, rev: 20, message: "ET POLICY PE EXE or DLL Windows file download Non-HTTP", classification: "policy-violation", priority: 2, proto: tcp, dst_port: 443, direction: out}
+  - {sid: 2000419, rev: 20, message: "ET POLICY PE EXE or DLL Windows file download Non-HTTP", classification: "policy-violation", priority: 2, proto: tcp, dst_port: 443, direction: out, inspection: payload_cleartext}
   - {sid: 2000428, rev: 10, message: "ET POLICY ZIP file download", classification: "policy-violation", priority: 3, proto: tcp, dst_port: 80, direction: out}
-  - {sid: 2001114, rev: 9, message: "ET POLICY Mozilla XPI install files download", classification: "policy-violation", priority: 3, proto: tcp, dst_port: 443, direction: out}
-  - {sid: 2001115, rev: 7, message: "ET POLICY MSI (microsoft installer file) download", classification: "policy-violation", priority: 3, proto: tcp, dst_port: 443, direction: out}
+  - {sid: 2001114, rev: 9, message: "ET POLICY Mozilla XPI install files download", classification: "policy-violation", priority: 3, proto: tcp, dst_port: 443, direction: out, inspection: payload_cleartext}
+  - {sid: 2001115, rev: 7, message: "ET POLICY MSI (microsoft installer file) download", classification: "policy-violation", priority: 3, proto: tcp, dst_port: 443, direction: out, inspection: payload_cleartext}
   - {sid: 2000560, rev: 10, message: "ET POLICY HTTP CONNECT Tunnel Attempt Inbound", classification: "policy-violation", priority: 2, proto: tcp, dst_port: 8080, direction: out}
 
   # Info: observed domains and services
@@ -113,7 +113,7 @@ signatures:
   - {sid: 2024392, rev: 2, message: "ET INFO STUN Binding Success Response", classification: "misc-activity", priority: 3, proto: udp, dst_port: 3478, direction: in}
 
   # NTP
-  - {sid: 2017919, rev: 3, message: "ET INFO NTP Monlist Request from non-standard source port", classification: "misc-activity", priority: 2, proto: udp, dst_port: 123, direction: out}
+  - {sid: 2017919, rev: 3, message: "ET INFO NTP Monlist Request from non-standard source port", classification: "misc-activity", priority: 2, proto: udp, dst_port: 123, direction: out, baseline_fp_allowed: false}
 
   # ===== ICMP =====
   - {sid: 384, rev: 1, message: "PROTOCOL-ICMP PING", classification: "icmp-event", priority: 3, proto: icmp, dst_port: 0, direction: in}

--- a/src/evidenceforge/config/activity/ids_signatures.yaml
+++ b/src/evidenceforge/config/activity/ids_signatures.yaml
@@ -61,6 +61,16 @@ signatures:
   - {sid: 2019876, rev: 2, message: "ET INFO Packed Executable Download", classification: "misc-activity", priority: 2, proto: tcp, dst_port: 80, direction: in, baseline_fp_allowed: false}
 
   # Scanning activity
+  - sid: 2002910
+    rev: 4
+    message: "ET SCAN Rapid HTTP/HTTPS Connection Attempts"
+    classification: "attempted-recon"
+    priority: 2
+    proto: tcp
+    dst_port: 80
+    direction: in
+    alert_policy:
+      event_filter: {type: both, track: by_src, count: 5, seconds: 60}
   - {sid: 2002911, rev: 7, message: "ET SCAN Potential SSH Scan", classification: "attempted-recon", priority: 2, proto: tcp, dst_port: 22, direction: in}
   - {sid: 2010937, rev: 3, message: "ET SCAN Suspicious inbound to mySQL port 3306", classification: "attempted-recon", priority: 2, proto: tcp, dst_port: 3306, direction: in, target_services: [mysql, mssql]}
   - {sid: 2010936, rev: 3, message: "ET SCAN Suspicious inbound to MSSQL port 1433", classification: "attempted-recon", priority: 2, proto: tcp, dst_port: 1433, direction: in, target_services: [mssql]}

--- a/src/evidenceforge/config/activity/timing_profiles.yaml
+++ b/src/evidenceforge/config/activity/timing_profiles.yaml
@@ -338,22 +338,22 @@ network_sensor_observation:
   profiles:
     distributed_taps:
       clock_offset_us:
-        min: -18000
-        max: 22000
+        min: -35000
+        max: 35000
       clock_drift_ppm:
-        min: -2
-        max: 2
+        min: -1
+        max: 1
       route_delay_us:
-        min: 1200
-        max: 18000
+        min: 500
+        max: 25000
       event_jitter_us:
-        min: -750
-        max: 750
+        min: -90000
+        max: 90000
       capture_loss:
-        probability: 0.0
-        min_fraction: 0.0
-        max_fraction: 0.0
-        max_missed_bytes: 0
+        probability: 0.12
+        min_fraction: 0.0005
+        max_fraction: 0.012
+        max_missed_bytes: 32768
     well_synced:
       clock_offset_us:
         min: -4000

--- a/src/evidenceforge/config/evaluation/cross_source_pairs.yaml
+++ b/src/evidenceforge/config/evaluation/cross_source_pairs.yaml
@@ -108,3 +108,4 @@ pairs:
       - a_field: server_name
         b_field: san.dns
         b_is_list: true
+        normalize: lower

--- a/src/evidenceforge/config/evaluation/thresholds.yaml
+++ b/src/evidenceforge/config/evaluation/thresholds.yaml
@@ -64,6 +64,11 @@ pillars:
         aspirational: 95
         hard_gate: false
         # 1–5 % goldilocks band; validate bands against calibration data.
+      ids_integrity:
+        minimum: 100
+        aspirational: 100
+        hard_gate: true
+        # Exact rendered-output contract; any contradiction is a generator defect.
 
   # Pillar 3 — Causality
   # Goal: before/after relationships are correct in background noise and

--- a/src/evidenceforge/config/formats/snort_alert.yaml
+++ b/src/evidenceforge/config/formats/snort_alert.yaml
@@ -82,4 +82,4 @@ output:
   file_extension: ".alert"
   encoding: utf-8
   template: |
-    {{ timestamp.strftime('%m/%d-%H:%M:%S.%f') }} [**] [{{ gid | default(1) }}:{{ sid }}:{{ rev | default(1) }}] {{ message }} [**] [Classification: {{ classification }}] [Priority: {{ priority }}] {{ '{' }}{{ protocol }}{{ '}' }} {{ src_ip }}{% if src_port %}:{{ src_port }}{% endif %} -> {{ dst_ip }}{% if dst_port %}:{{ dst_port }}{% endif %}
+    {{ timestamp.strftime('%m/%d-%H:%M:%S.%f') }} [**] [{{ gid | default(1) }}:{{ sid }}:{{ rev | default(1) }}] {{ message }} [**] [Classification: {{ classification }}] [Priority: {{ priority }}] {{ '{' }}{{ protocol }}{{ '}' }} {% if ':' in src_ip %}[{{ src_ip }}]{% else %}{{ src_ip }}{% endif %}{% if src_port %}:{{ src_port }}{% endif %} -> {% if ':' in dst_ip %}[{{ dst_ip }}]{% else %}{{ dst_ip }}{% endif %}{% if dst_port %}:{{ dst_port }}{% endif %}

--- a/src/evidenceforge/config/formats/windows_event_sysmon.yaml
+++ b/src/evidenceforge/config/formats/windows_event_sysmon.yaml
@@ -217,13 +217,10 @@ variants:
       - name: SourceProcessId
         type: integer
         required: true
-      - name: SourceImage
-        type: string
-        required: true
       - name: SourceThreadId
         type: integer
         required: true
-      - name: SourceUser
+      - name: SourceImage
         type: string
         required: true
       - name: TargetProcessGUID
@@ -235,15 +232,18 @@ variants:
       - name: TargetImage
         type: string
         required: true
-      - name: TargetUser
-        type: string
-        required: true
       - name: GrantedAccess
         type: string
         required: true
       - name: CallTrace
         type: string
         required: false
+      - name: SourceUser
+        type: string
+        required: true
+      - name: TargetUser
+        type: string
+        required: true
 
   # Sysmon EventID 3: Network Connection
   - name: sysmon_network_connect
@@ -355,6 +355,9 @@ variants:
       - name: SignatureStatus
         type: string
         required: true
+      - name: User
+        type: string
+        required: true
 
   # Sysmon EventID 11: File Created
   - name: sysmon_file_create
@@ -376,13 +379,13 @@ variants:
       - name: Image
         type: string
         required: true
-      - name: User
-        type: string
-        required: true
       - name: TargetFilename
         type: string
         required: true
       - name: CreationUtcTime
+        type: string
+        required: true
+      - name: User
         type: string
         required: true
 
@@ -409,10 +412,10 @@ variants:
       - name: Image
         type: string
         required: true
-      - name: User
+      - name: TargetObject
         type: string
         required: true
-      - name: TargetObject
+      - name: User
         type: string
         required: true
 
@@ -439,13 +442,13 @@ variants:
       - name: Image
         type: string
         required: true
-      - name: User
-        type: string
-        required: true
       - name: TargetObject
         type: string
         required: true
       - name: Details
+        type: string
+        required: true
+      - name: User
         type: string
         required: true
 
@@ -559,15 +562,15 @@ output:
         <Data Name="UtcTime">{{ UtcTime }}</Data>
         <Data Name="SourceProcessGUID">{{ SourceProcessGUID }}</Data>
         <Data Name="SourceProcessId">{{ SourceProcessId }}</Data>
-        <Data Name="SourceImage">{{ SourceImage }}</Data>
         <Data Name="SourceThreadId">{{ SourceThreadId }}</Data>
-        <Data Name="SourceUser">{{ SourceUser }}</Data>
+        <Data Name="SourceImage">{{ SourceImage }}</Data>
         <Data Name="TargetProcessGUID">{{ TargetProcessGUID }}</Data>
         <Data Name="TargetProcessId">{{ TargetProcessId }}</Data>
         <Data Name="TargetImage">{{ TargetImage }}</Data>
-        <Data Name="TargetUser">{{ TargetUser }}</Data>
         <Data Name="GrantedAccess">{{ GrantedAccess }}</Data>
         <Data Name="CallTrace">{{ CallTrace | default('') }}</Data>
+        <Data Name="SourceUser">{{ SourceUser }}</Data>
+        <Data Name="TargetUser">{{ TargetUser }}</Data>
         {% elif EventID == 3 %}
         <Data Name="RuleName">{{ RuleName | default('-') }}</Data>
         <Data Name="UtcTime">{{ UtcTime }}</Data>
@@ -603,15 +606,16 @@ output:
         <Data Name="Signed">{{ Signed }}</Data>
         <Data Name="Signature">{{ Signature | default('-') }}</Data>
         <Data Name="SignatureStatus">{{ SignatureStatus }}</Data>
+        <Data Name="User">{{ User }}</Data>
         {% elif EventID == 11 %}
         <Data Name="RuleName">{{ RuleName | default('-') }}</Data>
         <Data Name="UtcTime">{{ UtcTime }}</Data>
         <Data Name="ProcessGuid">{{ ProcessGuid }}</Data>
         <Data Name="ProcessId">{{ ProcessId }}</Data>
         <Data Name="Image">{{ Image }}</Data>
-        <Data Name="User">{{ User }}</Data>
         <Data Name="TargetFilename">{{ TargetFilename }}</Data>
         <Data Name="CreationUtcTime">{{ CreationUtcTime }}</Data>
+        <Data Name="User">{{ User }}</Data>
         {% elif EventID == 12 %}
         <Data Name="RuleName">{{ RuleName | default('-') }}</Data>
         <Data Name="EventType">{{ EventType }}</Data>
@@ -619,8 +623,8 @@ output:
         <Data Name="ProcessGuid">{{ ProcessGuid }}</Data>
         <Data Name="ProcessId">{{ ProcessId }}</Data>
         <Data Name="Image">{{ Image }}</Data>
-        <Data Name="User">{{ User }}</Data>
         <Data Name="TargetObject">{{ TargetObject }}</Data>
+        <Data Name="User">{{ User }}</Data>
         {% elif EventID == 13 %}
         <Data Name="RuleName">{{ RuleName | default('-') }}</Data>
         <Data Name="EventType">SetValue</Data>
@@ -628,9 +632,9 @@ output:
         <Data Name="ProcessGuid">{{ ProcessGuid }}</Data>
         <Data Name="ProcessId">{{ ProcessId }}</Data>
         <Data Name="Image">{{ Image }}</Data>
-        <Data Name="User">{{ User }}</Data>
         <Data Name="TargetObject">{{ TargetObject }}</Data>
         <Data Name="Details">{{ Details | default('-') }}</Data>
+        <Data Name="User">{{ User }}</Data>
         {% elif EventID == 22 %}
         <Data Name="RuleName">{{ RuleName | default('-') }}</Data>
         <Data Name="UtcTime">{{ UtcTime }}</Data>

--- a/src/evidenceforge/evaluation/context.py
+++ b/src/evidenceforge/evaluation/context.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from evidenceforge.events.ground_truth import GroundTruthDocument
 from evidenceforge.events.observation_manifest import ObservationManifest
 
 
@@ -15,6 +16,7 @@ class EvaluationContext:
     """Additional dataset metadata available to scorers."""
 
     observation_manifest: ObservationManifest | None = None
+    ground_truth: GroundTruthDocument | None = None
     # storyline_id -> {"values": [rendered on-disk credentials], "time": datetime},
     # from GROUND_TRUTH.json. Lets the causality pillar match spillage events
     # without re-running synthesis, anchored to the actual emitted time.

--- a/src/evidenceforge/evaluation/engine.py
+++ b/src/evidenceforge/evaluation/engine.py
@@ -45,6 +45,7 @@ from evidenceforge.evaluation.pillars import (
     TimingScorer,
 )
 from evidenceforge.evaluation.thresholds import EvalThresholds, load_thresholds
+from evidenceforge.events.ground_truth import load_ground_truth_document
 from evidenceforge.events.observation_manifest import load_observation_manifest
 from evidenceforge.models.scenario import Scenario
 from evidenceforge.output_targets import read_output_target_marker
@@ -235,20 +236,34 @@ class EvaluationEngine:
         if document is None:
             return result
         for rec in document.events:
-            if rec.kind != "email_message" or not rec.emitted:
+            if rec.kind not in {"email_message", "email_read"} or not rec.emitted:
                 continue
             sid = rec.storyline_id
-            message_id = rec.attributes.message_id
-            if not (sid and message_id):
+            if not sid:
                 continue
-            result[sid] = {
-                "message_id": message_id,
-                "artifact_path": rec.attributes.artifact_path,
-                "smtp_uids": list(rec.attributes.smtp_uids or ()),
-                "subject": rec.attributes.subject,
-                "sender": rec.attributes.sender,
-                "recipients": list(rec.attributes.recipients or ()),
-            }
+            if rec.kind == "email_message":
+                message_id = rec.attributes.message_id
+                if not message_id:
+                    continue
+                result[sid] = {
+                    "kind": rec.kind,
+                    "time": rec.time,
+                    "message_id": message_id,
+                    "artifact_path": rec.attributes.artifact_path,
+                    "smtp_uids": list(rec.attributes.smtp_uids or ()),
+                    "subject": rec.attributes.subject,
+                    "sender": rec.attributes.sender,
+                    "recipients": list(rec.attributes.recipients or ()),
+                    "outcome": rec.attributes.outcome,
+                }
+            else:
+                result[sid] = {
+                    "kind": rec.kind,
+                    "time": rec.time,
+                    "uid": rec.attributes.uid,
+                    "server": rec.attributes.server,
+                    "protocol": rec.attributes.protocol,
+                }
         return result
 
     def run(self) -> QualityReport:
@@ -268,8 +283,10 @@ class EvaluationEngine:
 
         logger.info(f"Parsed {total_records} records across {len(source_counts)} sources")
         observation_manifest = load_observation_manifest(self.output_dir, self.scenario)
+        ground_truth = load_ground_truth_document(self.output_dir, self.scenario)
         context = EvaluationContext(
             observation_manifest=observation_manifest,
+            ground_truth=ground_truth,
             spillage_ground_truth=self._load_spillage_ground_truth(),
             adversarial_payload_ground_truth=self._load_adversarial_payload_ground_truth(),
             email_ground_truth=self._load_email_ground_truth(),
@@ -352,6 +369,7 @@ class EvaluationEngine:
 
         return QualityReport(
             scenario_name=self.scenario.name,
+            generated_at=ground_truth.generated_at if ground_truth is not None else None,
             evaluated_at=datetime.now(UTC),
             total_records=total_records,
             source_counts=source_counts,
@@ -374,7 +392,7 @@ class EvaluationEngine:
         source_counts: dict[str, int] = {}
 
         total_formats = len(file_map)
-        for i, (format_name, paths) in enumerate(file_map.items(), 1):
+        for i, (format_name, paths) in enumerate(sorted(file_map.items()), 1):
             self._progress(
                 "parsing_format",
                 {
@@ -387,13 +405,30 @@ class EvaluationEngine:
             parser.scenario = self.scenario
             parser.output_target = self.output_target
             format_records: list[ParsedRecord] = []
-            for path in paths:
+            for path in sorted(paths):
                 logger.info(f"Parsing {format_name}: {path.name}")
-                format_records.extend(parser.parse_file(path))
+                source_instance = self._source_instance(path)
+                parsed = list(parser.parse_file(path))
+                for record in parsed:
+                    record.source_instance = source_instance
+                parsed.sort(key=lambda record: (record.line_number or 0, record.raw))
+                format_records.extend(parsed)
             records[format_name] = format_records
             source_counts[format_name] = len(format_records)
 
         return records, source_counts
+
+    def _source_instance(self, path: Path) -> str:
+        """Return the nearest non-year directory identifying a host or sensor."""
+
+        try:
+            parts = path.resolve().relative_to(self.output_dir.resolve()).parts[:-1]
+        except ValueError:
+            return "__artifact__"
+        for part in reversed(parts):
+            if not (len(part) == 4 and part.isdigit()):
+                return part
+        return "__direct__"
 
     @staticmethod
     def _compute_overall(pillars: list[PillarScore]) -> float | None:

--- a/src/evidenceforge/evaluation/parsers/__init__.py
+++ b/src/evidenceforge/evaluation/parsers/__init__.py
@@ -49,6 +49,7 @@ class ParsedRecord(BaseModel):
     parse_errors: list[str] = Field(default_factory=list)
     line_number: int | None = None
     source_host: str | None = None
+    source_instance: str | None = None
 
 
 class LogParser(ABC):
@@ -195,7 +196,10 @@ def discover_log_files(output_dir: Path, output_target: Any = None) -> dict[str,
             if parser.can_parse(candidate):
                 result.setdefault(format_name, []).append(candidate)
 
-    return result
+    return {
+        format_name: sorted(paths, key=lambda path: path.as_posix())
+        for format_name, paths in sorted(result.items())
+    }
 
 
 # Import parsers to trigger registration

--- a/src/evidenceforge/evaluation/parsers/snort.py
+++ b/src/evidenceforge/evaluation/parsers/snort.py
@@ -22,9 +22,10 @@
 
 """Parser for Snort/Suricata fast alert files."""
 
+import ipaddress
 import re
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from . import LogParser, ParsedRecord, register_parser
@@ -50,14 +51,17 @@ class SnortAlertParser(LogParser):
         return path.name in {"snort_alert.log", "snort_alert.alert"}
 
     def parse_file(self, path: Path) -> Iterator[ParsedRecord]:
+        seed_year = self.scenario.time_window.start.year if self.scenario is not None else None
+        if seed_year is None:
+            seed_year = datetime.now(UTC).year
         with path.open(encoding="utf-8") as f:
             for line_num, line in enumerate(f, 1):
                 line = line.rstrip("\n")
                 if not line:
                     continue
-                yield self._parse_line(line, line_num)
+                yield self._parse_line(line, line_num, seed_year)
 
-    def _parse_line(self, raw: str, line_num: int) -> ParsedRecord:
+    def _parse_line(self, raw: str, line_num: int, seed_year: int) -> ParsedRecord:
         fields: dict = {}
         errors: list[str] = []
         timestamp = None
@@ -80,8 +84,8 @@ class SnortAlertParser(LogParser):
 
         # Parse timestamp (MM/DD-HH:MM:SS.ffffff — no year)
         try:
-            ts_with_year = f"{datetime.now().year}/{ts_str}"
-            timestamp = datetime.strptime(ts_with_year, "%Y/%m/%d-%H:%M:%S.%f")
+            ts_with_year = f"{seed_year}/{ts_str}"
+            timestamp = datetime.strptime(ts_with_year, "%Y/%m/%d-%H:%M:%S.%f").replace(tzinfo=UTC)
         except ValueError:
             errors.append(f"Invalid timestamp: {ts_str}")
 
@@ -117,11 +121,29 @@ class SnortAlertParser(LogParser):
 
     @staticmethod
     def _parse_endpoint(endpoint: str) -> tuple[str, int | None]:
-        """Parse 'ip:port' or just 'ip'."""
-        if ":" in endpoint:
-            parts = endpoint.rsplit(":", 1)
+        """Parse IPv4/bracketed-IPv6 endpoints; bare IPv6 is portless."""
+
+        bracketed = re.fullmatch(r"\[([^]]+)](?::(\d+))?", endpoint)
+        if bracketed:
+            address, port = bracketed.groups()
             try:
-                return parts[0], int(parts[1])
+                ipaddress.ip_address(address)
             except ValueError:
                 return endpoint, None
+            return address, int(port) if port is not None else None
+
+        try:
+            ipaddress.ip_address(endpoint)
+        except ValueError:
+            pass
+        else:
+            return endpoint, None
+
+        address, separator, port = endpoint.rpartition(":")
+        if separator and port.isdigit():
+            try:
+                ipaddress.ip_address(address)
+            except ValueError:
+                return endpoint, None
+            return address, int(port)
         return endpoint, None

--- a/src/evidenceforge/evaluation/pillars/causality.py
+++ b/src/evidenceforge/evaluation/pillars/causality.py
@@ -143,11 +143,16 @@ class CausalityScorer(DimensionScorer):
             systems_by_name = {system.hostname: system for system in scenario.environment.systems}
             email_config = getattr(scenario.environment, "email", None)
             self._email_server_ips = {}
+            self._email_server_hosts = {}
             if email_config is not None:
                 self._email_server_ips = {
                     server.name.lower(): systems_by_name[server.system].ip
                     for server in email_config.mail_servers
                     if server.system in systems_by_name
+                }
+                self._email_server_hosts = {
+                    server.name.lower(): server.hostname.lower()
+                    for server in email_config.mail_servers
                 }
             # Build host-time index and find traces
             host_time_index = self._build_host_time_index(records)
@@ -157,6 +162,7 @@ class CausalityScorer(DimensionScorer):
             self._proxy_ips = set()
             self._email_actor_emails = {}
             self._email_server_ips = {}
+            self._email_server_hosts = {}
             host_time_index = self._build_host_time_index(records)
 
         enabled = {log_spec["format"] for log_spec in scenario.output.logs if "format" in log_spec}
@@ -189,7 +195,7 @@ class CausalityScorer(DimensionScorer):
         sub_scores = [s1, s2, s3, s4, s5, s6]
         dim_score = aggregate_sub_scores(sub_scores)
 
-        host_log_profile = _build_host_log_profile(records, vis)
+        host_log_profile = _build_host_log_profile(records, vis, scenario)
 
         return PillarScore(
             number=self.number,
@@ -290,12 +296,26 @@ class CausalityScorer(DimensionScorer):
             for record in record_list:
                 if id(record) in seen:
                     continue
-                if not self._record_near_event(record, event):
-                    continue
-                if self._record_matches(record, format_name, event, event_type):
+                matches = self._record_matches(record, format_name, event, event_type)
+                if matches and (
+                    self._record_near_event(record, event)
+                    or self._email_record_has_ground_truth_identity(record, event)
+                ):
                     found.append(record)
                     seen.add(id(record))
         return found
+
+    def _email_record_has_ground_truth_identity(
+        self,
+        record: ParsedRecord,
+        event: ResolvedEvent,
+    ) -> bool:
+        ground_truth = self._email_gt.get(event.storyline_id) or {}
+        message_id = ground_truth.get("message_id")
+        if message_id and record.fields.get("message_id") == message_id:
+            return True
+        uid = record.fields.get("uid")
+        return bool(uid and uid in set(ground_truth.get("smtp_uids") or ()))
 
     @staticmethod
     def _record_near_event(record: ParsedRecord, event: ResolvedEvent) -> bool:
@@ -875,6 +895,11 @@ class CausalityScorer(DimensionScorer):
             gt = self._email_gt.get(event.storyline_id) or {}
             message_id = gt.get("message_id")
             return bool(message_id and fields.get("message_id") == message_id)
+        gt = self._email_gt.get(event.storyline_id) or {}
+        if format_name in {"zeek_smtp", "zeek_conn", "zeek_ssl"}:
+            uid = fields.get("uid")
+            if uid and uid in set(gt.get("smtp_uids") or ()):
+                return True
         if format_name != "zeek_smtp":
             return False
 
@@ -910,6 +935,12 @@ class CausalityScorer(DimensionScorer):
         event: ResolvedEvent,
     ) -> bool:
         """Match opaque TLS mailbox reads to Zeek connection/SSL evidence."""
+        if format_name == "proxy_access":
+            if event.system_ip and fields.get("client_ip") != event.system_ip:
+                return False
+            server_name = str(event.details.get("server") or "").lower()
+            expected_host = self._email_server_hosts.get(server_name)
+            return bool(expected_host and str(fields.get("host") or "").lower() == expected_host)
         if format_name not in {"zeek_conn", "zeek_ssl"}:
             return False
         if event.system_ip and fields.get("id.orig_h") != event.system_ip:
@@ -1653,6 +1684,16 @@ class CausalityScorer(DimensionScorer):
                 break
             failures.append(failure)
 
+        parent_total, parent_correct, parent_failures = self._score_process_parent_integrity(
+            records
+        )
+        total_pairs += parent_total
+        correct_pairs += parent_correct
+        for failure in parent_failures:
+            if len(failures) >= 10:
+                break
+            failures.append(failure)
+
         score = (100.0 * correct_pairs / total_pairs) if total_pairs > 0 else 100.0
         return SubScore(
             name="Causal Ordering",
@@ -1722,6 +1763,83 @@ class CausalityScorer(DimensionScorer):
                     f"{record.line_number} precedes its exact inbound FLOW"
                 )
         return total, correct, failures
+
+    @classmethod
+    def _score_process_parent_integrity(
+        cls,
+        records: dict[str, list[ParsedRecord]],
+    ) -> tuple[int, int, list[str]]:
+        """Reject only parents proven terminated before a child without PID reuse."""
+
+        lifecycles: dict[tuple[str, str, int], dict[str, list[datetime]]] = defaultdict(
+            lambda: {"create": [], "terminate": []}
+        )
+        children: list[tuple[str, str, int, datetime, int | None]] = []
+        for format_name in ("ecar", "windows_event_sysmon"):
+            for record in records.get(format_name, []):
+                if record.timestamp is None:
+                    continue
+                fields = record.fields
+                host = str(
+                    fields.get("hostname") or fields.get("Computer") or record.source_host or ""
+                ).lower()
+                if not host:
+                    continue
+                is_create = (
+                    format_name == "ecar"
+                    and fields.get("object") == "PROCESS"
+                    and fields.get("action") == "CREATE"
+                ) or (format_name == "windows_event_sysmon" and fields.get("EventID") == 1)
+                is_terminate = (
+                    format_name == "ecar"
+                    and fields.get("object") == "PROCESS"
+                    and fields.get("action") == "TERMINATE"
+                ) or (format_name == "windows_event_sysmon" and fields.get("EventID") == 5)
+                if not (is_create or is_terminate):
+                    continue
+                pid = cls._coerce_pid(fields.get("pid") or fields.get("ProcessId"))
+                if pid is None:
+                    continue
+                timestamp = _normalize_ts(record.timestamp)
+                key = (format_name, host, pid)
+                lifecycles[key]["create" if is_create else "terminate"].append(timestamp)
+                if is_create:
+                    parent = cls._coerce_pid(fields.get("ppid") or fields.get("ParentProcessId"))
+                    children.append((format_name, host, pid, timestamp, parent))
+
+        total = 0
+        correct = 0
+        failures: list[str] = []
+        for format_name, host, child_pid, child_time, parent_pid in children:
+            if parent_pid in {None, 0, 4}:
+                continue
+            lifecycle = lifecycles.get((format_name, host, parent_pid))
+            if lifecycle is None or not lifecycle["create"] or not lifecycle["terminate"]:
+                continue
+            prior_creates = [time for time in lifecycle["create"] if time <= child_time]
+            prior_terminations = [time for time in lifecycle["terminate"] if time < child_time]
+            if not prior_creates or not prior_terminations:
+                continue
+            total += 1
+            last_create = max(prior_creates)
+            last_terminate = max(prior_terminations)
+            if last_create > last_terminate:
+                correct += 1
+            elif len(failures) < 10:
+                failures.append(
+                    f"{format_name} {host} child PID {child_pid} references stale parent "
+                    f"PID {parent_pid}"
+                )
+        return total, correct, failures
+
+    @staticmethod
+    def _coerce_pid(value: Any) -> int | None:
+        if value in (None, "", "-"):
+            return None
+        try:
+            return int(str(value), 0)
+        except ValueError:
+            return None
 
     @staticmethod
     def _ecar_remote_auth_transport_key(fields: dict[str, Any]) -> tuple[str, ...] | None:
@@ -1835,7 +1953,7 @@ class CausalityScorer(DimensionScorer):
                     total_checks += 1
                     if is_correct:
                         correct_checks += 1
-                    elif len(failures) < 10:
+                    else:
                         failures.append(
                             f"Event {event.index}: {indicator_name} mismatch in {trace.source_format}"
                         )
@@ -1847,7 +1965,7 @@ class CausalityScorer(DimensionScorer):
             weight=0.15,
             score=score,
             details=f"{correct_checks}/{total_checks} indicator checks correct",
-            sample_failures=failures,
+            sample_failures=sorted(failures)[:10],
         )
 
     def _check_indicators(
@@ -1876,10 +1994,11 @@ class CausalityScorer(DimensionScorer):
                         user_ok = self._username_indicator_matches(f[uf], event)
                     checks.append(("username", user_ok))
                     break
-        for hf in ["Computer", "hostname"]:
-            if hf in f and f[hf]:
-                checks.append(("hostname", self._host_matches(f[hf], event.system)))
-                break
+        if trace.source_format != "cisco_asa":
+            for hf in ["Computer", "hostname"]:
+                if hf in f and f[hf]:
+                    checks.append(("hostname", self._host_matches(f[hf], event.system)))
+                    break
         if "source_ip" in details:
             for ipf in ["IpAddress", "id.orig_h", "src_ip"]:
                 if ipf in f and f[ipf] and f[ipf] != "-":
@@ -1982,76 +2101,141 @@ class CausalityScorer(DimensionScorer):
                 score=100.0,
                 details="Fewer than 2 events — nothing to link",
             )
-        raw_total_pairs = len(resolved) - 1
-        raw_linkable = 0
+        expected_by_event = {
+            event.index: self._expected_indicator_values(event) for event in resolved
+        }
+        events_by_indicator: dict[str, list[ResolvedEvent]] = defaultdict(list)
+        for event in resolved:
+            for indicator in expected_by_event[event.index]:
+                events_by_indicator[indicator].append(event)
+        edges: dict[tuple[int, int], set[str]] = defaultdict(set)
+        for indicator, events in events_by_indicator.items():
+            ordered = sorted(events, key=lambda event: (event.time, event.index))
+            for first, second in zip(ordered, ordered[1:], strict=False):
+                edges[(first.index, second.index)].add(indicator)
+
         total_pairs = 0
         linkable = 0
         excluded = 0
         failures: list[str] = []
-        for i in range(raw_total_pairs):
-            a, b = resolved[i], resolved[i + 1]
-            pair_linkable = bool(
-                self._extract_indicator_values(a) & self._extract_indicator_values(b)
-            )
-            if pair_linkable:
-                raw_linkable += 1
+        by_index = {event.index: event for event in resolved}
+        for (first_index, second_index), indicators in sorted(edges.items()):
+            a, b = by_index[first_index], by_index[second_index]
             if (not a.traces and self._event_observation_exempt(a, context)) or (
                 not b.traces and self._event_observation_exempt(b, context)
             ):
                 excluded += 1
                 continue
             total_pairs += 1
+            observed_a = self._observed_indicator_values(a)
+            observed_b = self._observed_indicator_values(b)
+            pair_linkable = bool(indicators & observed_a & observed_b)
             if pair_linkable:
                 linkable += 1
             elif len(failures) < 10:
                 failures.append(
-                    f"Events {i}→{i + 1}: no shared indicator "
-                    f"({a.actor}@{a.system} → {b.actor}@{b.system})"
+                    f"Events {first_index}→{second_index}: expected pivot not present in both "
+                    f"rendered traces ({a.actor}@{a.system} → {b.actor}@{b.system})"
                 )
         score = (100.0 * linkable / total_pairs) if total_pairs > 0 else 100.0
-        raw_score = (100.0 * raw_linkable / raw_total_pairs) if raw_total_pairs > 0 else 100.0
+        connected = {index for edge in edges for index in edge}
+        isolated = len(resolved) - len(connected)
         return SubScore(
             name="Pivot Linkability",
             key="pivot_linkability",
             weight=0.15,
             score=score,
-            raw_score=raw_score if excluded else None,
             adjusted=excluded > 0,
-            details=self._adjusted_details(
-                f"{linkable}/{total_pairs} expected-visible consecutive pairs share a "
-                "pivotable indicator",
-                raw_linkable,
-                raw_total_pairs,
-                excluded,
+            details=(
+                f"{linkable}/{total_pairs} inferred expected-visible narrative edges retain a "
+                f"shared rendered pivot; {isolated} isolated events, {excluded} observation-exempt"
             ),
             sample_failures=failures,
         )
 
-    def _extract_indicator_values(self, event: ResolvedEvent) -> set[str]:
-        values: set[str] = {event.actor.lower(), event.system.lower()}
+    def _expected_indicator_values(self, event: ResolvedEvent) -> set[str]:
+        values = {
+            self._scoped_actor_indicator(event.actor, event.system),
+            f"host:{event.system.lower()}",
+        }
         if event.system_ip:
-            values.add(event.system_ip)
-        for key in ("source_ip", "dst_ip"):
-            if key in event.details and event.details[key]:
-                values.add(str(event.details[key]))
+            values.add(f"ip:{event.system_ip.lower()}")
+        key_namespaces = {
+            "source_ip": "ip",
+            "dst_ip": "ip",
+            "answer_ip": "ip",
+            "hostname": "host",
+            "server": "host",
+            "target_system": "host",
+            "query": "domain",
+            "base_domain": "domain",
+            "url": "url",
+            "uri": "url",
+            "artifact_id": "artifact",
+            "message_ids": "artifact",
+            "target_username": "user",
+            "success_account": "user",
+            "output_file": "file",
+            "process_name": "process",
+        }
+        for detail in event.sub_details or [event.details]:
+            for key, namespace in key_namespaces.items():
+                raw = detail.get(key)
+                items = raw if isinstance(raw, list) else [raw]
+                for item in items:
+                    if item not in (None, "", "-"):
+                        values.add(f"{namespace}:{str(item).lower()}")
+        email_gt = self._email_gt.get(event.storyline_id) or {}
+        for key, namespace in (("message_id", "artifact"), ("smtp_uids", "artifact")):
+            raw = email_gt.get(key)
+            items = raw if isinstance(raw, list) else [raw]
+            for item in items:
+                if item:
+                    values.add(f"{namespace}:{str(item).lower()}")
+        return values
+
+    def _observed_indicator_values(self, event: ResolvedEvent) -> set[str]:
+        values: set[str] = set()
         for trace in event.traces:
-            for field_name in (
-                "TargetUserName",
-                "SubjectUserName",
-                "principal",
-                "username",
-                "Computer",
-                "hostname",
-                "IpAddress",
-                "id.orig_h",
-                "id.resp_h",
-                "src_ip",
-                "dst_ip",
-            ):
+            field_namespaces = {
+                "TargetUserName": "user",
+                "SubjectUserName": "user",
+                "principal": "user",
+                "username": "user",
+                "Computer": "host",
+                "hostname": "host",
+                "host": "host",
+                "server_name": "host",
+                "IpAddress": "ip",
+                "id.orig_h": "ip",
+                "id.resp_h": "ip",
+                "src_ip": "ip",
+                "dst_ip": "ip",
+                "query": "domain",
+                "url": "url",
+                "uri": "url",
+                "message_id": "artifact",
+                "msg_id": "artifact",
+                "uid": "artifact",
+                "sha256": "file",
+                "image_path": "process",
+                "NewProcessName": "process",
+            }
+            for field_name, namespace in field_namespaces.items():
                 val = trace.fields.get(field_name)
                 if val and val != "-":
-                    values.add(str(val).lower())
+                    values.add(f"{namespace}:{str(val).lower()}")
+        actor_indicator = self._scoped_actor_indicator(event.actor, event.system)
+        if any(value in values for value in {f"user:{event.actor.lower()}", actor_indicator}):
+            values.add(actor_indicator)
         return values
+
+    @staticmethod
+    def _scoped_actor_indicator(actor: str, system: str) -> str:
+        normalized = actor.lower()
+        if normalized in {"root", "system", "local service", "network service"}:
+            return f"user:{normalized}@{system.lower()}"
+        return f"user:{normalized}"
 
     # --- Sub-score 5: Temporal Integrity ---
 
@@ -2178,7 +2362,11 @@ class CausalityScorer(DimensionScorer):
         failures: list[str] = []
 
         for event in resolved:
-            groups = vis.get_expected_format_groups(event.system, event.event_types)
+            groups = vis.get_expected_format_groups(
+                event.system,
+                event.event_types,
+                event.sub_details,
+            )
             evt_time = _normalize_ts(event.time)
             evt_bucket = int(evt_time.timestamp()) // 60
 
@@ -2196,18 +2384,17 @@ class CausalityScorer(DimensionScorer):
                 group_found = False
                 for fmt in group_formats:
                     if fmt not in host_time_index.get("__formats__", {fmt: True}):
-                        # Check if format has any records at all
                         has_format = any(
-                            fmt in host_time_index.get(k, {})
-                            for lk in lookup_keys
-                            for b in range(evt_bucket - 2, evt_bucket + 3)
-                            for k in [f"{lk}|{b}"]
+                            fmt in host_time_index.get(key, {})
+                            for lookup_key in lookup_keys
+                            for bucket in range(evt_bucket - 2, evt_bucket + 3)
+                            for key in [f"{lookup_key}|{bucket}"]
                         )
                         if not has_format:
                             continue
-                    for b in range(evt_bucket - 2, evt_bucket + 3):
-                        for lk in lookup_keys:
-                            key = f"{lk}|{b}"
+                    for bucket in range(evt_bucket - 2, evt_bucket + 3):
+                        for lookup_key in lookup_keys:
+                            key = f"{lookup_key}|{bucket}"
                             if key in host_time_index and fmt in host_time_index[key]:
                                 group_found = True
                                 break
@@ -2256,6 +2443,7 @@ class CausalityScorer(DimensionScorer):
 def _build_host_log_profile(
     records: dict[str, list[ParsedRecord]],
     vis: VisibilityModel,
+    scenario: Scenario | None = None,
 ) -> dict[str, dict]:
     present: dict[str, set[str]] = defaultdict(set)
     counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
@@ -2278,11 +2466,22 @@ def _build_host_log_profile(
             if canonical:
                 all_hosts.add(canonical.lower())
 
+    shell_hosts = {
+        event.system.lower()
+        for event in (
+            *((scenario.storyline or []) if scenario is not None else []),
+            *((scenario.red_herrings or []) if scenario is not None else []),
+        )
+        if any(spec.type in {"process", "ssh_session"} for spec in event.events)
+    }
+
     for hostname in sorted(all_hosts):
-        expected = vis.get_expected_formats(hostname)
+        expected = set(vis.get_expected_formats(hostname))
         if not expected:
             continue
         present_fmts = present.get(hostname, set())
+        if "bash_history" not in present_fmts and hostname not in shell_hosts:
+            expected.discard("bash_history")
         missing = sorted(expected - present_fmts)
         profile[hostname] = {
             "expected_formats": sorted(expected),

--- a/src/evidenceforge/evaluation/pillars/plausibility.py
+++ b/src/evidenceforge/evaluation/pillars/plausibility.py
@@ -31,9 +31,10 @@ Sub-scores (weights sum to 1.0):
   anomaly_rate        (0.10): Realistic 1-5% anomalous-but-benign event rate.
 """
 
+import hashlib
+import itertools
 import logging
 import math
-import random
 from collections import Counter, defaultdict
 from datetime import UTC, datetime
 from typing import Any
@@ -56,6 +57,7 @@ from evidenceforge.evaluation.models import PillarScore, SubScore
 from evidenceforge.evaluation.parsers import ParsedRecord
 from evidenceforge.evaluation.rules import load_rules_file
 from evidenceforge.evaluation.visibility import VisibilityModel
+from evidenceforge.events.ids_evaluation import new_ids_digest, update_ids_digest
 from evidenceforge.models.scenario import Scenario
 
 logger = logging.getLogger(__name__)
@@ -85,34 +87,39 @@ class PlausibilityScorer(DimensionScorer):
         context: EvaluationContext | None = None,
         progress: ProgressCallback = _noop_callback,
     ) -> PillarScore:
+        context = context or EvaluationContext()
         enabled = {log_spec["format"] for log_spec in scenario.output.logs if "format" in log_spec}
         vis = VisibilityModel(scenario, enabled)
 
-        progress("sub_score_start", {"name": "Value & OS Plausibility", "step": 1, "total": 6})
+        progress("sub_score_start", {"name": "Value & OS Plausibility", "step": 1, "total": 7})
         s1 = self._score_value_plausibility(records, vis)
         progress("sub_score_done", {"name": "Value & OS Plausibility", "score": s1.score})
 
-        progress("sub_score_start", {"name": "Co-occurrence Rules", "step": 2, "total": 6})
+        progress("sub_score_start", {"name": "Co-occurrence Rules", "step": 2, "total": 7})
         s2 = self._score_co_occurrence(records)
         progress("sub_score_done", {"name": "Co-occurrence Rules", "score": s2.score})
 
-        progress("sub_score_start", {"name": "Distribution Fit", "step": 3, "total": 6})
+        progress("sub_score_start", {"name": "Distribution Fit", "step": 3, "total": 7})
         s3 = self._score_distribution_fit(records)
         progress("sub_score_done", {"name": "Distribution Fit", "score": s3.score})
 
-        progress("sub_score_start", {"name": "Cross-Source Field Agreement", "step": 4, "total": 6})
+        progress("sub_score_start", {"name": "Cross-Source Field Agreement", "step": 4, "total": 7})
         s4 = self._score_field_agreement(records)
         progress("sub_score_done", {"name": "Cross-Source Field Agreement", "score": s4.score})
 
-        progress("sub_score_start", {"name": "User Behavioral Diversity", "step": 5, "total": 6})
+        progress("sub_score_start", {"name": "User Behavioral Diversity", "step": 5, "total": 7})
         s5 = self._score_user_diversity(records)
         progress("sub_score_done", {"name": "User Behavioral Diversity", "score": s5.score})
 
-        progress("sub_score_start", {"name": "Anomaly Rate", "step": 6, "total": 6})
+        progress("sub_score_start", {"name": "Anomaly Rate", "step": 6, "total": 7})
         s6 = self._score_anomaly_rate(records, scenario)
         progress("sub_score_done", {"name": "Anomaly Rate", "score": s6.score})
 
-        sub_scores = [s1, s2, s3, s4, s5, s6]
+        progress("sub_score_start", {"name": "IDS Correlation Integrity", "step": 7, "total": 7})
+        s7 = self._score_ids_integrity(records, scenario, context)
+        progress("sub_score_done", {"name": "IDS Correlation Integrity", "score": s7.score})
+
+        sub_scores = [s1, s2, s3, s4, s5, s6, s7]
         dim_score = aggregate_sub_scores(sub_scores)
 
         return PillarScore(
@@ -220,7 +227,7 @@ class PlausibilityScorer(DimensionScorer):
                 continue
             valid = [r for r in record_list if not r.parse_errors]
             if len(valid) > max_sample:
-                valid = random.sample(valid, max_sample)
+                valid = _stable_records(valid, max_sample)
 
             for record in valid:
                 for rule in rules:
@@ -365,8 +372,6 @@ class PlausibilityScorer(DimensionScorer):
     # --- Sub-score 5: User Behavioral Diversity ---
 
     def _score_user_diversity(self, records: dict[str, list[ParsedRecord]]) -> SubScore:
-        import itertools
-
         user_types: dict[str, Counter] = defaultdict(Counter)
         for _fmt, record_list in records.items():
             for record in record_list:
@@ -385,22 +390,19 @@ class PlausibilityScorer(DimensionScorer):
                 details="Fewer than 2 users with sufficient data — skipped",
             )
 
-        user_list = list(users_with_data.keys())
+        user_list = sorted(users_with_data)
         total_pairs = len(user_list) * (len(user_list) - 1) // 2
         max_pairs = 200
 
         if total_pairs <= max_pairs:
             pairs = list(itertools.combinations(range(len(user_list)), 2))
         else:
-            pairs_set: set = set()
-            while len(pairs_set) < max_pairs:
-                import random as _rng
-
-                i = _rng.randrange(len(user_list))
-                j = _rng.randrange(len(user_list))
-                if i != j:
-                    pairs_set.add((min(i, j), max(i, j)))
-            pairs = list(pairs_set)
+            pairs = sorted(
+                itertools.combinations(range(len(user_list)), 2),
+                key=lambda pair: hashlib.sha256(
+                    f"{user_list[pair[0]]}\0{user_list[pair[1]]}".encode()
+                ).digest(),
+            )[:max_pairs]
 
         similarities: list[float] = []
         for i, j in pairs:
@@ -461,8 +463,161 @@ class PlausibilityScorer(DimensionScorer):
             details=f"{anomalous}/{total} events anomalous ({rate:.1%}), target 1-5%",
         )
 
+    def _score_ids_integrity(
+        self,
+        records: dict[str, list[ParsedRecord]],
+        scenario: Scenario,
+        context: EvaluationContext,
+    ) -> SubScore:
+        """Reconcile rendered alerts with canonical sensor-local IDS ground truth."""
+
+        document = context.ground_truth
+        if document is None or document.ids_evaluation is None:
+            if _scenario_has_ids_attachments(scenario):
+                return SubScore(
+                    name="IDS Correlation Integrity",
+                    key="ids_integrity",
+                    weight=0.0,
+                    score=0.0,
+                    details="Authored ids_alerts require GROUND_TRUTH.json ids_evaluation",
+                    sample_failures=["Missing or invalid IDS evaluation ground truth"],
+                )
+            return SubScore(
+                name="IDS Correlation Integrity",
+                key="ids_integrity",
+                weight=0.0,
+                score=None,
+                skipped=True,
+                details="Legacy dataset has no IDS evaluation summary; check skipped",
+            )
+
+        checks = 0
+        passing = 0
+        failures: list[str] = []
+
+        def check(condition: bool, message: str) -> None:
+            nonlocal checks, passing
+            checks += 1
+            if condition:
+                passing += 1
+            elif len(failures) < 10:
+                failures.append(message)
+
+        for event in document.events:
+            for attachment in event.attributes.ids_alerts or []:
+                candidate = int(attachment.get("candidate", 0))
+                emitted = int(attachment.get("emitted", 0))
+                filtered = int(attachment.get("policy_filtered", 0))
+                check(
+                    candidate == emitted + filtered,
+                    f"{event.storyline_id} SID {attachment.get('sid')} totals disagree",
+                )
+
+        actual: dict[str, dict[str, dict[str, Any]]] = {}
+        for record in records.get("snort_alert", []):
+            if record.parse_errors or record.timestamp is None:
+                continue
+            sensor = record.source_instance or "__direct__"
+            key = f"{int(record.fields.get('gid', 1))}:{int(record.fields['sid'])}"
+            summary = actual.setdefault(sensor, {}).setdefault(
+                key,
+                {"emitted": 0, "digest": new_ids_digest()},
+            )
+            summary["emitted"] += 1
+            update_ids_digest(
+                summary["digest"],
+                sensor,
+                record.fields | {"timestamp": record.timestamp},
+            )
+
+        expected_keys = {
+            (sensor, key)
+            for sensor, signatures in document.ids_evaluation.sensors.items()
+            for key in signatures
+        }
+        actual_keys = {(sensor, key) for sensor, signatures in actual.items() for key in signatures}
+        for sensor, key in sorted(expected_keys | actual_keys):
+            expected = document.ids_evaluation.sensors.get(sensor, {}).get(key)
+            observed = actual.get(sensor, {}).get(key)
+            check(expected is not None, f"Unexpected Snort rows for {sensor} {key}")
+            check(observed is not None, f"Missing Snort rows for {sensor} {key}")
+            if expected is None or observed is None:
+                continue
+            check(
+                expected.emitted == observed["emitted"],
+                f"{sensor} {key} emitted {observed['emitted']} != expected {expected.emitted}",
+            )
+            check(
+                expected.emitted_sha256 == observed["digest"].hexdigest(),
+                f"{sensor} {key} normalized alert digest differs",
+            )
+
+        observation = document.ids_evaluation.observation
+        signatures = [
+            signature
+            for sensor_signatures in document.ids_evaluation.sensors.values()
+            for signature in sensor_signatures.values()
+        ]
+        rendered = sum(signature.emitted for signature in signatures)
+        policy_filtered = sum(signature.policy_filtered for signature in signatures)
+        check(
+            rendered == observation.get("visible", 0) + observation.get("delayed", 0),
+            "IDS visible/delayed totals do not equal rendered alerts",
+        )
+        check(
+            observation.get("filtered", 0) >= policy_filtered,
+            "IDS filtered observation total is lower than policy-filtered candidates",
+        )
+        source_observation: dict[str, int] = {}
+        for source_status in document.source_evidence_status.values():
+            for status, count in source_status.get("ids", {}).items():
+                source_observation[status] = source_observation.get(status, 0) + count
+        check(
+            source_observation == observation,
+            "IDS summary disagrees with ground-truth source_evidence_status",
+        )
+        if context.observation_manifest is not None:
+            check(
+                context.observation_manifest.source_summary.get("ids", {}) == observation,
+                "IDS summary disagrees with OBSERVATION_MANIFEST.json",
+            )
+
+        score = 100.0 * passing / checks if checks else 100.0
+        return SubScore(
+            name="IDS Correlation Integrity",
+            key="ids_integrity",
+            weight=0.0,
+            score=score,
+            details=f"{passing}/{checks} IDS integrity checks pass",
+            sample_failures=failures,
+        )
+
 
 # --- Module-level helpers ---
+
+
+def _stable_records(records: list[ParsedRecord], limit: int) -> list[ParsedRecord]:
+    """Select a repeatable bounded record sample independent of process RNG state."""
+
+    return sorted(
+        records,
+        key=lambda record: hashlib.sha256(
+            (
+                f"{record.source_format}\0{record.source_instance or ''}\0"
+                f"{record.line_number or 0}\0{record.raw}"
+            ).encode()
+        ).digest(),
+    )[:limit]
+
+
+def _scenario_has_ids_attachments(scenario: Scenario) -> bool:
+    """Return whether a typed storyline or red-herring event authors IDS attachments."""
+
+    return any(
+        bool(getattr(spec, "ids_alerts", None))
+        for cluster in (*(scenario.storyline or []), *(scenario.red_herrings or []))
+        for spec in cluster.events
+    )
 
 
 def _check_os_plausibility(record: ParsedRecord, fmt: str) -> bool | None:

--- a/src/evidenceforge/evaluation/visibility.py
+++ b/src/evidenceforge/evaluation/visibility.py
@@ -148,7 +148,10 @@ class VisibilityModel:
         return self._host_formats.get(resolved, set()) if resolved else set()
 
     def get_expected_format_groups(
-        self, hostname: str, event_types: list[str]
+        self,
+        hostname: str,
+        event_types: list[str],
+        event_details: list[dict] | None = None,
     ) -> list[tuple[str, set[str]]]:
         """Get format groups applicable to a storyline event on this host.
 
@@ -173,29 +176,18 @@ class VisibilityModel:
         if not host_formats:
             return []
 
-        _HOST_LOCAL = {
+        host_local_formats = {
             "windows_event_security",
             "windows_event_sysmon",
             "syslog",
             "bash_history",
             "ecar",
         }
-        _NETWORK = {
-            "zeek_conn",
-            "zeek_dns",
-            "zeek_http",
-            "zeek_ssl",
-            "zeek_dhcp",
-            "snort_alert",
-            "cisco_asa",
-            "web_access",
-            "proxy_access",
-        }
-
-        host_local = host_formats & _HOST_LOCAL
-        # Network types apply if connection events are present
-        network_types = {
+        host_local = host_formats & host_local_formats
+        transport_types = {
             "connection",
+            "ssh_session",
+            "rdp_session",
             "dhcp_lease",
             "port_scan",
             "beacon",
@@ -204,16 +196,53 @@ class VisibilityModel:
             "dga_queries",
             "dns_tunnel",
         }
-        # Note: credential_spray produces auth events (4625/syslog), not network traces —
-        # intentionally excluded from network_types so eval doesn't require Zeek/ASA traces.
+        protocol_groups: dict[str, tuple[set[str], set[str]]] = {
+            "dns": (
+                {"dns_query", "dga_queries", "dns_tunnel"},
+                {"zeek_dns"},
+            ),
+            "dhcp": ({"dhcp_lease"}, {"zeek_dhcp"}),
+            "http": (
+                {"web_scan"},
+                {"zeek_http", "web_access", "proxy_access"},
+            ),
+            "smtp": (
+                {"email_message"},
+                {"zeek_smtp", "email_artifacts", "zeek_conn", "zeek_ssl"},
+            ),
+            "mailbox": (
+                {"email_read"},
+                {"zeek_conn", "zeek_ssl", "proxy_access"},
+            ),
+        }
 
         groups: list[tuple[str, set[str]]] = []
         if host_local:
             groups.append(("host_local", host_local))
-        if network_types & set(event_types):
-            # Include network group — these won't be in host_formats but
-            # should be checked in the records if available
-            groups.append(("network", _NETWORK))
+        event_type_set = set(event_types)
+        if transport_types & event_type_set:
+            transport = {"zeek_conn", "snort_alert", "cisco_asa"} & self._enabled
+            if transport:
+                groups.append(("network_transport", transport))
+        for group_name, (applicable_types, formats) in protocol_groups.items():
+            enabled_formats = formats & self._enabled
+            if applicable_types & event_type_set and enabled_formats:
+                groups.append((group_name, enabled_formats))
+
+        details = event_details or []
+        services = {str(detail.get("service") or "").lower() for detail in details}
+        if services & {"http", "https"}:
+            http_formats = {"zeek_http", "web_access", "proxy_access"} & self._enabled
+            if http_formats:
+                groups.append(("http", http_formats))
+        if services & {"ssl", "https", "tls"}:
+            tls_formats = {"zeek_ssl", "zeek_x509", "zeek_ocsp", "zeek_files"} & self._enabled
+            if tls_formats:
+                groups.append(("tls", tls_formats))
+        if services & {"ntp"}:
+            ntp_formats = {"zeek_ntp"} & self._enabled
+            if ntp_formats:
+                groups.append(("ntp", ntp_formats))
 
         return groups
 

--- a/src/evidenceforge/events/base.py
+++ b/src/evidenceforge/events/base.py
@@ -113,6 +113,7 @@ class SecurityEvent:
     remote_thread: RemoteThreadContext | None = None
     process_access: ProcessAccessContext | None = None
     ids: IdsContext | None = None
+    ids_alerts: list[IdsContext] = field(default_factory=list)
     image_load: ImageLoadContext | None = None
     syslog: SyslogContext | None = None
     weird: WeirdContext | None = None
@@ -167,6 +168,16 @@ class SecurityEvent:
     # Planned source-native observation times keyed by source family/profile.
     # SecurityEvent.timestamp remains canonical world time.
     source_timing: SourceTimingPlan | None = None
+
+    def all_ids_alerts(self) -> tuple[IdsContext, ...]:
+        """Return canonical IDS alerts, including the legacy singular context."""
+
+        alerts = list(self.ids_alerts)
+        if self.ids is not None and not any(
+            alert.gid == self.ids.gid and alert.sid == self.ids.sid for alert in alerts
+        ):
+            alerts.insert(0, self.ids)
+        return tuple(alerts)
 
     # Correlated action lifecycle and frozen network-sensor projections.
     # EventDispatcher allocates event_id before state application and observation.

--- a/src/evidenceforge/events/contexts.py
+++ b/src/evidenceforge/events/contexts.py
@@ -413,6 +413,33 @@ class ImageLoadContext:
 
 
 @dataclass(slots=True)
+class IdsDetectionFilterContext:
+    """Sensor-local rate threshold applied before IDS event generation."""
+
+    track: str
+    count: int
+    seconds: int
+
+
+@dataclass(slots=True)
+class IdsEventFilterContext:
+    """Sensor-local output filter applied after IDS detection."""
+
+    type: str
+    track: str
+    count: int
+    seconds: int
+
+
+@dataclass(slots=True)
+class IdsAlertPolicyContext:
+    """Effective Snort-style filtering policy for an IDS alert."""
+
+    detection_filter: IdsDetectionFilterContext | None = None
+    event_filter: IdsEventFilterContext | None = None
+
+
+@dataclass(slots=True)
 class IdsContext:
     """IDS/IPS alert details for Snort."""
 
@@ -422,6 +449,7 @@ class IdsContext:
     priority: int = 2
     rev: int = 1
     gid: int = 1
+    policy: IdsAlertPolicyContext | None = None
 
 
 @dataclass(slots=True)

--- a/src/evidenceforge/events/dispatcher.py
+++ b/src/evidenceforge/events/dispatcher.py
@@ -295,6 +295,7 @@ class EventDispatcher:
                     event_to_emit.timestamp,
                 )
             self._record_observation(event, format_name, status)
+            event_to_emit._source_observation_status = status
             if event.raw is not None:
                 emitter.emit_raw(event_to_emit.raw.fields)
             else:
@@ -660,3 +661,20 @@ class EventDispatcher:
         cluster = self._source_evidence_status.setdefault(cluster_id, {})
         source_counts = cluster.setdefault(source, ObservationSummary())
         source_counts.record(status)
+
+    def reconcile_ids_policy_filtering(
+        self,
+        cluster_id: str,
+        *,
+        emitted_visible: int,
+        emitted_delayed: int,
+        policy_filtered: int,
+    ) -> None:
+        """Replace pre-policy IDS admissions with finalized alert-level counts."""
+        if not cluster_id:
+            return
+        cluster = self._source_evidence_status.setdefault(cluster_id, {})
+        summary = cluster.setdefault("ids", ObservationSummary())
+        summary.visible = emitted_visible
+        summary.delayed = emitted_delayed
+        summary.filtered += policy_filtered

--- a/src/evidenceforge/events/ground_truth.py
+++ b/src/evidenceforge/events/ground_truth.py
@@ -44,6 +44,7 @@ class GroundTruthAttributesBase(BaseModel):
     family: str | None = None
     group_name: str | None = None
     interval: str | int | float | None = None
+    ids_alerts: list[dict[str, object]] | None = None
     logon_id: str | None = None
     logon_type: int | None = None
     mail_action: str | None = None

--- a/src/evidenceforge/events/ground_truth.py
+++ b/src/evidenceforge/events/ground_truth.py
@@ -541,6 +541,60 @@ class GroundTruthStep(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class IdsEvaluationSignature(BaseModel):
+    """Bounded expected-output summary for one signature on one IDS sensor."""
+
+    gid: int = Field(ge=0)
+    sid: int = Field(gt=0)
+    candidate: int = Field(ge=0)
+    emitted: int = Field(ge=0)
+    policy_filtered: int = Field(ge=0)
+    emitted_visible: int = Field(ge=0)
+    emitted_delayed: int = Field(ge=0)
+    origins: dict[Literal["authored_attachment", "built_in", "raw"], int] = Field(
+        default_factory=dict
+    )
+    emitted_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_totals(self) -> IdsEvaluationSignature:
+        """Keep candidate, emission, filtering, and origin totals internally consistent."""
+
+        if self.candidate != self.emitted + self.policy_filtered:
+            raise ValueError("IDS candidate must equal emitted plus policy_filtered")
+        if self.emitted != self.emitted_visible + self.emitted_delayed:
+            raise ValueError("IDS emitted must equal emitted_visible plus emitted_delayed")
+        if sum(self.origins.values()) != self.emitted:
+            raise ValueError("IDS origin totals must equal emitted")
+        return self
+
+
+class IdsEvaluationSummary(BaseModel):
+    """Sensor-local IDS integrity contract stored in canonical ground truth."""
+
+    observation: dict[str, int] = Field(default_factory=dict)
+    sensors: dict[str, dict[str, IdsEvaluationSignature]] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_sensor_keys(self) -> IdsEvaluationSummary:
+        """Require stable ``gid:sid`` keys and non-negative observation counts."""
+
+        for status, count in self.observation.items():
+            if status not in {"visible", "delayed", "dropped", "filtered", "out_of_window"}:
+                raise ValueError(f"unknown IDS observation status {status!r}")
+            if count < 0:
+                raise ValueError(f"IDS observation count for {status!r} must be non-negative")
+        for signatures in self.sensors.values():
+            for key, summary in signatures.items():
+                if key != f"{summary.gid}:{summary.sid}":
+                    raise ValueError(f"IDS signature key {key!r} does not match its gid/sid")
+        return self
+
+
 class GroundTruthDocument(BaseModel):
     """Canonical machine-readable ground-truth document."""
 
@@ -551,6 +605,7 @@ class GroundTruthDocument(BaseModel):
     observation_profile: str
     collection_window: dict[str, str | None]
     source_evidence_status: dict[str, dict[str, dict[str, int]]] = Field(default_factory=dict)
+    ids_evaluation: IdsEvaluationSummary | None = None
     storyline_steps: list[GroundTruthStep] = Field(default_factory=list)
     red_herring_steps: list[GroundTruthStep] = Field(default_factory=list)
     events: list[GroundTruthEvent] = Field(default_factory=list)

--- a/src/evidenceforge/events/ids_evaluation.py
+++ b/src/evidenceforge/events/ids_evaluation.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Canonical normalization for IDS evaluation fingerprints."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+
+def normalize_ids_alert(sensor: str, fields: dict[str, Any]) -> dict[str, Any]:
+    """Return the stable, source-native IDS fields covered by integrity evaluation."""
+
+    timestamp = fields.get("timestamp") or fields.get("ts")
+    if not isinstance(timestamp, datetime):
+        timestamp = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
+    timestamp = (
+        timestamp.replace(tzinfo=UTC) if timestamp.tzinfo is None else timestamp.astimezone(UTC)
+    )
+
+    return {
+        "sensor": sensor,
+        "timestamp": timestamp.isoformat(timespec="microseconds").replace("+00:00", "Z"),
+        "gid": int(fields.get("gid", 1)),
+        "sid": int(fields["sid"]),
+        "rev": int(fields.get("rev", 1)),
+        "message": str(fields.get("message") or "").strip(),
+        "classification": str(fields.get("classification") or "").strip(),
+        "priority": int(fields.get("priority", 0)),
+        "protocol": str(fields.get("protocol") or fields.get("proto") or "").upper(),
+        "src_ip": _normalize_ip(fields.get("src_ip") or fields.get("id.orig_h")),
+        "src_port": _normalize_port(fields.get("src_port") or fields.get("id.orig_p")),
+        "dst_ip": _normalize_ip(fields.get("dst_ip") or fields.get("id.resp_h")),
+        "dst_port": _normalize_port(fields.get("dst_port") or fields.get("id.resp_p")),
+    }
+
+
+def update_ids_digest(hasher: Any, sensor: str, fields: dict[str, Any]) -> None:
+    """Append one normalized alert to an ordered SHA-256 digest."""
+
+    payload = json.dumps(
+        normalize_ids_alert(sensor, fields),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    hasher.update(payload.encode("utf-8"))
+    hasher.update(b"\n")
+
+
+def new_ids_digest() -> Any:
+    """Return a fresh SHA-256 hash object without exposing hashlib to callers."""
+
+    return hashlib.sha256()
+
+
+def _normalize_ip(value: Any) -> str:
+    text = str(value or "")
+    try:
+        return ipaddress.ip_address(text.strip("[]")).compressed
+    except ValueError:
+        return text
+
+
+def _normalize_port(value: Any) -> int | None:
+    if value in (None, "", "-"):
+        return None
+    return int(value)

--- a/src/evidenceforge/events/observation.py
+++ b/src/evidenceforge/events/observation.py
@@ -331,8 +331,11 @@ class ObservationPolicy:
             return f"registry:{event.registry.key}:{event.registry.value}"
         if event.file:
             return f"file:{event.file.path}:{event.file.action}"
-        if event.ids:
-            return f"ids:{event.ids.sid}:{event.ids.message}"
+        ids_alerts = event.all_ids_alerts()
+        if ids_alerts:
+            return "ids:" + ",".join(
+                f"{alert.gid}:{alert.sid}:{alert.message}" for alert in ids_alerts
+            )
         return "event"
 
     @staticmethod

--- a/src/evidenceforge/generation/actions/dhcp_lease.py
+++ b/src/evidenceforge/generation/actions/dhcp_lease.py
@@ -24,11 +24,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from random import Random
 from typing import Protocol
 
+from evidenceforge.events.contexts import IdsContext
 from evidenceforge.generation.actions.base import ActionAnchor
 from evidenceforge.models.scenario import System
 from evidenceforge.utils.rng import _stable_seed
@@ -54,6 +55,7 @@ class DhcpLeaseRequest:
     msg_types: list[str] | None = None
     domain: str | None = None
     renewal_interval: float | None = None
+    ids_alerts: list[IdsContext] = field(default_factory=list)
     source: str = "activity_generator"
 
     @property
@@ -65,7 +67,8 @@ class DhcpLeaseRequest:
             "action_bundle:dhcp_lease:"
             f"{self.system.hostname}:{self.system.ip}:{self.time.isoformat()}:"
             f"{self.mac}:{self.server_addr}:{self.lease_time}:{self.uid}:"
-            f"{msg_types}:{self.domain or ''}:{self.renewal_interval or ''}:{self.source}"
+            f"{msg_types}:{self.domain or ''}:{self.renewal_interval or ''}:"
+            f"{self.ids_alerts}:{self.source}"
         )
         return f"dhcp-lease-{seed:016x}"
 

--- a/src/evidenceforge/generation/actions/ids_alert.py
+++ b/src/evidenceforge/generation/actions/ids_alert.py
@@ -30,8 +30,16 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from evidenceforge.events.contexts import DnsContext, IdsContext
+from evidenceforge.events.contexts import (
+    DnsContext,
+    IdsAlertPolicyContext,
+    IdsContext,
+    IdsDetectionFilterContext,
+    IdsEventFilterContext,
+)
 from evidenceforge.generation.actions.base import ActionAnchor
+from evidenceforge.generation.activity.ids_signatures import effective_alert_policy
+from evidenceforge.models.ids import IdsAlertPolicyOverride, IdsAlertPolicySpec
 from evidenceforge.utils.rng import _stable_seed
 
 DnsContextFactory = Callable[..., DnsContext | None]
@@ -65,6 +73,7 @@ class IdsAlertRequest:
     dns_server_ip: str | None = None
     include_dns_payload: bool = False
     dns_context_factory: DnsContextFactory | None = None
+    policy: IdsAlertPolicyOverride | None = None
 
     @property
     def stable_id(self) -> str:
@@ -110,6 +119,7 @@ class IdsAlertActionBundle:
         """Return IDS context plus optional signature-owned DNS context."""
 
         signature = dict(self.request.signature)
+        policy = self._effective_policy(signature)
         ids = IdsContext(
             sid=int(signature["sid"]),
             rev=int(signature.get("rev", 1)),
@@ -117,6 +127,7 @@ class IdsAlertActionBundle:
             classification=str(signature.get("classification", "misc-activity")),
             priority=int(signature.get("priority", 2)),
             gid=int(signature.get("gid", 1)),
+            policy=self._policy_context(policy),
         )
         dns = None
         if (
@@ -131,6 +142,41 @@ class IdsAlertActionBundle:
                 dns_server_ip=self.request.dns_server_ip,
             )
         return IdsAlertResult(ids=ids, dns=dns)
+
+    def _effective_policy(self, signature: Mapping[str, Any]) -> IdsAlertPolicySpec | None:
+        """Resolve scenario replacement policy over the signature default."""
+
+        return effective_alert_policy(dict(signature), self.request.policy)
+
+    @staticmethod
+    def _policy_context(policy: IdsAlertPolicySpec | None) -> IdsAlertPolicyContext | None:
+        """Convert validated configuration into canonical immutable-style context."""
+
+        if policy is None:
+            return None
+        detection = policy.detection_filter
+        event_filter = policy.event_filter
+        return IdsAlertPolicyContext(
+            detection_filter=(
+                None
+                if detection is None
+                else IdsDetectionFilterContext(
+                    track=detection.track,
+                    count=detection.count,
+                    seconds=detection.seconds,
+                )
+            ),
+            event_filter=(
+                None
+                if event_filter is None
+                else IdsEventFilterContext(
+                    type=event_filter.type,
+                    track=event_filter.track,
+                    count=event_filter.count,
+                    seconds=event_filter.seconds,
+                )
+            ),
+        )
 
     def execute(self) -> IdsContext:
         """Return the canonical IDS context."""

--- a/src/evidenceforge/generation/actions/network_connection.py
+++ b/src/evidenceforge/generation/actions/network_connection.py
@@ -56,12 +56,15 @@ def _context_fingerprint(value: object) -> str:
 
     if value is None:
         return ""
+    if isinstance(value, list | tuple):
+        return ";".join(_context_fingerprint(item) for item in value)
     parts = []
     for name in (
         "query",
         "query_type",
         "signature_id",
         "signature",
+        "sid",
         "method",
         "host",
         "uri",
@@ -101,6 +104,7 @@ class NetworkConnectionRequest:
     x509_chain: list[X509Context] = field(default_factory=list)
     tls_presentation: TlsCertificatePresentationPlan | None = None
     ids: IdsContext | None = None
+    ids_alerts: list[IdsContext] = field(default_factory=list)
     http: HttpContext | None = None
     file_transfer: FileTransferContext | None = None
     file_transfers: list[FileTransferContext] = field(default_factory=list)
@@ -138,6 +142,7 @@ class NetworkConnectionRequest:
             f"{self.emit_dns}:{self.pid}:{source_hostname}:{self.conn_state or ''}:"
             f"{_context_fingerprint(self.dns)}:{_context_fingerprint(self.ssl)}:"
             f"{_context_fingerprint(self.ids)}:"
+            f"{_context_fingerprint(self.ids_alerts)}:"
             f"{_context_fingerprint(self.http)}:{_context_fingerprint(self.file_transfer)}:"
             f"{_context_fingerprint(self.file_transfers)}:"
             f"{_context_fingerprint(self.pe)}:{_context_fingerprint(self.ocsp)}:"

--- a/src/evidenceforge/generation/actions/network_transaction_planner.py
+++ b/src/evidenceforge/generation/actions/network_transaction_planner.py
@@ -1875,6 +1875,7 @@ class NetworkTransactionPlanner:
                     existing_user_agent=user_agent,
                     override_user_agent=proxy_ua_override,
                     apply_domain_override=apply_domain_user_agent,
+                    source_identity=src_ip,
                 )
                 proxy_referrer = generator_module._source_native_http_referrer(
                     user_agent,
@@ -2003,28 +2004,6 @@ class NetworkTransactionPlanner:
             and conn_state == "SF"
             and event.http is None  # Skip auto-generation if caller provided HttpContext
         ):
-            _USER_AGENTS_WINDOWS = [
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0",
-            ]
-            _USER_AGENTS_LINUX = [
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
-                "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0",
-                "curl/7.88.1",
-                "python-requests/2.31.0",
-                "Wget/1.21.3",
-            ]
-            if source_system and generator_module._get_os_category(source_system.os) == "linux":
-                ua = rng.choice(_USER_AGENTS_LINUX)
-            else:
-                ua = rng.choice(_USER_AGENTS_WINDOWS)
             # Use the already-resolved hostname for HTTP Host header and URI templates.
             # Honor hostname="" (suppressed) — use raw IP instead of REVERSE_DNS.
             host = (
@@ -2077,6 +2056,7 @@ class NetworkTransactionPlanner:
                 existing_user_agent="",
                 override_user_agent=http_ua_override,
                 apply_domain_override=True,
+                source_identity=src_ip,
             )
             redirect_status = plaintext_http_redirect_status(
                 web_host,

--- a/src/evidenceforge/generation/actions/network_transaction_planner.py
+++ b/src/evidenceforge/generation/actions/network_transaction_planner.py
@@ -59,6 +59,7 @@ class _NetworkOccurrenceDraft:
     email: Any = None
     smtp: Any = None
     ids: Any = None
+    ids_alerts: list[Any] = field(default_factory=list)
     ssl: Any = None
     http: Any = None
     file_transfer: Any = None
@@ -95,6 +96,7 @@ class _NetworkOccurrenceDraft:
             email=self.email,
             smtp=self.smtp,
             ids=self.ids,
+            ids_alerts=self.ids_alerts,
             ssl=self.ssl,
             http=self.http,
             file_transfer=self.file_transfer,
@@ -209,6 +211,7 @@ class NetworkTransactionPlanner:
         x509 = request.x509
         x509_chain = request.x509_chain
         ids = request.ids
+        ids_alerts = list(request.ids_alerts)
         http = request.http
         caller_supplied_http = http is not None
         file_transfer = request.file_transfer
@@ -517,6 +520,7 @@ class NetworkTransactionPlanner:
                 conn_state=conn_state,
                 dns=dns,
                 ids=ids,
+                ids_alerts=ids_alerts,
                 http=http,
                 file_transfer=file_transfer,
                 ocsp=ocsp,
@@ -1584,6 +1588,8 @@ class NetworkTransactionPlanner:
         # Caller-provided context overrides
         if ids is not None:
             event.ids = ids
+        if ids_alerts:
+            event.ids_alerts = list(ids_alerts)
         if email is not None:
             event.email = email
         if smtp is not None:

--- a/src/evidenceforge/generation/actions/proxy_transaction.py
+++ b/src/evidenceforge/generation/actions/proxy_transaction.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from typing import Any, Protocol
 
@@ -102,6 +102,7 @@ class ProxyTransactionRequest:
     ocsp_transaction: OcspTransactionPlan | None = None
     parent_action_group_id: str | None = None
     source: str = "activity_generator"
+    ids_alerts: list[IdsContext] = field(default_factory=list)
 
     @property
     def stable_id(self) -> str:
@@ -241,6 +242,7 @@ class ProxyTransactionExecutor(Protocol):
         conn_state: str | None = None,
         dns: DnsContext | None = None,
         ids: IdsContext | None = None,
+        ids_alerts: list[IdsContext] | None = None,
         http: HttpContext | None = None,
         file_transfer: FileTransferContext | None = None,
         pe: PeContext | None = None,
@@ -474,6 +476,8 @@ class ProxyTransactionActionBundle:
             pid=client_pid,
             source_system=request.source_system,
             conn_state=request.conn_state or "SF",
+            ids=request.ids,
+            ids_alerts=list(request.ids_alerts),
             http=client_http,
             file_transfer=client_file_transfer,
             pe=client_pe,
@@ -527,6 +531,7 @@ class ProxyTransactionActionBundle:
             conn_state=phase_plan.origin_conn_state,
             dns=request.dns,
             ids=request.ids,
+            ids_alerts=list(request.ids_alerts),
             http=egress_http,
             file_transfer=egress_file_transfer,
             pe=egress_pe,

--- a/src/evidenceforge/generation/actions/rdp_session.py
+++ b/src/evidenceforge/generation/actions/rdp_session.py
@@ -31,10 +31,11 @@ activity generator as the runtime adapter for shared state and dispatch.
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Protocol
 
+from evidenceforge.events.contexts import IdsContext
 from evidenceforge.events.dispatcher import EventDispatcher
 from evidenceforge.events.lifecycle import SessionEndPlan
 from evidenceforge.events.network import NetworkTuple
@@ -72,6 +73,7 @@ class RdpSessionRequest:
     logon_id: str = ""
     preserve_explicit_source: bool = False
     session_end_plan: SessionEndPlan | None = None
+    ids_alerts: list[IdsContext] = field(default_factory=list)
     source: str = "activity_generator"
 
     @property
@@ -87,6 +89,7 @@ class RdpSessionRequest:
             f"{self.target_system.hostname}:{self.target_system.ip}:"
             f"{self.logon_id}:"
             f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
+            f"{self.ids_alerts}:"
             f"{self.source}:{self.time.isoformat()}"
         )
         return f"rdp-session-{seed:016x}"
@@ -273,6 +276,7 @@ class RdpSessionActionBundle:
             conn_state="SF",
             parent_action_group_id=remote_request.stable_id,
             preserve_start_time=True,
+            ids_alerts=list(self._request.ids_alerts),
             source="rdp_session",
         )
         transaction_id = network_request.stable_id

--- a/src/evidenceforge/generation/actions/ssh_session.py
+++ b/src/evidenceforge/generation/actions/ssh_session.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import logging
 import math
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Protocol
 
@@ -41,6 +41,7 @@ from evidenceforge.events.contexts import (
     AuthContext,
     EdrContext,
     HostContext,
+    IdsContext,
     ProcessContext,
     SyslogContext,
 )
@@ -122,6 +123,7 @@ class SshSessionRequest:
     public_key_hash: str = ""
     emit_session_close: bool = False
     session_end_plan: SessionEndPlan | None = None
+    ids_alerts: list[IdsContext] = field(default_factory=list)
     source: str = "activity_generator"
 
     @property
@@ -140,6 +142,7 @@ class SshSessionRequest:
             f"{self.auth_method}:{self.public_key_type}:{self.public_key_hash}:"
             f"{self.emit_session_close}:"
             f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
+            f"{self.ids_alerts}:"
             f"{self.source}:{self.time.isoformat()}"
         )
         return f"ssh-session-{seed:016x}"
@@ -157,7 +160,7 @@ class SshSessionRequest:
             f"{self.duration or ''}:{self.orig_bytes or ''}:{self.resp_bytes or ''}:"
             f"{self.auth_method}:{self.public_key_type}:{self.public_key_hash}:"
             f"{self.session_end_plan.canonical_end.isoformat() if self.session_end_plan else ''}:"
-            f"{self.emit_session_close}:{self.source}:{self.time.isoformat()}"
+            f"{self.emit_session_close}:{self.ids_alerts}:{self.source}:{self.time.isoformat()}"
         )
         return f"ssh-session-exec-{seed:016x}"
 
@@ -567,6 +570,7 @@ class SshSessionActionBundle:
             preserve_dst_ip=True,
             responding_pid=responding_pid or -1,
             ssh_attempted_username=request.user.username,
+            ids_alerts=list(request.ids_alerts),
         )
         state.uid = network_uid
         state.network_visible = bool(network_uid)

--- a/src/evidenceforge/generation/actions/tls_certificate.py
+++ b/src/evidenceforge/generation/actions/tls_certificate.py
@@ -65,8 +65,10 @@ class TlsCertificatePlanner:
         validity: tuple[int, int],
         issuer_name: str,
         event_time: datetime,
+        *,
+        identity: str,
     ) -> tuple[int, int]:
-        """Keep a child validity interval within a configured active issuer interval."""
+        """Keep a child interval inside its issuer without copying the issuer boundary."""
 
         profile = certificate_authority_profile(issuer_name)
         if profile is None:
@@ -76,7 +78,17 @@ class TlsCertificatePlanner:
         event_epoch = int(event_time.timestamp())
         if not (issuer_start < event_epoch < issuer_end):
             return validity
-        start = max(validity[0], issuer_start)
+        start = validity[0]
+        if start <= issuer_start:
+            available_seconds = max(1, event_epoch - issuer_start - 1)
+            maximum_offset = min(45 * 86400, available_seconds)
+            minimum_offset = min(3600, maximum_offset)
+            bound_rng = random.Random(
+                _stable_seed(f"tls_child_issuer_bound:{identity}:{issuer_name}")
+            )
+            start = issuer_start + bound_rng.randint(minimum_offset, maximum_offset)
+        else:
+            start = max(start, issuer_start + 1)
         end = min(validity[1], issuer_end)
         start = min(start, event_epoch - 1)
         end = max(end, event_epoch + 1)
@@ -97,15 +109,21 @@ class TlsCertificatePlanner:
         """Return final stable chain composition and per-handshake file identities."""
 
         issuer_name = str(issuer_config["name"])
+        leaf_identity = f"leaf:{backend_identity}:{cert_name}:{issuer_name}:{key_type}:{key_size}"
         validity_fallback = int(issuer_config.get("validity_days", 397))
         validity = self._validity_window(
-            identity=f"leaf:{backend_identity}:{cert_name}:{issuer_name}:{key_type}:{key_size}",
+            identity=leaf_identity,
             event_time=event_time,
             validity_days_min=int(issuer_config.get("validity_days_min", validity_fallback)),
             validity_days_max=int(issuer_config.get("validity_days_max", validity_fallback)),
             not_before_max_days=int(issuer_config.get("not_before_max_days", 300)),
         )
-        validity = self._bound_to_issuer(validity, issuer_name, event_time)
+        validity = self._bound_to_issuer(
+            validity,
+            issuer_name,
+            event_time,
+            identity=leaf_identity,
+        )
         leaf = self._registry.resolve_certificate(
             backend_identity=backend_identity,
             subject_name=f"CN={cert_name}",

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -12751,6 +12751,7 @@ class ActivityGenerator:
         x509_chain: list[X509Context] | None = None,
         tls_presentation: TlsCertificatePresentationPlan | None = None,
         ids: Optional["IdsContext"] = None,
+        ids_alerts: list["IdsContext"] | None = None,
         http: Optional["HttpContext"] = None,
         file_transfer: FileTransferContext | None = None,
         file_transfers: list[FileTransferContext] | None = None,
@@ -12797,6 +12798,7 @@ class ActivityGenerator:
             src_port: Source port (auto-assigned ephemeral if None)
             emit_dns: If True, emit a DNS lookup for dst_ip before the connection
             ids: Optional IdsContext for IDS alert correlation (Snort emitter)
+            ids_alerts: Optional additional IDS contexts for multi-signature correlation
             http: Optional HttpContext override (skips auto-generation)
             preserve_dst_ip: Preserve caller-supplied dst_ip when the scenario or caller
                 intentionally pairs an authored hostname with a specific address. This keeps
@@ -12830,6 +12832,7 @@ class ActivityGenerator:
             x509_chain=list(x509_chain or []),
             tls_presentation=tls_presentation,
             ids=ids,
+            ids_alerts=list(ids_alerts or []),
             http=http,
             file_transfer=file_transfer,
             file_transfers=list(file_transfers or []),

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -6575,6 +6575,7 @@ class ActivityGenerator:
         existing_user_agent: str = "",
         override_user_agent: str | None = None,
         apply_domain_override: bool = True,
+        source_identity: str | None = None,
     ) -> str:
         """Return a source-sticky proxy User-Agent for one logical client context."""
 
@@ -6624,7 +6625,7 @@ class ActivityGenerator:
             return normalize_selected_user_agent(existing_user_agent)
 
         domain_class = get_proxy_domain_class(host) or ""
-        source_key = "unknown"
+        source_key = source_identity or "unknown"
         os_category = ""
         if source_system is not None:
             os_category = _get_os_category(getattr(source_system, "os", ""))
@@ -20494,7 +20495,11 @@ class ActivityGenerator:
             tgs_before_ms=(8, 65),
             tgt_before_tgs_ms=(35, 220),
         )
-        source_port = self._reserve_kerberos_source_port(source_ip, dc_hostname, tgt_time)
+        kerberos_source_port = self._reserve_kerberos_source_port(
+            source_ip,
+            dc_hostname,
+            tgt_time,
+        )
         session_obj_id = stable_uuid(
             "ecar-machine-account-session",
             request.stable_id,
@@ -20505,25 +20510,21 @@ class ActivityGenerator:
             source_ip=source_ip,
             dc_hostname=dc_hostname,
             time=tgt_time,
-            source_port=source_port,
+            source_port=kerberos_source_port,
         )
-        service_name = rng.choices(
-            [
-                f"host/{dc_hostname}",
-                f"ldap/{dc_hostname}",
-                f"cifs/{dc_hostname}",
-                f"DNS/{dc_hostname}",
-            ],
-            weights=[35, 35, 20, 10],
+        service, destination_port = rng.choices(
+            [("ldap", 389), ("cifs", 445)],
+            weights=[55, 45],
             k=1,
         )[0]
+        service_name = f"{service}/{dc_hostname}"
         self.generate_kerberos_service_ticket(
             username=machine_username,
             service_name=service_name,
             source_ip=source_ip,
             dc_hostname=dc_hostname,
             time=tgs_time,
-            source_port=source_port,
+            source_port=kerberos_source_port,
         )
         target_system = self._ip_to_system.get(dc_ip)
         if target_system is None:
@@ -20533,19 +20534,27 @@ class ActivityGenerator:
                 os="Windows Server 2022",
                 type="domain_controller",
             )
+        service_source_port = self._allocate_ephemeral_port(
+            source_ip,
+            dc_ip,
+            destination_port,
+            "tcp",
+            time,
+            self._os_for_ip(source_ip),
+        )
         remote_request = WindowsRemoteAuthenticationRequest(
             target_system=target_system,
             time=time,
             source_ip=source_ip,
-            source_port=source_port,
+            source_port=service_source_port,
             logon_type=3,
             auth_protocol="Kerberos",
             outcome="success",
-            destination_port=88,
+            destination_port=destination_port,
             source_system=self._ip_to_system.get(source_ip),
             session_object_id=session_obj_id,
             logon_id=logon_id,
-            transport_role="kerberos_validation",
+            transport_role="target_service",
             source="machine_account_logon",
         )
         remote_authentication_plan = WindowsRemoteAuthenticationActionBundle(
@@ -20563,7 +20572,7 @@ class ActivityGenerator:
                 logon_type=3,
                 auth_package="Kerberos",
                 source_ip=source_ip,
-                source_port=source_port,
+                source_port=service_source_port,
                 logon_process="Kerberos",
                 lm_package="-",
                 logon_guid="{00000000-0000-0000-0000-000000000000}",

--- a/src/evidenceforge/generation/activity/generator.py
+++ b/src/evidenceforge/generation/activity/generator.py
@@ -16984,6 +16984,7 @@ class ActivityGenerator:
         public_key_hash: str = "",
         emit_session_close: bool = False,
         session_end_plan: SessionEndPlan | None = None,
+        ids_alerts: list[IdsContext] | None = None,
         source: str = "activity_generator",
     ) -> str:
         """Generate an SSH session through the SSH action-bundle adapter.
@@ -17018,6 +17019,7 @@ class ActivityGenerator:
             public_key_hash=public_key_hash,
             emit_session_close=emit_session_close,
             session_end_plan=session_end_plan,
+            ids_alerts=list(ids_alerts or []),
             source=source,
         )
         return SshSessionActionBundle(request=request, executor=self).execute()
@@ -17044,6 +17046,7 @@ class ActivityGenerator:
         public_key_hash: str = "",
         emit_session_close: bool = False,
         session_end_plan: SessionEndPlan | None = None,
+        ids_alerts: list[IdsContext] | None = None,
         source: str = "activity_generator",
     ) -> tuple[str, str]:
         """Execute the canonical SSH bundle and return transport and session IDs."""
@@ -17069,6 +17072,7 @@ class ActivityGenerator:
             public_key_hash=public_key_hash,
             emit_session_close=emit_session_close,
             session_end_plan=session_end_plan,
+            ids_alerts=list(ids_alerts or []),
             source=source,
         )
         return SshSessionActionBundle(request=request, executor=self).execute_with_identity()
@@ -21404,6 +21408,7 @@ class ActivityGenerator:
         source_process_factory: RdpSourceProcessFactory | None = None,
         preserve_explicit_source: bool = False,
         session_end_plan: SessionEndPlan | None = None,
+        ids_alerts: list[IdsContext] | None = None,
     ) -> str:
         """Generate RDP session: Zeek conn + 4624 type 10 + eCAR on target.
 
@@ -21423,6 +21428,7 @@ class ActivityGenerator:
             source_process_factory=source_process_factory,
             preserve_explicit_source=preserve_explicit_source,
             session_end_plan=session_end_plan,
+            ids_alerts=ids_alerts,
         )
         return uid
 
@@ -21440,6 +21446,7 @@ class ActivityGenerator:
         source_process_factory: RdpSourceProcessFactory | None = None,
         preserve_explicit_source: bool = False,
         session_end_plan: SessionEndPlan | None = None,
+        ids_alerts: list[IdsContext] | None = None,
     ) -> tuple[str, str]:
         """Execute the canonical RDP bundle and return transport and session IDs."""
 
@@ -21457,6 +21464,7 @@ class ActivityGenerator:
                 logon_id=logon_id or "",
                 preserve_explicit_source=preserve_explicit_source,
                 session_end_plan=session_end_plan,
+                ids_alerts=list(ids_alerts or []),
             ),
             source_process_factory=source_process_factory,
         )
@@ -23103,6 +23111,7 @@ class ActivityGenerator:
         msg_types: list[str] | None = None,
         domain: str | None = None,
         renewal_interval: float | None = None,
+        ids_alerts: list[IdsContext] | None = None,
     ) -> None:
         """Generate a DHCP lease event via canonical SecurityEvent dispatch."""
         request = DhcpLeaseRequest(
@@ -23115,6 +23124,7 @@ class ActivityGenerator:
             msg_types=msg_types,
             domain=domain,
             renewal_interval=renewal_interval,
+            ids_alerts=list(ids_alerts or []),
         )
         DhcpLeaseActionBundle(executor=self, request=request).execute()
 
@@ -23193,6 +23203,7 @@ class ActivityGenerator:
                 msg_types=msg_types,
                 duration=dhcp_duration,
             ),
+            ids_alerts=list(request.ids_alerts),
         )
         self.dispatcher.dispatch(event)
         dispatcher_emitters = getattr(self.dispatcher, "emitters", {})

--- a/src/evidenceforge/generation/activity/ids_signatures.py
+++ b/src/evidenceforge/generation/activity/ids_signatures.py
@@ -82,6 +82,24 @@ def signature_by_sid(sid: int) -> dict[str, Any] | None:
     return None
 
 
+def signature_matches_inspection_visibility(
+    signature: dict[str, Any],
+    service: str,
+    *,
+    payload_decrypted: bool = False,
+) -> bool:
+    """Return whether a signature can inspect the modeled application view.
+
+    Payload-content signatures cannot fire on an opaque encrypted service.
+    Metadata signatures remain eligible because they inspect handshakes,
+    certificates, flow properties, or other visible protocol metadata.
+    """
+
+    if signature.get("inspection") != "payload_cleartext":
+        return True
+    return payload_decrypted or service not in {"ssl", "tls"}
+
+
 def effective_alert_policy(
     signature: dict[str, Any],
     override: IdsAlertPolicyOverride | None = None,

--- a/src/evidenceforge/generation/activity/ids_signatures.py
+++ b/src/evidenceforge/generation/activity/ids_signatures.py
@@ -11,7 +11,8 @@ from string import Formatter
 from typing import Any
 
 from evidenceforge.config import get_activity_directory
-from evidenceforge.config.overlay import extend_list, load_with_overlay
+from evidenceforge.config.overlay import load_with_overlay, merge_keyed_list
+from evidenceforge.models.ids import IdsAlertPolicyOverride, IdsAlertPolicySpec
 
 _CONFIG_PATH = get_activity_directory() / "ids_signatures.yaml"
 _CACHED_DATA: dict[str, Any] | None = None
@@ -23,7 +24,30 @@ def _merge_ids_signatures(default: dict[str, Any], overlay: dict[str, Any]) -> d
     """Merge IDS signature overlay with package defaults."""
     result = dict(default)
     if "signatures" in overlay:
-        result["signatures"] = extend_list(default.get("signatures", []), overlay["signatures"])
+        overlay_signatures = overlay["signatures"]
+        policy_overrides = (
+            {
+                entry["sid"]: entry["alert_policy"]
+                for entry in overlay_signatures
+                if isinstance(entry, dict) and "sid" in entry and "alert_policy" in entry
+            }
+            if isinstance(overlay_signatures, list)
+            else {}
+        )
+        merge_entries = (
+            [
+                {key: value for key, value in entry.items() if key != "alert_policy"}
+                if isinstance(entry, dict)
+                else entry
+                for entry in overlay_signatures
+            ]
+            if isinstance(overlay_signatures, list)
+            else overlay_signatures
+        )
+        result["signatures"] = merge_keyed_list(default.get("signatures", []), merge_entries, "sid")
+        for signature in result["signatures"]:
+            if isinstance(signature, dict) and signature.get("sid") in policy_overrides:
+                signature["alert_policy"] = policy_overrides[signature["sid"]]
     return result
 
 
@@ -56,6 +80,22 @@ def signature_by_sid(sid: int) -> dict[str, Any] | None:
         if signature.get("sid") == sid:
             return dict(signature)
     return None
+
+
+def effective_alert_policy(
+    signature: dict[str, Any],
+    override: IdsAlertPolicyOverride | None = None,
+) -> IdsAlertPolicySpec | None:
+    """Resolve an attachment override over a signature-level alert policy."""
+
+    if override == "every":
+        return None
+    if isinstance(override, IdsAlertPolicySpec):
+        return override
+    configured = signature.get("alert_policy")
+    if configured is None or configured == "every":
+        return None
+    return IdsAlertPolicySpec.model_validate(configured)
 
 
 def validate_dns_query_template(template: str) -> str | None:

--- a/src/evidenceforge/generation/emitters/ecar.py
+++ b/src/evidenceforge/generation/emitters/ecar.py
@@ -608,13 +608,19 @@ class EcarEmitter(HostMultiplexEmitter):
             module_path = event.image_load.image_loaded
         elif event.file is not None:
             module_path = event.file.path
+        if isinstance(process_identity, ProcessIdentity):
+            principal = process_identity.principal
+        elif proc is not None:
+            principal = proc.username
+        else:
+            principal = event.auth.username if event.auth else ""
         event_data = {
             "timestamp": self._after_process_create_timestamp(event, process_identity),
             "hostname": self._host_name(host),
             "object": "MODULE",
             "action": "LOAD",
             "pid": proc.pid if proc else (event.file.pid if event.file else -1),
-            "principal": event.auth.username if event.auth else "",
+            "principal": principal,
             "file_path": module_path,
             "_host_fqdn": self._host_fqdn(host),
         }

--- a/src/evidenceforge/generation/emitters/snort.py
+++ b/src/evidenceforge/generation/emitters/snort.py
@@ -38,6 +38,7 @@ from evidenceforge.events.contexts import (
     IdsDetectionFilterContext,
     IdsEventFilterContext,
 )
+from evidenceforge.events.ids_evaluation import new_ids_digest, update_ids_digest
 from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
 from evidenceforge.generation.ids_filtering import IdsAlertCandidate, IdsAlertFilterEngine
 
@@ -63,6 +64,7 @@ class SnortEmitter(SensorMultiplexEmitter):
         self._spool_connection: sqlite3.Connection | None = None
         self._spool_path: Path | None = None
         self._ids_alert_summary: dict[str, dict[int, dict[str, Any]]] = {}
+        self._ids_evaluation_summary: dict[str, dict[str, dict[str, Any]]] = {}
 
     def can_handle(self, event: SecurityEvent) -> bool:
         """Handle physical canonical transports that carry an IdsContext."""
@@ -75,6 +77,7 @@ class SnortEmitter(SensorMultiplexEmitter):
     def emit(self, event: SecurityEvent) -> None:
         """Render IdsContext to Snort fast alert format."""
         net = event.network
+        authored = {(alert.gid, alert.sid) for alert in event.ids_alerts}
         for ids in event.all_ids_alerts():
             event_data = {
                 "timestamp": event.timestamp,
@@ -96,6 +99,9 @@ class SnortEmitter(SensorMultiplexEmitter):
                 "_source_observation_status": getattr(
                     event, "_source_observation_status", "visible"
                 ),
+                "_ids_origin": (
+                    "authored_attachment" if (ids.gid, ids.sid) in authored else "built_in"
+                ),
                 **self._sensor_metadata(event, "snort_alert"),
             }
             self.emit_event(event_data)
@@ -110,7 +116,24 @@ class SnortEmitter(SensorMultiplexEmitter):
         if event_data.pop("_ids_candidate", False):
             self._spool_candidate(event_data)
             return None
-        return self._render_alert(event_data)
+        rendered = self._render_alert(event_data)
+        if rendered is not None:
+            sensor = str(event_data.get("_sensor_identity", "__direct__"))
+            self._record_evaluation_emission(
+                sensor,
+                event_data,
+                origin=str(event_data.get("_ids_origin", "raw")),
+                observation_status=str(event_data.get("_source_observation_status", "visible")),
+                count_candidate=True,
+            )
+        return rendered
+
+    def emit_raw(self, event_data: dict[str, Any]) -> None:
+        """Render an unchanged raw Snort entry while recording its authorized origin."""
+
+        payload = dict(event_data)
+        payload["_ids_origin"] = "raw"
+        super().emit_raw(payload)
 
     def _render_alert(self, event_data: dict[str, Any]) -> str | None:
         """Render one already-admitted alert or an unchanged raw Snort entry."""
@@ -156,7 +179,8 @@ class SnortEmitter(SensorMultiplexEmitter):
                 policy TEXT,
                 cluster_id TEXT NOT NULL,
                 event_id TEXT NOT NULL,
-                observation_status TEXT NOT NULL
+                observation_status TEXT NOT NULL,
+                origin TEXT NOT NULL
             )"""
         )
         self._spool_connection = connection
@@ -180,8 +204,8 @@ class SnortEmitter(SensorMultiplexEmitter):
             connection.execute(
                 """INSERT INTO candidates
                 (sensor, timestamp, gid, sid, payload, policy, cluster_id, event_id,
-                 observation_status)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                 observation_status, origin)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     str(event_data.get("_sensor_identity", "__direct__")),
                     timestamp.isoformat(),
@@ -192,6 +216,7 @@ class SnortEmitter(SensorMultiplexEmitter):
                     str(event_data.get("_cluster_id", "")),
                     str(event_data.get("_event_id", "")),
                     str(event_data.get("_source_observation_status", "visible")),
+                    str(event_data.get("_ids_origin", "built_in")),
                 ),
             )
 
@@ -224,7 +249,7 @@ class SnortEmitter(SensorMultiplexEmitter):
         filter_engine = IdsAlertFilterEngine()
         rows = connection.execute(
             """SELECT sensor, timestamp, gid, sid, payload, policy, cluster_id,
-            observation_status
+            observation_status, origin
             FROM candidates
             ORDER BY timestamp, sensor, event_id, gid, sid, sequence"""
         )
@@ -237,6 +262,7 @@ class SnortEmitter(SensorMultiplexEmitter):
             policy_json,
             cluster_id,
             observation_status,
+            origin,
         ) in rows:
             payload = json.loads(payload_json)
             payload["timestamp"] = datetime.fromisoformat(timestamp)
@@ -263,8 +289,11 @@ class SnortEmitter(SensorMultiplexEmitter):
                 },
             )
             sid_summary["candidate"] += 1
+            evaluation = self._evaluation_signature(sensor, gid, sid)
+            evaluation["candidate"] += 1
             if not filter_engine.admit(candidate):
                 sid_summary["policy_filtered"] += 1
+                evaluation["policy_filtered"] += 1
                 continue
             rendered = self._render_alert(payload)
             if rendered is not None:
@@ -274,6 +303,51 @@ class SnortEmitter(SensorMultiplexEmitter):
                     "emitted_delayed" if observation_status == "delayed" else "emitted_visible"
                 )
                 sid_summary[status_key] += 1
+                self._record_evaluation_emission(
+                    sensor,
+                    payload,
+                    origin=origin,
+                    observation_status=observation_status,
+                    count_candidate=False,
+                )
+
+    def _evaluation_signature(self, sensor: str, gid: int, sid: int) -> dict[str, Any]:
+        signatures = self._ids_evaluation_summary.setdefault(sensor, {})
+        return signatures.setdefault(
+            f"{gid}:{sid}",
+            {
+                "gid": gid,
+                "sid": sid,
+                "candidate": 0,
+                "emitted": 0,
+                "policy_filtered": 0,
+                "emitted_visible": 0,
+                "emitted_delayed": 0,
+                "origins": {},
+                "_digest": new_ids_digest(),
+            },
+        )
+
+    def _record_evaluation_emission(
+        self,
+        sensor: str,
+        payload: dict[str, Any],
+        *,
+        origin: str,
+        observation_status: str,
+        count_candidate: bool,
+    ) -> None:
+        summary = self._evaluation_signature(
+            sensor, int(payload.get("gid", 1)), int(payload["sid"])
+        )
+        if count_candidate:
+            summary["candidate"] += 1
+        summary["emitted"] += 1
+        status_key = "emitted_delayed" if observation_status == "delayed" else "emitted_visible"
+        summary[status_key] += 1
+        origins = summary["origins"]
+        origins[origin] = origins.get(origin, 0) + 1
+        update_ids_digest(summary["_digest"], sensor, payload)
 
     def flush(self) -> None:
         """Commit deferred candidates and flush already-rendered raw alerts."""
@@ -303,3 +377,20 @@ class SnortEmitter(SensorMultiplexEmitter):
     def ids_alert_summary(self) -> dict[str, dict[int, dict[str, Any]]]:
         """Return per-storyline-event, per-SID candidate and filtering totals."""
         return self._ids_alert_summary
+
+    @property
+    def ids_evaluation_summary(self) -> dict[str, dict[str, dict[str, Any]]]:
+        """Return bounded sensor/SID totals and expected rendered-alert digests."""
+
+        return {
+            sensor: {
+                key: {
+                    name: (value.hexdigest() if name == "_digest" else value)
+                    for name, value in summary.items()
+                    if name != "_digest"
+                }
+                | {"emitted_sha256": summary["_digest"].hexdigest()}
+                for key, summary in signatures.items()
+            }
+            for sensor, signatures in self._ids_evaluation_summary.items()
+        }

--- a/src/evidenceforge/generation/emitters/snort.py
+++ b/src/evidenceforge/generation/emitters/snort.py
@@ -55,7 +55,6 @@ class SnortEmitter(SensorMultiplexEmitter):
     _log_filename = "snort_alert.log"
     _flat_filename = "snort_alert.log"
     _sort_before_flush: bool = True
-    _supported_types: set[str] = {"connection"}
     _include_sensor_identity: bool = True
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -66,11 +65,11 @@ class SnortEmitter(SensorMultiplexEmitter):
         self._ids_alert_summary: dict[str, dict[int, dict[str, Any]]] = {}
 
     def can_handle(self, event: SecurityEvent) -> bool:
-        """Handle connection events that carry an IdsContext."""
+        """Handle physical canonical transports that carry an IdsContext."""
         return (
-            event.event_type in self._supported_types
+            event.network is not None
             and bool(event.all_ids_alerts())
-            and not (event.network is not None and event.network.application_layer_only)
+            and not event.network.application_layer_only
         )
 
     def emit(self, event: SecurityEvent) -> None:

--- a/src/evidenceforge/generation/emitters/snort.py
+++ b/src/evidenceforge/generation/emitters/snort.py
@@ -20,12 +20,26 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Snort/Suricata alert emitter."""
+"""Snort/Suricata alert emitter with deferred sensor-local filtering."""
 
+import json
+import os
+import sqlite3
+import tempfile
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Lock
 from typing import Any
 
 from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.contexts import (
+    IdsAlertPolicyContext,
+    IdsDetectionFilterContext,
+    IdsEventFilterContext,
+)
 from evidenceforge.generation.emitters.zeek_base import SensorMultiplexEmitter
+from evidenceforge.generation.ids_filtering import IdsAlertCandidate, IdsAlertFilterEngine
 
 
 class SnortEmitter(SensorMultiplexEmitter):
@@ -42,36 +56,50 @@ class SnortEmitter(SensorMultiplexEmitter):
     _flat_filename = "snort_alert.log"
     _sort_before_flush: bool = True
     _supported_types: set[str] = {"connection"}
+    _include_sensor_identity: bool = True
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._spool_lock = Lock()
+        self._spool_connection: sqlite3.Connection | None = None
+        self._spool_path: Path | None = None
+        self._ids_alert_summary: dict[str, dict[int, dict[str, Any]]] = {}
 
     def can_handle(self, event: SecurityEvent) -> bool:
         """Handle connection events that carry an IdsContext."""
         return (
             event.event_type in self._supported_types
-            and event.ids is not None
+            and bool(event.all_ids_alerts())
             and not (event.network is not None and event.network.application_layer_only)
         )
 
     def emit(self, event: SecurityEvent) -> None:
         """Render IdsContext to Snort fast alert format."""
-        ids = event.ids
         net = event.network
-
-        event_data = {
-            "timestamp": event.timestamp,
-            "gid": ids.gid,
-            "sid": ids.sid,
-            "rev": ids.rev,
-            "message": ids.message,
-            "classification": ids.classification,
-            "priority": ids.priority,
-            "protocol": (net.protocol or "TCP").upper() if net else "TCP",
-            "src_ip": net.src_ip if net else "",
-            "src_port": net.src_port if net else 0,
-            "dst_ip": net.dst_ip if net else "",
-            "dst_port": net.dst_port if net else 0,
-            **self._sensor_metadata(event, "snort_alert"),
-        }
-        self._dispatch(event_data)
+        for ids in event.all_ids_alerts():
+            event_data = {
+                "timestamp": event.timestamp,
+                "gid": ids.gid,
+                "sid": ids.sid,
+                "rev": ids.rev,
+                "message": ids.message,
+                "classification": ids.classification,
+                "priority": ids.priority,
+                "protocol": (net.protocol or "TCP").upper() if net else "TCP",
+                "src_ip": net.src_ip if net else "",
+                "src_port": net.src_port if net else 0,
+                "dst_ip": net.dst_ip if net else "",
+                "dst_port": net.dst_port if net else 0,
+                "_ids_candidate": True,
+                "_ids_policy": asdict(ids.policy) if ids.policy is not None else None,
+                "_cluster_id": event.storyline_cluster_id or event.event_id,
+                "_event_id": event.event_id,
+                "_source_observation_status": getattr(
+                    event, "_source_observation_status", "visible"
+                ),
+                **self._sensor_metadata(event, "snort_alert"),
+            }
+            self.emit_event(event_data)
 
     def _render_event(self, event_data: dict[str, Any]) -> str | None:
         """Render Snort/Suricata alert to fast alert format.
@@ -80,6 +108,13 @@ class SnortEmitter(SensorMultiplexEmitter):
         which means it's a plain connection event that should not generate an
         IDS alert. The caller must handle None returns.
         """
+        if event_data.pop("_ids_candidate", False):
+            self._spool_candidate(event_data)
+            return None
+        return self._render_alert(event_data)
+
+    def _render_alert(self, event_data: dict[str, Any]) -> str | None:
+        """Render one already-admitted alert or an unchanged raw Snort entry."""
         if not event_data.get("sid") and not event_data.get("message"):
             return None
 
@@ -102,3 +137,170 @@ class SnortEmitter(SensorMultiplexEmitter):
 
         rendered = self._template.render(**context)
         return rendered.strip()
+
+    def _open_spool(self) -> sqlite3.Connection:
+        """Create the bounded-memory, disk-backed candidate store lazily."""
+        if self._spool_connection is not None:
+            return self._spool_connection
+        descriptor, raw_path = tempfile.mkstemp(prefix="evidenceforge-ids-", suffix=".sqlite3")
+        os.close(descriptor)
+        self._spool_path = Path(raw_path)
+        connection = sqlite3.connect(raw_path, check_same_thread=False)
+        connection.execute(
+            """CREATE TABLE candidates (
+                sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                sensor TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                gid INTEGER NOT NULL,
+                sid INTEGER NOT NULL,
+                payload TEXT NOT NULL,
+                policy TEXT,
+                cluster_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                observation_status TEXT NOT NULL
+            )"""
+        )
+        self._spool_connection = connection
+        return connection
+
+    def _spool_candidate(self, event_data: dict[str, Any]) -> None:
+        """Persist one post-observation candidate without retaining it in memory."""
+        payload = {
+            key: value.isoformat() if isinstance(value, datetime) else value
+            for key, value in event_data.items()
+            if not key.startswith("_")
+        }
+        timestamp = event_data.get("timestamp")
+        if not isinstance(timestamp, datetime):
+            timestamp = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
+        timestamp = (
+            timestamp.replace(tzinfo=UTC) if timestamp.tzinfo is None else timestamp.astimezone(UTC)
+        )
+        with self._spool_lock:
+            connection = self._open_spool()
+            connection.execute(
+                """INSERT INTO candidates
+                (sensor, timestamp, gid, sid, payload, policy, cluster_id, event_id,
+                 observation_status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    str(event_data.get("_sensor_identity", "__direct__")),
+                    timestamp.isoformat(),
+                    int(event_data["gid"]),
+                    int(event_data["sid"]),
+                    json.dumps(payload, sort_keys=True),
+                    json.dumps(event_data.get("_ids_policy"), sort_keys=True),
+                    str(event_data.get("_cluster_id", "")),
+                    str(event_data.get("_event_id", "")),
+                    str(event_data.get("_source_observation_status", "visible")),
+                ),
+            )
+
+    @staticmethod
+    def _policy_from_json(value: str) -> IdsAlertPolicyContext | None:
+        data = json.loads(value)
+        if data is None:
+            return None
+        detection = data.get("detection_filter")
+        event_filter = data.get("event_filter")
+        return IdsAlertPolicyContext(
+            detection_filter=(
+                IdsDetectionFilterContext(**detection) if detection is not None else None
+            ),
+            event_filter=(
+                IdsEventFilterContext(**event_filter) if event_filter is not None else None
+            ),
+        )
+
+    @staticmethod
+    def _summary_policy(policy: IdsAlertPolicyContext | None) -> str | dict[str, Any]:
+        return "every" if policy is None else asdict(policy)
+
+    def _finalize_candidates(self) -> None:
+        """Sort and filter all candidates, then write admitted alerts."""
+        connection = self._spool_connection
+        if connection is None:
+            return
+        connection.commit()
+        filter_engine = IdsAlertFilterEngine()
+        rows = connection.execute(
+            """SELECT sensor, timestamp, gid, sid, payload, policy, cluster_id,
+            observation_status
+            FROM candidates
+            ORDER BY timestamp, sensor, event_id, gid, sid, sequence"""
+        )
+        for (
+            sensor,
+            timestamp,
+            gid,
+            sid,
+            payload_json,
+            policy_json,
+            cluster_id,
+            observation_status,
+        ) in rows:
+            payload = json.loads(payload_json)
+            payload["timestamp"] = datetime.fromisoformat(timestamp)
+            policy = self._policy_from_json(policy_json)
+            candidate = IdsAlertCandidate(
+                sensor=sensor,
+                timestamp=payload["timestamp"],
+                gid=gid,
+                sid=sid,
+                src_ip=payload.get("src_ip", ""),
+                dst_ip=payload.get("dst_ip", ""),
+                policy=policy,
+            )
+            sid_summary = self._ids_alert_summary.setdefault(cluster_id, {}).setdefault(
+                sid,
+                {
+                    "sid": sid,
+                    "effective_policy": self._summary_policy(policy),
+                    "candidate": 0,
+                    "emitted": 0,
+                    "policy_filtered": 0,
+                    "emitted_visible": 0,
+                    "emitted_delayed": 0,
+                },
+            )
+            sid_summary["candidate"] += 1
+            if not filter_engine.admit(candidate):
+                sid_summary["policy_filtered"] += 1
+                continue
+            rendered = self._render_alert(payload)
+            if rendered is not None:
+                self._get_writer("" if sensor == "__direct__" else sensor).write(rendered)
+                sid_summary["emitted"] += 1
+                status_key = (
+                    "emitted_delayed" if observation_status == "delayed" else "emitted_visible"
+                )
+                sid_summary[status_key] += 1
+
+    def flush(self) -> None:
+        """Commit deferred candidates and flush already-rendered raw alerts."""
+        with self._spool_lock:
+            if self._spool_connection is not None:
+                self._spool_connection.commit()
+        super().flush()
+
+    def close(self) -> None:
+        """Drain, filter, render, and always remove the temporary candidate spool."""
+        if self.threaded:
+            self.stop_thread()
+        try:
+            with self._spool_lock:
+                self._finalize_candidates()
+            super().close()
+        finally:
+            with self._spool_lock:
+                if self._spool_connection is not None:
+                    self._spool_connection.close()
+                    self._spool_connection = None
+                if self._spool_path is not None:
+                    self._spool_path.unlink(missing_ok=True)
+                    self._spool_path = None
+
+    @property
+    def ids_alert_summary(self) -> dict[str, dict[int, dict[str, Any]]]:
+        """Return per-storyline-event, per-SID candidate and filtering totals."""
+        return self._ids_alert_summary

--- a/src/evidenceforge/generation/emitters/sysmon.py
+++ b/src/evidenceforge/generation/emitters/sysmon.py
@@ -1242,17 +1242,17 @@ class SysmonEventEmitter(LogEmitter):
             "UtcTime": utc_time,
             "SourceProcessGUID": source_guid,
             "SourceProcessId": proc.pid,
-            "SourceImage": proc.image,
             "SourceThreadId": access.source_thread_id,
-            "SourceUser": user,
+            "SourceImage": proc.image,
             "TargetProcessGUID": target_guid,
             "TargetProcessId": target_pid,
             "TargetImage": target_image,
-            "TargetUser": target_user,
             "GrantedAccess": granted_access,
             "CallTrace": access.call_trace
             if access and access.call_trace
             else self._get_call_trace(host.hostname),
+            "SourceUser": user,
+            "TargetUser": target_user,
         }
         self.emit_event(event_data)
 
@@ -1533,6 +1533,12 @@ class SysmonEventEmitter(LogEmitter):
                 il.signature,
             )
         signature_status = il.signature_status if il.signed else "Unavailable"
+        if event.auth and event.auth.username:
+            user = self._format_user(event.auth.username, host.netbios_domain)
+        elif proc and proc.username:
+            user = self._format_user(proc.username, host.netbios_domain)
+        else:
+            user = "NT AUTHORITY\\SYSTEM"
         hashes = self._generate_hashes(
             il.image_loaded,
             host,
@@ -1567,6 +1573,7 @@ class SysmonEventEmitter(LogEmitter):
             "Signed": "true" if il.signed else "false",
             "Signature": il.signature if il.signed else "-",
             "SignatureStatus": signature_status,
+            "User": user,
         }
         self.emit_event(event_data)
 
@@ -1605,9 +1612,9 @@ class SysmonEventEmitter(LogEmitter):
             "ProcessGuid": process_guid,
             "ProcessId": pid,
             "Image": image,
-            "User": user,
             "TargetFilename": fc.path,
             "CreationUtcTime": utc_time,
+            "User": user,
         }
         self.emit_event(event_data)
 
@@ -1664,7 +1671,6 @@ class SysmonEventEmitter(LogEmitter):
             "ProcessGuid": process_guid,
             "ProcessId": pid,
             "Image": image,
-            "User": user,
             "EventType": event_type,
             "TargetObject": self._native_registry_target_object(reg.key, event),
         }
@@ -1672,6 +1678,7 @@ class SysmonEventEmitter(LogEmitter):
         # Event 13 includes the Details field
         if event_id == 13:
             event_data["Details"] = reg.value or "-"
+        event_data["User"] = user
 
         self.emit_event(event_data)
 

--- a/src/evidenceforge/generation/emitters/zeek_base.py
+++ b/src/evidenceforge/generation/emitters/zeek_base.py
@@ -219,6 +219,7 @@ class SensorMultiplexEmitter(LogEmitter):
     _flat_filename: str = ""  # Used only for explicit direct-file mode.
     _supported_types: set[str] = set()
     _sort_before_flush: bool = True
+    _include_sensor_identity: bool = False
 
     def __init__(
         self,
@@ -466,6 +467,8 @@ class SensorMultiplexEmitter(LogEmitter):
                 return
             _enforce_http_body_invariants(event_data)
             _enforce_ip_byte_invariants(event_data)
+            if self._include_sensor_identity:
+                event_data["_sensor_identity"] = "__direct__"
             rendered = self._render_event(event_data)
             if rendered is None:
                 return
@@ -473,6 +476,8 @@ class SensorMultiplexEmitter(LogEmitter):
         else:
             for hostname in targets:
                 render_data = dict(event_data)
+                if self._include_sensor_identity:
+                    render_data["_sensor_identity"] = hostname
                 observation = observations.get(hostname)
                 if observation is not None:
                     self._apply_sensor_observation(
@@ -523,7 +528,7 @@ class SensorMultiplexEmitter(LogEmitter):
                 _enforce_ip_byte_invariants(render_data)
                 rendered = self._render_event(render_data)
                 if rendered is None:
-                    return
+                    continue
                 self._get_writer(hostname).write(rendered)
 
     def _render_zeek_json(self, event_data: dict[str, Any]) -> str:

--- a/src/evidenceforge/generation/engine/baseline.py
+++ b/src/evidenceforge/generation/engine/baseline.py
@@ -86,6 +86,7 @@ from evidenceforge.generation.activity.host_activity_profiles import (
 from evidenceforge.generation.activity.ids_signatures import (
     load_ids_signatures,
     render_dns_query_template,
+    signature_matches_inspection_visibility,
 )
 from evidenceforge.generation.activity.linux_interfaces import linux_primary_interface
 from evidenceforge.generation.activity.network import _generate_random_external_ip, _is_private_ip
@@ -113,6 +114,7 @@ from evidenceforge.generation.world_model import (
 )
 from evidenceforge.models.scenario import EmailMessageEventSpec, Persona, System, User
 from evidenceforge.utils.rng import _get_rng, _stable_seed, stable_uuid
+from evidenceforge.utils.time import ensure_utc
 
 logger = logging.getLogger(__name__)
 
@@ -628,6 +630,42 @@ def _extra_syslog_limit_key(system_hostname: str, entry: dict[str, Any]) -> str:
     messages = entry.get("messages") if isinstance(entry.get("messages"), list) else []
     marker = "|".join(str(message) for message in messages[:2])
     return f"{system_hostname}:{entry.get('app', '<unknown>')}:{marker}"
+
+
+def _extra_syslog_effective_limit(
+    system: System,
+    entry: dict[str, Any],
+    window_start: datetime,
+) -> int:
+    """Return a stable host-conditioned admission limit for ambient syslog.
+
+    Most program limits are literal safety caps. Ambient sudo is different: if
+    every busy host saturates the same cap, the cap becomes a fleet-wide count
+    fingerprint. Sample a zero-capable, right-skewed host/day target beneath the
+    configured ceiling while leaving all other program limits unchanged.
+    """
+    configured_limit = int(entry.get("max_per_host_window", 0) or 0)
+    if configured_limit <= 0 or entry.get("app") != "sudo":
+        return configured_limit
+
+    normalized_start = ensure_utc(window_start)
+    system_type = (system.type or "workstation").lower()
+    roles = ",".join(sorted(str(role).lower() for role in (system.roles or [])))
+    target_rng = random.Random(
+        _stable_seed(
+            "extra_syslog_sudo_target:"
+            f"{system.hostname}:{system_type}:{roles}:{normalized_start.date().isoformat()}"
+        )
+    )
+    zero_probability = 0.04 if system_type == "server" else 0.14
+    if target_rng.random() < zero_probability:
+        return 0
+
+    median_fraction = 0.52 if system_type == "server" else 0.30
+    role_factor = min(1.22, 1.0 + (0.035 * len(system.roles or [])))
+    sampled_fraction = target_rng.lognormvariate(math.log(median_fraction), 0.48)
+    target = round(configured_limit * sampled_fraction * role_factor)
+    return max(1, min(configured_limit, target))
 
 
 def _networkmanager_message_timestamp(ts: datetime) -> str:
@@ -8955,14 +8993,16 @@ class BaselineMixin:
                         k=1,
                     )[0]
                     app = entry["app"]
-                    limit = entry.get("max_per_host_window")
+                    limit = _extra_syslog_effective_limit(system, entry, self.start_time)
                     limit_key = ""
-                    if isinstance(limit, int) and limit > 0:
+                    if limit > 0:
                         if not hasattr(self, "_extra_syslog_entry_counts"):
                             self._extra_syslog_entry_counts = {}
                         limit_key = _extra_syslog_limit_key(system.hostname, entry)
                         if self._extra_syslog_entry_counts.get(limit_key, 0) >= limit:
                             continue
+                    elif entry.get("max_per_host_window"):
+                        continue
                     # Format placeholders vary by daemon
                     if app == "dhclient":
                         # DHCP syslog must be tied to the canonical lease
@@ -9234,6 +9274,17 @@ class BaselineMixin:
                     if not _filtered:
                         _filtered = _pool
                     _filtered = [s for s in _filtered if s.get("baseline_fp_allowed", True)]
+                    _filtered = [
+                        s
+                        for s in _filtered
+                        if signature_matches_inspection_visibility(
+                            s,
+                            {80: "http", 443: "ssl", 53: "dns"}.get(
+                                int(s.get("dst_port", 0)),
+                                "",
+                            ),
+                        )
+                    ]
                     _filtered = [
                         s
                         for s in _filtered

--- a/src/evidenceforge/generation/engine/core.py
+++ b/src/evidenceforge/generation/engine/core.py
@@ -516,6 +516,7 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
         ids_summary = getattr(snort_emitter, "ids_alert_summary", {})
         if ids_summary:
             self._apply_ids_alert_summary(ids_summary)
+        self._ids_evaluation_summary = getattr(snort_emitter, "ids_evaluation_summary", None)
 
         if self.activity_generator is not None:
             self.activity_generator.write_artifacts_manifest()
@@ -585,6 +586,7 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
             malicious_events=self.malicious_events,
             red_herring_events=self.red_herring_events,
             source_evidence_status=source_evidence_status,
+            ids_evaluation_summary=getattr(self, "_ids_evaluation_summary", None),
         )
 
         document = generator.build_document()

--- a/src/evidenceforge/generation/engine/core.py
+++ b/src/evidenceforge/generation/engine/core.py
@@ -512,6 +512,11 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
             logger.info(f"Stopping {format_name} emitter thread")
             emitter.close()
 
+        snort_emitter = self.emitters.get("snort_alert")
+        ids_summary = getattr(snort_emitter, "ids_alert_summary", {})
+        if ids_summary:
+            self._apply_ids_alert_summary(ids_summary)
+
         if self.activity_generator is not None:
             self.activity_generator.write_artifacts_manifest()
 
@@ -520,6 +525,49 @@ class GenerationEngine(EmitterSetupMixin, BaselineMixin, StorylineMixin):
         write_collection_profile(self.ground_truth_dir, self.scenario, self.output_target)
 
         logger.info("All emitters closed")
+
+    def _apply_ids_alert_summary(
+        self,
+        summary: dict[str, dict[int, dict[str, object]]],
+    ) -> None:
+        """Attach finalized sensor totals to ground truth and observation accounting."""
+        for cluster_id, sid_totals in summary.items():
+            filtered = sum(int(totals.get("policy_filtered", 0)) for totals in sid_totals.values())
+            emitted_visible = sum(
+                int(totals.get("emitted_visible", 0)) for totals in sid_totals.values()
+            )
+            emitted_delayed = sum(
+                int(totals.get("emitted_delayed", 0)) for totals in sid_totals.values()
+            )
+            self.dispatcher.reconcile_ids_policy_filtering(
+                cluster_id,
+                emitted_visible=emitted_visible,
+                emitted_delayed=emitted_delayed,
+                policy_filtered=filtered,
+            )
+            for event in (*self.malicious_events, *self.red_herring_events):
+                if event.get("storyline_cluster_id") != cluster_id:
+                    continue
+                attachments = event.get("ids_alerts")
+                if not isinstance(attachments, list):
+                    continue
+                for attachment in attachments:
+                    if not isinstance(attachment, dict):
+                        continue
+                    totals = sid_totals.get(attachment.get("sid"))
+                    if totals is not None:
+                        attachment.update(
+                            {
+                                key: totals[key]
+                                for key in (
+                                    "sid",
+                                    "effective_policy",
+                                    "candidate",
+                                    "emitted",
+                                    "policy_filtered",
+                                )
+                            }
+                        )
 
     def _generate_ground_truth(self) -> None:
         """Generate GROUND_TRUTH.json, derived GROUND_TRUTH.md, and the observation manifest."""

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -72,6 +72,7 @@ from evidenceforge.generation.activity.http_content import (
 )
 from evidenceforge.generation.activity.network import _is_private_ip
 from evidenceforge.models.exceptions import StateError
+from evidenceforge.models.ids import IdsAlertAttachmentSpec
 from evidenceforge.models.scenario import (
     MAX_HTTP_RESPONSE_BODY_LEN,
     BeaconHttpSequenceEntry,
@@ -113,6 +114,80 @@ _HTTP_USER_AGENT_OVERRIDE_PATTERNS = (
         """
     ),
 )
+
+
+def _build_ids_alert_contexts(
+    attachments: Sequence[IdsAlertAttachmentSpec],
+    *,
+    time: datetime,
+    src_ip: str,
+    dst_ip: str,
+    dst_port: int,
+    proto: str,
+    rng: random.Random,
+    source: str,
+) -> list[Any]:
+    """Resolve authored SID references into canonical IDS contexts."""
+
+    if not attachments:
+        return []
+    from evidenceforge.generation.activity.ids_signatures import signature_by_sid
+
+    contexts = []
+    for attachment in attachments:
+        signature = signature_by_sid(attachment.sid)
+        if signature is None:
+            raise ValueError(
+                f"Unknown IDS signature SID {attachment.sid}; add it to ids_signatures.yaml"
+            )
+        contexts.append(
+            IdsAlertActionBundle(
+                IdsAlertRequest(
+                    signature=signature,
+                    time=time,
+                    src_ip=src_ip,
+                    dst_ip=dst_ip,
+                    dst_port=dst_port,
+                    proto=proto,
+                    rng=rng,
+                    source=source,
+                    direction=str(signature.get("direction", "")),
+                    policy=attachment.policy,
+                )
+            ).execute()
+        )
+    return contexts
+
+
+def _ids_attachment_ground_truth(
+    attachments: Sequence[IdsAlertAttachmentSpec],
+) -> list[dict[str, Any]]:
+    """Describe effective attachment policies before sensor totals are finalized."""
+    from evidenceforge.generation.activity.ids_signatures import (
+        effective_alert_policy,
+        signature_by_sid,
+    )
+
+    result = []
+    for attachment in attachments:
+        signature = signature_by_sid(attachment.sid)
+        if signature is None:
+            continue
+        policy = effective_alert_policy(signature, attachment.policy)
+        result.append(
+            {
+                "sid": attachment.sid,
+                "effective_policy": (
+                    "every" if policy is None else policy.model_dump(mode="json", exclude_none=True)
+                ),
+                "candidate": 0,
+                "emitted": 0,
+                "policy_filtered": 0,
+            }
+        )
+    return result
+
+
 _NET_USER_ADD_WITH_PASSWORD_RE = re.compile(
     r"\bnet1?\s+user\s+(?P<username>\S+)\s+(?P<password>\S+)\s+/add\b",
     re.IGNORECASE,
@@ -3901,6 +3976,16 @@ class StorylineMixin:
                 network_time=time,
                 rng=rng,
             )
+            ids_alerts = _build_ids_alert_contexts(
+                getattr(spec, "ids_alerts", []),
+                time=connection_time,
+                src_ip=source_ip,
+                dst_ip=effective_dst_ip,
+                dst_port=dst_port,
+                proto="tcp",
+                rng=rng,
+                source="storyline_connection",
+            )
             uid = self.activity_generator.generate_connection(
                 src_ip=source_ip,
                 dst_ip=effective_dst_ip,
@@ -3914,6 +3999,7 @@ class StorylineMixin:
                 emit_dns=emit_dns,
                 source_system=src_sys,
                 http=http_ctx,
+                ids_alerts=ids_alerts,
                 pid=story_pid,
                 process_image=story_image,
                 hostname=conn_hostname,
@@ -3930,6 +4016,8 @@ class StorylineMixin:
             malicious_event["dst_ip"] = logged_dst_ip
             malicious_event["dst_port"] = dst_port
             malicious_event["uid"] = _ground_truth_uid(uid, source_ip, logged_dst_ip)
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
             # Causal expansion: SMB to file server emits type 3 logon pair
             if dst_port == 445:
@@ -4757,6 +4845,16 @@ class StorylineMixin:
                         src_sys,
                         tick_time,
                     )
+                tick_ids_alerts = _build_ids_alert_contexts(
+                    getattr(spec, "ids_alerts", []),
+                    time=tick_time,
+                    src_ip=beacon_src_ip,
+                    dst_ip=beacon_dst_ip,
+                    dst_port=spec.dst_port,
+                    proto=spec.protocol,
+                    rng=rng,
+                    source="storyline_beacon",
+                )
                 if spec.action == "deny":
                     proxy_chain = getattr(self.activity_generator, "_proxy_routes", {}).get(
                         beacon_src_ip
@@ -4821,6 +4919,7 @@ class StorylineMixin:
                             emit_dns=tick_emit_dns,
                             source_system=src_sys,
                             http=tick_http_ctx,
+                            ids_alerts=tick_ids_alerts,
                             proxy=proxy_ctx,
                             hostname=conn_hostname if conn_hostname is not None else spec.hostname,
                             pid=story_pid,
@@ -4841,6 +4940,7 @@ class StorylineMixin:
                             proto=spec.protocol,
                             conn_state=deny_conn_state,
                             firewall=fw_ctx,
+                            ids_alerts=tick_ids_alerts,
                             emit_dns=False,
                         )
                 else:
@@ -4859,6 +4959,7 @@ class StorylineMixin:
                         emit_dns=tick_emit_dns,
                         source_system=src_sys,
                         http=tick_http_ctx,
+                        ids_alerts=tick_ids_alerts,
                         hostname=conn_hostname,
                         pid=story_pid,
                         process_image=story_image,
@@ -4878,6 +4979,8 @@ class StorylineMixin:
             term = spec.duration or spec.end_time or f"count={spec.count}"
             malicious_event["termination"] = term
             malicious_event["attempt_count"] = attempt_count
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
         elif spec.type == "dns_query":
             # QTYPE name → numeric mapping

--- a/src/evidenceforge/generation/engine/storyline.py
+++ b/src/evidenceforge/generation/engine/storyline.py
@@ -4017,7 +4017,9 @@ class StorylineMixin:
             malicious_event["dst_port"] = dst_port
             malicious_event["uid"] = _ground_truth_uid(uid, source_ip, logged_dst_ip)
             if getattr(spec, "ids_alerts", []):
-                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(
+                    getattr(spec, "ids_alerts", [])
+                )
 
             # Causal expansion: SMB to file server emits type 3 logon pair
             if dst_port == 445:
@@ -4058,6 +4060,16 @@ class StorylineMixin:
             target = next(
                 (s for s in self.scenario.environment.systems if s.ip == system.ip), system
             )
+            authored_ids_alerts = _build_ids_alert_contexts(
+                getattr(spec, "ids_alerts", []),
+                time=time,
+                src_ip=spec.source_ip or system.ip,
+                dst_ip=target.ip,
+                dst_port=22,
+                proto="tcp",
+                rng=rng,
+                source="storyline_ssh_session",
+            )
             if hasattr(self, "world_planner"):
                 source_system = (
                     self.world_model.system_for_ip(spec.source_ip)
@@ -4075,6 +4087,7 @@ class StorylineMixin:
                     source_ip_override=spec.source_ip,
                     storyline_protected=True,
                     session_end_plan=self._session_end_plan_for_current_start(),
+                    ids_alerts=authored_ids_alerts,
                 )
             else:
                 source_ip = spec.source_ip or system.ip
@@ -4084,6 +4097,7 @@ class StorylineMixin:
                     time=time,
                     source_ip=source_ip,
                     emit_session_close=True,
+                    ids_alerts=authored_ids_alerts,
                 )
                 result = SimpleNamespace(network_uid=uid)
             if getattr(result, "session", None) is not None:
@@ -4111,10 +4125,22 @@ class StorylineMixin:
                 result_source_ip,
                 target.ip,
             )
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
         elif spec.type == "rdp_session":
             target = next(
                 (s for s in self.scenario.environment.systems if s.ip == system.ip), system
+            )
+            authored_ids_alerts = _build_ids_alert_contexts(
+                getattr(spec, "ids_alerts", []),
+                time=time,
+                src_ip=spec.source_ip or system.ip,
+                dst_ip=target.ip,
+                dst_port=3389,
+                proto="tcp",
+                rng=rng,
+                source="storyline_rdp_session",
             )
             if hasattr(self, "world_planner"):
                 source_system = (
@@ -4133,6 +4159,7 @@ class StorylineMixin:
                     source_ip_override=spec.source_ip,
                     storyline_protected=True,
                     session_end_plan=self._session_end_plan_for_current_start(),
+                    ids_alerts=authored_ids_alerts,
                 )
             else:
                 source_ip = spec.source_ip or system.ip
@@ -4141,6 +4168,7 @@ class StorylineMixin:
                     target_system=target,
                     time=time,
                     source_ip=source_ip,
+                    ids_alerts=authored_ids_alerts,
                 )
                 result = SimpleNamespace(network_uid=uid)
             if getattr(result, "session", None) is not None:
@@ -4169,6 +4197,8 @@ class StorylineMixin:
                 result_source_ip,
                 target.ip,
             )
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
         elif spec.type == "account_created":
             dc = next(
@@ -4479,6 +4509,16 @@ class StorylineMixin:
             )
             renewal_interval = dhcp_renewal_interval_seconds(lease_time, rng)
             msg_types = ["REQUEST", "ACK"] if existing_lease else None
+            authored_ids_alerts = _build_ids_alert_contexts(
+                getattr(spec, "ids_alerts", []),
+                time=time,
+                src_ip=system.ip,
+                dst_ip=dhcp_server,
+                dst_port=67,
+                proto="udp",
+                rng=rng,
+                source="storyline_dhcp_lease",
+            )
             self.activity_generator.generate_dhcp_lease(
                 system=system,
                 time=time,
@@ -4488,6 +4528,7 @@ class StorylineMixin:
                 uid=generate_zeek_uid("C"),
                 msg_types=msg_types,
                 renewal_interval=renewal_interval,
+                ids_alerts=authored_ids_alerts,
             )
             if hasattr(self, "_dhcp_lease_state"):
                 self._dhcp_lease_state[system.hostname] = {
@@ -4499,6 +4540,8 @@ class StorylineMixin:
                     "system": system,
                 }
             malicious_event["mac_address"] = mac
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
         elif spec.type == "port_scan":
             malicious_event = PortScanActionBundle(
@@ -5044,6 +5087,16 @@ class StorylineMixin:
                 rejected=spec.rcode == "REFUSED",
                 rtt=_dns_rtt(rng, dns_server_ip),
             )
+            authored_ids_alerts = _build_ids_alert_contexts(
+                getattr(spec, "ids_alerts", []),
+                time=time,
+                src_ip=query_src_ip,
+                dst_ip=dns_server_ip,
+                dst_port=53,
+                proto="udp",
+                rng=rng,
+                source="storyline_dns_query",
+            )
 
             self.activity_generator.generate_connection(
                 src_ip=query_src_ip,
@@ -5058,11 +5111,14 @@ class StorylineMixin:
                 resp_bytes=rng.randint(80, 400) if spec.rcode == "NOERROR" else rng.randint(40, 80),
                 conn_state="SF",
                 duration=rng.uniform(0.001, 0.05),
+                ids_alerts=authored_ids_alerts,
             )
 
             malicious_event["query"] = spec.query
             malicious_event["qtype"] = spec.qtype
             malicious_event["rcode"] = spec.rcode
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
         elif spec.type == "web_scan":
             malicious_event = WebScanActionBundle(
@@ -5249,6 +5305,16 @@ class StorylineMixin:
                     rejected=False,
                     rtt=_dns_rtt(rng, dns_server_ip),
                 )
+                authored_ids_alerts = _build_ids_alert_contexts(
+                    getattr(spec, "ids_alerts", []),
+                    time=tick_time,
+                    src_ip=query_src_ip,
+                    dst_ip=dns_server_ip,
+                    dst_port=53,
+                    proto="udp",
+                    rng=rng,
+                    source="storyline_dga_queries",
+                )
 
                 self.activity_generator.generate_connection(
                     src_ip=query_src_ip,
@@ -5265,6 +5331,7 @@ class StorylineMixin:
                     else rng.randint(40, 80),
                     conn_state="SF",
                     duration=rng.uniform(0.001, 0.05),
+                    ids_alerts=authored_ids_alerts,
                 )
                 query_count += 1
                 if query_count % 500 == 0:
@@ -5276,6 +5343,8 @@ class StorylineMixin:
             malicious_event["nxdomain_count"] = nxdomain_count
             malicious_event["domain_sample"] = domain_sample
             malicious_event["tld"] = spec.tld
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
         elif spec.type == "dns_tunnel":
             import base64 as _b64
@@ -5547,6 +5616,16 @@ class StorylineMixin:
                 )
 
                 dns_server_ip = rng.choice(dns_server_ips)
+                authored_ids_alerts = _build_ids_alert_contexts(
+                    getattr(spec, "ids_alerts", []),
+                    time=tick_time,
+                    src_ip=query_src_ip,
+                    dst_ip=dns_server_ip,
+                    dst_port=53,
+                    proto="udp",
+                    rng=rng,
+                    source="storyline_dns_tunnel",
+                )
                 self.activity_generator.generate_connection(
                     src_ip=query_src_ip,
                     dst_ip=dns_server_ip,
@@ -5558,6 +5637,7 @@ class StorylineMixin:
                     emit_dns=False,
                     resp_bytes=resp_bytes,
                     duration=dns_ctx.rtt,
+                    ids_alerts=authored_ids_alerts,
                 )
                 total_bytes += len(visible_payload)
                 query_count += 1
@@ -5567,6 +5647,8 @@ class StorylineMixin:
             malicious_event["qtype"] = spec.qtype
             malicious_event["total_queries"] = query_count
             malicious_event["bytes_exfiltrated"] = total_bytes
+            if getattr(spec, "ids_alerts", []):
+                malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
 
         elif spec.type == "explicit_credentials":
             story_pid, _story_image = self._last_storyline_process_for_system(system)
@@ -5894,6 +5976,16 @@ class StorylineMixin:
             jitter_offset = rng.uniform(-spacing * 0.45, spacing * 0.55)
             scan_time = time + timedelta(seconds=total_count * spacing + jitter_offset)
             self.state_manager.set_current_time(scan_time)
+            authored_ids_alerts = _build_ids_alert_contexts(
+                getattr(spec, "ids_alerts", []),
+                time=scan_time,
+                src_ip=scan_src_ip,
+                dst_ip=target_ip,
+                dst_port=port,
+                proto=spec.protocol,
+                rng=rng,
+                source="storyline_port_scan",
+            )
 
             from evidenceforge.events.contexts import FirewallContext
 
@@ -5961,6 +6053,7 @@ class StorylineMixin:
                 conn_state=None if spec.protocol == "icmp" else scan_conn_state,
                 firewall=firewall,
                 emit_dns=False,
+                ids_alerts=authored_ids_alerts,
             )
             total_count += 1
 
@@ -5968,6 +6061,8 @@ class StorylineMixin:
         malicious_event["ports"] = spec.ports
         malicious_event["total_connections"] = total_count
         malicious_event["protocol"] = spec.protocol
+        if getattr(spec, "ids_alerts", []):
+            malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
         return malicious_event
 
     def _execute_web_scan_bundle(self, request: WebScanRequest) -> dict[str, Any]:
@@ -6222,6 +6317,16 @@ class StorylineMixin:
                 rng, is_tls=is_tls
             )
             http_for_conn = http_ctx if conn_state == "SF" else None
+            authored_ids_alerts = _build_ids_alert_contexts(
+                getattr(spec, "ids_alerts", []),
+                time=tick_time,
+                src_ip=scan_src_ip,
+                dst_ip=scan_dst_ip,
+                dst_port=spec.dst_port,
+                proto="tcp",
+                rng=rng,
+                source="storyline_web_scan",
+            )
 
             self.activity_generator.generate_connection(
                 src_ip=scan_src_ip,
@@ -6239,6 +6344,7 @@ class StorylineMixin:
                 hostname=scan_host if spec.hostname else None,
                 pid=story_pid,
                 ids=ids_ctx,
+                ids_alerts=authored_ids_alerts,
             )
             request_count += 1
 
@@ -6246,6 +6352,8 @@ class StorylineMixin:
         malicious_event["dst_port"] = spec.dst_port
         malicious_event["preset"] = spec.preset
         malicious_event["request_count"] = request_count
+        if getattr(spec, "ids_alerts", []):
+            malicious_event["ids_alerts"] = _ids_attachment_ground_truth(spec.ids_alerts)
         return malicious_event
 
     def _resolve_firewall_interface(self, ip: str) -> str:

--- a/src/evidenceforge/generation/ground_truth.py
+++ b/src/evidenceforge/generation/ground_truth.py
@@ -91,11 +91,13 @@ class GroundTruthGenerator:
         malicious_events: list[dict],
         red_herring_events: list[dict] | None = None,
         source_evidence_status: dict[str, dict[str, dict[str, int]]] | None = None,
+        ids_evaluation_summary: dict[str, dict[str, dict[str, object]]] | None = None,
     ):
         self.scenario = scenario
         self.malicious_events = malicious_events
         self.red_herring_events = red_herring_events or []
         self.source_evidence_status = source_evidence_status or {}
+        self.ids_evaluation_summary = ids_evaluation_summary
 
     def build_document(self) -> GroundTruthDocument:
         """Build the canonical machine-readable ground-truth document."""
@@ -113,6 +115,7 @@ class GroundTruthGenerator:
                 "observation_profile": self.scenario.observation_profile,
                 "collection_window": self._collection_window(),
                 "source_evidence_status": self._sorted_source_evidence_status(),
+                "ids_evaluation": self._build_ids_evaluation(),
                 "storyline_steps": self._build_storyline_steps(),
                 "red_herring_steps": self._build_red_herring_steps(),
                 "events": self._build_event_records(),
@@ -156,6 +159,10 @@ class GroundTruthGenerator:
         if self._include_source_evidence_status(doc):
             content.append("\n## Source Evidence Status\n")
             content.append(self._create_source_evidence_status_section(doc))
+
+        if doc.ids_evaluation is not None:
+            content.append("\n## IDS Evaluation Summary\n")
+            content.append(self._create_ids_evaluation_section(doc))
 
         content.append("\n## Indicators of Compromise (IOCs)\n")
         content.append(self._format_iocs(self._extract_iocs(doc)))
@@ -313,6 +320,54 @@ class GroundTruthGenerator:
             }
             for cluster_id, source_status in sorted(self.source_evidence_status.items())
         }
+
+    def _build_ids_evaluation(self) -> dict | None:
+        if self.ids_evaluation_summary is None:
+            return None
+        observation: dict[str, int] = {}
+        for source_status in self.source_evidence_status.values():
+            for status, count in source_status.get("ids", {}).items():
+                observation[status] = observation.get(status, 0) + int(count)
+        return {
+            "observation": {key: observation[key] for key in sorted(observation)},
+            "sensors": {
+                sensor: {
+                    key: signatures[key]
+                    for key in sorted(
+                        signatures,
+                        key=lambda value: tuple(int(part) for part in value.split(":")),
+                    )
+                }
+                for sensor, signatures in sorted(self.ids_evaluation_summary.items())
+            },
+        }
+
+    @staticmethod
+    def _create_ids_evaluation_section(document: GroundTruthDocument) -> str:
+        summary = document.ids_evaluation
+        if summary is None:
+            return "*No IDS evaluation summary was generated.*\n"
+        observation = ", ".join(
+            f"{status}={count}" for status, count in sorted(summary.observation.items())
+        )
+        lines = [
+            f"Observation totals: {observation or 'none'}.\n",
+            "| Sensor | GID:SID | Candidates | Emitted | Policy Filtered | Origins | Digest |",
+            "|--------|---------|------------|---------|-----------------|---------|--------|",
+        ]
+        for sensor, signatures in sorted(summary.sensors.items()):
+            for key, signature in sorted(signatures.items()):
+                origins = ", ".join(
+                    f"{origin}={count}" for origin, count in sorted(signature.origins.items())
+                )
+                lines.append(
+                    f"| {sensor} | {key} | {signature.candidate} | {signature.emitted} | "
+                    f"{signature.policy_filtered} | {origins or 'none'} | "
+                    f"`{signature.emitted_sha256[:12]}` |"
+                )
+        if not summary.sensors:
+            lines.append("| *(none)* | - | 0 | 0 | 0 | none | - |")
+        return "\n".join(lines) + "\n"
 
     def _storyline_event_dicts(self, document: GroundTruthDocument) -> list[dict]:
         return [

--- a/src/evidenceforge/generation/ground_truth.py
+++ b/src/evidenceforge/generation/ground_truth.py
@@ -404,11 +404,19 @@ class GroundTruthGenerator:
             )
         if event_type == "rdp_session":
             return (
-                f"RDP session to {event.get('dst_ip', 'N/A')}:3389 (UID: {event.get('uid', 'N/A')})"
+                f"RDP session to {event.get('dst_ip', 'N/A')}:3389 "
+                f"(UID: {event.get('uid', 'N/A')}){self._format_ids_alert_totals(event)}"
             )
         if event_type == "ssh_session":
             return (
-                f"SSH session to {event.get('dst_ip', 'N/A')}:22 (UID: {event.get('uid', 'N/A')})"
+                f"SSH session to {event.get('dst_ip', 'N/A')}:22 "
+                f"(UID: {event.get('uid', 'N/A')}){self._format_ids_alert_totals(event)}"
+            )
+        if event_type == "dhcp_lease":
+            return (
+                f"DHCP lease for {event.get('system', 'N/A')} "
+                f"(MAC: {event.get('mac_address', 'N/A')})"
+                f"{self._format_ids_alert_totals(event)}"
             )
         if event_type == "service_installed":
             return f"Service installed: {event.get('service_name', 'N/A')} ({event.get('service_file_name', 'N/A')})"
@@ -426,7 +434,8 @@ class GroundTruthGenerator:
         if event_type == "port_scan":
             return (
                 f"Port scan: {event.get('target_count', 'N/A')} targets, ports {event.get('ports', [])}, "
-                f"{event.get('total_connections', 'N/A')} denied connections + ASA threat detection alert (733100)"
+                f"{event.get('total_connections', 'N/A')} denied connections + ASA threat "
+                f"detection alert (733100){self._format_ids_alert_totals(event)}"
             )
         if event_type == "beacon":
             label = "Denied beacon" if event.get("action", "allow") == "deny" else "Beacon"
@@ -439,6 +448,7 @@ class GroundTruthGenerator:
             return (
                 f"DNS query: {event.get('query', 'N/A')} "
                 f"({event.get('qtype', 'A')}, {event.get('rcode', 'NOERROR')})"
+                f"{self._format_ids_alert_totals(event)}"
             )
         if event_type == "email_message":
             recipients = event.get("recipients", [])
@@ -462,6 +472,7 @@ class GroundTruthGenerator:
                 f"Web scan ({event.get('preset', 'custom')}) against "
                 f"{event.get('dst_ip', 'N/A')}:{event.get('dst_port', 'N/A')} "
                 f"({event.get('request_count', 'N/A')} requests)"
+                f"{self._format_ids_alert_totals(event)}"
             )
         if event_type == "credential_spray":
             result = (
@@ -479,13 +490,14 @@ class GroundTruthGenerator:
             return (
                 f"DGA queries: {event.get('total_queries', 'N/A')} total "
                 f"({event.get('nxdomain_count', 'N/A')} NXDOMAIN, TLD: {event.get('tld', '.com')}, "
-                f"sample: {sample[:3]})"
+                f"sample: {sample[:3]}){self._format_ids_alert_totals(event)}"
             )
         if event_type == "dns_tunnel":
             return (
                 f"DNS tunnel via {event.get('base_domain', 'N/A')} "
                 f"({event.get('encoding', 'hex')}, {event.get('total_queries', 'N/A')} queries, "
                 f"{event.get('bytes_exfiltrated', 0)} bytes exfiltrated)"
+                f"{self._format_ids_alert_totals(event)}"
             )
         if event_type == "explicit_credentials":
             return (

--- a/src/evidenceforge/generation/ground_truth.py
+++ b/src/evidenceforge/generation/ground_truth.py
@@ -400,7 +400,7 @@ class GroundTruthGenerator:
         if event_type == "connection":
             return (
                 f"Connection to {event.get('dst_ip', 'N/A')}:{event.get('dst_port', 'N/A')} "
-                f"(UID: {event.get('uid', 'N/A')})"
+                f"(UID: {event.get('uid', 'N/A')}){self._format_ids_alert_totals(event)}"
             )
         if event_type == "rdp_session":
             return (
@@ -433,6 +433,7 @@ class GroundTruthGenerator:
             return (
                 f"{label} to {event.get('dst_ip', 'N/A')}:{event.get('dst_port', 'N/A')} "
                 f"({event.get('attempt_count', 'N/A')} attempts, {event.get('termination', 'N/A')})"
+                f"{self._format_ids_alert_totals(event)}"
             )
         if event_type == "dns_query":
             return (
@@ -531,6 +532,28 @@ class GroundTruthGenerator:
                 f"{shown} (sha256:{digest[:12]}){ids_suffix}"
             )
         return event.get("activity", "N/A")
+
+    @staticmethod
+    def _format_ids_alert_totals(event: dict) -> str:
+        """Render compact correlated IDS totals for Markdown ground truth."""
+        attachments = event.get("ids_alerts")
+        if not isinstance(attachments, list) or not attachments:
+            return ""
+        rendered = []
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            rendered.append(
+                "SID {sid} policy={policy} candidates={candidate} emitted={emitted} "
+                "filtered={filtered}".format(
+                    sid=attachment.get("sid", "N/A"),
+                    policy=attachment.get("effective_policy", attachment.get("policy", "pending")),
+                    candidate=attachment.get("candidate", 0),
+                    emitted=attachment.get("emitted", 0),
+                    filtered=attachment.get("policy_filtered", 0),
+                )
+            )
+        return f" [IDS: {'; '.join(rendered)}]" if rendered else ""
 
     def _include_source_evidence_status(self, document: GroundTruthDocument | None = None) -> bool:
         source_evidence_status = (

--- a/src/evidenceforge/generation/ids_filtering.py
+++ b/src/evidenceforge/generation/ids_filtering.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Deterministic sensor-local IDS alert filtering state machines."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+
+from evidenceforge.events.contexts import IdsAlertPolicyContext
+
+
+@dataclass(frozen=True, slots=True)
+class IdsAlertCandidate:
+    """One signature match observed by one IDS sensor."""
+
+    sensor: str
+    timestamp: datetime
+    gid: int
+    sid: int
+    src_ip: str
+    dst_ip: str
+    policy: IdsAlertPolicyContext | None
+
+
+@dataclass(slots=True)
+class _EventWindow:
+    start: datetime
+    matches: int = 0
+    emitted: bool = False
+
+
+class IdsAlertFilterEngine:
+    """Apply Snort-style filters to timestamp-ordered alert candidates."""
+
+    def __init__(self) -> None:
+        self._detection_windows: dict[tuple[object, ...], deque[datetime]] = {}
+        self._event_windows: dict[tuple[object, ...], _EventWindow] = {}
+
+    @staticmethod
+    def _tracked_ip(candidate: IdsAlertCandidate, track: str) -> str:
+        return candidate.src_ip if track == "by_src" else candidate.dst_ip
+
+    def admit(self, candidate: IdsAlertCandidate) -> bool:
+        """Return whether an observed signature match should be logged."""
+
+        policy = candidate.policy
+        if policy is None:
+            return True
+        detection = policy.detection_filter
+        if detection is not None:
+            key = (
+                candidate.sensor,
+                candidate.gid,
+                candidate.sid,
+                "detection",
+                detection.track,
+                self._tracked_ip(candidate, detection.track),
+            )
+            timestamps = self._detection_windows.setdefault(key, deque())
+            while (
+                timestamps
+                and (candidate.timestamp - timestamps[0]).total_seconds() >= detection.seconds
+            ):
+                timestamps.popleft()
+            timestamps.append(candidate.timestamp)
+            if len(timestamps) <= detection.count:
+                return False
+
+        event_filter = policy.event_filter
+        if event_filter is None:
+            return True
+        key = (
+            candidate.sensor,
+            candidate.gid,
+            candidate.sid,
+            "event",
+            event_filter.type,
+            event_filter.track,
+            self._tracked_ip(candidate, event_filter.track),
+        )
+        window = self._event_windows.get(key)
+        if (
+            window is None
+            or (candidate.timestamp - window.start).total_seconds() >= event_filter.seconds
+        ):
+            window = _EventWindow(start=candidate.timestamp)
+            self._event_windows[key] = window
+        window.matches += 1
+
+        if event_filter.type == "limit":
+            return window.matches <= event_filter.count
+        if event_filter.type == "threshold":
+            if window.matches < event_filter.count:
+                return False
+            self._event_windows.pop(key, None)
+            return True
+        if window.emitted or window.matches < event_filter.count:
+            return False
+        window.emitted = True
+        return True

--- a/src/evidenceforge/generation/source_timing.py
+++ b/src/evidenceforge/generation/source_timing.py
@@ -86,6 +86,8 @@ class SourceTimingPlanner:
     def __init__(self, clock_profile_name: str = "complete") -> None:
         self.clock_profile_name = clock_profile_name or "complete"
         self._ecar_process_create_times: dict[str, datetime] = {}
+        self._kerberos_service_times: dict[tuple[str, str, str, str], list[datetime]] = {}
+        self._latest_session_start_times: dict[tuple[str, str], datetime] = {}
         self._latest_session_dependent_times: dict[tuple[str, str], datetime] = {}
         self._admitted_ecar_remote_transports: dict[_REMOTE_TRANSPORT_KEY, datetime] = {}
         self._admitted_windows_remote_transports: dict[_REMOTE_TRANSPORT_KEY, datetime] = {}
@@ -128,6 +130,20 @@ class SourceTimingPlanner:
         format_name: str,
     ) -> None:
         """Publish an admitted transport anchor for later authentication siblings."""
+
+        if (
+            format_name in {"windows_security", "windows_event_security"}
+            and event.event_type == "kerberos_service"
+            and event.kerberos is not None
+            and event.dst_host is not None
+        ):
+            key = self._kerberos_prerequisite_key(
+                format_name,
+                event.kerberos.target_username,
+                event.kerberos.source_ip,
+                event.dst_host.hostname,
+            )
+            self._kerberos_service_times.setdefault(key, []).append(event.timestamp)
 
         network = event.network
         lifecycle = event.lifecycle
@@ -273,7 +289,9 @@ class SourceTimingPlanner:
         )
         plan = self._ensure_plan(event)
         if lifecycle == "logout":
-            plan.finalized_times[ecar_session_render_key(lifecycle)] = event.timestamp
+            plan.finalized_times[ecar_session_render_key(lifecycle)] = (
+                self.session_closure_source_time(event, "ecar")
+            )
             return
         host = event.dst_host or event.src_host
         canonical_timestamp = plan.canonical_timestamp
@@ -358,7 +376,33 @@ class SourceTimingPlanner:
             self._admitted_windows_remote_transports,
             self._admitted_windows_transport_transactions,
         )
+        ticket_time: datetime | None = None
+        if event.event_type == "machine_logon" and event.auth is not None:
+            host = event.dst_host or event.src_host
+            if host is not None:
+                candidates = self._kerberos_service_times.get(
+                    self._kerberos_prerequisite_key(
+                        "windows_event_security",
+                        event.auth.username,
+                        event.auth.source_ip,
+                        host.hostname,
+                    ),
+                    [],
+                )
+                nearby = [
+                    candidate
+                    for candidate in candidates
+                    if abs((candidate - event.timestamp).total_seconds()) <= 5.0
+                ]
+                if nearby:
+                    ticket_time = max(nearby)
         if anchor is None:
+            if ticket_time is not None:
+                timestamp = max(event.timestamp, ticket_time + _SOURCE_EPSILON)
+                self._ensure_plan(event).finalized_times["windows.remote_authentication"] = (
+                    timestamp
+                )
+                return replace(event, timestamp=timestamp)
             return event
         timestamp = anchor + sample_timing_delta(
             "windows.network_logon_after_transport",
@@ -369,8 +413,27 @@ class SourceTimingPlanner:
                 event.event_type,
             ),
         )
+        if ticket_time is not None:
+            timestamp = max(timestamp, ticket_time + _SOURCE_EPSILON)
         self._ensure_plan(event).finalized_times["windows.remote_authentication"] = timestamp
         return replace(event, timestamp=timestamp)
+
+    @staticmethod
+    def _kerberos_prerequisite_key(
+        format_name: str,
+        username: str,
+        source_ip: str,
+        dc_hostname: str,
+    ) -> tuple[str, str, str, str]:
+        """Return a normalized source-local machine-ticket dependency key."""
+
+        principal = username.split("@", maxsplit=1)[0].lower()
+        return (
+            format_name,
+            principal,
+            source_ip.removeprefix("::ffff:"),
+            dc_hostname.lower(),
+        )
 
     def _remote_auth_transport_anchor(
         self,
@@ -836,6 +899,18 @@ class SourceTimingPlanner:
         lifecycle = event.lifecycle
         if lifecycle is None:
             return event
+        if event.event_type in {"logon", "machine_logon", "ssh_session"}:
+            source_time = event.timestamp
+            if format_name == "ecar" and event.source_timing is not None:
+                source_time = event.source_timing.finalized_times.get(
+                    ecar_session_render_key("login"),
+                    source_time,
+                )
+            key = (format_name, lifecycle.group_id)
+            previous = self._latest_session_start_times.get(key)
+            if previous is None or source_time > previous:
+                self._latest_session_start_times[key] = source_time
+            return event
         if event.event_type == "process_terminate" and lifecycle.parent_group_id:
             source_time = self._process_termination_source_time(event, format_name)
             key = (format_name, lifecycle.parent_group_id)
@@ -920,10 +995,17 @@ class SourceTimingPlanner:
             preferred = canonical_end
         latest = self._latest_session_dependent_times.get((format_name, lifecycle.group_id))
         earliest = canonical_end
+        visible_start = self._latest_session_start_times.get((format_name, lifecycle.group_id))
+        if visible_start is not None:
+            earliest = max(earliest, visible_start + _SOURCE_EPSILON)
         if latest is not None:
-            earliest = latest + sample_timing_delta(
-                "windows.logoff_after_rendered_dependents",
-                seed_parts=(format_name, lifecycle.group_id, latest),
+            earliest = max(
+                earliest,
+                latest
+                + sample_timing_delta(
+                    "windows.logoff_after_rendered_dependents",
+                    seed_parts=(format_name, lifecycle.group_id, latest),
+                ),
             )
         tail_seconds = 4 if format_name == "syslog" else 15
         latest_allowed = canonical_end + timedelta(seconds=tail_seconds)

--- a/src/evidenceforge/generation/world_model.py
+++ b/src/evidenceforge/generation/world_model.py
@@ -28,6 +28,7 @@ from evidenceforge.utils.time import ensure_utc
 if TYPE_CHECKING:
     import random
 
+    from evidenceforge.events.contexts import IdsContext
     from evidenceforge.generation.activity.generator import ActivityGenerator
     from evidenceforge.generation.state_manager import StateManager
     from evidenceforge.models.scenario import Scenario, System, User
@@ -873,6 +874,7 @@ class WorldPlanner:
         storyline_protected: bool = False,
         required_until: datetime | None = None,
         session_end_plan: SessionEndPlan | None = None,
+        ids_alerts: list[IdsContext] | None = None,
     ) -> SessionBootstrapResult:
         if allow_existing and session_kind in (None, "interactive"):
             existing_interactive = self._find_windows_interactive_session(
@@ -970,6 +972,7 @@ class WorldPlanner:
                 rng,
                 required_until=required_until,
                 session_end_plan=session_end_plan,
+                ids_alerts=ids_alerts,
             )
             if storyline_protected and result.session:
                 result.session.storyline_protected = True
@@ -982,6 +985,7 @@ class WorldPlanner:
                 time,
                 rng,
                 session_end_plan=session_end_plan,
+                ids_alerts=ids_alerts,
             )
             if storyline_protected and result.session:
                 result.session.storyline_protected = True
@@ -1238,6 +1242,7 @@ class WorldPlanner:
         rng: random.Random,
         required_until: datetime | None = None,
         session_end_plan: SessionEndPlan | None = None,
+        ids_alerts: list[IdsContext] | None = None,
     ) -> SessionBootstrapResult:
         source_os = (
             self.world_model.hosts[plan.source_system.hostname].os_category
@@ -1268,6 +1273,7 @@ class WorldPlanner:
             source_port=source_port,
             min_duration=min_duration,
             session_end_plan=session_end_plan,
+            ids_alerts=ids_alerts,
         )
         session = self.state_manager.get_session(logon_id)
         if session is None:
@@ -1302,6 +1308,7 @@ class WorldPlanner:
         activity_time: datetime,
         rng: random.Random,
         session_end_plan: SessionEndPlan | None = None,
+        ids_alerts: list[IdsContext] | None = None,
     ) -> SessionBootstrapResult:
         source_pid = -1
         source_process_time = logon_time - timedelta(milliseconds=rng.randint(1800, 3200))
@@ -1329,6 +1336,7 @@ class WorldPlanner:
             source_process_time=source_process_time if plan.source_system is not None else None,
             source_process_factory=source_process_factory,
             session_end_plan=session_end_plan,
+            ids_alerts=ids_alerts,
         )
         session = self.state_manager.get_session(logon_id)
         if session is None:

--- a/src/evidenceforge/models/ids.py
+++ b/src/evidenceforge/models/ids.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Scenario and configuration models for correlated IDS alert policies."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+PositiveFilterInt = Annotated[int, Field(strict=True, ge=1, le=2_147_483_647)]
+IdsTrackMode = Literal["by_src", "by_dst"]
+
+
+class IdsDetectionFilterSpec(BaseModel):
+    """Snort-style rate threshold required before a rule produces events."""
+
+    track: IdsTrackMode
+    count: PositiveFilterInt
+    seconds: PositiveFilterInt
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class IdsEventFilterSpec(BaseModel):
+    """Snort-style output filter applied after rule detection."""
+
+    type: Literal["limit", "threshold", "both"]
+    track: IdsTrackMode
+    count: PositiveFilterInt
+    seconds: PositiveFilterInt
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class IdsAlertPolicySpec(BaseModel):
+    """Composable detection and output filters for one IDS signature."""
+
+    detection_filter: IdsDetectionFilterSpec | None = None
+    event_filter: IdsEventFilterSpec | None = None
+
+    @model_validator(mode="after")
+    def require_filter(self) -> IdsAlertPolicySpec:
+        """Reject ambiguous empty objects; use ``every`` explicitly instead."""
+
+        if self.detection_filter is None and self.event_filter is None:
+            raise ValueError("IDS alert policy must define detection_filter or event_filter")
+        return self
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+IdsAlertPolicyOverride = Literal["every"] | IdsAlertPolicySpec
+
+
+class IdsAlertAttachmentSpec(BaseModel):
+    """Reference one configured IDS signature from a canonical network event."""
+
+    sid: Annotated[int, Field(strict=True, ge=1, le=2_147_483_647)]
+    policy: IdsAlertPolicyOverride | None = None
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def policy_fingerprint(policy: IdsAlertPolicySpec | None) -> tuple[object, ...]:
+    """Return a stable comparable representation of an effective policy."""
+
+    if policy is None:
+        return ("every",)
+    detection = policy.detection_filter
+    event_filter = policy.event_filter
+    return (
+        "policy",
+        None if detection is None else (detection.track, detection.count, detection.seconds),
+        None
+        if event_filter is None
+        else (event_filter.type, event_filter.track, event_filter.count, event_filter.seconds),
+    )

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -752,6 +752,27 @@ class _EventSpecBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class _IdsAttachableEventSpec(_EventSpecBase):
+    """Base for typed events that own one or more canonical network transports."""
+
+    ids_alerts: list[IdsAlertAttachmentSpec] = Field(
+        default_factory=list,
+        description="IDS signatures asserted on each owned sensor-observable transport.",
+    )
+
+    @field_validator("ids_alerts")
+    @classmethod
+    def validate_unique_ids_alerts(
+        cls, v: list[IdsAlertAttachmentSpec]
+    ) -> list[IdsAlertAttachmentSpec]:
+        """Reject duplicate SID attachments on one authored event."""
+
+        sids = [attachment.sid for attachment in v]
+        if len(sids) != len(set(sids)):
+            raise ValueError("ids_alerts must not contain duplicate SIDs")
+        return v
+
+
 class ProcessEventSpec(_EventSpecBase):
     """Process execution event (generates 4688, Sysmon 1, eCAR PROCESS/CREATE)."""
 
@@ -790,7 +811,7 @@ class LogoffEventSpec(_EventSpecBase):
     type: Literal["logoff"] = "logoff"
 
 
-class ConnectionEventSpec(_EventSpecBase):
+class ConnectionEventSpec(_IdsAttachableEventSpec):
     """Network connection event (generates Zeek conn, eCAR FLOW, optionally web_access/zeek_http)."""
 
     type: Literal["connection"] = "connection"
@@ -812,22 +833,6 @@ class ConnectionEventSpec(_EventSpecBase):
     orig_bytes: int | None = None  # Originator payload bytes (large for exfil)
     resp_bytes: int | None = None  # Responder payload bytes (large for downloads)
     conn_state: str | None = None  # Connection outcome (default: SF for storyline)
-    ids_alerts: list[IdsAlertAttachmentSpec] = Field(
-        default_factory=list,
-        description="IDS signatures asserted on each sensor-observable canonical connection.",
-    )
-
-    @field_validator("ids_alerts")
-    @classmethod
-    def validate_unique_ids_alerts(
-        cls, v: list[IdsAlertAttachmentSpec]
-    ) -> list[IdsAlertAttachmentSpec]:
-        """Reject duplicate SID attachments on one connection."""
-
-        sids = [attachment.sid for attachment in v]
-        if len(sids) != len(set(sids)):
-            raise ValueError("connection ids_alerts must not contain duplicate SIDs")
-        return v
 
     @field_validator("hostname")
     @classmethod
@@ -838,14 +843,14 @@ class ConnectionEventSpec(_EventSpecBase):
         return v
 
 
-class SshSessionEventSpec(_EventSpecBase):
+class SshSessionEventSpec(_IdsAttachableEventSpec):
     """SSH session event (generates Zeek conn + syslog sshd + eCAR)."""
 
     type: Literal["ssh_session"] = "ssh_session"
     source_ip: str | None = None
 
 
-class RdpSessionEventSpec(_EventSpecBase):
+class RdpSessionEventSpec(_IdsAttachableEventSpec):
     """RDP session event (generates Zeek conn + 4624 type 10 + eCAR on target)."""
 
     type: Literal["rdp_session"] = "rdp_session"
@@ -915,7 +920,7 @@ class ProcessAccessEventSpec(_EventSpecBase):
     access_mask: str = "0x1010"
 
 
-class DhcpLeaseEventSpec(_EventSpecBase):
+class DhcpLeaseEventSpec(_IdsAttachableEventSpec):
     """DHCP lease event for rogue/new devices appearing on the network."""
 
     type: Literal["dhcp_lease"] = "dhcp_lease"
@@ -924,7 +929,7 @@ class DhcpLeaseEventSpec(_EventSpecBase):
     model_config = ConfigDict(extra="forbid")
 
 
-class PortScanEventSpec(_EventSpecBase):
+class PortScanEventSpec(_IdsAttachableEventSpec):
     """Port scan producing firewall deny records (ASA 106023).
 
     Generates many denied connection attempts from the storyline system to
@@ -1086,7 +1091,28 @@ class _PeriodicEventBase(_EventSpecBase):
         return self
 
 
-class BeaconEventSpec(_PeriodicEventBase):
+class _IdsAttachablePeriodicEventSpec(_PeriodicEventBase):
+    """Periodic typed event whose ticks own canonical network transports."""
+
+    ids_alerts: list[IdsAlertAttachmentSpec] = Field(
+        default_factory=list,
+        description="IDS signatures asserted on each owned sensor-observable transport.",
+    )
+
+    @field_validator("ids_alerts")
+    @classmethod
+    def validate_unique_ids_alerts(
+        cls, v: list[IdsAlertAttachmentSpec]
+    ) -> list[IdsAlertAttachmentSpec]:
+        """Reject duplicate SID attachments on one authored periodic event."""
+
+        sids = [attachment.sid for attachment in v]
+        if len(sids) != len(set(sids)):
+            raise ValueError("ids_alerts must not contain duplicate SIDs")
+        return v
+
+
+class BeaconEventSpec(_IdsAttachablePeriodicEventSpec):
     """Periodic beacon — repeated connections at regular intervals.
 
     Produces allowed or denied connections at configurable intervals.
@@ -1130,22 +1156,6 @@ class BeaconEventSpec(_PeriodicEventBase):
             "on the first tick; 'each_tick' emits resolver evidence for every tick."
         ),
     )
-    ids_alerts: list[IdsAlertAttachmentSpec] = Field(
-        default_factory=list,
-        description="IDS signatures asserted on each sensor-observable canonical beacon connection.",
-    )
-
-    @field_validator("ids_alerts")
-    @classmethod
-    def validate_unique_ids_alerts(
-        cls, v: list[IdsAlertAttachmentSpec]
-    ) -> list[IdsAlertAttachmentSpec]:
-        """Reject duplicate SID attachments on one beacon."""
-
-        sids = [attachment.sid for attachment in v]
-        if len(sids) != len(set(sids)):
-            raise ValueError("beacon ids_alerts must not contain duplicate SIDs")
-        return v
 
     @field_validator("hostname")
     @classmethod
@@ -1188,7 +1198,7 @@ class BeaconEventSpec(_PeriodicEventBase):
         return self
 
 
-class DnsQueryEventSpec(_EventSpecBase):
+class DnsQueryEventSpec(_IdsAttachableEventSpec):
     """Standalone DNS query event (generates Zeek dns.log, conn.log, Sysmon Event 22).
 
     Produces a single DNS query as a UDP/53 connection with DnsContext.
@@ -1270,7 +1280,7 @@ class DnsQueryEventSpec(_EventSpecBase):
                 raise ValueError("DKIM TXT p= must identify an RSA public key")
 
 
-class WebScanEventSpec(_PeriodicEventBase):
+class WebScanEventSpec(_IdsAttachablePeriodicEventSpec):
     """Web scanning attack — repeated HTTP requests from scanner presets.
 
     Generates high-volume HTTP requests to a target web server using
@@ -1358,7 +1368,7 @@ class CredentialSprayEventSpec(_PeriodicEventBase):
         return self
 
 
-class DgaQueriesEventSpec(_PeriodicEventBase):
+class DgaQueriesEventSpec(_IdsAttachablePeriodicEventSpec):
     """DGA bulk DNS queries — algorithmically generated domain lookups.
 
     Generates many DNS queries with random domain names, mostly returning
@@ -1414,7 +1424,7 @@ class DgaQueriesEventSpec(_PeriodicEventBase):
         return self
 
 
-class DnsTunnelEventSpec(_PeriodicEventBase):
+class DnsTunnelEventSpec(_IdsAttachablePeriodicEventSpec):
     """DNS tunneling — data exfiltration via encoded DNS subdomain labels.
 
     Generates DNS queries with encoded payload chunks as subdomain labels

--- a/src/evidenceforge/models/scenario.py
+++ b/src/evidenceforge/models/scenario.py
@@ -48,6 +48,8 @@ from pydantic import (
     model_validator,
 )
 
+from evidenceforge.models.ids import IdsAlertAttachmentSpec
+
 MAX_HTTP_RESPONSE_BODY_LEN = 10_000_000_000
 
 _HOSTNAME_RE = re.compile(
@@ -810,6 +812,22 @@ class ConnectionEventSpec(_EventSpecBase):
     orig_bytes: int | None = None  # Originator payload bytes (large for exfil)
     resp_bytes: int | None = None  # Responder payload bytes (large for downloads)
     conn_state: str | None = None  # Connection outcome (default: SF for storyline)
+    ids_alerts: list[IdsAlertAttachmentSpec] = Field(
+        default_factory=list,
+        description="IDS signatures asserted on each sensor-observable canonical connection.",
+    )
+
+    @field_validator("ids_alerts")
+    @classmethod
+    def validate_unique_ids_alerts(
+        cls, v: list[IdsAlertAttachmentSpec]
+    ) -> list[IdsAlertAttachmentSpec]:
+        """Reject duplicate SID attachments on one connection."""
+
+        sids = [attachment.sid for attachment in v]
+        if len(sids) != len(set(sids)):
+            raise ValueError("connection ids_alerts must not contain duplicate SIDs")
+        return v
 
     @field_validator("hostname")
     @classmethod
@@ -1112,6 +1130,22 @@ class BeaconEventSpec(_PeriodicEventBase):
             "on the first tick; 'each_tick' emits resolver evidence for every tick."
         ),
     )
+    ids_alerts: list[IdsAlertAttachmentSpec] = Field(
+        default_factory=list,
+        description="IDS signatures asserted on each sensor-observable canonical beacon connection.",
+    )
+
+    @field_validator("ids_alerts")
+    @classmethod
+    def validate_unique_ids_alerts(
+        cls, v: list[IdsAlertAttachmentSpec]
+    ) -> list[IdsAlertAttachmentSpec]:
+        """Reject duplicate SID attachments on one beacon."""
+
+        sids = [attachment.sid for attachment in v]
+        if len(sids) != len(set(sids)):
+            raise ValueError("beacon ids_alerts must not contain duplicate SIDs")
+        return v
 
     @field_validator("hostname")
     @classmethod

--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -323,36 +323,92 @@ class ScenarioValidator:
                                     ),
                                 )
                             )
-                        protocol = str(getattr(spec, "protocol", "tcp")).lower()
+                        protocol, dst_ports, observed_direction = self._ids_transport_shape(
+                            spec,
+                            event.system,
+                            source_ip,
+                        )
                         if protocol != str(signature.get("proto", "tcp")).lower():
                             self._warn_ids_mismatch(path, attachment.sid, "protocol", protocol)
-                        dst_port = getattr(spec, "dst_port", None)
-                        signature_port = signature.get("dst_port", 0)
-                        if dst_port is not None and signature_port not in (0, dst_port):
+                        signature_port = int(signature.get("dst_port", 0))
+                        if dst_ports and signature_port not in {0, *dst_ports}:
+                            observed_ports: object = (
+                                next(iter(dst_ports)) if len(dst_ports) == 1 else sorted(dst_ports)
+                            )
                             self._warn_ids_mismatch(
-                                path, attachment.sid, "destination port", dst_port
+                                path,
+                                attachment.sid,
+                                "destination port",
+                                observed_ports,
                             )
-                        dst_ip = getattr(spec, "dst_ip", None)
-                        if source_ip and dst_ip:
-                            src_internal = source_ip in self.ips
-                            dst_internal = dst_ip in self.ips
-                            observed_direction = (
-                                "out"
-                                if src_internal and not dst_internal
-                                else "in"
-                                if not src_internal and dst_internal
-                                else None
+                        if observed_direction and signature.get("direction") != observed_direction:
+                            self._warn_ids_mismatch(
+                                path,
+                                attachment.sid,
+                                "direction",
+                                observed_direction,
                             )
-                            if (
-                                observed_direction
-                                and signature.get("direction") != observed_direction
-                            ):
-                                self._warn_ids_mismatch(
-                                    path,
-                                    attachment.sid,
-                                    "direction",
-                                    observed_direction,
-                                )
+
+    def _ids_transport_shape(
+        self,
+        spec: Any,
+        event_system_name: str,
+        default_source_ip: str | None,
+    ) -> tuple[str, set[int], str | None]:
+        """Return the protocol, destination ports, and derivable direction for an event."""
+
+        event_type = str(getattr(spec, "type", ""))
+        if event_type in {"ssh_session", "rdp_session"}:
+            protocol = "tcp"
+            dst_ports = {22 if event_type == "ssh_session" else 3389}
+        elif event_type == "dhcp_lease":
+            protocol = "udp"
+            dst_ports = {67}
+        elif event_type in {"dns_query", "dga_queries", "dns_tunnel"}:
+            protocol = "udp"
+            dst_ports = {53}
+        elif event_type == "web_scan":
+            protocol = "tcp"
+            dst_ports = {int(spec.dst_port)}
+        elif event_type == "port_scan":
+            protocol = str(spec.protocol).lower()
+            dst_ports = {int(port) for port in spec.ports}
+        else:
+            protocol = str(getattr(spec, "protocol", "tcp")).lower()
+            dst_port = getattr(spec, "dst_port", None)
+            dst_ports = {int(dst_port)} if dst_port is not None else set()
+
+        source_ip = getattr(spec, "source_ip", None) or default_source_ip
+        destination_ips: list[str] = []
+        if event_type in {"ssh_session", "rdp_session"}:
+            target_system = next(
+                (
+                    system
+                    for system in self.scenario.environment.systems
+                    if system.hostname == event_system_name
+                ),
+                None,
+            )
+            if target_system is not None and getattr(spec, "source_ip", None):
+                destination_ips = [target_system.ip]
+        elif event_type == "port_scan":
+            destination_ips = list(spec.target_ips)
+        else:
+            dst_ip = getattr(spec, "dst_ip", None)
+            if dst_ip:
+                destination_ips = [dst_ip]
+
+        directions = set()
+        if source_ip:
+            for dst_ip in destination_ips:
+                src_internal = source_ip in self.ips
+                dst_internal = dst_ip in self.ips
+                if src_internal and not dst_internal:
+                    directions.add("out")
+                elif not src_internal and dst_internal:
+                    directions.add("in")
+        observed_direction = next(iter(directions)) if len(directions) == 1 else None
+        return protocol, dst_ports, observed_direction
 
     def _warn_ids_mismatch(self, path: str, sid: int, field: str, value: object) -> None:
         """Record a non-blocking signature/event plausibility mismatch."""

--- a/src/evidenceforge/validation/schema.py
+++ b/src/evidenceforge/validation/schema.py
@@ -40,6 +40,7 @@ from typing import Any
 import yaml
 
 from evidenceforge.models import Scenario
+from evidenceforge.models.ids import policy_fingerprint
 from evidenceforge.utils.rng import _stable_seed
 
 logger = logging.getLogger(__name__)
@@ -225,6 +226,7 @@ class ScenarioValidator:
         self._validate_user_primary_system_references()
         self._validate_group_member_references()
         self._validate_storyline_references()
+        self._validate_ids_alert_attachments()
         self._validate_uniqueness()
         self._validate_expanded_activities()
         self._validate_event_sequences()
@@ -258,6 +260,113 @@ class ScenarioValidator:
         self._validate_traffic_affinities()
         self._sort_issues()
         return self.issues
+
+    def _validate_ids_alert_attachments(self) -> None:
+        """Resolve attached signatures and reject scenario-wide policy ambiguity."""
+        from evidenceforge.generation.activity.ids_signatures import (
+            effective_alert_policy,
+            signature_by_sid,
+        )
+
+        effective_by_sid: dict[tuple[int, int], tuple[object, ...]] = {}
+        for section_name, events in (
+            ("storyline", self.scenario.storyline or []),
+            ("red_herrings", self.scenario.red_herrings or []),
+        ):
+            for event_idx, event in enumerate(events):
+                source_system = next(
+                    (
+                        system
+                        for system in self.scenario.environment.systems
+                        if system.hostname == event.system
+                    ),
+                    None,
+                )
+                source_ip = source_system.ip if source_system is not None else None
+                for spec_idx, spec in enumerate(event.events):
+                    attachments = getattr(spec, "ids_alerts", ())
+                    for attachment_idx, attachment in enumerate(attachments):
+                        path = (
+                            f"{section_name}.{event_idx}.events.{spec_idx}."
+                            f"ids_alerts.{attachment_idx}"
+                        )
+                        signature = signature_by_sid(attachment.sid)
+                        if signature is None:
+                            self.issues.append(
+                                ValidationIssue(
+                                    severity="error",
+                                    field_path=f"{path}.sid",
+                                    message=f"Unknown IDS signature SID {attachment.sid}",
+                                    suggestion=(
+                                        "Add the SID to activity/ids_signatures.yaml or choose "
+                                        "an existing configured signature."
+                                    ),
+                                )
+                            )
+                            continue
+                        policy = effective_alert_policy(signature, attachment.policy)
+                        identity = (int(signature.get("gid", 1)), attachment.sid)
+                        fingerprint = policy_fingerprint(policy)
+                        prior = effective_by_sid.setdefault(identity, fingerprint)
+                        if prior != fingerprint:
+                            self.issues.append(
+                                ValidationIssue(
+                                    severity="error",
+                                    field_path=f"{path}.policy",
+                                    message=(
+                                        f"SID {attachment.sid} has conflicting effective IDS "
+                                        "alert policies in this scenario"
+                                    ),
+                                    suggestion=(
+                                        "Use the same effective policy for every attachment of "
+                                        "a SID, or use different SIDs."
+                                    ),
+                                )
+                            )
+                        protocol = str(getattr(spec, "protocol", "tcp")).lower()
+                        if protocol != str(signature.get("proto", "tcp")).lower():
+                            self._warn_ids_mismatch(path, attachment.sid, "protocol", protocol)
+                        dst_port = getattr(spec, "dst_port", None)
+                        signature_port = signature.get("dst_port", 0)
+                        if dst_port is not None and signature_port not in (0, dst_port):
+                            self._warn_ids_mismatch(
+                                path, attachment.sid, "destination port", dst_port
+                            )
+                        dst_ip = getattr(spec, "dst_ip", None)
+                        if source_ip and dst_ip:
+                            src_internal = source_ip in self.ips
+                            dst_internal = dst_ip in self.ips
+                            observed_direction = (
+                                "out"
+                                if src_internal and not dst_internal
+                                else "in"
+                                if not src_internal and dst_internal
+                                else None
+                            )
+                            if (
+                                observed_direction
+                                and signature.get("direction") != observed_direction
+                            ):
+                                self._warn_ids_mismatch(
+                                    path,
+                                    attachment.sid,
+                                    "direction",
+                                    observed_direction,
+                                )
+
+    def _warn_ids_mismatch(self, path: str, sid: int, field: str, value: object) -> None:
+        """Record a non-blocking signature/event plausibility mismatch."""
+        self.issues.append(
+            ValidationIssue(
+                severity="warning",
+                field_path=path,
+                message=f"IDS SID {sid} does not normally match event {field} {value!r}",
+                suggestion=(
+                    "Keep the attachment for an intentional nonstandard deployment, or choose "
+                    "a signature whose configured protocol, port, and direction match."
+                ),
+            )
+        )
 
     def has_errors(self) -> bool:
         """Check if any error-level issues were found.

--- a/tests/integration/test_ids_alert_generation.py
+++ b/tests/integration/test_ids_alert_generation.py
@@ -6,6 +6,7 @@
 import json
 from datetime import UTC, datetime
 
+from evidenceforge.evaluation.engine import EvaluationEngine
 from evidenceforge.generation.engine import GenerationEngine
 from evidenceforge.models.scenario import (
     BaselineActivity,
@@ -115,9 +116,18 @@ def test_beacon_ids_policy_output_and_reporting_are_consistent(tmp_path) -> None
     assert totals["emitted"] == 1
     assert totals["policy_filtered"] == 2
     assert totals["candidate"] == totals["emitted"] + totals["policy_filtered"]
+    ids_evaluation = ground_truth["ids_evaluation"]
+    sensor_summary = ids_evaluation["sensors"]["ids01"]["1:2028401"]
+    assert sensor_summary["candidate"] == 3
+    assert sensor_summary["emitted"] == 1
+    assert sensor_summary["policy_filtered"] == 2
+    assert sensor_summary["origins"] == {"authored_attachment": 1}
+    assert len(sensor_summary["emitted_sha256"]) == 64
     markdown = (tmp_path / "GROUND_TRUTH.md").read_text(encoding="utf-8")
     assert "SID 2028401" in markdown
     assert "candidates=3 emitted=1 filtered=2" in markdown
+    assert "## IDS Evaluation Summary" in markdown
+    assert sensor_summary["emitted_sha256"][:12] in markdown
 
     manifest = json.loads((tmp_path / "OBSERVATION_MANIFEST.json").read_text(encoding="utf-8"))
     storyline = next(
@@ -126,6 +136,16 @@ def test_beacon_ids_policy_output_and_reporting_are_consistent(tmp_path) -> None
     ids_status = storyline["source_status"]["ids"]
     assert ids_status["filtered"] == 2
     assert ids_status.get("visible", 0) + ids_status.get("delayed", 0) == 1
+
+    report = EvaluationEngine(output_dir=tmp_path, scenario=scenario).run()
+    ids_score = next(
+        score
+        for pillar in report.pillars
+        for score in pillar.sub_scores
+        if score.key == "ids_integrity"
+    )
+    assert ids_score.score == 100.0
+    assert report.generated_at == datetime.fromisoformat(ground_truth["generated_at"])
 
 
 def test_transport_owner_ids_attachments_emit_and_report_only_owned_transports(tmp_path) -> None:

--- a/tests/integration/test_ids_alert_generation.py
+++ b/tests/integration/test_ids_alert_generation.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""End-to-end coverage for typed canonical IDS attachments."""
+
+import json
+from datetime import UTC, datetime
+
+from evidenceforge.generation.engine import GenerationEngine
+from evidenceforge.models.scenario import (
+    BaselineActivity,
+    Environment,
+    NetworkConfig,
+    NetworkSegment,
+    NetworkSensor,
+    OutputSpec,
+    Scenario,
+    StorylineEvent,
+    System,
+    TimeWindow,
+    User,
+)
+
+
+def test_beacon_ids_policy_output_and_reporting_are_consistent(tmp_path) -> None:
+    scenario = Scenario(
+        version="1.0",
+        name="ids-beacon-integration",
+        description="Canonical IDS beacon attachment",
+        environment=Environment(
+            description="test",
+            users=[
+                User(
+                    username="alice",
+                    full_name="Alice",
+                    email="alice@example.test",
+                    primary_system="ws01",
+                )
+            ],
+            systems=[System(hostname="ws01", ip="10.0.0.8", os="Windows 11", type="workstation")],
+            network=NetworkConfig(
+                segments=[
+                    NetworkSegment(
+                        name="workstations",
+                        cidr="10.0.0.0/24",
+                        exposure="internal",
+                        systems=["ws01"],
+                    )
+                ],
+                sensors=[
+                    NetworkSensor(
+                        type="ids",
+                        name="ids01",
+                        hostname="ids01",
+                        monitoring_segments=["workstations"],
+                        direction="bidirectional",
+                        placement="tap",
+                        log_formats=["snort_alert"],
+                    )
+                ],
+            ),
+        ),
+        time_window=TimeWindow(start=datetime(2026, 8, 3, tzinfo=UTC), duration="10m"),
+        baseline_activity=BaselineActivity(description="minimal", intensity="low", variation="low"),
+        storyline=[
+            StorylineEvent(
+                id="beacon-ids",
+                time="+1m",
+                actor="alice",
+                system="ws01",
+                activity="three signature-matching callbacks",
+                events=[
+                    {
+                        "type": "beacon",
+                        "dst_ip": "45.83.221.30",
+                        "dst_port": 443,
+                        "service": "ssl",
+                        "interval": "1s",
+                        "count": 3,
+                        "jitter": 0,
+                        "ids_alerts": [
+                            {
+                                "sid": 2028401,
+                                "policy": {
+                                    "event_filter": {
+                                        "type": "threshold",
+                                        "track": "by_src",
+                                        "count": 2,
+                                        "seconds": 60,
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                ],
+            )
+        ],
+        output=OutputSpec(logs=[{"format": "snort_alert"}], destination="./output"),
+    )
+
+    GenerationEngine(scenario, tmp_path).generate()
+
+    alert_lines = [
+        line
+        for path in tmp_path.rglob("snort_alert.log")
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if "[1:2028401:1]" in line
+    ]
+    assert len(alert_lines) == 1
+
+    ground_truth = json.loads((tmp_path / "GROUND_TRUTH.json").read_text(encoding="utf-8"))
+    beacon = next(event for event in ground_truth["events"] if event["kind"] == "beacon")
+    totals = beacon["attributes"]["ids_alerts"][0]
+    assert totals["candidate"] == 3
+    assert totals["emitted"] == 1
+    assert totals["policy_filtered"] == 2
+    assert totals["candidate"] == totals["emitted"] + totals["policy_filtered"]
+    markdown = (tmp_path / "GROUND_TRUTH.md").read_text(encoding="utf-8")
+    assert "SID 2028401" in markdown
+    assert "candidates=3 emitted=1 filtered=2" in markdown
+
+    manifest = json.loads((tmp_path / "OBSERVATION_MANIFEST.json").read_text(encoding="utf-8"))
+    storyline = next(
+        step for step in manifest["storyline_events"] if step["storyline_id"] == "beacon-ids"
+    )
+    ids_status = storyline["source_status"]["ids"]
+    assert ids_status["filtered"] == 2
+    assert ids_status.get("visible", 0) + ids_status.get("delayed", 0) == 1

--- a/tests/integration/test_ids_alert_generation.py
+++ b/tests/integration/test_ids_alert_generation.py
@@ -291,10 +291,11 @@ def test_transport_owner_ids_attachments_emit_and_report_only_owned_transports(t
                 ],
             ),
         ),
-        time_window=TimeWindow(start=datetime(2026, 8, 3, tzinfo=UTC), duration="12m", warmup=None),
+        time_window=TimeWindow(start=datetime(2026, 8, 3, tzinfo=UTC), duration="1h", warmup=None),
         baseline_activity=BaselineActivity(description="minimal", intensity="low", variation="low"),
         storyline=storyline,
         output=OutputSpec(logs=[{"format": "snort_alert"}], destination="./output"),
+        observation_profile="complete",
     )
 
     GenerationEngine(scenario, tmp_path).generate()

--- a/tests/integration/test_ids_alert_generation.py
+++ b/tests/integration/test_ids_alert_generation.py
@@ -54,7 +54,7 @@ def test_beacon_ids_policy_output_and_reporting_are_consistent(tmp_path) -> None
                         hostname="ids01",
                         monitoring_segments=["workstations"],
                         direction="bidirectional",
-                        placement="tap",
+                        placement="span",
                         log_formats=["snort_alert"],
                     )
                 ],
@@ -126,3 +126,187 @@ def test_beacon_ids_policy_output_and_reporting_are_consistent(tmp_path) -> None
     ids_status = storyline["source_status"]["ids"]
     assert ids_status["filtered"] == 2
     assert ids_status.get("visible", 0) + ids_status.get("delayed", 0) == 1
+
+
+def test_transport_owner_ids_attachments_emit_and_report_only_owned_transports(tmp_path) -> None:
+    systems = [
+        System(hostname="ws01", ip="10.0.0.8", os="Windows 11", type="workstation"),
+        System(
+            hostname="linux01",
+            ip="10.0.0.20",
+            os="Ubuntu 24.04",
+            type="server",
+            roles=["application_server"],
+            services=["ssh"],
+        ),
+        System(
+            hostname="rdp01",
+            ip="10.0.0.30",
+            os="Windows Server 2022",
+            type="server",
+            services=["rdp"],
+        ),
+        System(
+            hostname="dc01",
+            ip="10.0.0.65",
+            os="Windows Server 2022",
+            type="domain_controller",
+            roles=["domain_controller", "dns_server"],
+            services=["dns"],
+        ),
+    ]
+    attached = [{"sid": 2002911, "policy": "every"}]
+    storyline_specs = [
+        ("ssh", "linux01", {"type": "ssh_session", "source_ip": "10.0.0.8"}),
+        ("rdp", "rdp01", {"type": "rdp_session", "source_ip": "10.0.0.8"}),
+        ("dhcp", "ws01", {"type": "dhcp_lease"}),
+        (
+            "port-scan",
+            "ws01",
+            {
+                "type": "port_scan",
+                "target_ips": ["10.0.0.20"],
+                "target_count": 1,
+                "ports": [22],
+                "scan_rate": 10,
+            },
+        ),
+        (
+            "dns",
+            "ws01",
+            {"type": "dns_query", "query": "missing.example.test", "rcode": "NXDOMAIN"},
+        ),
+        (
+            "web-scan",
+            "ws01",
+            {
+                "type": "web_scan",
+                "dst_ip": "10.0.0.20",
+                "dst_port": 80,
+                "paths": [{"uri": "/admin", "method": "GET", "status": 404}],
+                "rate": 1,
+                "count": 1,
+            },
+        ),
+        (
+            "dga",
+            "ws01",
+            {
+                "type": "dga_queries",
+                "interval": "1s",
+                "count": 2,
+                "rcode_distribution": {"NXDOMAIN": 1.0},
+            },
+        ),
+        (
+            "tunnel",
+            "ws01",
+            {
+                "type": "dns_tunnel",
+                "base_domain": "tunnel.example.test",
+                "payload": "owned transport",
+                "interval": "1s",
+                "count": 2,
+            },
+        ),
+    ]
+    storyline = []
+    for minute, (event_id, hostname, event_spec) in enumerate(storyline_specs, start=1):
+        storyline.append(
+            StorylineEvent(
+                id=event_id,
+                time=f"+{minute}m",
+                actor="alice",
+                system=hostname,
+                activity=event_id,
+                events=[{**event_spec, "ids_alerts": attached}],
+            )
+        )
+    scenario = Scenario(
+        version="1.0",
+        name="ids-transport-owners",
+        description="Canonical IDS transport-owner attachments",
+        environment=Environment(
+            description="test",
+            users=[
+                User(
+                    username="alice",
+                    full_name="Alice",
+                    email="alice@example.test",
+                    primary_system="ws01",
+                )
+            ],
+            systems=systems,
+            network=NetworkConfig(
+                segments=[
+                    NetworkSegment(
+                        name="clients",
+                        cidr="10.0.0.0/28",
+                        exposure="internal",
+                        systems=["ws01"],
+                    ),
+                    NetworkSegment(
+                        name="servers",
+                        cidr="10.0.0.16/27",
+                        exposure="internal",
+                        systems=["linux01", "rdp01"],
+                    ),
+                    NetworkSegment(
+                        name="infra",
+                        cidr="10.0.0.64/26",
+                        exposure="internal",
+                        systems=["dc01"],
+                    ),
+                ],
+                sensors=[
+                    NetworkSensor(
+                        type="ids",
+                        name="ids01",
+                        hostname="ids01",
+                        monitoring_segments=["clients", "servers", "infra"],
+                        direction="bidirectional",
+                        placement="span",
+                        log_formats=["snort_alert"],
+                    )
+                ],
+            ),
+        ),
+        time_window=TimeWindow(start=datetime(2026, 8, 3, tzinfo=UTC), duration="12m", warmup=None),
+        baseline_activity=BaselineActivity(description="minimal", intensity="low", variation="low"),
+        storyline=storyline,
+        output=OutputSpec(logs=[{"format": "snort_alert"}], destination="./output"),
+    )
+
+    GenerationEngine(scenario, tmp_path).generate()
+
+    ground_truth = json.loads((tmp_path / "GROUND_TRUTH.json").read_text(encoding="utf-8"))
+    attached_events = {
+        event["kind"]: event["attributes"]["ids_alerts"][0]
+        for event in ground_truth["events"]
+        if event["attributes"].get("ids_alerts")
+    }
+    expected_kinds = {
+        "ssh_session",
+        "rdp_session",
+        "dhcp_lease",
+        "port_scan",
+        "dns_query",
+        "web_scan",
+        "dga_queries",
+        "dns_tunnel",
+    }
+    assert attached_events.keys() == expected_kinds
+    zero_candidate_kinds = {
+        kind for kind, totals in attached_events.items() if totals["candidate"] == 0
+    }
+    assert not zero_candidate_kinds, zero_candidate_kinds
+    assert all(totals["candidate"] == totals["emitted"] for totals in attached_events.values())
+    assert all(totals["policy_filtered"] == 0 for totals in attached_events.values())
+
+    alert_lines = [
+        line
+        for path in tmp_path.rglob("snort_alert.log")
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if "[1:2002911:7]" in line
+    ]
+    assert len(alert_lines) == sum(totals["emitted"] for totals in attached_events.values())

--- a/tests/integration/test_spillage_generation.py
+++ b/tests/integration/test_spillage_generation.py
@@ -252,7 +252,7 @@ class TestSpillageEval:
     def test_eval_acceptance_passes(self, spillage_scenario, tmp_path):
         out = _generate(spillage_scenario, tmp_path / "out")
         report = EvaluationEngine(output_dir=out, scenario=Scenario(**spillage_scenario)).run()
-        hard = [c for c in report.acceptance_criteria if c.level == "hard"]
+        hard = [c for c in report.acceptance_criteria if c.level == "hard" and c.passed is not None]
         assert hard and all(c.passed for c in hard), [
             (c.name, c.actual) for c in hard if not c.passed
         ]

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -3694,23 +3694,25 @@ class TestActivityGenerator:
         assert machine_logon.remote_auth is not None
         assert machine_logon.remote_auth.outcome == "success"
         assert machine_logon.remote_auth.primary_transport is not None
-        assert machine_logon.remote_auth.primary_transport.role == "kerberos_validation"
+        assert machine_logon.remote_auth.primary_transport.role == "target_service"
+        assert machine_logon.remote_auth.primary_transport.tuple.dst_port in {389, 445}
         assert machine_logon.edr.object_id == machine_logoff.edr.object_id
         assert machine_logon.lifecycle.group_id == machine_logoff.lifecycle.group_id
         assert machine_logon.lifecycle.phase == "start"
         assert machine_logoff.lifecycle.phase == "closure"
-        kerberos_connection = next(
+        service_connection = next(
             call.args[0]
             for call in mock_emitters["zeek_conn"].emit.call_args_list
             if call.args[0].event_type == "connection"
+            and call.args[0].network.dst_port in {389, 445}
         )
-        assert machine_logon.auth.source_port == kerberos_connection.network.src_port
+        assert machine_logon.auth.source_port == service_connection.network.src_port
         assert (
             machine_logon.remote_auth.primary_transport.transaction_id
-            == kerberos_connection.network.transaction.stable_id
+            == service_connection.network.transaction.stable_id
         )
         assert all(
-            event.kerberos.source_port == machine_logon.auth.source_port
+            event.kerberos.source_port != machine_logon.auth.source_port
             for event in kerberos_events
         )
 

--- a/tests/unit/test_cryptographic_material_contract.py
+++ b/tests/unit/test_cryptographic_material_contract.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
 from evidenceforge.generation.actions.tls_certificate import TlsCertificatePlanner
+from evidenceforge.generation.activity.tls_realism import certificate_authority_profile
 from evidenceforge.generation.cryptographic_material import CryptographicMaterialRegistry
 
 _EVENT_TIME = datetime(2024, 10, 14, 12, 0, tzinfo=UTC)
@@ -75,3 +76,37 @@ def test_tls_presentation_is_stable_but_file_ids_are_connection_scoped() -> None
     planner.validate_projection(first, contexts)
     with pytest.raises(FrozenInstanceError):
         first.backend_identity = "mutated.example"  # type: ignore[misc]
+
+
+def test_leaf_issuer_bound_preserves_independent_issuance_seconds() -> None:
+    issuer_name = "CN=GlobalSign Atlas R3 DV TLS CA 2024 Q1, O=GlobalSign nv-sa, C=BE"
+    profile = certificate_authority_profile(issuer_name)
+    assert profile is not None
+    issuer_start = int(profile["not_valid_before"])
+    issuer_end = int(profile["not_valid_after"])
+    event_time = datetime(2024, 3, 18, 12, 0, tzinfo=UTC)
+    raw_validity = (issuer_start - 30 * 86400, issuer_end + 30 * 86400)
+
+    first = TlsCertificatePlanner._bound_to_issuer(
+        raw_validity,
+        issuer_name,
+        event_time,
+        identity="leaf:first.example",
+    )
+    repeated = TlsCertificatePlanner._bound_to_issuer(
+        raw_validity,
+        issuer_name,
+        event_time,
+        identity="leaf:first.example",
+    )
+    second = TlsCertificatePlanner._bound_to_issuer(
+        raw_validity,
+        issuer_name,
+        event_time,
+        identity="leaf:second.example",
+    )
+
+    assert first == repeated
+    assert issuer_start < first[0] < int(event_time.timestamp())
+    assert first[1] <= issuer_end
+    assert second[0] != first[0]

--- a/tests/unit/test_ecar_spec_compliance.py
+++ b/tests/unit/test_ecar_spec_compliance.py
@@ -45,6 +45,7 @@ from evidenceforge.events.contexts import (
     EdrContext,
     FileContext,
     HostContext,
+    ImageLoadContext,
     NetworkContext,
     ProcessContext,
     RegistryContext,
@@ -643,6 +644,54 @@ class TestFileEventActions:
         record = json.loads(emitter._render_event(row))
         assert record["properties"]["image_path"] == proc.image
         assert record["properties"]["command_line"] == proc.command_line
+
+
+class TestModuleEventActorIdentity:
+    def test_module_load_promotes_canonical_actor_principal(self, emitter, ts):
+        """MODULE/LOAD should expose the canonical actor principal at top level."""
+        host = HostContext(
+            hostname="WS-01",
+            ip="10.0.0.10",
+            os="Windows 11",
+            os_category="windows",
+            system_type="workstation",
+            fqdn="ws-01.example.com",
+        )
+        actor = _canonical_process_identity(
+            host.hostname,
+            4321,
+            ts,
+            image=r"C:\Windows\System32\svchost.exe",
+            principal=r"NT AUTHORITY\NETWORK SERVICE",
+            os_category="windows",
+        )
+        process = ProcessContext(
+            pid=actor.pid,
+            parent_pid=actor.parent_pid,
+            image=actor.image,
+            command_line=actor.command_line,
+            username=actor.principal,
+            start_time=actor.started_at,
+        )
+        emitter.emit_event = Mock()
+
+        emitter._render_module_event(
+            SecurityEvent(
+                timestamp=ts,
+                event_type="image_load",
+                src_host=host,
+                process=process,
+                image_load=ImageLoadContext(image_loaded=r"C:\Windows\System32\kernel32.dll"),
+                identity_plan=EventIdentityPlan(actor=actor),
+            )
+        )
+
+        row = emitter.emit_event.call_args.args[0]
+        record = json.loads(emitter._render_event(row))
+        assert record["principal"] == actor.principal
+        assert record["actorID"] == actor.object_id
+        assert record["pid"] == actor.pid
+        assert record["properties"]["source_principal"] == actor.principal
 
     def test_registry_event_carries_known_process_provenance(self, emitter, ts):
         """eCAR REGISTRY rows should preserve known source process provenance."""

--- a/tests/unit/test_eval_engine.py
+++ b/tests/unit/test_eval_engine.py
@@ -76,6 +76,10 @@ class TestEvaluationEngine:
         hard_criteria = [c for c in report.acceptance_criteria if c.level == "hard"]
         assert len(hard_criteria) > 0
         for c in hard_criteria:
+            if c.sub_score_key == "ids_integrity":
+                assert c.actual is None
+                assert c.passed is None
+                continue
             assert c.actual is not None
             assert c.passed is not None
 
@@ -102,3 +106,13 @@ class TestEvaluationEngine:
 
         assert report.total_records == 0
         assert report.overall_score is not None  # 100 (no failures)
+
+    def test_report_is_repeatable_except_evaluated_at(self, retail_scenario):
+        """Stable discovery and sampling produce identical evaluation content."""
+
+        first = EvaluationEngine(output_dir=GOOD_FIXTURES, scenario=retail_scenario).run()
+        second = EvaluationEngine(output_dir=GOOD_FIXTURES, scenario=retail_scenario).run()
+
+        assert first.model_dump(exclude={"evaluated_at"}) == second.model_dump(
+            exclude={"evaluated_at"}
+        )

--- a/tests/unit/test_eval_ids_integrity.py
+++ b/tests/unit/test_eval_ids_integrity.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Exact IDS evaluation contract tests."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from evidenceforge.evaluation.context import EvaluationContext
+from evidenceforge.evaluation.parsers import ParsedRecord
+from evidenceforge.evaluation.pillars.plausibility import PlausibilityScorer
+from evidenceforge.events.ground_truth import (
+    GroundTruthDocument,
+    IdsEvaluationSignature,
+    IdsEvaluationSummary,
+)
+from evidenceforge.events.ids_evaluation import new_ids_digest, update_ids_digest
+from evidenceforge.models.scenario import Scenario
+from evidenceforge.utils.files import load_yaml
+
+SCENARIO_PATH = Path(__file__).parent.parent / "fixtures/scenarios/retail-store-ftp-attack.yaml"
+ALERT_TIME = datetime(2025, 2, 3, 12, 34, 56, 123456, tzinfo=UTC)
+
+
+@pytest.fixture
+def scenario() -> Scenario:
+    return Scenario(**load_yaml(SCENARIO_PATH))
+
+
+def _record(*, dst_port: int = 443, sensor: str = "ids-edge") -> ParsedRecord:
+    fields = {
+        "gid": 1,
+        "sid": 2028401,
+        "rev": 3,
+        "message": "Test correlated alert",
+        "classification": "Potentially Bad Traffic",
+        "priority": 2,
+        "protocol": "TCP",
+        "src_ip": "2001:db8::10",
+        "src_port": 49152,
+        "dst_ip": "198.51.100.20",
+        "dst_port": dst_port,
+    }
+    return ParsedRecord(
+        source_format="snort_alert",
+        source_instance=sensor,
+        raw="alert",
+        fields=fields,
+        timestamp=ALERT_TIME,
+        line_number=1,
+    )
+
+
+def _document(record: ParsedRecord | None) -> GroundTruthDocument:
+    sensors: dict[str, dict[str, IdsEvaluationSignature]] = {}
+    observation: dict[str, int] = {}
+    source_status: dict[str, dict[str, dict[str, int]]] = {}
+    if record is not None:
+        digest = new_ids_digest()
+        update_ids_digest(
+            digest,
+            record.source_instance or "__direct__",
+            record.fields | {"timestamp": record.timestamp},
+        )
+        sensors[record.source_instance or "__direct__"] = {
+            "1:2028401": IdsEvaluationSignature(
+                gid=1,
+                sid=2028401,
+                candidate=1,
+                emitted=1,
+                policy_filtered=0,
+                emitted_visible=1,
+                emitted_delayed=0,
+                origins={"authored_attachment": 1},
+                emitted_sha256=digest.hexdigest(),
+            )
+        }
+        observation = {"visible": 1}
+        source_status = {"ids-edge": {"ids": {"visible": 1}}}
+    return GroundTruthDocument(
+        scenario_name="ids-eval-test",
+        scenario_description="IDS contract test",
+        generated_at=ALERT_TIME,
+        observation_profile="complete",
+        collection_window={"start": None, "end": None},
+        source_evidence_status=source_status,
+        ids_evaluation=IdsEvaluationSummary(observation=observation, sensors=sensors),
+    )
+
+
+def _score(
+    scenario: Scenario,
+    document: GroundTruthDocument | None,
+    records: list[ParsedRecord],
+):
+    return PlausibilityScorer()._score_ids_integrity(
+        {"snort_alert": records},
+        scenario,
+        EvaluationContext(ground_truth=document),
+    )
+
+
+def test_exact_sensor_tuple_timestamp_and_digest_pass(scenario: Scenario) -> None:
+    record = _record()
+
+    score = _score(scenario, _document(record), [record])
+
+    assert score.score == 100.0
+    assert not score.sample_failures
+
+
+@pytest.mark.parametrize(
+    ("changed_record", "failure"),
+    [
+        (_record(dst_port=8443), "digest differs"),
+        (_record(sensor="ids-inside"), "Unexpected Snort rows"),
+    ],
+)
+def test_mutated_or_misplaced_alert_fails(
+    scenario: Scenario,
+    changed_record: ParsedRecord,
+    failure: str,
+) -> None:
+    expected = _record()
+
+    score = _score(scenario, _document(expected), [changed_record])
+
+    assert score.score is not None and score.score < 100.0
+    assert any(failure in message for message in score.sample_failures)
+
+
+def test_extra_alert_fails_count_and_digest(scenario: Scenario) -> None:
+    record = _record()
+
+    score = _score(
+        scenario, _document(record), [record, record.model_copy(update={"line_number": 2})]
+    )
+
+    assert score.score is not None and score.score < 100.0
+    assert any("emitted 2 != expected 1" in message for message in score.sample_failures)
+
+
+def test_zero_candidate_summary_passes_without_snort_rows(scenario: Scenario) -> None:
+    assert _score(scenario, _document(None), []).score == 100.0
+
+
+def test_legacy_summary_is_skipped_without_authored_ids(scenario: Scenario) -> None:
+    score = _score(scenario, None, [])
+
+    assert score.skipped
+    assert score.score is None
+    assert "Legacy dataset" in score.details
+
+
+def test_missing_summary_fails_when_scenario_authors_ids(scenario: Scenario) -> None:
+    first_cluster = scenario.storyline[0]
+    first_event = first_cluster.events[0].model_copy(update={"ids_alerts": [{"sid": 2028401}]})
+    authored = scenario.model_copy(
+        update={
+            "storyline": [
+                first_cluster.model_copy(update={"events": [first_event]}),
+                *scenario.storyline[1:],
+            ]
+        }
+    )
+
+    score = _score(authored, None, [])
+
+    assert score.score == 0.0
+    assert not score.skipped
+
+
+def test_signature_summary_rejects_unauthorized_origin_totals() -> None:
+    with pytest.raises(ValidationError, match="origin totals"):
+        IdsEvaluationSignature(
+            gid=1,
+            sid=2028401,
+            candidate=1,
+            emitted=1,
+            policy_filtered=0,
+            emitted_visible=1,
+            emitted_delayed=0,
+            origins={},
+            emitted_sha256="0" * 64,
+        )

--- a/tests/unit/test_eval_noise_realism.py
+++ b/tests/unit/test_eval_noise_realism.py
@@ -380,4 +380,6 @@ class TestEndToEnd:
         assert result.name == "Plausibility"
         assert result.weight == 0.25
         assert result.score is not None
-        assert len(result.sub_scores) == 6
+        assert len(result.sub_scores) == 7
+        ids = next(score for score in result.sub_scores if score.key == "ids_integrity")
+        assert ids.skipped

--- a/tests/unit/test_eval_parsers.py
+++ b/tests/unit/test_eval_parsers.py
@@ -453,6 +453,37 @@ class TestSnortAlertParser:
         assert first.fields["dst_ip"] == "10.0.10.50"
         assert first.fields["dst_port"] == 54321
 
+    def test_uses_scenario_year_and_utc(self, tmp_path):
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        from evidenceforge.evaluation.parsers.snort import SnortAlertParser
+
+        path = tmp_path / "snort_alert.log"
+        path.write_text(
+            "02/03-12:34:56.123456 [**] [1:99:1] test [**] "
+            "[Classification: Misc activity] [Priority: 3] {UDP} "
+            "192.0.2.1:53 -> 198.51.100.2:5353\n",
+            encoding="utf-8",
+        )
+        parser = SnortAlertParser()
+        parser.scenario = SimpleNamespace(
+            time_window=SimpleNamespace(start=datetime(2031, 2, 1, tzinfo=UTC))
+        )
+
+        record = next(parser.parse_file(path))
+
+        assert record.timestamp == datetime(2031, 2, 3, 12, 34, 56, 123456, tzinfo=UTC)
+
+    def test_parses_bracketed_and_portless_ipv6(self):
+        from evidenceforge.evaluation.parsers.snort import SnortAlertParser
+
+        parser = SnortAlertParser()
+
+        assert parser._parse_endpoint("[2001:db8::1]:49152") == ("2001:db8::1", 49152)
+        assert parser._parse_endpoint("[2001:db8::2]") == ("2001:db8::2", None)
+        assert parser._parse_endpoint("2001:db8::3") == ("2001:db8::3", None)
+
 
 class TestWebAccessParser:
     def test_parses_all_lines(self):

--- a/tests/unit/test_eval_signal_integrity.py
+++ b/tests/unit/test_eval_signal_integrity.py
@@ -98,6 +98,49 @@ def _scenario_with_storyline(storyline_yaml: list[dict]) -> Scenario:
     )
 
 
+class TestProcessParentIntegrity:
+    @staticmethod
+    def _ecar(action: str, pid: int, at: int, ppid: int | None = None) -> ParsedRecord:
+        fields = {"object": "PROCESS", "action": action, "hostname": "WS-01", "pid": pid}
+        if ppid is not None:
+            fields["ppid"] = ppid
+        return _record("ecar", fields, T0 + timedelta(seconds=at))
+
+    def test_detects_parent_terminated_before_child(self) -> None:
+        records = {
+            "ecar": [
+                self._ecar("CREATE", 100, 0, 4),
+                self._ecar("TERMINATE", 100, 10),
+                self._ecar("CREATE", 200, 20, 100),
+            ]
+        }
+
+        total, correct, failures = CausalityScorer._score_process_parent_integrity(records)
+
+        assert (total, correct) == (1, 0)
+        assert "stale parent PID 100" in failures[0]
+
+    def test_allows_parent_pid_reuse_before_child(self) -> None:
+        records = {
+            "ecar": [
+                self._ecar("CREATE", 100, 0, 4),
+                self._ecar("TERMINATE", 100, 10),
+                self._ecar("CREATE", 100, 15, 4),
+                self._ecar("CREATE", 200, 20, 100),
+            ]
+        }
+
+        total, correct, failures = CausalityScorer._score_process_parent_integrity(records)
+
+        assert (total, correct) == (1, 1)
+        assert not failures
+
+    def test_pre_window_or_observation_gap_is_not_scored(self) -> None:
+        records = {"ecar": [self._ecar("CREATE", 200, 20, 100)]}
+
+        assert CausalityScorer._score_process_parent_integrity(records) == (0, 0, [])
+
+
 class TestStorylineResolution:
     def test_iso_timestamp(self):
         scenario = _scenario_with_storyline(

--- a/tests/unit/test_explicit_proxy.py
+++ b/tests/unit/test_explicit_proxy.py
@@ -85,6 +85,38 @@ def test_activity_generator_stabilizes_generic_server_proxy_user_agent():
     assert all("Mozilla/" not in user_agent for user_agent in user_agents)
 
 
+def test_unmodeled_sources_get_stable_population_diverse_user_agents():
+    generator = ActivityGenerator(StateManager(), {})
+    sources = [f"198.51.100.{index}" for index in range(1, 65)]
+
+    first = [
+        generator._proxy_user_agent_for_context(
+            random.Random(42),
+            None,
+            hostname="portal.example.org",
+            domain_tags=["web"],
+            apply_domain_override=False,
+            source_identity=source,
+        )
+        for source in sources
+    ]
+    second = [
+        generator._proxy_user_agent_for_context(
+            random.Random(999),
+            None,
+            hostname="portal.example.org",
+            domain_tags=["web"],
+            apply_domain_override=False,
+            source_identity=source,
+        )
+        for source in sources
+    ]
+
+    assert first == second
+    assert len(set(first)) >= 5
+    assert max(first.count(user_agent) for user_agent in set(first)) < 32
+
+
 def test_activity_generator_uses_browser_agent_for_workstation_browser_domains():
     generator = ActivityGenerator(StateManager(), {})
     workstation = System(

--- a/tests/unit/test_explicit_proxy.py
+++ b/tests/unit/test_explicit_proxy.py
@@ -684,7 +684,7 @@ def _emitters() -> dict[str, Mock]:
     emitters["zeek_http"].can_handle.side_effect = lambda event: event.http is not None
     emitters["zeek_ssl"].can_handle.side_effect = lambda event: event.ssl is not None
     emitters["proxy_access"].can_handle.side_effect = lambda event: event.proxy is not None
-    emitters["snort_alert"].can_handle.side_effect = lambda event: event.ids is not None
+    emitters["snort_alert"].can_handle.side_effect = lambda event: bool(event.all_ids_alerts())
     emitters["cisco_asa"].can_handle.side_effect = lambda event: (
         event.network is not None and not event.network.application_layer_only
     )
@@ -3427,6 +3427,82 @@ class TestExplicitProxyVisibility:
             not call.args[0].network.application_layer_only
             for call in emitters["proxy_access"].emit.call_args_list
         )
+
+    def test_ids_attachments_follow_both_existing_proxy_transport_legs(self):
+        generator, emitters = _generator(
+            [
+                NetworkSensor(
+                    type="ids",
+                    name="both-sides-ids",
+                    monitoring_segments=["workstations", "dmz"],
+                    direction="bidirectional",
+                    log_formats=["snort_alert"],
+                )
+            ]
+        )
+        ids = IdsContext(
+            sid=2028401,
+            message="ET JA3 test",
+            classification="potentially-bad-traffic",
+        )
+
+        generator.generate_connection(
+            src_ip="10.0.1.10",
+            dst_ip="93.184.216.34",
+            time=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+            dst_port=443,
+            proto="tcp",
+            service="ssl",
+            duration=1.0,
+            orig_bytes=500,
+            resp_bytes=5000,
+            source_system=generator._ip_to_system["10.0.1.10"],
+            hostname="example.com",
+            conn_state="SF",
+            ids_alerts=[ids],
+            http=HttpContext(
+                method="GET",
+                host="example.com",
+                uri="/first",
+                version="1.1",
+                status_code=200,
+                status_msg="OK",
+            ),
+        )
+
+        alerts = [call.args[0] for call in emitters["snort_alert"].emit.call_args_list]
+        assert len(alerts) == 2
+        tuples = {
+            (event.network.src_ip, event.network.dst_ip, event.network.dst_port) for event in alerts
+        }
+        assert ("10.0.1.10", "10.0.3.10", 8080) in tuples
+        assert any(src == "10.0.3.10" and port == 443 for src, _dst, port in tuples)
+        assert all(event.ids_alerts == [ids] for event in alerts)
+
+        generator.generate_connection(
+            src_ip="10.0.1.10",
+            dst_ip="93.184.216.34",
+            time=datetime(2024, 1, 15, 10, 0, 3, tzinfo=UTC),
+            dst_port=443,
+            proto="tcp",
+            service="ssl",
+            duration=1.0,
+            orig_bytes=500,
+            resp_bytes=5000,
+            source_system=generator._ip_to_system["10.0.1.10"],
+            hostname="example.com",
+            conn_state="SF",
+            ids_alerts=[ids],
+            http=HttpContext(
+                method="GET",
+                host="example.com",
+                uri="/second",
+                version="1.1",
+                status_code=200,
+                status_msg="OK",
+            ),
+        )
+        assert emitters["snort_alert"].emit.call_count == 2
 
     def test_denied_request_stops_before_origin_side_sources(self):
         generator, emitters = _generator(

--- a/tests/unit/test_ids_alert_attachments.py
+++ b/tests/unit/test_ids_alert_attachments.py
@@ -595,6 +595,61 @@ def test_authored_plural_ids_context_overrides_automatic_same_sid() -> None:
     assert event.all_ids_alerts() == (authored,)
 
 
+def test_authored_same_sid_precedence_records_authored_origin(tmp_path) -> None:
+    automatic = IdsContext(sid=1001, message="automatic", classification="misc-activity")
+    authored = IdsContext(sid=1001, message="authored", classification="misc-activity")
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"), output_path=tmp_path / "snort.log"
+    )
+    emitter.emit(
+        SecurityEvent(
+            timestamp=T0,
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.0.8",
+                src_port=50000,
+                dst_ip="198.51.100.10",
+                dst_port=443,
+                protocol="tcp",
+            ),
+            ids=automatic,
+            ids_alerts=[authored],
+        )
+    )
+    emitter.close()
+
+    summary = emitter.ids_evaluation_summary["__direct__"]["1:1001"]
+    assert summary["origins"] == {"authored_attachment": 1}
+    assert "authored" in (tmp_path / "snort.log").read_text()
+
+
+def test_raw_snort_entry_is_included_without_output_change(tmp_path) -> None:
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"), output_path=tmp_path / "snort.log"
+    )
+    raw = {
+        "timestamp": T0,
+        "gid": 1,
+        "sid": 77,
+        "rev": 2,
+        "message": "raw alert",
+        "classification": "misc-activity",
+        "priority": 3,
+        "protocol": "udp",
+        "src_ip": "2001:db8::1",
+        "src_port": 53,
+        "dst_ip": "2001:db8::2",
+        "dst_port": 53000,
+    }
+    emitter.emit_raw(raw)
+    emitter.close()
+
+    assert "[1:77:2] raw alert" in (tmp_path / "snort.log").read_text()
+    summary = emitter.ids_evaluation_summary["__direct__"]["1:77"]
+    assert summary["candidate"] == summary["emitted"] == 1
+    assert summary["origins"] == {"raw": 1}
+
+
 def test_snort_sensor_filter_counters_are_independent(tmp_path) -> None:
     policy = IdsAlertPolicyContext(
         event_filter=IdsEventFilterContext(type="limit", track="by_src", count=1, seconds=60)
@@ -634,6 +689,12 @@ def test_snort_sensor_filter_counters_are_independent(tmp_path) -> None:
     assert totals["candidate"] == 4
     assert totals["emitted"] == 2
     assert totals["policy_filtered"] == 2
+    evaluation = emitter.ids_evaluation_summary
+    for sensor in ("inside", "outside"):
+        summary = evaluation[sensor]["1:2028401"]
+        assert summary["candidate"] == 2
+        assert summary["emitted"] == 1
+        assert summary["policy_filtered"] == 1
 
 
 def test_snort_spool_is_removed_when_final_rendering_fails(tmp_path, monkeypatch) -> None:
@@ -769,3 +830,5 @@ def test_ids_documentation_and_skill_reference_stay_in_parity() -> None:
         assert "dhcp_lease" in content
         assert "dns_tunnel" in content
         assert "email" in content
+        if "evidence" in path.name.lower():
+            assert "ids_evaluation" in content

--- a/tests/unit/test_ids_alert_attachments.py
+++ b/tests/unit/test_ids_alert_attachments.py
@@ -35,14 +35,25 @@ from evidenceforge.models import (
     TimeWindow,
     User,
 )
-from evidenceforge.models.scenario import BeaconEventSpec, ConnectionEventSpec
+from evidenceforge.models.scenario import (
+    BeaconEventSpec,
+    ConnectionEventSpec,
+    DgaQueriesEventSpec,
+    DhcpLeaseEventSpec,
+    DnsQueryEventSpec,
+    DnsTunnelEventSpec,
+    PortScanEventSpec,
+    RdpSessionEventSpec,
+    SshSessionEventSpec,
+    WebScanEventSpec,
+)
 from evidenceforge.validation import ScenarioValidator
 
 T0 = datetime(2026, 8, 3, tzinfo=UTC)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _scenario(*events: ConnectionEventSpec | BeaconEventSpec) -> Scenario:
+def _scenario(*events: object) -> Scenario:
     return Scenario(
         version="1.0",
         name="ids-test",
@@ -120,6 +131,71 @@ def test_connection_and_beacon_accept_multiple_ids_alerts() -> None:
     )
     assert [item.sid for item in connection.ids_alerts] == [2028401, 2002910]
     assert [item.sid for item in beacon.ids_alerts] == [2028401, 2002910]
+
+
+def _transport_owner_specs(ids_alerts: list[dict[str, object]]) -> list[object]:
+    """Return one valid instance of every IDS-attachable typed transport owner."""
+
+    return [
+        ConnectionEventSpec(dst_ip="198.51.100.10", ids_alerts=ids_alerts),
+        BeaconEventSpec(
+            dst_ip="198.51.100.10",
+            interval="1m",
+            count=2,
+            ids_alerts=ids_alerts,
+        ),
+        SshSessionEventSpec(ids_alerts=ids_alerts),
+        RdpSessionEventSpec(ids_alerts=ids_alerts),
+        DhcpLeaseEventSpec(ids_alerts=ids_alerts),
+        PortScanEventSpec(target_ips=["198.51.100.10"], ids_alerts=ids_alerts),
+        DnsQueryEventSpec(query="missing.example.test", rcode="NXDOMAIN", ids_alerts=ids_alerts),
+        WebScanEventSpec(
+            dst_ip="198.51.100.10",
+            rate=1,
+            count=2,
+            preset="nikto",
+            ids_alerts=ids_alerts,
+        ),
+        DgaQueriesEventSpec(interval="1s", count=2, ids_alerts=ids_alerts),
+        DnsTunnelEventSpec(
+            base_domain="tunnel.example.test",
+            interval="1s",
+            count=2,
+            ids_alerts=ids_alerts,
+        ),
+    ]
+
+
+def test_every_transport_owner_accepts_shared_multi_sid_policy_schema() -> None:
+    attachments = [
+        {"sid": 2028401},
+        {
+            "sid": 2002910,
+            "policy": {
+                "detection_filter": {"track": "by_src", "count": 2, "seconds": 30},
+                "event_filter": {
+                    "type": "both",
+                    "track": "by_dst",
+                    "count": 3,
+                    "seconds": 60,
+                },
+            },
+        },
+    ]
+    for spec in _transport_owner_specs(attachments):
+        assert [item.sid for item in spec.ids_alerts] == [2028401, 2002910]
+
+
+def test_every_transport_owner_rejects_duplicate_sid() -> None:
+    with pytest.raises(ValidationError, match="duplicate SID"):
+        _transport_owner_specs([{"sid": 384}, {"sid": 384}])
+
+
+def test_non_transport_event_rejects_ids_alerts() -> None:
+    from evidenceforge.models.scenario import ProcessEventSpec
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ProcessEventSpec(process_name="whoami.exe", ids_alerts=[{"sid": 384}])
 
 
 @pytest.mark.parametrize("model", [ConnectionEventSpec, BeaconEventSpec])
@@ -299,6 +375,41 @@ def test_validator_warns_on_signature_port_and_direction_mismatch() -> None:
     assert any("direction" in message for message in warnings)
 
 
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SshSessionEventSpec(source_ip="198.51.100.10", ids_alerts=[{"sid": 2028401}]),
+        RdpSessionEventSpec(source_ip="198.51.100.10", ids_alerts=[{"sid": 2028401}]),
+        DhcpLeaseEventSpec(ids_alerts=[{"sid": 2028401}]),
+        DnsQueryEventSpec(
+            query="missing.example.test",
+            rcode="NXDOMAIN",
+            ids_alerts=[{"sid": 2028401}],
+        ),
+        PortScanEventSpec(
+            target_ips=["198.51.100.10"],
+            ports=[22, 80],
+            ids_alerts=[{"sid": 2028401}],
+        ),
+        WebScanEventSpec(
+            dst_ip="198.51.100.10",
+            dst_port=80,
+            rate=1,
+            count=1,
+            preset="nikto",
+            ids_alerts=[{"sid": 2028401}],
+        ),
+    ],
+)
+def test_validator_uses_transport_owner_protocol_and_ports_for_warnings(spec: object) -> None:
+    warnings = [
+        issue.message
+        for issue in ScenarioValidator(_scenario(spec)).validate()
+        if issue.severity == "warning" and "IDS SID" in issue.message
+    ]
+    assert any("protocol" in message or "destination port" in message for message in warnings)
+
+
 def test_detection_filter_suppresses_warmup_then_stays_above_rolling_threshold() -> None:
     policy = IdsAlertPolicyContext(
         detection_filter=IdsDetectionFilterContext(track="by_src", count=2, seconds=60)
@@ -434,6 +545,54 @@ def test_snort_multiple_sids_are_independent(tmp_path) -> None:
     output = (tmp_path / "snort.log").read_text()
     assert "[1:1001:1]" in output
     assert "[1:1002:1]" in output
+
+
+def test_snort_requires_both_network_and_ids_context() -> None:
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"),
+        output_path=Path("unused.log"),
+    )
+    tuple_only = SecurityEvent(
+        timestamp=T0,
+        event_type="dhcp_lease",
+        network=NetworkContext(
+            src_ip="10.0.0.8",
+            src_port=68,
+            dst_ip="10.0.0.1",
+            dst_port=67,
+            protocol="udp",
+        ),
+    )
+    ids_only = SecurityEvent(
+        timestamp=T0,
+        event_type="custom",
+        ids_alerts=[IdsContext(sid=1001, message="test", classification="misc-activity")],
+    )
+    dhcp_alert = SecurityEvent(
+        timestamp=T0,
+        event_type="dhcp_lease",
+        network=tuple_only.network,
+        ids_alerts=[IdsContext(sid=1001, message="test", classification="misc-activity")],
+    )
+    assert not emitter.can_handle(tuple_only)
+    assert not emitter.can_handle(ids_only)
+    assert emitter.can_handle(dhcp_alert)
+
+
+def test_authored_plural_ids_context_overrides_automatic_same_sid() -> None:
+    automatic = IdsContext(sid=1001, message="automatic", classification="misc-activity")
+    authored = IdsContext(
+        sid=1001,
+        message="authored",
+        classification="misc-activity",
+        policy=IdsAlertPolicyContext(
+            event_filter=IdsEventFilterContext(type="limit", track="by_src", count=1, seconds=60)
+        ),
+    )
+    event = SecurityEvent(
+        timestamp=T0, event_type="connection", ids=automatic, ids_alerts=[authored]
+    )
+    assert event.all_ids_alerts() == (authored,)
 
 
 def test_snort_sensor_filter_counters_are_independent(tmp_path) -> None:
@@ -607,3 +766,6 @@ def test_ids_documentation_and_skill_reference_stay_in_parity() -> None:
         assert "ids_alerts" in content
         assert "policy" in content
         assert "does not" in content
+        assert "dhcp_lease" in content
+        assert "dns_tunnel" in content
+        assert "email" in content

--- a/tests/unit/test_ids_alert_attachments.py
+++ b/tests/unit/test_ids_alert_attachments.py
@@ -22,6 +22,7 @@ from evidenceforge.generation.actions.ids_alert import IdsAlertActionBundle, Ids
 from evidenceforge.generation.activity.ids_signatures import (
     reset_ids_signatures_cache,
     signature_by_sid,
+    signature_matches_inspection_visibility,
 )
 from evidenceforge.generation.emitters.snort import SnortEmitter
 from evidenceforge.generation.ids_filtering import IdsAlertCandidate, IdsAlertFilterEngine
@@ -51,6 +52,16 @@ from evidenceforge.validation import ScenarioValidator
 
 T0 = datetime(2026, 8, 3, tzinfo=UTC)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_payload_signature_requires_cleartext_or_explicit_decryption() -> None:
+    """Opaque TLS cannot produce content-signature evidence."""
+
+    signature = {"inspection": "payload_cleartext"}
+
+    assert signature_matches_inspection_visibility(signature, "http")
+    assert not signature_matches_inspection_visibility(signature, "ssl")
+    assert signature_matches_inspection_visibility(signature, "ssl", payload_decrypted=True)
 
 
 def _scenario(*events: object) -> Scenario:

--- a/tests/unit/test_ids_alert_attachments.py
+++ b/tests/unit/test_ids_alert_attachments.py
@@ -1,0 +1,609 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Edge-case coverage for canonical IDS attachments and filter state."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from evidenceforge.events.base import SecurityEvent
+from evidenceforge.events.contexts import (
+    IdsAlertPolicyContext,
+    IdsContext,
+    IdsDetectionFilterContext,
+    IdsEventFilterContext,
+    NetworkContext,
+)
+from evidenceforge.formats.loader import load_format
+from evidenceforge.generation.actions.ids_alert import IdsAlertActionBundle, IdsAlertRequest
+from evidenceforge.generation.activity.ids_signatures import (
+    reset_ids_signatures_cache,
+    signature_by_sid,
+)
+from evidenceforge.generation.emitters.snort import SnortEmitter
+from evidenceforge.generation.ids_filtering import IdsAlertCandidate, IdsAlertFilterEngine
+from evidenceforge.models import (
+    BaselineActivity,
+    Environment,
+    OutputSpec,
+    Scenario,
+    StorylineEvent,
+    System,
+    TimeWindow,
+    User,
+)
+from evidenceforge.models.scenario import BeaconEventSpec, ConnectionEventSpec
+from evidenceforge.validation import ScenarioValidator
+
+T0 = datetime(2026, 8, 3, tzinfo=UTC)
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _scenario(*events: ConnectionEventSpec | BeaconEventSpec) -> Scenario:
+    return Scenario(
+        version="1.0",
+        name="ids-test",
+        description="IDS attachment validation",
+        environment=Environment(
+            description="test",
+            users=[User(username="alice", full_name="Alice", email="alice@example.test")],
+            systems=[
+                System(
+                    hostname="ws-01",
+                    ip="10.0.0.8",
+                    os="Windows 11",
+                    type="workstation",
+                )
+            ],
+        ),
+        time_window=TimeWindow(start=T0, duration="1h"),
+        baseline_activity=BaselineActivity(description="test", intensity="low", variation="low"),
+        output=OutputSpec(destination="./output", logs=[{"format": "snort_alert"}]),
+        storyline=[
+            StorylineEvent(
+                id="ids-1",
+                time=T0.isoformat(),
+                actor="alice",
+                system="ws-01",
+                activity="test",
+                events=list(events),
+            )
+        ],
+    )
+
+
+def _candidate(
+    seconds: float,
+    policy: IdsAlertPolicyContext | None,
+    *,
+    sid: int = 2028401,
+    sensor: str = "ids-01",
+    src_ip: str = "10.0.0.8",
+    dst_ip: str = "2001:db8::20",
+) -> IdsAlertCandidate:
+    return IdsAlertCandidate(
+        sensor=sensor,
+        timestamp=T0 + timedelta(seconds=seconds),
+        gid=1,
+        sid=sid,
+        src_ip=src_ip,
+        dst_ip=dst_ip,
+        policy=policy,
+    )
+
+
+def test_connection_and_beacon_accept_multiple_ids_alerts() -> None:
+    attachments = [
+        {"sid": 2028401},
+        {
+            "sid": 2002910,
+            "policy": {
+                "detection_filter": {"track": "by_src", "count": 5, "seconds": 60},
+                "event_filter": {
+                    "type": "limit",
+                    "track": "by_src",
+                    "count": 1,
+                    "seconds": 300,
+                },
+            },
+        },
+    ]
+    connection = ConnectionEventSpec(dst_ip="198.51.100.10", ids_alerts=attachments)
+    beacon = BeaconEventSpec(
+        dst_ip="198.51.100.10",
+        interval="2m",
+        duration="45m",
+        ids_alerts=attachments,
+    )
+    assert [item.sid for item in connection.ids_alerts] == [2028401, 2002910]
+    assert [item.sid for item in beacon.ids_alerts] == [2028401, 2002910]
+
+
+@pytest.mark.parametrize("model", [ConnectionEventSpec, BeaconEventSpec])
+def test_ids_alerts_reject_duplicate_sid(model: type) -> None:
+    kwargs = {"dst_ip": "198.51.100.10", "ids_alerts": [{"sid": 384}, {"sid": 384}]}
+    if model is BeaconEventSpec:
+        kwargs.update(interval="1m", duration="2m")
+    with pytest.raises(ValidationError, match="duplicate SID"):
+        model(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [0, -1, 1.5, True, 2_147_483_648],
+)
+def test_filter_counts_and_windows_are_bounded_strict_positive_integers(
+    bad_value: object,
+) -> None:
+    with pytest.raises(ValidationError):
+        ConnectionEventSpec(
+            dst_ip="198.51.100.10",
+            ids_alerts=[
+                {
+                    "sid": 384,
+                    "policy": {
+                        "event_filter": {
+                            "type": "limit",
+                            "track": "by_src",
+                            "count": bad_value,
+                            "seconds": 60,
+                        }
+                    },
+                }
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {},
+        {"event_filter": {"type": "bogus", "track": "by_src", "count": 1, "seconds": 1}},
+        {"event_filter": {"type": "limit", "track": "host", "count": 1, "seconds": 1}},
+        {
+            "event_filter": {
+                "type": "limit",
+                "track": "by_src",
+                "count": 1,
+                "seconds": 1,
+                "unknown": True,
+            }
+        },
+    ],
+)
+def test_policy_rejects_empty_invalid_and_unknown_fields(policy: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        ConnectionEventSpec(
+            dst_ip="198.51.100.10",
+            ids_alerts=[{"sid": 384, "policy": policy}],
+        )
+
+
+def test_explicit_every_is_accepted() -> None:
+    spec = ConnectionEventSpec(
+        dst_ip="198.51.100.10",
+        ids_alerts=[{"sid": 384, "policy": "every"}],
+    )
+    assert spec.ids_alerts[0].policy == "every"
+
+
+def test_signature_policy_is_inherited_and_every_replaces_it() -> None:
+    import random
+
+    signature = signature_by_sid(2002910)
+    assert signature is not None
+    base = dict(
+        signature=signature,
+        time=T0,
+        src_ip="198.51.100.1",
+        dst_ip="10.0.0.8",
+        dst_port=5800,
+        proto="tcp",
+        rng=random.Random(1),
+    )
+    inherited = IdsAlertActionBundle(IdsAlertRequest(**base)).execute()
+    explicit_every = IdsAlertActionBundle(IdsAlertRequest(**base, policy="every")).execute()
+    assert inherited.policy is not None
+    assert inherited.policy.event_filter is not None
+    assert inherited.policy.event_filter.type == "both"
+    assert explicit_every.policy is None
+
+
+def test_signature_overlay_replaces_policy_and_cache_reset_reloads(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    overlay = tmp_path / ".eforge" / "config" / "activity" / "ids_signatures.yaml"
+    overlay.parent.mkdir(parents=True)
+    overlay.write_text(
+        """signatures:
+  - sid: 2002910
+    alert_policy:
+      event_filter: {type: limit, track: by_dst, count: 2, seconds: 30}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    reset_ids_signatures_cache()
+    try:
+        signature = signature_by_sid(2002910)
+        assert signature is not None
+        assert signature["alert_policy"]["event_filter"]["type"] == "limit"
+        overlay.write_text(
+            """signatures:
+  - sid: 2002910
+    alert_policy: every
+""",
+            encoding="utf-8",
+        )
+        assert signature_by_sid(2002910)["alert_policy"] != "every"
+        reset_ids_signatures_cache()
+        assert signature_by_sid(2002910)["alert_policy"] == "every"
+    finally:
+        reset_ids_signatures_cache()
+
+
+def test_validator_rejects_unknown_sid() -> None:
+    scenario = _scenario(
+        ConnectionEventSpec(dst_ip="198.51.100.10", ids_alerts=[{"sid": 2_000_000_000}])
+    )
+    issues = ScenarioValidator(scenario).validate()
+    assert any(
+        issue.severity == "error" and "Unknown IDS signature" in issue.message for issue in issues
+    )
+
+
+def test_validator_allows_identical_but_rejects_conflicting_effective_policy() -> None:
+    common = {"event_filter": {"type": "limit", "track": "by_src", "count": 1, "seconds": 60}}
+    identical = _scenario(
+        ConnectionEventSpec(
+            dst_ip="198.51.100.10", ids_alerts=[{"sid": 2028401, "policy": common}]
+        ),
+        ConnectionEventSpec(
+            dst_ip="198.51.100.11", ids_alerts=[{"sid": 2028401, "policy": common}]
+        ),
+    )
+    assert not any(
+        "conflicting effective" in issue.message
+        for issue in ScenarioValidator(identical).validate()
+    )
+
+    conflicting = _scenario(
+        ConnectionEventSpec(
+            dst_ip="198.51.100.10", ids_alerts=[{"sid": 2028401, "policy": common}]
+        ),
+        ConnectionEventSpec(
+            dst_ip="198.51.100.11", ids_alerts=[{"sid": 2028401, "policy": "every"}]
+        ),
+    )
+    assert any(
+        issue.severity == "error" and "conflicting effective" in issue.message
+        for issue in ScenarioValidator(conflicting).validate()
+    )
+
+
+def test_validator_warns_on_signature_port_and_direction_mismatch() -> None:
+    scenario = _scenario(
+        ConnectionEventSpec(
+            dst_ip="198.51.100.10",
+            dst_port=443,
+            ids_alerts=[{"sid": 2002910}],
+        )
+    )
+    issues = ScenarioValidator(scenario).validate()
+    warnings = [issue.message for issue in issues if issue.severity == "warning"]
+    assert any("destination port" in message for message in warnings)
+    assert any("direction" in message for message in warnings)
+
+
+def test_detection_filter_suppresses_warmup_then_stays_above_rolling_threshold() -> None:
+    policy = IdsAlertPolicyContext(
+        detection_filter=IdsDetectionFilterContext(track="by_src", count=2, seconds=60)
+    )
+    engine = IdsAlertFilterEngine()
+    assert [engine.admit(_candidate(second, policy)) for second in (0, 1, 2, 60)] == [
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected"),
+    [
+        ("limit", [True, True, False, True]),
+        ("threshold", [False, True, False, True]),
+        ("both", [False, True, False, False]),
+    ],
+)
+def test_event_filters_follow_snort_window_semantics(
+    filter_type: str,
+    expected: list[bool],
+) -> None:
+    policy = IdsAlertPolicyContext(
+        event_filter=IdsEventFilterContext(
+            type=filter_type,
+            track="by_dst",
+            count=2,
+            seconds=60,
+        )
+    )
+    engine = IdsAlertFilterEngine()
+    times = (0, 1, 2, 60) if filter_type != "both" else (0, 1, 2, 59)
+    assert [engine.admit(_candidate(second, policy)) for second in times] == expected
+
+
+def test_exact_boundary_equal_timestamps_and_independent_tracking_keys() -> None:
+    policy = IdsAlertPolicyContext(
+        event_filter=IdsEventFilterContext(type="limit", track="by_src", count=1, seconds=60)
+    )
+    engine = IdsAlertFilterEngine()
+    assert engine.admit(_candidate(0, policy))
+    assert not engine.admit(_candidate(0, policy))
+    assert engine.admit(_candidate(0, policy, src_ip="10.0.0.9"))
+    assert engine.admit(_candidate(0, policy, sensor="ids-02"))
+    assert engine.admit(_candidate(0, policy, sid=384))
+    assert engine.admit(_candidate(60, policy))
+
+
+def test_combined_filters_count_only_detection_admitted_matches() -> None:
+    policy = IdsAlertPolicyContext(
+        detection_filter=IdsDetectionFilterContext(track="by_src", count=2, seconds=60),
+        event_filter=IdsEventFilterContext(type="threshold", track="by_dst", count=2, seconds=60),
+    )
+    engine = IdsAlertFilterEngine()
+    assert [engine.admit(_candidate(second, policy)) for second in range(5)] == [
+        False,
+        False,
+        False,
+        True,
+        False,
+    ]
+
+
+def test_snort_emitter_sorts_before_filtering_and_cleans_spool(tmp_path) -> None:
+    policy = IdsAlertPolicyContext(
+        event_filter=IdsEventFilterContext(type="threshold", track="by_src", count=2, seconds=60)
+    )
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"),
+        output_path=tmp_path,
+        sensor_hostnames=["ids-01"],
+    )
+    for second in (2, 0, 1):
+        event = SecurityEvent(
+            timestamp=T0 + timedelta(seconds=second),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.0.8",
+                src_port=50000 + second,
+                dst_ip="198.51.100.10",
+                dst_port=443,
+                protocol="tcp",
+            ),
+            ids_alerts=[
+                IdsContext(
+                    sid=2028401,
+                    message="test signature",
+                    classification="misc-activity",
+                    policy=policy,
+                )
+            ],
+            storyline_cluster_id="beacon-1",
+        )
+        event._sensor_hostnames_by_format = {"snort_alert": ["ids-01"]}
+        emitter.emit(event)
+    spool_path = emitter._spool_path
+    assert spool_path is not None and spool_path.exists()
+    emitter.close()
+    assert not spool_path.exists()
+    lines = (tmp_path / "ids-01" / "snort_alert.log").read_text().splitlines()
+    assert len(lines) == 1
+    assert "10.0.0.8:50001" in lines[0]
+    assert emitter.ids_alert_summary["beacon-1"][2028401]["candidate"] == 3
+    assert emitter.ids_alert_summary["beacon-1"][2028401]["emitted"] == 1
+    assert emitter.ids_alert_summary["beacon-1"][2028401]["policy_filtered"] == 2
+
+
+def test_snort_multiple_sids_are_independent(tmp_path) -> None:
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"),
+        output_path=tmp_path / "snort.log",
+    )
+    event = SecurityEvent(
+        timestamp=T0,
+        event_type="connection",
+        network=NetworkContext(
+            src_ip="2001:db8::1",
+            src_port=55555,
+            dst_ip="2001:db8::2",
+            dst_port=443,
+            protocol="tcp",
+        ),
+        ids_alerts=[
+            IdsContext(sid=1001, message="first", classification="misc-activity"),
+            IdsContext(sid=1002, message="second", classification="misc-activity"),
+        ],
+    )
+    emitter.emit(event)
+    emitter.close()
+    output = (tmp_path / "snort.log").read_text()
+    assert "[1:1001:1]" in output
+    assert "[1:1002:1]" in output
+
+
+def test_snort_sensor_filter_counters_are_independent(tmp_path) -> None:
+    policy = IdsAlertPolicyContext(
+        event_filter=IdsEventFilterContext(type="limit", track="by_src", count=1, seconds=60)
+    )
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"),
+        output_path=tmp_path,
+        sensor_hostnames=["inside", "outside"],
+    )
+    for second in (0, 1):
+        event = SecurityEvent(
+            timestamp=T0 + timedelta(seconds=second),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.0.8",
+                src_port=50000,
+                dst_ip="198.51.100.10",
+                dst_port=443,
+                protocol="tcp",
+            ),
+            ids_alerts=[
+                IdsContext(
+                    sid=2028401,
+                    message="test",
+                    classification="misc-activity",
+                    policy=policy,
+                )
+            ],
+            storyline_cluster_id="multi-sensor",
+        )
+        event._sensor_hostnames_by_format = {"snort_alert": ["inside", "outside"]}
+        emitter.emit(event)
+    emitter.close()
+    assert len((tmp_path / "inside" / "snort_alert.log").read_text().splitlines()) == 1
+    assert len((tmp_path / "outside" / "snort_alert.log").read_text().splitlines()) == 1
+    totals = emitter.ids_alert_summary["multi-sensor"][2028401]
+    assert totals["candidate"] == 4
+    assert totals["emitted"] == 2
+    assert totals["policy_filtered"] == 2
+
+
+def test_snort_spool_is_removed_when_final_rendering_fails(tmp_path, monkeypatch) -> None:
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"),
+        output_path=tmp_path / "snort.log",
+    )
+    event = SecurityEvent(
+        timestamp=T0,
+        event_type="connection",
+        network=NetworkContext(
+            src_ip="10.0.0.8",
+            src_port=50000,
+            dst_ip="198.51.100.10",
+            dst_port=443,
+            protocol="tcp",
+        ),
+        ids_alerts=[IdsContext(sid=1001, message="test", classification="misc-activity")],
+    )
+    emitter.emit(event)
+    spool_path = emitter._spool_path
+    assert spool_path is not None and spool_path.exists()
+
+    def fail_render(_event_data):
+        raise RuntimeError("render failed")
+
+    monkeypatch.setattr(emitter, "_render_alert", fail_render)
+    with pytest.raises(RuntimeError, match="render failed"):
+        emitter.close()
+    assert not spool_path.exists()
+
+
+def test_no_ids_sensor_creates_no_candidate_totals_or_output(tmp_path) -> None:
+    emitter = SnortEmitter(format_def=load_format("snort_alert"), output_path=tmp_path)
+    event = SecurityEvent(
+        timestamp=T0,
+        event_type="connection",
+        network=NetworkContext(
+            src_ip="10.0.0.8",
+            src_port=50000,
+            dst_ip="198.51.100.10",
+            dst_port=443,
+            protocol="tcp",
+        ),
+        ids_alerts=[IdsContext(sid=1001, message="test", classification="misc-activity")],
+        storyline_cluster_id="no-sensor",
+    )
+    emitter.emit(event)
+    emitter.close()
+    assert emitter.ids_alert_summary == {}
+    assert not list(tmp_path.rglob("snort_alert.log"))
+
+
+def test_threaded_and_non_threaded_snort_are_byte_equivalent(tmp_path) -> None:
+    def generate(output_path: Path, *, threaded: bool) -> bytes:
+        emitter = SnortEmitter(
+            format_def=load_format("snort_alert"),
+            output_path=output_path,
+            threaded=threaded,
+        )
+        for second in (4, 0, 2, 1, 3):
+            event = SecurityEvent(
+                timestamp=T0 + timedelta(seconds=second),
+                event_type="connection",
+                network=NetworkContext(
+                    src_ip="10.0.0.8",
+                    src_port=50000 + second,
+                    dst_ip="198.51.100.10",
+                    dst_port=443,
+                    protocol="tcp",
+                ),
+                ids_alerts=[IdsContext(sid=1001, message="test", classification="misc-activity")],
+            )
+            emitter.emit(event)
+        emitter.barrier_flush()
+        emitter.close()
+        return output_path.read_bytes()
+
+    plain = generate(tmp_path / "plain.log", threaded=False)
+    threaded = generate(tmp_path / "threaded.log", threaded=True)
+    assert threaded == plain
+
+
+def test_multi_day_candidates_remain_out_of_memory_buffers(tmp_path) -> None:
+    policy = IdsAlertPolicyContext(
+        event_filter=IdsEventFilterContext(type="limit", track="by_src", count=1, seconds=86_400)
+    )
+    emitter = SnortEmitter(
+        format_def=load_format("snort_alert"),
+        output_path=tmp_path / "multi-day.log",
+    )
+    for minute in range(4_000):
+        event = SecurityEvent(
+            timestamp=T0 + timedelta(minutes=minute),
+            event_type="connection",
+            network=NetworkContext(
+                src_ip="10.0.0.8",
+                src_port=50000 + minute % 1000,
+                dst_ip="198.51.100.10",
+                dst_port=443,
+                protocol="tcp",
+            ),
+            ids_alerts=[
+                IdsContext(
+                    sid=1001,
+                    message="test",
+                    classification="misc-activity",
+                    policy=policy,
+                )
+            ],
+        )
+        emitter.emit(event)
+    assert emitter._writers == {}
+    assert emitter._spool_connection is not None
+    count = emitter._spool_connection.execute("SELECT COUNT(*) FROM candidates").fetchone()[0]
+    assert count == 4_000
+    emitter.close()
+    assert len((tmp_path / "multi-day.log").read_text().splitlines()) == 3
+
+
+def test_ids_documentation_and_skill_reference_stay_in_parity() -> None:
+    paths = (
+        PROJECT_ROOT / "docs" / "reference" / "scenario-reference.md",
+        PROJECT_ROOT / "commands" / "eforge" / "references" / "scenario-reference.md",
+        PROJECT_ROOT / "docs" / "reference" / "EVIDENCE_FORMATS.md",
+        PROJECT_ROOT / "commands" / "eforge" / "references" / "evidence-formats.md",
+    )
+    for path in paths:
+        content = path.read_text(encoding="utf-8")
+        assert "ids_alerts" in content
+        assert "policy" in content
+        assert "does not" in content

--- a/tests/unit/test_install_skills.py
+++ b/tests/unit/test_install_skills.py
@@ -105,7 +105,7 @@ class TestInstallSkills:
         assert "email_message" in scenario_skill
         assert "one effective policy" in (root / "validate.md").read_text()
         assert "policy-filtered" in (root / "generate.md").read_text()
-        assert "candidate/emitted/policy-filtered" in (root / "evaluate.md").read_text()
+        assert "ids_integrity" in (root / "evaluate.md").read_text()
         ids_ref = (root / "references" / "config-ids.md").read_text()
         assert "detection_filter" in ids_ref
         assert "limit | threshold | both" in ids_ref
@@ -303,6 +303,7 @@ class TestInstallChatGPTSkills:
         assert "rdp_session" in scenario_skill
         assert "email_read" in scenario_skill
         assert "policy-filtered" in (tmp_path / "eforge-generate" / "SKILL.md").read_text()
+        assert "ids_integrity" in (tmp_path / "eforge-evaluate" / "SKILL.md").read_text()
         ids_ref = tmp_path / "eforge-config" / "references" / "config-ids.md"
         assert ids_ref.is_file()
         assert "event_filter" in ids_ref.read_text()

--- a/tests/unit/test_install_skills.py
+++ b/tests/unit/test_install_skills.py
@@ -99,13 +99,18 @@ class TestInstallSkills:
         install_skills(tmp_path)
 
         root = tmp_path / "eforge"
-        assert "ids_alerts" in (root / "scenario.md").read_text()
+        scenario_skill = (root / "scenario.md").read_text()
+        assert "ids_alerts" in scenario_skill
+        assert "dhcp_lease" in scenario_skill
+        assert "email_message" in scenario_skill
         assert "one effective policy" in (root / "validate.md").read_text()
         assert "policy-filtered" in (root / "generate.md").read_text()
         assert "candidate/emitted/policy-filtered" in (root / "evaluate.md").read_text()
         ids_ref = (root / "references" / "config-ids.md").read_text()
         assert "detection_filter" in ids_ref
         assert "limit | threshold | both" in ids_ref
+        assert "dns_tunnel" in ids_ref
+        assert "does not decrypt" in ids_ref
 
     def test_no_persona_files_installed(self, tmp_path):
         """Persona YAMLs are NOT installed (skills use eforge info instead)."""
@@ -293,11 +298,15 @@ class TestInstallChatGPTSkills:
         """Generated SKILL.md trees retain correlated IDS guidance and detailed references."""
         install_chatgpt_skills(tmp_path)
 
-        assert "ids_alerts" in (tmp_path / "eforge-scenario" / "SKILL.md").read_text()
+        scenario_skill = (tmp_path / "eforge-scenario" / "SKILL.md").read_text()
+        assert "ids_alerts" in scenario_skill
+        assert "rdp_session" in scenario_skill
+        assert "email_read" in scenario_skill
         assert "policy-filtered" in (tmp_path / "eforge-generate" / "SKILL.md").read_text()
         ids_ref = tmp_path / "eforge-config" / "references" / "config-ids.md"
         assert ids_ref.is_file()
         assert "event_filter" in ids_ref.read_text()
+        assert "mail-event" in ids_ref.read_text()
 
     def test_chatgpt_references_are_limited_per_skill(self, tmp_path):
         """ChatGPT skills only receive the references they need."""

--- a/tests/unit/test_install_skills.py
+++ b/tests/unit/test_install_skills.py
@@ -94,6 +94,19 @@ class TestInstallSkills:
         assert "external_actor_profiles.yaml" in config_ref
         assert "command_parameter_pools.yaml" in validation_ref
 
+    def test_installed_skills_include_correlated_ids_guidance(self, tmp_path):
+        """Claude command install includes IDS authoring, validation, and config references."""
+        install_skills(tmp_path)
+
+        root = tmp_path / "eforge"
+        assert "ids_alerts" in (root / "scenario.md").read_text()
+        assert "one effective policy" in (root / "validate.md").read_text()
+        assert "policy-filtered" in (root / "generate.md").read_text()
+        assert "candidate/emitted/policy-filtered" in (root / "evaluate.md").read_text()
+        ids_ref = (root / "references" / "config-ids.md").read_text()
+        assert "detection_filter" in ids_ref
+        assert "limit | threshold | both" in ids_ref
+
     def test_no_persona_files_installed(self, tmp_path):
         """Persona YAMLs are NOT installed (skills use eforge info instead)."""
         install_skills(tmp_path)
@@ -275,6 +288,16 @@ class TestInstallChatGPTSkills:
 
         assert "identity_pools" in config_skill
         assert "mail_public_identities.yaml" in config_ref
+
+    def test_chatgpt_and_codex_installs_bundle_ids_guidance(self, tmp_path):
+        """Generated SKILL.md trees retain correlated IDS guidance and detailed references."""
+        install_chatgpt_skills(tmp_path)
+
+        assert "ids_alerts" in (tmp_path / "eforge-scenario" / "SKILL.md").read_text()
+        assert "policy-filtered" in (tmp_path / "eforge-generate" / "SKILL.md").read_text()
+        ids_ref = tmp_path / "eforge-config" / "references" / "config-ids.md"
+        assert ids_ref.is_file()
+        assert "event_filter" in ids_ref.read_text()
 
     def test_chatgpt_references_are_limited_per_skill(self, tmp_path):
         """ChatGPT skills only receive the references they need."""

--- a/tests/unit/test_log_realism_fixes.py
+++ b/tests/unit/test_log_realism_fixes.py
@@ -68,7 +68,7 @@ class TestSnortRevField:
         )
         event._sensor_hostnames_by_format = {"snort_alert": ["ids-01"]}
         emitter.emit(event)
-        emitter.flush()
+        emitter.close()
 
         output = (tmp_path / "ids-01" / "snort_alert.log").read_text()
         assert "[1:2002677:14]" in output
@@ -100,7 +100,7 @@ class TestSnortRevField:
         )
         event._sensor_hostnames_by_format = {"snort_alert": ["ids-01"]}
         emitter.emit(event)
-        emitter.flush()
+        emitter.close()
 
         output = (tmp_path / "ids-01" / "snort_alert.log").read_text()
         assert "[1:384:1]" in output

--- a/tests/unit/test_network_observation.py
+++ b/tests/unit/test_network_observation.py
@@ -34,7 +34,11 @@ from evidenceforge.models.scenario import (
 T0 = datetime(2026, 3, 19, 10, 0, 0, tzinfo=UTC)
 
 
-def _visibility_engine(*, destination_profile: str = "") -> NetworkVisibilityEngine:
+def _visibility_engine(
+    *,
+    source_profile: str = "",
+    destination_profile: str = "",
+) -> NetworkVisibilityEngine:
     config = NetworkConfig(
         segments=[
             NetworkSegment(
@@ -53,6 +57,7 @@ def _visibility_engine(*, destination_profile: str = "") -> NetworkVisibilityEng
                 type="network",
                 name="source-tap",
                 monitoring_segments=["workstations"],
+                capture_profile=source_profile,
                 log_formats=["zeek"],
             ),
             NetworkSensor(
@@ -144,7 +149,9 @@ def test_lossless_and_nat_only_observations_retain_canonical_accounting() -> Non
             "local_orig": False,
         }
     }
-    planner = NetworkObservationPlanner(_visibility_engine())
+    planner = NetworkObservationPlanner(
+        _visibility_engine(source_profile="well_synced", destination_profile="well_synced")
+    )
 
     first = planner.plan(event, {"zeek_conn", "zeek_dns"})
     second = planner.plan(event, {"zeek_conn", "zeek_dns"})
@@ -167,6 +174,30 @@ def test_lossless_and_nat_only_observations_retain_canonical_accounting() -> Non
         assert observation.connection_id(event.network.zeek_uid) == observation.connection_uid
         assert observation.traffic.missed_bytes == 0
         assert observation.observed_duration >= event.network.duration
+
+
+def test_distributed_taps_have_sensor_local_timing_and_accounting_texture() -> None:
+    """Default distributed taps should not clone every cross-sensor observation."""
+
+    planner = NetworkObservationPlanner(_visibility_engine())
+    differing_traffic = 0
+    relative_offsets: list[float] = []
+    for index in range(200):
+        event = _network_event(
+            start=T0 + timedelta(seconds=index * 3),
+            stable_id=f"network:distributed-texture:{index}",
+        )
+        observations = _observation_by_sensor(planner.plan(event, {"zeek_conn", "zeek_dns"}))
+        source = observations["source-tap"]
+        destination = observations["destination-tap"]
+        differing_traffic += source.traffic != destination.traffic
+        relative_offsets.append(
+            (destination.observed_start_time - source.observed_start_time).total_seconds()
+        )
+
+    assert differing_traffic >= 20
+    assert any(offset < 0 for offset in relative_offsets)
+    assert any(offset > 0 for offset in relative_offsets)
 
 
 def test_explicit_loss_profile_is_deterministic_bounded_and_auditable(monkeypatch) -> None:
@@ -261,10 +292,9 @@ def test_protocol_siblings_share_one_sensor_identity_and_tuple(tmp_path) -> None
 
     event = _network_event()
     event._nat_swaps_by_sensor = {"destination-tap": {"src_ip": "198.51.100.25", "src_port": 62000}}
-    event.network_observations = NetworkObservationPlanner(_visibility_engine()).plan(
-        event,
-        {"zeek_conn", "zeek_dns"},
-    )
+    event.network_observations = NetworkObservationPlanner(
+        _visibility_engine(source_profile="well_synced", destination_profile="well_synced")
+    ).plan(event, {"zeek_conn", "zeek_dns"})
     event.network_observations_planned = True
     conn_emitter = ZeekEmitter(
         load_format("zeek_conn"),

--- a/tests/unit/test_phase5_system_traffic.py
+++ b/tests/unit/test_phase5_system_traffic.py
@@ -42,6 +42,7 @@ from evidenceforge.generation.engine.baseline import (
     _cron_shell_command_line,
     _dc_kerberos_cycle_range,
     _dc_kerberos_tgs_range,
+    _extra_syslog_effective_limit,
     _is_kerberos_member_server,
     _is_windows_singleton_service_image,
     _kernel_uptime_stamp,
@@ -559,6 +560,44 @@ def test_dbus_extra_syslog_is_window_capped():
 
     assert dbus["max_per_host_window"] <= 8
     assert dbus["weight"] <= 1
+
+
+def test_ambient_sudo_limits_are_stable_host_conditioned_and_below_ceiling(linux_system):
+    """A safety ceiling must not become an identical target across Linux hosts."""
+    entry = {"app": "sudo", "messages": ["COMMAND={sudo_command}"], "max_per_host_window": 18}
+    window_start = datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC)
+    systems = [
+        linux_system.model_copy(
+            update={
+                "hostname": f"LINUX-{index:02d}",
+                "type": "server" if index < 9 else "workstation",
+                "roles": ["web_server"] if index % 2 else ["database"],
+            }
+        )
+        for index in range(14)
+    ]
+
+    first = [_extra_syslog_effective_limit(system, entry, window_start) for system in systems]
+    second = [_extra_syslog_effective_limit(system, entry, window_start) for system in systems]
+
+    assert first == second
+    assert all(0 <= count <= 18 for count in first)
+    assert len(set(first)) >= 5
+    assert sum(count == 18 for count in first) <= 2
+
+
+def test_non_sudo_extra_syslog_limits_remain_literal(linux_system):
+    """Host-conditioned sudo admission must not change sibling program caps."""
+    entry = {"app": "dbus-daemon", "messages": ["activated"], "max_per_host_window": 8}
+
+    assert (
+        _extra_syslog_effective_limit(
+            linux_system,
+            entry,
+            datetime(2024, 3, 18, 12, 0, 0, tzinfo=UTC),
+        )
+        == 8
+    )
 
 
 def test_anacron_lifecycle_emits_once_per_host_day(linux_system):

--- a/tests/unit/test_realism_quick_wins.py
+++ b/tests/unit/test_realism_quick_wins.py
@@ -314,7 +314,7 @@ def test_snort_direct_emission_preserves_canonical_timestamps(tmp_path):
         )
         emitter.emit(event)
 
-    emitter.flush()
+    emitter.close()
 
     output = (tmp_path / "snort_alert.log").read_text()
     lines = [line for line in output.strip().split("\n") if line.strip()]

--- a/tests/unit/test_remaining_expert_review.py
+++ b/tests/unit/test_remaining_expert_review.py
@@ -345,5 +345,21 @@ class TestIdsFalsePositiveSignatures:
     def test_protocol_artifact_signatures_are_not_baseline_false_positives(self):
         signatures = {sig["sid"]: sig for sig in load_ids_signatures()["signatures"]}
 
-        for sid in (255, 2000536, 2000537, 2000545, 2002106, 2019876, 2024364):
+        for sid in (
+            255,
+            2000536,
+            2000537,
+            2000545,
+            2002106,
+            2017919,
+            2019876,
+            2024364,
+            2025331,
+        ):
             assert signatures[sid]["baseline_fp_allowed"] is False
+
+    def test_payload_signatures_declare_cleartext_inspection_visibility(self):
+        signatures = {sig["sid"]: sig for sig in load_ids_signatures()["signatures"]}
+
+        for sid in (2000419, 2001114, 2001115):
+            assert signatures[sid]["inspection"] == "payload_cleartext"

--- a/tests/unit/test_source_timing.py
+++ b/tests/unit/test_source_timing.py
@@ -19,6 +19,7 @@ from evidenceforge.events.contexts import (
     DnsContext,
     FileContext,
     HostContext,
+    KerberosContext,
     NetworkContext,
     ProcessAccessContext,
     ProcessContext,
@@ -221,6 +222,66 @@ def test_session_closure_follows_same_source_process_termination_with_bounded_ta
     assert planned.source_timing.canonical_timestamp == canonical_end
     assert planned.timestamp > process_source_time
     assert planned.timestamp <= canonical_end + timedelta(seconds=15)
+
+
+def test_ecar_logout_finalized_time_consumes_bundle_closure_plan() -> None:
+    """eCAR must clamp an unplanned closure after delayed remote authentication."""
+
+    planner = SourceTimingPlanner()
+    flow_event, login_event = _remote_auth_timing_events()
+    canonical_end = login_event.timestamp + timedelta(milliseconds=25)
+    lifecycle = ActionLifecycleContext(
+        group_id="network-session-group",
+        canonical_start=login_event.timestamp,
+        phase="start",
+    )
+    login_event.lifecycle = lifecycle
+    logoff_event = SecurityEvent(
+        timestamp=canonical_end,
+        event_type="logoff",
+        dst_host=login_event.dst_host,
+        auth=login_event.auth,
+        lifecycle=replace(lifecycle, phase="closure"),
+    )
+
+    planner.plan_event(flow_event, "ecar")
+    planner.record_admitted_source_event(flow_event, "ecar")
+    planner.plan_event(login_event, "ecar")
+    planned_logoff = planner.plan_event(logoff_event, "ecar")
+
+    login_time = login_event.source_timing.finalized_times[ecar_session_render_key("login")]
+    logout_time = planned_logoff.source_timing.finalized_times[ecar_session_render_key("logout")]
+    assert planned_logoff.timestamp == logout_time
+    assert logout_time > login_time
+
+
+def test_machine_logon_follows_visible_kerberos_service_ticket() -> None:
+    """Rendered machine authentication must follow its admitted service ticket."""
+
+    planner = SourceTimingPlanner()
+    flow_event, login_event = _remote_auth_timing_events()
+    login_event.event_type = "machine_logon"
+    login_event.auth.username = "WIN-TEST-01$"
+    ticket_event = SecurityEvent(
+        timestamp=login_event.timestamp + timedelta(milliseconds=500),
+        event_type="kerberos_service",
+        dst_host=login_event.dst_host,
+        kerberos=KerberosContext(
+            target_username="WIN-TEST-01$",
+            target_domain="CORP.LOCAL",
+            service_name="cifs/DC-01",
+            source_ip=f"::ffff:{login_event.auth.source_ip}",
+            source_port=54213,
+        ),
+    )
+
+    planned_ticket = planner.plan_event(ticket_event, "windows_event_security")
+    planner.record_admitted_source_event(planned_ticket, "windows_event_security")
+    planner.plan_event(flow_event, "windows_event_security")
+    planner.record_admitted_source_event(flow_event, "windows_event_security")
+    planned_login = planner.plan_event(login_event, "windows_event_security")
+
+    assert planned_login.timestamp > planned_ticket.timestamp
 
 
 def test_ecar_identity_plan_preserves_parent_create_dependent_terminate_order(

--- a/tests/unit/test_storyline_command_networks.py
+++ b/tests/unit/test_storyline_command_networks.py
@@ -29,7 +29,13 @@ from evidenceforge.generation.engine.storyline import (
 )
 from evidenceforge.generation.source_timing import SourceTimingPlanner
 from evidenceforge.generation.state_manager import StateManager
-from evidenceforge.models.scenario import BeaconEventSpec, ConnectionEventSpec, System, User
+from evidenceforge.models.scenario import (
+    BeaconEventSpec,
+    ConnectionEventSpec,
+    DhcpLeaseEventSpec,
+    System,
+    User,
+)
 
 
 class TestStorylineCommandNetworks:
@@ -3315,7 +3321,7 @@ class TestStorylineCommandSideEffects:
                 "system": source,
             }
         }
-        spec = SimpleNamespace(type="dhcp_lease", requested_ip=None, mac_address=None)
+        spec = DhcpLeaseEventSpec(ids_alerts=[{"sid": 2002911, "policy": "every"}])
 
         engine._execute_typed_event(
             spec=spec,
@@ -3331,6 +3337,8 @@ class TestStorylineCommandSideEffects:
         assert lease["lease_time"] == 7200.0
         assert lease["msg_types"] == ["REQUEST", "ACK"]
         assert lease["renewal_interval"] > 0
+        assert [context.sid for context in lease["ids_alerts"]] == [2002911]
+        assert "ids_alerts" not in engine._dhcp_lease_state["ROGUE-LAPTOP"]
         assert (
             engine._dhcp_lease_state["ROGUE-LAPTOP"]["next_renewal"]
             == lease["time"].timestamp() + lease["renewal_interval"]

--- a/tests/unit/test_sysmon_emitter.py
+++ b/tests/unit/test_sysmon_emitter.py
@@ -260,6 +260,83 @@ class TestSysmonEventEmitter:
         assert '<Data Name="Image">C:\\Windows\\System32\\cmd.exe</Data>' in content
         assert '<Data Name="User">CORP\\jsmith</Data>' in content
 
+    def test_versioned_eventdata_uses_native_manifest_order(self, format_def, temp_output):
+        """Later-version Sysmon user fields must stay at their manifest positions."""
+        emitter = SysmonEventEmitter(format_def, temp_output, buffer_size=10)
+        common = {
+            "TimeCreated": datetime(2024, 1, 15, 10, 30, tzinfo=UTC),
+            "Computer": "WKS-01.corp.local",
+            "Channel": "Microsoft-Windows-Sysmon/Operational",
+            "Level": 4,
+            "ExecutionProcessID": 2756,
+            "ExecutionThreadID": 3632,
+            "UtcTime": "2024-01-15 10:30:00.000",
+            "ProcessGuid": "{12345678-abcd-ef01-2345-678901234567}",
+            "ProcessId": 8052,
+            "Image": r"C:\Windows\System32\cmd.exe",
+            "User": r"CORP\jsmith",
+        }
+        emitter.emit_event(
+            {
+                **common,
+                "EventID": 7,
+                "ImageLoaded": r"C:\Windows\System32\user32.dll",
+                "Signed": "true",
+                "Signature": "Microsoft Windows",
+                "SignatureStatus": "Valid",
+            }
+        )
+        emitter.emit_event(
+            {
+                **common,
+                "EventID": 10,
+                "SourceProcessGUID": common["ProcessGuid"],
+                "SourceProcessId": 8052,
+                "SourceThreadId": 8060,
+                "SourceImage": common["Image"],
+                "TargetProcessGUID": "{87654321-abcd-ef01-2345-678901234567}",
+                "TargetProcessId": 640,
+                "TargetImage": r"C:\Windows\System32\lsass.exe",
+                "GrantedAccess": "0x1010",
+                "CallTrace": "C:\\Windows\\SYSTEM32\\ntdll.dll+9d000",
+                "SourceUser": common["User"],
+                "TargetUser": r"NT AUTHORITY\SYSTEM",
+            }
+        )
+        emitter.emit_event(
+            {
+                **common,
+                "EventID": 11,
+                "TargetFilename": r"C:\Temp\sample.txt",
+                "CreationUtcTime": common["UtcTime"],
+            }
+        )
+        emitter.emit_event(
+            {
+                **common,
+                "EventID": 13,
+                "EventType": "SetValue",
+                "TargetObject": r"HKLM\Software\Example\Value",
+                "Details": "DWORD (0x00000001)",
+            }
+        )
+        emitter.close()
+
+        content = temp_output.read_text()
+
+        def names(event_id):
+            event_xml = re.search(
+                rf"<Event\b[^>]*>.*?<EventID>{event_id}</EventID>.*?</Event>",
+                content,
+                re.DOTALL,
+            ).group(0)
+            return re.findall(r'<Data Name="([^"]+)">', event_xml)
+
+        assert names(7)[-2:] == ["SignatureStatus", "User"]
+        assert names(10)[-4:] == ["GrantedAccess", "CallTrace", "SourceUser", "TargetUser"]
+        assert names(11)[-3:] == ["TargetFilename", "CreationUtcTime", "User"]
+        assert names(13)[-3:] == ["TargetObject", "Details", "User"]
+
     def test_emit_sysmon_process_terminate_via_event(self, format_def, tmp_path):
         """Test Sysmon Event 5 via SecurityEvent dispatch."""
         from evidenceforge.events.base import SecurityEvent

--- a/tests/unit/test_sysmon_new_events.py
+++ b/tests/unit/test_sysmon_new_events.py
@@ -564,6 +564,7 @@ class TestRenderEvent7:
         assert "plugin.dll" in content
         assert "Unavailable" in content
         assert '<Data Name="Signed">false</Data>' in content
+        assert '<Data Name="User">CORP\\user</Data>' in content
 
     def test_event7_system_dll_renders_windows_metadata(self, emitter):
         """System DLL image loads should not render application PE metadata."""

--- a/tests/unit/test_timing_profiles.py
+++ b/tests/unit/test_timing_profiles.py
@@ -199,13 +199,13 @@ def test_timing_profiles_load_default_relationship():
     assert asset_window.min_ms > zeek_conn_window.max_ms + zeek_http_window.max_ms
 
     sensor_timing = network_sensor_observation_timing()
-    assert sensor_timing.clock_skew_min_us == -18000
-    assert sensor_timing.clock_skew_max_us == 22000
-    assert sensor_timing.path_delay_min_us == 1200
-    assert sensor_timing.path_delay_max_us == 18000
-    assert sensor_timing.clock_drift_min_ppm == -2
-    assert sensor_timing.event_jitter_max_us == 750
-    assert sensor_timing.capture_loss_probability == 0.0
+    assert sensor_timing.clock_skew_min_us == -35000
+    assert sensor_timing.clock_skew_max_us == 35000
+    assert sensor_timing.path_delay_min_us == 500
+    assert sensor_timing.path_delay_max_us == 25000
+    assert sensor_timing.clock_drift_min_ppm == -1
+    assert sensor_timing.event_jitter_max_us == 90000
+    assert sensor_timing.capture_loss_probability == 0.12
 
     endpoint_timing = endpoint_clock_timing("enterprise_standard", "windows")
     assert endpoint_timing.host_offset_min_ms == -1250

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -1972,6 +1972,43 @@ class TestValidateConfig:
             for issue in result.issues
         )
 
+    def test_validate_config_rejects_malformed_ids_alert_policy(self, monkeypatch):
+        from evidenceforge.generation.activity import ids_signatures
+
+        def load_invalid_ids_signatures():
+            return {
+                "signatures": [
+                    {
+                        "sid": 999004,
+                        "rev": 1,
+                        "message": "ET TEST Invalid Policy",
+                        "classification": "misc-activity",
+                        "priority": 3,
+                        "proto": "tcp",
+                        "dst_port": 443,
+                        "direction": "out",
+                        "alert_policy": {
+                            "event_filter": {
+                                "type": "limit",
+                                "track": "by_src",
+                                "count": True,
+                                "seconds": 0,
+                                "unknown": "field",
+                            }
+                        },
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(ids_signatures, "load_ids_signatures", load_invalid_ids_signatures)
+        result = validate_config()
+        assert any(
+            issue.severity == "ERROR"
+            and issue.file == "ids_signatures.yaml"
+            and "invalid alert_policy" in issue.message
+            for issue in result.issues
+        )
+
     def test_validate_config_rejects_conflicting_ids_rule_identity(self, monkeypatch):
         from evidenceforge.generation.activity import ids_signatures
 


### PR DESCRIPTION
## Summary

- fix source-timing and lifecycle realism across eCAR and Windows session evidence
- correct machine-account transport semantics, Sysmon manifests, eCAR module ownership, TLS certificate issuance, and sensor-local network observations
- diversify baseline sudo and public-client behavior
- enforce IDS signature eligibility and payload-inspection visibility
- add focused regression coverage for each corrected family-level contract

## Why

Ten independent assessment cycles identified recurring generator fingerprints and cross-source contradictions. The fixes address each issue at its owning configuration, canonical planning, timing, or source-native rendering layer instead of patching generated scenario output.

## Scope

This PR contains only implementation/configuration fixes and automated tests. It intentionally excludes generated scenarios, blind-review artifacts, score files, dashboards, assessment results, and local agent files.

## Validation

- `uv run pytest --no-cov`: 5,089 passed, 19 skipped
- `uv run pytest --include-slow -m slow --no-cov --durations=20`: 13 passed, 1 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
